### PR TITLE
Tests are marked as serial per test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,7 +58,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       run: mkdir -p test_tmp && aws s3 sync s3://shotover-test-captures ./test_tmp
     - name: Run tests
-      run: cargo test -- --test-threads 1 --include-ignored
+      run: cargo test -- --include-ignored
       timeout-minutes: 30
 #    - name: Build
 #      run: cargo build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ httparse = "1.3.0"
 threadpool = "1.0"
 num_cpus = "1.0"
 anyhow = "1.0.38"
+serial_test = "0.5.1"
 
 [[bench]]
 name = "redis_benches"

--- a/docs/developer/shotover-development.md
+++ b/docs/developer/shotover-development.md
@@ -32,9 +32,7 @@ The way you build shotover will dramatically impact performance. To build shotov
 or for any benchmarking use `cargo build --release`. The resulting executeable will be found in `target/release/shotover-proxy`. 
 
 ## Testing shotover
-See cargo's [documentation suite](https://doc.rust-lang.org/cargo/commands/cargo-test.html) for running tests. If you want to run the entire test suite,
-you will want to restrict the number of tests that can execute at any given period of time. Some of the integration tests depend on 
-external databases running in a docker environment and there are still some overlaps in port numbers etc. This means tests can only run one at a time.
+See cargo's [documentation suite](https://doc.rust-lang.org/cargo/commands/cargo-test.html) for running tests.
 
-To run the full set of shotover tests, use `cargo test -- --test-threads 1`
+To run the full set of shotover tests, use `cargo test`
 

--- a/tests/redis_int_tests/basic_driver_tests.rs
+++ b/tests/redis_int_tests/basic_driver_tests.rs
@@ -13,6 +13,7 @@ use tokio::runtime;
 use tracing::info;
 use tracing::trace;
 use tracing::Level;
+use serial_test::serial;
 
 fn try_register_cleanup() {
     let _ = ctrlc::set_handler(move || {
@@ -747,6 +748,7 @@ fn test_pass_through_one() {
 }
 
 #[test]
+#[serial(redis)]
 fn test_active_active_redis() {
     try_register_cleanup();
     let _subscriber = tracing_subscriber::fmt()
@@ -758,6 +760,7 @@ fn test_active_active_redis() {
 }
 
 #[test]
+#[serial(redis)]
 // #[allow(dead_code)]
 fn test_active_one_active_redis() {
     try_register_cleanup();
@@ -795,6 +798,7 @@ fn test_active_one_active_redis() {
 }
 
 #[test]
+#[serial(redis)]
 fn test_pass_redis_cluster_one() {
     let compose_config = "examples/redis-cluster/docker-compose.yml".to_string();
     load_docker_compose(compose_config);
@@ -828,6 +832,7 @@ fn test_pass_redis_cluster_one() {
 
 // TODO Re-enable Redis Auth support
 // #[test]
+// #[serial(redis)]
 fn _test_cluster_auth_redis() {
     info!("test_cluster_auth_redis");
     try_register_cleanup();
@@ -906,6 +911,7 @@ fn _test_cluster_auth_redis() {
 }
 
 #[test]
+#[serial(redis)]
 fn test_cluster_all_redis() {
     try_register_cleanup();
     let compose_config = "examples/redis-cluster/docker-compose.yml".to_string();
@@ -918,6 +924,7 @@ fn test_cluster_all_redis() {
 }
 
 #[test]
+#[serial(redis)]
 fn test_cluster_all_script_redis() {
     try_register_cleanup();
     let compose_config = "examples/redis-cluster/docker-compose.yml".to_string();
@@ -951,6 +958,7 @@ fn test_cluster_all_script_redis() {
 }
 
 #[test]
+#[serial(redis)]
 fn test_cluster_all_pipeline_safe_redis() {
     info!("test_cluster_all_pipeline_safe_redis");
 


### PR DESCRIPTION
Advantages:
*   developers dont need to know or remember to run as `cargo test -- test-threads 1` instead simply `cargo test` will work
*   non-serial tests can be run in parallel speeding up test runs.
*   its a lot easier to make this change now compared to further down the line when we have a lot more tests. If all tests are run serially then developers will accidentally write thats that rely on being run serially when that could be easily avoided.

Disadvantages:
*   developers can fail to add serial to a test that needs it, causing hard to track down issues.


In the future we could possibly use https://github.com/testcontainers/testcontainers-rs
It claims to allow creation, use and deletion of docker containers in parallel integration tests via a rusty RAII abstraction.
However it doesn't support docker compose, so I don't think it will fit well into our test system as is.
But its worth keeping in mind if we ever want to significantly improve the time it takes to run our integration tests.