### PR TITLE
Fix redis auth test docker wait logic

### DIFF
--- a/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
+++ b/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
@@ -694,7 +694,7 @@ fn test_pass_redis_cluster_one() {
 #[serial]
 fn test_cluster_auth_redis() {
     let _compose = DockerCompose::new("examples/redis-cluster-auth/docker-compose.yml")
-        .wait_for("Cluster correctly created");
+        .wait_for_n("Cluster state changed", 6);
     let shotover_manager =
         ShotoverManager::from_topology_file("examples/redis-cluster-auth/topology.yaml");
     let mut connection = shotover_manager.redis_connection(6379);


### PR DESCRIPTION
This wait logic matches the other test that spins up a redis cluster.
The other test that uses this same wait logic will be removed in https://github.com/shotover/shotover-proxy/pull/205

I have tested this by running just this test in a loop in bash.
Without the change it fails about half the time.
With the change I haven't seen a failure in 20 loops.