### PR TITLE
Documentation spelling/formatting fixes

### DIFF
--- a/docs/developer/shotover-development.md
+++ b/docs/developer/shotover-development.md
@@ -20,7 +20,7 @@ Shotover requires the following in order to build:
 
 On ubuntu you can install them via `sudo apt-get install cmake gcc g++ libssl-dev pkg-config`
 
-While not required for building shotover, installing `docker` will allow you to run shotover's integration tests and also build
+While not required for building shotover, installing `docker` and `docker-compose` will allow you to run shotover's integration tests and also build
 the static libc version of shotover.
 
 Some tests will require `libpcap-dev` to be installed as well (reading pcap files for protocol tests).

--- a/docs/transforms/transforms.md
+++ b/docs/transforms/transforms.md
@@ -37,7 +37,7 @@ Note: this will just pass the query to the remote node. No cluster discovery or 
 ### KafkaDestination
 *State: Alpha*
 
-This transform will take a query and push it to.
+This transform will take a query and push it to a given Kafka topic.
 
 * `topic` - A String containing the name of the kafka topic. E.g. `topic: "my_kafka_topic"`
 * `keys` - A map of configuration options for the Kafka driver. Supports all flags as supported by the librdkafka driver. See

--- a/docs/user-guide/concepts.md
+++ b/docs/user-guide/concepts.md
@@ -49,7 +49,7 @@ impl Transform for NoOp {
  }
 }
 ```
-This will return a ChainResponse which will include the upstream databases reponse. This means
+This will return a ChainResponse which will include the upstream databases response. This means
 your transform can operate on both queries and responses. Once your transform is done handling the request and response, it will return 
 passing control to the upstream transform. 
 
@@ -60,8 +60,8 @@ configuration file and are linked to sources.
 
 The transform chain is a vector of mutable references to the enum Transforms (which is an enum dispatch wrapper around the various transform types).
  
- ## Topology
- A topology is the final constructed set of transforms, transformchains and sources in their final state, ready to receive messages.
+## Topology
+ A topology is the final constructed set of transforms, transform chains and sources in their final state, ready to receive messages.
  
 # Other concepts
 ## Topics
@@ -69,7 +69,7 @@ When a transform is first created, or cloned for a new connection. It gets acces
 to a map of multi-producer, single consumer channels. The transform can only access the sender part of the channel and can freely
 clone and share it as it sees fit. 
 A special source type called an MPSC source gets access to receiver side of the channel. This source can have a transform chain attached to it
-like any other source. This allows for complex routing and asynchonous passing of messages between trnasform chains in a topology.
+like any other source. This allows for complex routing and asynchonous passing of messages between transform chains in a topology.
 See [the cassandra and kafka example](/examples/cass-redis-kafka) as an example.
 
 Generally if you want to build blocking behaviour in your chain, you will use transforms that have child transform chains.

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -16,7 +16,8 @@ running.
 
 This can be done by a POST HTTP request to the `/filter` endpoint (configured located at the observability interface) with the 
 env_filter string set as the POST data. For example:
-```shell script
+
+```shell
 curl -X PUT -d 'info,shotover_proxy=info' http://127.0.0.1:9001/filter
 ```
 

--- a/docs/user-guide/introduction.md
+++ b/docs/user-guide/introduction.md
@@ -42,9 +42,9 @@ Shotover prioritises the following principals in the order listed:
 
 
 Shotover provides a set of predefined transforms that can modify, route and control queries from any number of sources 
-to a similar number of destinations. As the user you can construct chains of these transforms to acheive the behaviour required. 
+to a similar number of destinations. As the user you can construct chains of these transforms to achieve the behaviour required. 
 Each transform is configurable and functionality can generally be extended by Lua or WASM scripts. Each chain can then be attached
-to a "source" that speaks a the native protocol of you chosen database. The transform chain will process each request with access to
+to a "source" that speaks the native protocol of you chosen database. The transform chain will process each request with access to
 a unified/simplified representation of a generic query, the original raw query and optionally (for SQL like protocols) a 
 parsed AST representing the query.
 


### PR DESCRIPTION
Some small spelling/formatting fixes I picked up while going through the documentation.