### PR TITLE
Cleanup unused and non crates.io deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,3 @@ codegen-units = 1
 [profile.bench]
 lto = "fat"
 codegen-units = 1
-
-# Patches
-[patch.crates-io]
-cached = { git = "https://github.com/drwilco/cached", branch = "cloneless-result" }

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -23,10 +23,9 @@ derivative = "2.1.1"
 itertools = "0.9.0"
 rand = { version = "0.7.3", features = ["small_rng", "std"]}
 rand_distr = "0.2.2"
-cached = "0.16.0"
+cached = "0.24.0"
 pin-project = "1.0.1"
 pin-project-lite = "0.2"
-
 
 # Error handling
 thiserror = "1.0"
@@ -44,14 +43,12 @@ metrics = "0.12.1"
 metrics-core = "0.5.2"
 metrics-runtime = "0.13.1"
 tracing = { version = "0.1.15", features = ["release_max_level_info"]}
-tracing-subscriber = { version="0.2.11", features = ["env-filter"]}
+tracing-subscriber = { version = "0.2.11", features = ["env-filter"]}
 tracing-futures = "0.2.4"
 tracing-log = { version = "0.1.1", features = ["env_logger"] }
 tracing-appender = "0.1.1"
 hyper = { version = "0.14.2", features = ["server"] }
 halfbrown = "0.1.11"
-
-
 
 # Transform dependencies
 #redis-protocol = { path = "/home/ben/git/redis-protocol.rs"}
@@ -61,9 +58,6 @@ redis-protocol = { git = "https://github.com/benbromhead/redis-protocol.rs", bra
 cassandra-proto = { git = "https://github.com/benbromhead/cassandra-proto", branch = "move-to-bytes", features = ["v4"]}
 rdkafka = { version = "0.24", features = ["cmake-build"] }
 crc16 = { version = "0.4.0"}
-
-#test deps
-hex-literal = "0.2.1"
 
 #lua
 mlua = { version = "0.4.1", features = ["async","send", "vendored","lua53"] }
@@ -80,19 +74,16 @@ rusoto_signature = "0.46.0"
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["async_tokio", "html_reports"] }
-lazy_static = "1.4.0"
-ctrlc = "3.1.6"
-redis = {git = "https://github.com/benbromhead/redis-rs", branch = "parra_support", features = ["tokio-rt-core", "cluster"]}
+redis = { version = "0.21.0", features = ["tokio-comp", "cluster"] }
 pcap = "0.7.0"
 pktparse = {version = "0.4.0", features = ["derive"]}
 dns-parser = "0.8"
 tls-parser = "0.7"
-hwaddr = "0.1.2"
-httparse = "1.3.0"
 threadpool = "1.0"
 num_cpus = "1.0"
 serial_test = "0.5.1"
 test-helpers = { path = "../test-helpers" }
+hex-literal = "0.2.1"
 
 [[bench]]
 name = "redis_benches"

--- a/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
+++ b/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
@@ -1,16 +1,13 @@
 #![allow(clippy::let_unit_value)]
 
-
 use redis::{Commands, ErrorKind, RedisError, Value};
 
 use test_helpers::docker_compose::DockerCompose;
 use crate::helpers::run_shotover_with_topology;
 use crate::redis_int_tests::support::TestContext;
 
-use std::collections::{BTreeMap, BTreeSet};
-use std::collections::{HashMap, HashSet};
-use tracing::info;
-use tracing::trace;
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use tracing::{info, trace};
 use serial_test::serial;
 
 fn test_args() {
@@ -596,7 +593,7 @@ fn test_nice_list_api() {
     assert_eq!(con.rpush("my_list", &[5, 6, 7, 8]), Ok(8));
     assert_eq!(con.llen("my_list"), Ok(8));
 
-    assert_eq!(con.lpop("my_list"), Ok(1));
+    assert_eq!(con.lpop("my_list", None), Ok(1));
     assert_eq!(con.llen("my_list"), Ok(7));
 
     assert_eq!(con.lrange("my_list", 0, 2), Ok((2, 3, 4)));


### PR DESCRIPTION
The cached branch we were patching in has made it into a new cached release https://github.com/jaemk/cached/pull/46

The new lpop arg was added by redis-rs to support new functionality added in redis 6.2

The other non crates.io deps will be addressed in a later PR once we have figured out what we want to do with them.