### PR TITLE
Refactor SlotMap for future support of replicas

### DIFF
--- a/shotover-proxy/src/transforms/mod.rs
+++ b/shotover-proxy/src/transforms/mod.rs
@@ -1,13 +1,16 @@
 use core::fmt;
 use std::fmt::{Debug, Formatter};
+use std::pin::Pin;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use futures::Future;
 use serde::{Deserialize, Serialize};
 
+use crate::concurrency::FuturesOrdered;
 use crate::config::topology::TopicHolder;
 use crate::error::ChainResponse;
-use crate::message::Messages;
+use crate::message::{Message, Messages};
 use crate::transforms::cassandra::cassandra_codec_destination::{
     CodecConfiguration, CodecDestination,
 };
@@ -361,3 +364,7 @@ pub trait Transform: Send {
         Ok(())
     }
 }
+
+pub type ResponseFuturesOrdered = FuturesOrdered<
+    Pin<Box<dyn Future<Output = Result<(Message, Result<Messages>)>> + std::marker::Send>>,
+>;


### PR DESCRIPTION
Preparation work for #101, which will be adding support for connecting to replica nodes. This is further simplified compared to previous version - the `RawSlotMapping` has been merged into the `SlotMap`.

Old `SlotMap`: BTreeMap interval map from master slots to addresses.
New `SlotMap`: Struct containing master and replica interval maps, along with a list of nodes.

I encapsulated the required info built from the `CLUSTER SLOTS` output into a single struct.

Opportunistic changes:
- Extract `ResponseFuturesOrdered` type for future reuse.
- Add warning message for slots with no known masters. This may need a circuit breaker if the cluster goes into a bad state during heavy load. We don't want to make it worse by spamming the logs per request. 🤔