### PR TITLE
Improve bind failure handling

### DIFF
--- a/shotover-proxy/src/sources/redis_source.rs
+++ b/shotover-proxy/src/sources/redis_source.rs
@@ -87,7 +87,7 @@ impl RedisSource {
                 tokio::select! {
                     res = listener.run() => {
                         if let Err(err) = res {
-                            error!(cause = %err, "failed to accept");
+                            error!(cause = %err, "failed to accept connection");
                         }
                     }
                     _ =  trigger_shutdown_rx.changed() => {


### PR DESCRIPTION
Currently if these ports are already bound we get a panic.
This PR changes shotover to report the failure as an error instead of panicking.

As a bonus we also now handle runtime failures of the metrics http server at all.
Previously they caused the server to stop and silently fail.