### PR TITLE
Fix warnings

### DIFF
--- a/src/transforms/distributed/tunable_consistency_scatter.rs
+++ b/src/transforms/distributed/tunable_consistency_scatter.rs
@@ -262,10 +262,9 @@ mod scatter_transform_tests {
 
     use anyhow::Result;
 
-    use crate::config::topology::TopicHolder;
     use crate::message::{MessageDetails, Messages, QueryMessage, QueryResponse, QueryType, Value};
     use crate::protocols::RawFrame;
-    use crate::transforms::{Transform, Transforms, Wrapper};
+    use crate::transforms::{Transforms, Wrapper};
     use std::collections::HashMap;
 
     fn check_ok_responses(

--- a/src/transforms/load_balance.rs
+++ b/src/transforms/load_balance.rs
@@ -89,7 +89,6 @@ impl Transform for ConnectionBalanceAndPool {
 
 #[cfg(test)]
 mod test {
-    use crate::config::topology::TopicHolder;
     use crate::message::Messages;
     use crate::transforms::chain::TransformChain;
     use crate::transforms::load_balance::ConnectionBalanceAndPool;

--- a/src/transforms/lua.rs
+++ b/src/transforms/lua.rs
@@ -103,21 +103,21 @@ impl Transform for LuaFilterTransform {
 
 #[cfg(test)]
 mod lua_transform_tests {
-    use std::error::Error;
+    // use std::error::Error;
 
-    use crate::config::topology::TopicHolder;
-    use crate::message::{MessageDetails, Messages, QueryMessage, QueryResponse, QueryType, Value};
-    use crate::protocols::RawFrame;
-    use crate::transforms::chain::TransformChain;
-    use crate::transforms::lua::LuaConfig;
-    use crate::transforms::null::Null;
-    use crate::transforms::printer::Printer;
-    use crate::transforms::{Transform, Transforms, TransformsFromConfig, Wrapper};
+    // use crate::config::topology::TopicHolder;
+    // use crate::message::{MessageDetails, Messages, QueryMessage, QueryResponse, QueryType, Value};
+    // use crate::protocols::RawFrame;
+    // use crate::transforms::chain::TransformChain;
+    // use crate::transforms::lua::LuaConfig;
+    // use crate::transforms::null::Null;
+    // use crate::transforms::printer::Printer;
+    // use crate::transforms::{Transform, Transforms, TransformsFromConfig, Wrapper};
 
-    const REQUEST_STRING: &str = r###"
-qm.namespace = {"aaaaaaaaaa", "bbbbb"}
-return call_next_transform(qm)
-"###;
+//    const REQUEST_STRING: &str = r###"
+//qm.namespace = {"aaaaaaaaaa", "bbbbb"}
+//return call_next_transform(qm)
+//"###;
 
     // #[tokio::test(flavor = "multi_thread")]
     // async fn test_lua_script() -> Result<(), Box<dyn Error>> {

--- a/src/transforms/mod.rs
+++ b/src/transforms/mod.rs
@@ -151,7 +151,7 @@ impl Transforms {
         }
     }
 
-    async fn prep_transform_chain(&mut self, t: &mut TransformChain) -> Result<()> {
+    async fn _prep_transform_chain(&mut self, t: &mut TransformChain) -> Result<()> {
         match self {
             Transforms::CodecDestination(a) => a.prep_transform_chain(t).await,
             Transforms::RedisCodecDestination(a) => a.prep_transform_chain(t).await,

--- a/src/transforms/protect/mod.rs
+++ b/src/transforms/protect/mod.rs
@@ -271,7 +271,6 @@ mod protect_transform_tests {
     use cassandra_proto::consistency::Consistency;
     use cassandra_proto::frame::Frame;
     use sodiumoxide::crypto::secretbox;
-    use tokio::sync::mpsc::channel;
 
     use crate::config::topology::TopicHolder;
     use crate::message::{MessageDetails, Messages, QueryMessage, QueryResponse, QueryType, Value};

--- a/tests/codec/util/packet_capture.rs
+++ b/tests/codec/util/packet_capture.rs
@@ -2,7 +2,6 @@ use crate::codec::util::packet_parse::{PacketHeader, PacketParse, ParsedPacket};
 
 use anyhow::{anyhow, Result};
 use pcap::{Active, Capture, Device};
-use std::fs;
 use std::net::IpAddr;
 use std::sync::{Arc, Mutex};
 use threadpool::ThreadPool;
@@ -133,7 +132,6 @@ impl PacketCapture {
     pub fn parse_from_file(
         &mut self,
         file_name: &str,
-        save_file_path: Option<&str>,
         filter: Option<String>,
     ) -> Result<Vec<Result<ParsedPacket, String>>> {
         // TODO: Fix flakiness from out-of-order futures.
@@ -170,7 +168,7 @@ impl PacketCapture {
                 pool.join();
 
                 let packets: Vec<Result<ParsedPacket, String>> = Arc::try_unwrap(packets)
-                    .map_err(|e| anyhow!("more refs remaining"))?
+                    .map_err(|_| anyhow!("more refs remaining"))?
                     .into_inner()?;
 
                 return Ok(packets);

--- a/tests/redis_int_tests/basic_driver_tests.rs
+++ b/tests/redis_int_tests/basic_driver_tests.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::let_unit_value)]
 use anyhow::Result;
 
-use redis::{Commands, ConnectionLike, ErrorKind, RedisError, RedisResult, Value};
+use redis::{Commands, ErrorKind, RedisError, Value};
 
 use crate::load_docker_compose;
 use crate::redis_int_tests::support::TestContext;
@@ -838,7 +838,7 @@ fn test_pass_redis_cluster_one() -> Result<()> {
 
 // TODO Re-enable Redis Auth support
 // #[test]
-fn test_cluster_auth_redis() -> Result<()> {
+fn _test_cluster_auth_redis() -> Result<()> {
     info!("test_cluster_auth_redis");
     try_register_cleanup();
     let compose_config = "examples/redis-cluster-auth/docker-compose.yml".to_string();

--- a/tests/redis_presence_integration.rs
+++ b/tests/redis_presence_integration.rs
@@ -120,6 +120,7 @@ fn get_redis_conn() -> Result<Connection> {
     Ok(client.get_connection()?)
 }
 
+#[allow(dead_code)]
 async fn test_presence_fresh_join_single_workflow() -> Result<()> {
     let subkey = "demo-36";
     let channel = "channel1";
@@ -175,6 +176,7 @@ async fn test_presence_fresh_join_single_workflow() -> Result<()> {
 
     Ok(())
 }
+#[allow(dead_code)]
 async fn test_presence_fresh_join_pipeline_workflow() -> Result<()> {
     let subkey = "demo-36";
     let channel = "channel1";
@@ -201,6 +203,7 @@ async fn test_presence_fresh_join_pipeline_workflow() -> Result<()> {
     Ok(())
 }
 
+#[allow(dead_code)]
 async fn test_simple_pipeline_workflow() -> Result<()> {
     let mut connection = get_redis_conn().unwrap();
     run_basic_pipelined(&mut connection).unwrap();
@@ -208,7 +211,7 @@ async fn test_simple_pipeline_workflow() -> Result<()> {
 }
 
 // #[tokio::test(threaded_scheduler)]
-async fn run_all() -> Result<()> {
+async fn _run_all() -> Result<()> {
     let delaytime = time::Duration::from_secs(2);
     let _subscriber = tracing_subscriber::fmt()
         .with_max_level(Level::INFO)


### PR DESCRIPTION
Its important to keep our warning count at 0 so that we don't miss important warnings that can lead to bugs e.g. unused Result value warnings can hide failures.

... does raising the PR like this fix CI issues?
Edit: yes it does