### PR TITLE
Tests trigger shotover shutdown and then unwrap the result of the join handle

### DIFF
--- a/shotover-proxy/benches/helpers.rs
+++ b/shotover-proxy/benches/helpers.rs
@@ -1,18 +1,48 @@
 use anyhow::Result;
 use shotover_proxy::runner::{ConfigOpts, Runner};
 use tokio::runtime::Runtime;
+use tokio::sync::broadcast;
 use tokio::task::JoinHandle;
 
-pub fn run_shotover_with_topology(topology_path: &str) -> (Runtime, JoinHandle<Result<()>>) {
-    let opts = ConfigOpts {
-        topology_file: topology_path.into(),
-        config_file: "config/config.yaml".into(),
-        ..ConfigOpts::default()
-    };
-    let spawn = Runner::new(opts).unwrap().run_spawn();
+pub struct ShotoverManager {
+    pub runtime: Runtime,
+    pub handle: Option<JoinHandle<Result<()>>>,
+    pub trigger_shutdown_tx: broadcast::Sender<()>,
+}
 
-    // If we allow the tracing_guard to be dropped then the following tests in the same file will not get tracing so we mem::forget it.
-    // This is because tracing can only be initialized once in the same execution, secondary attempts to initalize tracing will silently fail.
-    std::mem::forget(spawn.tracing_guard);
-    (spawn.runtime, spawn.handle)
+impl ShotoverManager {
+    pub fn from_topology_file(topology_path: &str) -> ShotoverManager {
+        let opts = ConfigOpts {
+            topology_file: topology_path.into(),
+            config_file: "config/config.yaml".into(),
+            ..ConfigOpts::default()
+        };
+        let spawn = Runner::new(opts).unwrap().run_spawn();
+
+        // If we allow the tracing_guard to be dropped then the following tests in the same file will not get tracing so we mem::forget it.
+        // This is because tracing can only be initialized once in the same execution, secondary attempts to initalize tracing will silently fail.
+        std::mem::forget(spawn.tracing_guard);
+
+        ShotoverManager {
+            runtime: spawn.runtime,
+            handle: Some(spawn.handle),
+            trigger_shutdown_tx: spawn.trigger_shutdown_tx,
+        }
+    }
+}
+
+impl Drop for ShotoverManager {
+    fn drop(&mut self) {
+        if std::thread::panicking() {
+            // If already panicking do nothing in order to avoid a double panic.
+            // We only shutdown shotover to test the shutdown process not because we need to clean up any resources.
+            // So skipping shutdown on panic is fine.
+        } else {
+            self.trigger_shutdown_tx.send(()).unwrap();
+            self.runtime
+                .block_on(self.handle.take().unwrap())
+                .unwrap()
+                .unwrap();
+        }
+    }
 }

--- a/shotover-proxy/benches/redis_benches.rs
+++ b/shotover-proxy/benches/redis_benches.rs
@@ -4,11 +4,12 @@ use std::time::Duration;
 use test_helpers::docker_compose::DockerCompose;
 
 mod helpers;
-use helpers::run_shotover_with_topology;
+use helpers::ShotoverManager;
 
 fn redis_active_bench(c: &mut Criterion) {
     let _compose = DockerCompose::new("examples/redis-multi/docker-compose.yml");
-    let _running = run_shotover_with_topology("examples/redis-multi/topology.yaml");
+    let _shotover_manager =
+        ShotoverManager::from_topology_file("examples/redis-multi/topology.yaml");
 
     let client = redis::Client::open("redis://127.0.0.1:6379/").unwrap();
     let mut con;
@@ -40,7 +41,8 @@ fn redis_active_bench(c: &mut Criterion) {
 
 fn redis_cluster_bench(c: &mut Criterion) {
     let _compose = DockerCompose::new("examples/redis-cluster/docker-compose.yml");
-    let _running = run_shotover_with_topology("examples/redis-cluster/topology.yaml");
+    let _shotover_manager =
+        ShotoverManager::from_topology_file("examples/redis-cluster/topology.yaml");
 
     let client = redis::Client::open("redis://127.0.0.1:6379/").unwrap();
     let mut con;
@@ -72,7 +74,8 @@ fn redis_cluster_bench(c: &mut Criterion) {
 
 fn redis_passthrough_bench(c: &mut Criterion) {
     let _compose = DockerCompose::new("examples/redis-passthrough/docker-compose.yml");
-    let _running = run_shotover_with_topology("examples/redis-passthrough/topology.yaml");
+    let _shotover_manager =
+        ShotoverManager::from_topology_file("examples/redis-passthrough/topology.yaml");
 
     let client = redis::Client::open("redis://127.0.0.1:6379/").unwrap();
     let mut con;

--- a/shotover-proxy/src/server.rs
+++ b/shotover-proxy/src/server.rs
@@ -64,7 +64,7 @@ pub struct TcpCodecListener<C: Codec> {
     /// handle. When a graceful shutdown is initiated, a `()` value is sent via
     /// the broadcast::Sender. Each active connection receives it, reaches a
     /// safe terminal state, and completes the task.
-    pub notify_shutdown: broadcast::Sender<()>,
+    pub trigger_shutdown_tx: broadcast::Sender<()>,
 
     /// Used as part of the graceful shutdown process to wait for client
     /// connections to complete processing.
@@ -187,7 +187,7 @@ impl<C: Codec + 'static> TcpCodecListener<C> {
                 limit_connections: self.limit_connections.clone(),
 
                 // Receive shutdown notifications.
-                shutdown: Shutdown::new(self.notify_shutdown.subscribe()),
+                shutdown: Shutdown::new(self.trigger_shutdown_tx.subscribe()),
 
                 // Notifies the receiver half once all clones are
                 // dropped.

--- a/shotover-proxy/src/sources/mod.rs
+++ b/shotover-proxy/src/sources/mod.rs
@@ -62,20 +62,20 @@ impl SourcesConfig {
         &self,
         chain: &TransformChain,
         topics: &mut TopicHolder,
-        notify_shutdown: broadcast::Sender<()>,
+        trigger_shutdown_tx: broadcast::Sender<()>,
         shutdown_complete_tx: mpsc::Sender<()>,
     ) -> Result<Vec<Sources>> {
         match self {
             SourcesConfig::Cassandra(c) => {
-                c.get_source(chain, topics, notify_shutdown, shutdown_complete_tx)
+                c.get_source(chain, topics, trigger_shutdown_tx, shutdown_complete_tx)
                     .await
             }
             SourcesConfig::Mpsc(m) => {
-                m.get_source(chain, topics, notify_shutdown, shutdown_complete_tx)
+                m.get_source(chain, topics, trigger_shutdown_tx, shutdown_complete_tx)
                     .await
             }
             SourcesConfig::Redis(r) => {
-                r.get_source(chain, topics, notify_shutdown, shutdown_complete_tx)
+                r.get_source(chain, topics, trigger_shutdown_tx, shutdown_complete_tx)
                     .await
             }
         }
@@ -88,7 +88,7 @@ pub trait SourcesFromConfig: Send {
         &self,
         chain: &TransformChain,
         topics: &mut TopicHolder,
-        notify_shutdown: broadcast::Sender<()>,
+        trigger_shutdown: broadcast::Sender<()>,
         shutdown_complete_tx: mpsc::Sender<()>,
     ) -> Result<Vec<Sources>>;
 }

--- a/shotover-proxy/src/sources/mpsc_source.rs
+++ b/shotover-proxy/src/sources/mpsc_source.rs
@@ -29,7 +29,7 @@ impl SourcesFromConfig for AsyncMpscConfig {
         &self,
         chain: &TransformChain,
         topics: &mut TopicHolder,
-        notify_shutdown: broadcast::Sender<()>,
+        trigger_shutdown_on_drop_rx: broadcast::Sender<()>,
         shutdown_complete_tx: mpsc::Sender<()>,
     ) -> Result<Vec<Sources>> {
         if let Some(rx) = topics.get_rx(&self.topic_name) {
@@ -41,7 +41,7 @@ impl SourcesFromConfig for AsyncMpscConfig {
                 chain.clone(),
                 rx,
                 &self.topic_name,
-                Shutdown::new(notify_shutdown.subscribe()),
+                Shutdown::new(trigger_shutdown_on_drop_rx.subscribe()),
                 shutdown_complete_tx,
                 behavior.clone(),
             ))])

--- a/shotover-proxy/tests/helpers/mod.rs
+++ b/shotover-proxy/tests/helpers/mod.rs
@@ -1,18 +1,48 @@
 use anyhow::Result;
 use shotover_proxy::runner::{ConfigOpts, Runner};
 use tokio::runtime::Runtime;
+use tokio::sync::broadcast;
 use tokio::task::JoinHandle;
 
-pub fn run_shotover_with_topology(topology_path: &str) -> (Runtime, JoinHandle<Result<()>>) {
-    let opts = ConfigOpts {
-        topology_file: topology_path.into(),
-        config_file: "config/config.yaml".into(),
-        ..ConfigOpts::default()
-    };
-    let spawn = Runner::new(opts).unwrap().run_spawn();
+pub struct ShotoverManager {
+    pub runtime: Runtime,
+    pub handle: Option<JoinHandle<Result<()>>>,
+    pub trigger_shutdown_tx: broadcast::Sender<()>,
+}
 
-    // If we allow the tracing_guard to be dropped then the following tests in the same file will not get tracing so we mem::forget it.
-    // This is because tracing can only be initialized once in the same execution, secondary attempts to initalize tracing will silently fail.
-    std::mem::forget(spawn.tracing_guard);
-    (spawn.runtime, spawn.handle)
+impl ShotoverManager {
+    pub fn from_topology_file(topology_path: &str) -> ShotoverManager {
+        let opts = ConfigOpts {
+            topology_file: topology_path.into(),
+            config_file: "config/config.yaml".into(),
+            ..ConfigOpts::default()
+        };
+        let spawn = Runner::new(opts).unwrap().run_spawn();
+
+        // If we allow the tracing_guard to be dropped then the following tests in the same file will not get tracing so we mem::forget it.
+        // This is because tracing can only be initialized once in the same execution, secondary attempts to initalize tracing will silently fail.
+        std::mem::forget(spawn.tracing_guard);
+
+        ShotoverManager {
+            runtime: spawn.runtime,
+            handle: Some(spawn.handle),
+            trigger_shutdown_tx: spawn.trigger_shutdown_tx,
+        }
+    }
+}
+
+impl Drop for ShotoverManager {
+    fn drop(&mut self) {
+        if std::thread::panicking() {
+            // If already panicking do nothing in order to avoid a double panic.
+            // We only shutdown shotover to test the shutdown process not because we need to clean up any resources.
+            // So skipping shutdown on panic is fine.
+        } else {
+            self.trigger_shutdown_tx.send(()).unwrap();
+            self.runtime
+                .block_on(self.handle.take().unwrap())
+                .unwrap()
+                .unwrap();
+        }
+    }
 }

--- a/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
+++ b/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
@@ -2,7 +2,7 @@
 
 use redis::{Commands, ErrorKind, RedisError, Value};
 
-use crate::helpers::run_shotover_with_topology;
+use crate::helpers::ShotoverManager;
 use crate::redis_int_tests::support::TestContext;
 use test_helpers::docker_compose::DockerCompose;
 
@@ -693,7 +693,9 @@ fn test_cluster_script() {
 #[serial(redis)]
 fn test_pass_through() {
     let _compose = DockerCompose::new("examples/redis-passthrough/docker-compose.yml");
-    let _running = run_shotover_with_topology("examples/redis-passthrough/topology.yaml");
+    let _shotover_manager =
+        ShotoverManager::from_topology_file("examples/redis-passthrough/topology.yaml");
+
     run_all();
 }
 
@@ -702,7 +704,9 @@ fn test_pass_through() {
 #[allow(dead_code)]
 fn test_pass_through_one() {
     let _compose = DockerCompose::new("examples/redis-passthrough/docker-compose.yml");
-    let _running = run_shotover_with_topology("examples/redis-passthrough/topology.yaml");
+    let _shotover_manager =
+        ShotoverManager::from_topology_file("examples/redis-passthrough/topology.yaml");
+
     test_real_transaction();
 }
 
@@ -710,7 +714,9 @@ fn test_pass_through_one() {
 #[serial(redis)]
 fn test_active_active_redis() {
     let _compose = DockerCompose::new("examples/redis-multi/docker-compose.yml");
-    let _running = run_shotover_with_topology("examples/redis-multi/topology.yaml");
+    let _shotover_manager =
+        ShotoverManager::from_topology_file("examples/redis-multi/topology.yaml");
+
     run_all_active_safe();
 }
 
@@ -718,7 +724,8 @@ fn test_active_active_redis() {
 #[serial(redis)]
 fn test_active_one_active_redis() {
     let _compose = DockerCompose::new("examples/redis-multi/docker-compose.yml");
-    let _running = run_shotover_with_topology("examples/redis-multi/topology.yaml");
+    let _shotover_manager =
+        ShotoverManager::from_topology_file("examples/redis-multi/topology.yaml");
 
     // test_args();
     test_cluster_basics();
@@ -731,7 +738,8 @@ fn test_active_one_active_redis() {
 #[serial(redis)]
 fn test_pass_redis_cluster_one() {
     let _compose = DockerCompose::new("examples/redis-cluster/docker-compose.yml");
-    let _running = run_shotover_with_topology("examples/redis-cluster/topology.yaml");
+    let _shotover_manager =
+        ShotoverManager::from_topology_file("examples/redis-cluster/topology.yaml");
 
     // test_args()test_args;
     test_pipeline_error(); //TODO: script does not seem to be loading in the server?
@@ -742,7 +750,8 @@ fn test_pass_redis_cluster_one() {
 // #[serial(redis)]
 fn _test_cluster_auth_redis() {
     let _compose = DockerCompose::new("examples/redis-cluster-auth/docker-compose.yml");
-    let _running = run_shotover_with_topology("examples/redis-cluster-auth/topology.yaml");
+    let _shotover_manager =
+        ShotoverManager::from_topology_file("examples/redis-cluster-auth/topology.yaml");
 
     let ctx = TestContext::new_auth();
     let mut con = ctx.connection();
@@ -797,7 +806,8 @@ fn _test_cluster_auth_redis() {
 #[serial(redis)]
 fn test_cluster_all_redis() {
     let _compose = DockerCompose::new("examples/redis-cluster/docker-compose.yml");
-    let _running = run_shotover_with_topology("examples/redis-cluster/topology.yaml");
+    let _shotover_manager =
+        ShotoverManager::from_topology_file("examples/redis-cluster/topology.yaml");
     // panic!("Loooks like we are getting some out of order issues with pipelined request");
     run_all_cluster_safe();
 }
@@ -806,7 +816,8 @@ fn test_cluster_all_redis() {
 #[serial(redis)]
 fn test_cluster_all_script_redis() {
     let _compose = DockerCompose::new("examples/redis-cluster/docker-compose.yml");
-    let _running = run_shotover_with_topology("examples/redis-cluster/topology.yaml");
+    let _shotover_manager =
+        ShotoverManager::from_topology_file("examples/redis-cluster/topology.yaml");
     // panic!("Loooks like we are getting some out of order issues with pipelined request");
     for _i in 0..1999 {
         test_script();
@@ -817,7 +828,8 @@ fn test_cluster_all_script_redis() {
 #[serial(redis)]
 fn test_cluster_all_pipeline_safe_redis() {
     let _compose = DockerCompose::new("examples/redis-cluster/docker-compose.yml");
-    let _running = run_shotover_with_topology("examples/redis-cluster/topology.yaml");
+    let _shotover_manager =
+        ShotoverManager::from_topology_file("examples/redis-cluster/topology.yaml");
 
     let ctx = TestContext::new();
     let mut con = ctx.connection();

--- a/shotover-proxy/tests/redis_presence_integration.rs
+++ b/shotover-proxy/tests/redis_presence_integration.rs
@@ -1,6 +1,6 @@
 mod helpers;
 
-use helpers::run_shotover_with_topology;
+use helpers::ShotoverManager;
 use redis::{Commands, Connection, RedisResult};
 use std::{thread, time};
 use tracing::info;
@@ -198,7 +198,8 @@ async fn test_simple_pipeline_workflow() {
 // #[tokio::test(threaded_scheduler)]
 #[allow(dead_code)]
 async fn run_all() {
-    let _running = run_shotover_with_topology("examples/redis-multi/topology.yaml");
+    let _manager = ShotoverManager::from_topology_file("examples/redis-multi/topology.yaml");
+
     thread::sleep(time::Duration::from_secs(2));
     test_simple_pipeline_workflow().await;
     test_presence_fresh_join_pipeline_workflow().await;

--- a/test-helpers/Cargo.toml
+++ b/test-helpers/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2018"
 [dependencies]
 tracing = "0.1.15"
 subprocess = "0.2.7"
+anyhow = "1.0.42"

--- a/test-helpers/src/docker_compose.rs
+++ b/test-helpers/src/docker_compose.rs
@@ -1,23 +1,26 @@
+use anyhow::{anyhow, Result};
 use std::thread;
 use std::time;
 use subprocess::{Exec, Redirection};
 use tracing::info;
 
-fn run_command(command: &str, args: &[&str]) {
+fn run_command(command: &str, args: &[&str]) -> Result<()> {
     let data = Exec::cmd(command)
         .args(args)
         .stdout(Redirection::Pipe)
         .stderr(Redirection::Merge)
-        .capture()
-        .unwrap();
-    if !data.exit_status.success() {
-        panic!(
+        .capture()?;
+
+    if data.exit_status.success() {
+        Ok(())
+    } else {
+        Err(anyhow!(
             "command {} {:?} exited with {:?} and output:\n{}",
             command,
             args,
             data.exit_status,
             data.stdout_str()
-        )
+        ))
     }
 }
 
@@ -27,11 +30,11 @@ pub struct DockerCompose {
 
 impl DockerCompose {
     pub fn new(file_path: &str) -> Self {
-        DockerCompose::clean_up(file_path);
+        DockerCompose::clean_up(file_path).unwrap();
 
         info!("bringing up docker compose {}", file_path);
 
-        run_command("docker-compose", &["-f", file_path, "up", "-d"]);
+        run_command("docker-compose", &["-f", file_path, "up", "-d"]).unwrap();
 
         thread::sleep(time::Duration::from_secs(4));
 
@@ -40,18 +43,29 @@ impl DockerCompose {
         }
     }
 
-    fn clean_up(file_path: &str) {
+    fn clean_up(file_path: &str) -> Result<()> {
         info!("bringing down docker compose {}", file_path);
 
-        run_command("docker-compose", &["-f", file_path, "down", "-v"]);
-        run_command("docker-compose", &["-f", file_path, "rm", "-f", "-s", "-v"]);
+        run_command("docker-compose", &["-f", file_path, "down", "-v"])?;
+        run_command("docker-compose", &["-f", file_path, "rm", "-f", "-s", "-v"])?;
 
         thread::sleep(time::Duration::from_secs(1));
+
+        Ok(())
     }
 }
 
 impl Drop for DockerCompose {
     fn drop(&mut self) {
-        DockerCompose::clean_up(&self.file_path);
+        if std::thread::panicking() {
+            if let Err(err) = DockerCompose::clean_up(&self.file_path) {
+                println!(
+                    "ERROR: docker compose failed to bring down while already panicking: {:?}",
+                    err
+                );
+            }
+        } else {
+            DockerCompose::clean_up(&self.file_path).unwrap();
+        }
     }
 }


### PR DESCRIPTION
I figured out a solution to the problems I hinted at in https://github.com/shotover/shotover-proxy/pull/138
The solution to panicking in drops in test helpers is to check `std::thread::panicking` to tell if we are currently panicking. If we are panicking then we should not run any code that can panic.

We could possibly simplify the code in the future by allowing double panics if https://github.com/rust-lang/rust/issues/82850 is ever resolved. But the current implementation is fine and its probably desirable to never double panic  regardless of https://github.com/rust-lang/rust/issues/82850 anyway.

closes https://github.com/shotover/shotover-proxy/issues/134

This PR improves tests such that:
* Errors that bring down shotover are logged over `error!`
* `DockerCompose` can no longer cause double panics.
* Every test tests that shotover can shutdown after the test is run.

This PR improves the shutdown process by adding the trigger_shutdown broadcast channel so that we can trigger a shutdown from any source.

This PR supercedes https://github.com/shotover/shotover-proxy/pull/138 so we can just close 138 if we are happy with this one.