### PR TITLE
Implement outgoing redis TLS

### DIFF
--- a/shotover-proxy/examples/redis-tls/docker-compose.yml
+++ b/shotover-proxy/examples/redis-tls/docker-compose.yml
@@ -1,6 +1,10 @@
 version: "3.3"
 services:
   redis-one:
-    image: library/redis:5.0.9
+    image: library/redis:6.2.5
     ports:
       - "1111:6379"
+    volumes:
+    - ./redis.conf:/usr/local/etc/redis/redis.conf
+    - ./tls_keys:/usr/local/etc/redis/tls_keys
+    command: ["redis-server", "/usr/local/etc/redis/redis.conf"]

--- a/shotover-proxy/examples/redis-tls/redis.conf
+++ b/shotover-proxy/examples/redis-tls/redis.conf
@@ -1,0 +1,6 @@
+tls-cert-file /usr/local/etc/redis/tls_keys/redis.crt
+tls-key-file /usr/local/etc/redis/tls_keys/redis.key
+tls-ca-cert-file /usr/local/etc/redis/tls_keys/ca.crt
+
+port 0
+tls-port 6379

--- a/shotover-proxy/examples/redis-tls/topology.yaml
+++ b/shotover-proxy/examples/redis-tls/topology.yaml
@@ -12,5 +12,9 @@ chain_config:
   redis_chain:
     - RedisDestination:
         remote_address: "127.0.0.1:1111"
+        tls:
+          certificate_authority_path: "examples/redis-tls/tls_keys/ca.crt"
+          certificate_path: "examples/redis-tls/tls_keys/redis.crt"
+          private_key_path: "examples/redis-tls/tls_keys/redis.key"
 source_to_chain_mapping:
   redis_prod: redis_chain

--- a/shotover-proxy/src/tls.rs
+++ b/shotover-proxy/src/tls.rs
@@ -4,6 +4,7 @@ use openssl::ssl::{SslAcceptor, SslConnector, SslFiletype, SslMethod};
 use serde::{Deserialize, Serialize};
 use std::pin::Pin;
 use std::sync::Arc;
+use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::TcpStream;
 use tokio_openssl::SslStream;
 use tracing::warn;
@@ -80,3 +81,11 @@ impl TlsConnector {
         Ok(ssl_stream)
     }
 }
+
+/// A trait object can only consist of one trait + special language traits like Send/Sync etc
+/// So we need to use this trait when creating trait objects that need both AsyncRead and AsyncWrite
+pub trait AsyncStream: AsyncRead + AsyncWrite {}
+
+/// We need to tell rust that these types implement AsyncStream even though they already implement AsyncRead and AsyncWrite
+impl AsyncStream for tokio_openssl::SslStream<TcpStream> {}
+impl AsyncStream for TcpStream {}


### PR DESCRIPTION
Pretty straightforward most of the work was done in the previous TLS incoming PR.
This time we are using a trait object instead of generic types.
We could get away with generic types last time because we were calling into a function that spawned tasks.
To use generic types here would be really complicated, but we could possibly evaluate that after we add benchmarks in a follow up PR.

`tls::TlsConnector` was previously only used in test code so might want to check over that again, now that we are using it in production code.