### PR TITLE
Provide a useful error when docker-compose is not installed

### DIFF
--- a/test-helpers/src/docker_compose.rs
+++ b/test-helpers/src/docker_compose.rs
@@ -1,4 +1,6 @@
 use anyhow::{anyhow, Result};
+use std::io::ErrorKind;
+use std::process::Command;
 use std::thread;
 use std::time;
 use subprocess::{Exec, Redirection};
@@ -30,6 +32,13 @@ pub struct DockerCompose {
 
 impl DockerCompose {
     pub fn new(file_path: &str) -> Self {
+        if let Err(ErrorKind::NotFound) = Command::new("docker-compose")
+            .output()
+            .map_err(|e| e.kind())
+        {
+            panic!("Could not find docker-compose. Have you installed it?");
+        }
+
         DockerCompose::clean_up(file_path).unwrap();
 
         info!("bringing up docker compose {}", file_path);


### PR DESCRIPTION
error looks like:
```
     Running tests/lib.rs (target/debug/deps/lib-66713f8458f21753)

running 1 test
test redis_int_tests::basic_driver_tests::test_cluster_all_redis ... FAILED

failures:

---- redis_int_tests::basic_driver_tests::test_cluster_all_redis stdout ----
thread 'redis_int_tests::basic_driver_tests::test_cluster_all_redis' panicked at 'Could not find docker-compose. Have you installed it?', test-helpers/src/docker_compose.rs:36:13
stack backtrace:
   0: std::panicking::begin_panic
             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panicking.rs:541:12
   1: test_helpers::docker_compose::DockerCompose::new
             at /home/rukai2/Projects/Crates/shotover/shotover-proxy/test-helpers/src/docker_compose.rs:36:13
   2: lib::redis_int_tests::basic_driver_tests::test_cluster_all_redis::{{closure}}
             at ./tests/redis_int_tests/basic_driver_tests.rs:761:20
   3: core::ops::function::FnOnce::call_once
             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/ops/function.rs:227:5
   4: serial_test::serial_core
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/serial_test-0.5.1/src/lib.rs:64:5
   5: lib::redis_int_tests::basic_driver_tests::test_cluster_all_redis
             at ./tests/redis_int_tests/basic_driver_tests.rs:759:1
   6: lib::redis_int_tests::basic_driver_tests::test_cluster_all_redis::{{closure}}
             at ./tests/redis_int_tests/basic_driver_tests.rs:760:1
   7: core::ops::function::FnOnce::call_once
             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/ops/function.rs:227:5
   8: core::ops::function::FnOnce::call_once
             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.


failures:
    redis_int_tests::basic_driver_tests::test_cluster_all_redis

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 13 filtered out; finished in 0.04s
```