### PR TITLE
Support static build + Docker image

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,8 @@ mlua = { version = "0.4.1", features = ["async","send", "vendored","lua53"] }
 mlua_serde = { version = "0.5", features = ["lua53"] }
 
 #wasm
-wasmer-runtime = "0.13.1"
+wasmer-runtime = "0.17.1"
+#wasmer-runtime = "0.13.1"
 
 #Crypto
 sodiumoxide = "0.2.5"

--- a/build/build_static.sh
+++ b/build/build_static.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+echo "$SCRIPT_DIR"
+
+docker run --rm -it -v "$(pwd)":/home/rust/src -v "$(realpath ~/.cargo/git)":/home/rust/.cargo/git -v "$(realpath ~/.cargo/registry/)":/home/rust/.cargo/registry ekidd/rust-musl-builder:nightly-2020-08-15 bash -c "sudo chown -R rust:rust .; cargo build --release"
+
+cp "$SCRIPT_DIR"/../target/x86_64-unknown-linux-musl/release/shotover-proxy "$SCRIPT_DIR"/static
+
+docker build -f "$SCRIPT_DIR"/static/Dockerfile -t shotover/shotover-proxy-dev "$SCRIPT_DIR"/static
+
+rm "$SCRIPT_DIR"/static/shotover-proxy

--- a/build/static/Dockerfile
+++ b/build/static/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+COPY shotover-proxy /usr/local/bin/
+CMD /usr/local/bin/shotover-proxy


### PR DESCRIPTION
We can now build a staticly linked binary with musl libc.
This makes it easier to build a nice tiny docker image.
Also upgraded wasmer to fix musl compile issues