### PR TITLE
Use task-local to pass chain name into transforms

### DIFF
--- a/shotover-proxy/src/transforms/mod.rs
+++ b/shotover-proxy/src/transforms/mod.rs
@@ -276,19 +276,28 @@ impl<'a> Display for Wrapper<'a> {
     }
 }
 
+tokio::task_local! {
+    pub static CONTEXT_CHAIN_NAME: String;
+}
+
 impl<'a> Wrapper<'a> {
     pub async fn call_next_transform(mut self) -> ChainResponse {
-        let t = self.transforms.remove(0);
+        let transform = self.transforms.remove(0);
 
-        let name = t.get_name();
+        let transform_name = transform.get_name();
+        let chain_name = self.chain_name.clone();
+
         let start = Instant::now();
-        let result = t.transform(self).await;
+        let result = CONTEXT_CHAIN_NAME
+            .scope(chain_name, transform.transform(self))
+            .await;
         let end = Instant::now();
-        counter!("shotover_transform_total", 1, "transform" => name);
+
+        counter!("shotover_transform_total", 1, "transform" => transform_name);
         if result.is_err() {
-            counter!("shotover_transform_failures", 1, "transform" => name)
+            counter!("shotover_transform_failures", 1, "transform" => transform_name)
         }
-        timing!("shotover_transform_latency", start, end, "transform" => name);
+        timing!("shotover_transform_latency", start, end, "transform" => transform_name);
         result
     }
 

--- a/shotover-proxy/src/transforms/redis_transforms/redis_cluster.rs
+++ b/shotover-proxy/src/transforms/redis_transforms/redis_cluster.rs
@@ -19,7 +19,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use tokio::time::timeout;
 use tokio::time::Duration;
 use tokio_util::codec::Framed;
-use tracing::{debug, info, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 
 use crate::concurrency::FuturesOrdered;
 use crate::config::topology::TopicHolder;
@@ -29,6 +29,7 @@ use crate::protocols::redis_codec::RedisCodec;
 use crate::protocols::RawFrame;
 use crate::transforms::util::cluster_connection_pool::ConnectionPool;
 use crate::transforms::util::{Request, Response};
+use crate::transforms::CONTEXT_CHAIN_NAME;
 use crate::transforms::{Transform, Transforms, TransformsFromConfig, Wrapper};
 
 const SLOT_SIZE: usize = 16384;
@@ -128,7 +129,6 @@ impl RedisCluster {
         &mut self,
         host: &String,
         message: Message,
-        chain_name: &str,
     ) -> Result<tokio::sync::oneshot::Receiver<(Message, ChainResponse)>> {
         let (one_tx, one_rx) = tokio::sync::oneshot::channel::<Response>();
 
@@ -172,7 +172,7 @@ impl RedisCluster {
                             host
                         );
                         self.rebuild_slots = true;
-                        short_circuit(chain_name, one_tx);
+                        short_circuit(one_tx);
                         return Ok(one_rx);
                     }
                 } else {
@@ -181,7 +181,7 @@ impl RedisCluster {
                         host
                     );
                     self.rebuild_slots = true;
-                    short_circuit(chain_name, one_tx);
+                    short_circuit(one_tx);
                     return Ok(one_rx);
                 }
             }
@@ -194,7 +194,7 @@ impl RedisCluster {
         }) {
             if let Some(error_return) = e.0.return_chan {
                 self.rebuild_slots = true;
-                short_circuit(chain_name, error_return);
+                short_circuit(error_return);
             }
             self.channels.remove(host);
         }
@@ -458,9 +458,14 @@ fn get_hashtag(key: &[u8]) -> Option<&[u8]> {
 }
 
 #[inline(always)]
-fn short_circuit(chain_name: &str, one_tx: tokio::sync::oneshot::Sender<Response>) {
+fn short_circuit(one_tx: tokio::sync::oneshot::Sender<Response>) {
     warn!("Could not route request - short circuiting");
-    counter!("redis_cluster_failed_request", 1, "chain" => chain_name.to_string());
+    if let Err(e) = CONTEXT_CHAIN_NAME.try_with(|chain_name| {
+        counter!("redis_cluster_failed_request", 1, "chain" => chain_name.to_string());
+    }) {
+        error!("failed to count failed request - missing chain name: {}", e);
+    };
+
     if let Err(e) = one_tx.send((
         Message::new_bypass(RawFrame::None),
         Ok(Messages::new_single_response(
@@ -495,18 +500,14 @@ impl Transform for RedisCluster {
             responses.push(match sender.len() {
                 0 => {
                     let (one_tx, one_rx) = tokio::sync::oneshot::channel::<Response>();
-                    short_circuit(message_wrapper.chain_name.as_str(), one_tx);
+                    short_circuit(one_tx);
                     Box::pin(one_rx.map_err(|e| {
                         anyhow!("0 Couldn't get short circtuited for no channels - {}", e)
                     }))
                 }
                 1 => {
                     let one_rx = self
-                        .choose_and_send(
-                            sender.get(0).unwrap(),
-                            message.clone(),
-                            message_wrapper.chain_name.as_str(),
-                        )
+                        .choose_and_send(sender.get(0).unwrap(), message.clone())
                         .await?;
                     Box::pin(one_rx.map_err(|e| anyhow!("1 {}", e)))
                 }
@@ -515,13 +516,7 @@ impl Transform for RedisCluster {
                         tokio::sync::oneshot::Receiver<(Message, ChainResponse)>,
                     > = FuturesUnordered::new();
                     for chan in sender {
-                        let one_rx = self
-                            .choose_and_send(
-                                &chan,
-                                message.clone(),
-                                message_wrapper.chain_name.as_str(),
-                            )
-                            .await?;
+                        let one_rx = self.choose_and_send(&chan, message.clone()).await?;
                         futures.push(one_rx);
                     }
                     Box::pin(async move {
@@ -587,11 +582,7 @@ impl Transform for RedisCluster {
                     self.rebuild_slots = true;
 
                     let one_rx = self
-                        .choose_and_send(
-                            &format!("{}:{}", &host, port),
-                            original.clone(),
-                            message_wrapper.chain_name.as_str(),
-                        )
+                        .choose_and_send(&format!("{}:{}", &host, port), original.clone())
                         .await?;
 
                     responses.prepend(Box::pin(
@@ -602,11 +593,7 @@ impl Transform for RedisCluster {
                     debug!("Got ASK frame {} {} {}", slot, host, port);
 
                     let one_rx = self
-                        .choose_and_send(
-                            &format!("{}:{}", &host, port),
-                            original.clone(),
-                            message_wrapper.chain_name.as_str(),
-                        )
+                        .choose_and_send(&format!("{}:{}", &host, port), original.clone())
                         .await?;
 
                     responses.prepend(Box::pin(


### PR DESCRIPTION
The chain name is needed anywhere that could return errors because it is used to count them grouped by name. This is okay for now, but due to the extra error handling paths in #101, it's becoming too messy to explicitly pass it everywhere.

I understand that explicit is often preferred over implicit, but it seems worth it in this case.