### PR TITLE
nodelay

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -127,6 +127,8 @@ where
                     .unwrap_or_else(|_| "Unknown peer".to_string())
             );
 
+            socket.set_nodelay(true)?;
+
             let mut handler = Handler {
                 // Get a handle to the shared database. Internally, this is an
                 // `Arc`, so a clone only increments the ref count.


### PR DESCRIPTION
This patch disables nagles algorithm. Generally we want to send data as soon as we have it (being a proxy generally means we are bound by littles law, so reducing latency will primarily help throughput).

May need to let this be configurable for other protocols tho...