### PR TITLE
share setup code between tests and benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "shotover-proxy",
+    "test-helpers",
 ]
 
 # https://deterministic.space/high-performance-rust.html

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -80,7 +80,6 @@ rusoto_signature = "0.46.0"
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["async_tokio", "html_reports"] }
-#proptest = "0.10.0"
 lazy_static = "1.4.0"
 ctrlc = "3.1.6"
 redis = {git = "https://github.com/benbromhead/redis-rs", branch = "parra_support", features = ["tokio-rt-core", "cluster"]}
@@ -92,9 +91,8 @@ hwaddr = "0.1.2"
 httparse = "1.3.0"
 threadpool = "1.0"
 num_cpus = "1.0"
-anyhow = "1.0.38"
 serial_test = "0.5.1"
-subprocess = "0.2.7"
+test-helpers = { path = "../test-helpers" }
 
 [[bench]]
 name = "redis_benches"

--- a/shotover-proxy/benches/chain_benches.rs
+++ b/shotover-proxy/benches/chain_benches.rs
@@ -32,7 +32,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         BenchmarkId::new("input_example", "Empty Message"),
         &wrapper,
         move |b, s| {
-            let mut rt = tokio::runtime::Runtime::new().unwrap();
+            let rt = tokio::runtime::Runtime::new().unwrap();
             b.iter(|| {
                 let _ = rt.block_on(chain.process_request(s.clone(), "".to_string()));
             })
@@ -64,7 +64,7 @@ fn lua_benchmark(c: &mut Criterion) {
         RawFrame::None,
     ));
 
-    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let rt = tokio::runtime::Runtime::new().unwrap();
 
     let transform = rt.block_on(lua_t.get_source(&t_holder)).unwrap();
 

--- a/shotover-proxy/tests/lib.rs
+++ b/shotover-proxy/tests/lib.rs
@@ -1,60 +1,9 @@
 use anyhow::Result;
 use shotover_proxy::config::topology::Topology;
-use std::thread;
-use std::time;
 use tokio::task::JoinHandle;
-use tracing::info;
-use subprocess::{Exec, Redirection};
 
 pub mod redis_int_tests;
 pub mod codec;
-
-fn run_command(command: &str, args: &[&str]) {
-    let data = Exec::cmd(command)
-        .args(args)
-        .stdout(Redirection::Pipe)
-        .stderr(Redirection::Merge)
-        .capture()
-        .unwrap();
-    if !data.exit_status.success() {
-        panic!("command {} {:?} exited with {:?} and output:\n{}", command, args, data.exit_status, data.stdout_str())
-    }
-}
-
-struct DockerCompose {
-    file_path: String
-}
-
-impl DockerCompose {
-    pub fn new(file_path: &str) -> Self {
-        DockerCompose::clean_up(file_path);
-
-        info!("bringing up docker compose {}", file_path);
-
-        run_command("docker-compose", &["-f", file_path, "up", "-d"]);
-
-        thread::sleep(time::Duration::from_secs(4));
-
-        DockerCompose {
-            file_path: file_path.to_string()
-        }
-    }
-
-    fn clean_up(file_path: &str) {
-        info!("bringing down docker compose {}", file_path);
-
-        run_command("docker-compose", &["-f", file_path, "down", "-v"]);
-        run_command("docker-compose", &["-f", file_path, "rm", "-f", "-s", "-v"]);
-
-        thread::sleep(time::Duration::from_secs(1));
-    }
-}
-
-impl Drop for DockerCompose {
-    fn drop(&mut self) {
-        DockerCompose::clean_up(&self.file_path);
-    }
-}
 
 pub fn start_proxy(config: String) -> JoinHandle<Result<()>> {
     tokio::spawn(async move {

--- a/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
+++ b/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
@@ -2,7 +2,7 @@
 
 use redis::{Commands, ErrorKind, RedisError, Value};
 
-use crate::DockerCompose;
+use test_helpers::docker_compose::DockerCompose;
 use crate::redis_int_tests::support::TestContext;
 
 use shotover_proxy::config::topology::Topology;

--- a/test-helpers/Cargo.toml
+++ b/test-helpers/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "test-helpers"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tracing = "0.1.15"
+subprocess = "0.2.7"

--- a/test-helpers/src/docker_compose.rs
+++ b/test-helpers/src/docker_compose.rs
@@ -1,0 +1,51 @@
+use std::thread;
+use std::time;
+use tracing::info;
+use subprocess::{Exec, Redirection};
+
+fn run_command(command: &str, args: &[&str]) {
+    let data = Exec::cmd(command)
+        .args(args)
+        .stdout(Redirection::Pipe)
+        .stderr(Redirection::Merge)
+        .capture()
+        .unwrap();
+    if !data.exit_status.success() {
+        panic!("command {} {:?} exited with {:?} and output:\n{}", command, args, data.exit_status, data.stdout_str())
+    }
+}
+
+pub struct DockerCompose {
+    file_path: String
+}
+
+impl DockerCompose {
+    pub fn new(file_path: &str) -> Self {
+        DockerCompose::clean_up(file_path);
+
+        info!("bringing up docker compose {}", file_path);
+
+        run_command("docker-compose", &["-f", file_path, "up", "-d"]);
+
+        thread::sleep(time::Duration::from_secs(4));
+
+        DockerCompose {
+            file_path: file_path.to_string()
+        }
+    }
+
+    fn clean_up(file_path: &str) {
+        info!("bringing down docker compose {}", file_path);
+
+        run_command("docker-compose", &["-f", file_path, "down", "-v"]);
+        run_command("docker-compose", &["-f", file_path, "rm", "-f", "-s", "-v"]);
+
+        thread::sleep(time::Duration::from_secs(1));
+    }
+}
+
+impl Drop for DockerCompose {
+    fn drop(&mut self) {
+        DockerCompose::clean_up(&self.file_path);
+    }
+}

--- a/test-helpers/src/lib.rs
+++ b/test-helpers/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod docker_compose;


### PR DESCRIPTION
As per https://stackoverflow.com/questions/44539729/what-is-an-idiomatic-way-to-have-shared-utility-functions-for-integration-tests adding a new crate is the best solution for this.
