### PR TITLE
hard_limit enforcement

### DIFF
--- a/config/topology.yaml
+++ b/config/topology.yaml
@@ -5,6 +5,7 @@ sources:
       batch_size_hint: 1000
       listen_addr: "127.0.0.1:6379"
       connection_limit: 1000
+      hard_connection_limit: false
 chain_config:
   redis_chain:
     - PoolConnections:

--- a/src/config/topology.rs
+++ b/src/config/topology.rs
@@ -259,6 +259,7 @@ impl Topology {
             cassandra_ks,
             bypass_query_processing: false,
             connection_limit: None,
+            hard_connection_limit: None,
         });
 
         let tee_conf = TransformsConfig::MPSCTee(TeeConfig {


### PR DESCRIPTION
Introduces a new optional configuration variable for the redis and cassandra source, `hard_connection_limit`.

By default it's set to `false` or set to `false` if not included in the configuration file. When set to `false` behavior is the same as previous versions of shotover (when the number of allowed connections are exceeded, shotover will only `accept` them once other connections drop, however the underlying tcp connection will just sit in the tcp accept pool).

When set to `true`, shotover will stop listening on the cassandra or redis port when the connection limit has been exceeded. This will result in a `E_CONNECTIONREFUSED` error to the client. This is usefull when forcing misbehaving clients to not connect.