### PR TITLE
 delete test_shotover_panics_in_single_thread_runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.7.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
+checksum = "d9df67f7bf9ef8498769f994239c45613ef0c5899415fb58e9add412d2c1a538"
 
 [[package]]
 name = "byteorder"
@@ -1985,9 +1985,9 @@ dependencies = [
 
 [[package]]
 name = "rand_distr"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051b398806e42b9cd04ad9ec8f81e355d0a382c543ac6672c62f5a5b452ef142"
+checksum = "964d548f8e7d12e102ef183a0de7e98180c9f8729f555897a857b96e48122d2f"
 dependencies = [
  "num-traits 0.2.14",
  "rand 0.8.4",
@@ -2285,18 +2285,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rusty-fork"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
-dependencies = [
- "fnv",
- "quick-error",
- "tempfile",
- "wait-timeout",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2504,7 +2492,6 @@ dependencies = [
  "redis-protocol",
  "rusoto_kms",
  "rusoto_signature",
- "rusty-fork",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2902,9 +2889,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ba9ab62b7d6497a8638dfda5e5c4fb3b2d5a7fca4118f2b96151c8ef1a437e"
+checksum = "84f96e095c0c82419687c20ddf5cb3eadb61f4e1405923c9dc8e53a1adacbda8"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
@@ -2967,9 +2954,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c42e73a9d277d4d2b6a88389a137ccf3c58599660b17e8f5fc39305e490669"
+checksum = "fdd0568dbfe3baf7048b7908d2b32bca0d81cd56bec6d2a8f894b01d74f86be3"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -3067,15 +3054,6 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "walkdir"

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -74,7 +74,6 @@ serial_test = "0.5.1"
 test-helpers = { path = "../test-helpers" }
 hex-literal = "0.3.3"
 nix = "0.22.1"
-rusty-fork = "0.3.0"
 
 [[bench]]
 name = "redis_benches"

--- a/shotover-proxy/tests/runner/runner_int_tests.rs
+++ b/shotover-proxy/tests/runner/runner_int_tests.rs
@@ -1,7 +1,5 @@
-use rusty_fork::rusty_fork_test;
 use serial_test::serial;
 use std::any::Any;
-use tokio::runtime;
 
 use crate::helpers::{ShotoverManager, ShotoverProcess};
 
@@ -16,23 +14,6 @@ async fn test_runtime_use_existing() {
 
     // Assert that shotover did not create a runtime for itself
     assert!(shotover_manager.runtime.is_none());
-}
-
-rusty_fork_test! {
-    #![rusty_fork(timeout_ms = 10000)]
-    #[test]
-    #[serial]
-    fn test_shotover_panics_in_single_thread_runtime() {
-        let runtime = runtime::Builder::new_current_thread()
-            .build()
-            .unwrap();
-        runtime.block_on(async {
-            let result = std::panic::catch_unwind(|| {
-                ShotoverManager::from_topology_file("examples/null-redis/topology.yaml");
-            });
-            assert!(result.is_err());
-        });
-    }
 }
 
 #[test]


### PR DESCRIPTION
It has caused us many problems and is just testing a nice to have safety net for development purposes
The final issue it caused was leaving an entire shotover running in the background when running in --release due to the requirement of using rusty_fork.

If we really want to keep it maybe we can introduce a working version later?
For now I think getting the tests non flakey is higher priority.