### PR TITLE
run tests in both debug and release on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,14 @@ env:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        include:
+          - name: Testing release
+            cargo_profile: --release
+          - name: Testing debug
+            cargo_profile:
+    name: ${{ matrix.name }}
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
@@ -62,9 +70,9 @@ jobs:
     - name: Check `cargo fmt` was run
       run: cargo fmt --all -- --check
     - name: Build
-      run: cargo build --all-targets
+      run: cargo build ${{ matrix.cargo_profile }} --all-targets
     - name: Run tests
-      run: cargo test -- --include-ignored
+      run: cargo test ${{ matrix.cargo_profile }} -- --include-ignored
       timeout-minutes: 30
     - name: Cleanup docker
       run: ./shotover-proxy/tests/scripts/teardown.sh

--- a/shotover-proxy/build.rs
+++ b/shotover-proxy/build.rs
@@ -1,0 +1,6 @@
+use std::env;
+
+fn main() {
+    let profile = env::var("PROFILE").unwrap();
+    println!("cargo:rustc-env=PROFILE={}", profile);
+}

--- a/shotover-proxy/src/runner.rs
+++ b/shotover-proxy/src/runner.rs
@@ -114,10 +114,10 @@ impl Runner {
 
             tokio::select! {
                 _ = interrupt.recv() => {
-                    debug!("received SIGINT");
+                    info!("received SIGINT");
                 },
                 _ = terminate.recv() => {
-                    debug!("received SIGTERM");
+                    info!("received SIGTERM");
                 },
             };
 

--- a/shotover-proxy/tests/helpers/mod.rs
+++ b/shotover-proxy/tests/helpers/mod.rs
@@ -139,10 +139,17 @@ pub struct ShotoverProcess {
 impl ShotoverProcess {
     #[allow(unused)]
     pub fn new(topology_path: &str) -> ShotoverProcess {
-        let all_args = ["run", "--", "-t", topology_path];
+        // TODO: this will be nicer when --profile is stabilized
+        //let all_args = ["run", "--profile", env!("PROFILE"), "--", "-t", topology_path];
+
+        let all_args = if env!("PROFILE") == "release" {
+            vec!["run", "--release", "--", "-t", topology_path]
+        } else {
+            vec!["run", "--", "-t", topology_path]
+        };
         let child = Command::new(env!("CARGO"))
             .env("RUST_LOG", "debug,shotover_proxy=debug")
-            .args(all_args)
+            .args(&all_args)
             .stdout(Stdio::piped())
             .spawn()
             .unwrap();

--- a/shotover-proxy/tests/runner/runner_int_tests.rs
+++ b/shotover-proxy/tests/runner/runner_int_tests.rs
@@ -39,7 +39,12 @@ fn test_shotover_responds_sigterm() {
 
     let (code, stdout, _) = shotover_process.wait();
     assert_eq!(code, Some(0));
-    assert!(stdout.contains("received SIGTERM"));
+    if !stdout.contains("received SIGTERM") {
+        panic!(
+            "stdout does not contain 'received SIGTERM'. Instead was: {}",
+            stdout
+        );
+    }
 }
 
 #[test]
@@ -50,5 +55,10 @@ fn test_shotover_responds_sigint() {
 
     let (code, stdout, _) = shotover_process.wait();
     assert_eq!(code, Some(0));
-    assert!(stdout.contains("received SIGINT"));
+    if !stdout.contains("received SIGINT") {
+        panic!(
+            "stdout does not contain 'received SIGINT'. Instead was: {}",
+            stdout
+        );
+    }
 }


### PR DESCRIPTION
By running the debug and release builds on concurrent github actions instances we pay very little in terms of time to run and maintenance.

`debug!("received SIGINT");` needs to use `info!` otherwise it doesnt get compiled in when using the release profile.

We need to pass in the profile to the cargo run called in ShotoverProcess::new otherwise it will run in debug on the release CI which would blow up build times by recompiling everything in debug.