### PR TITLE
Implement TLS benchmark

### DIFF
--- a/shotover-proxy/examples/redis-tls/topology.yaml
+++ b/shotover-proxy/examples/redis-tls/topology.yaml
@@ -4,12 +4,16 @@ sources:
     Redis:
       batch_size_hint: 1
       listen_addr: "127.0.0.1:6379"
+  redis_prod_tls:
+    Redis:
+      batch_size_hint: 1
+      listen_addr: "127.0.0.1:6380"
       tls:
         certificate_authority_path: "examples/redis-tls/tls_keys/ca.crt"
         certificate_path: "examples/redis-tls/tls_keys/redis.crt"
         private_key_path: "examples/redis-tls/tls_keys/redis.key"
 chain_config:
-  redis_chain:
+  redis_chain_tls:
     - RedisDestination:
         remote_address: "127.0.0.1:1111"
         tls:
@@ -17,4 +21,5 @@ chain_config:
           certificate_path: "examples/redis-tls/tls_keys/redis.crt"
           private_key_path: "examples/redis-tls/tls_keys/redis.key"
 source_to_chain_mapping:
-  redis_prod: redis_chain
+  redis_prod: redis_chain_tls
+  redis_prod_tls: redis_chain_tls

--- a/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
+++ b/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
@@ -1003,7 +1003,7 @@ async fn test_cluster_tls() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
-async fn test_tls() {
+async fn test_source_tls_and_destination_tls() {
     let _compose = DockerCompose::new("examples/redis-tls/docker-compose.yml")
         .wait_for("Ready to accept connections");
     let shotover_manager = ShotoverManager::from_topology_file("examples/redis-tls/topology.yaml");
@@ -1015,7 +1015,7 @@ async fn test_tls() {
     };
 
     let mut connection = shotover_manager
-        .redis_connection_async_tls(6379, tls_config)
+        .redis_connection_async_tls(6380, tls_config)
         .await;
 
     run_all(&mut connection).await;


### PR DESCRIPTION
* I renamed the bench names to match the function names to avoid getting confused between them.
* Added benchmarks for cluster and direct destinations.
* redis-tls example is modified to allow direct connection as well as TLS connection to allow the benchmark to connect directly
* there are no benchmarks for incoming TLS as we cant make a TLS connection with non-async code. Maybe I can investigate async benchmarks in a follow up PR.

```
redis_cluster     time:   [85.282 us 88.942 us 92.726 us]                                
                        change: [-14.218% -10.139% -5.8821%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

redis_cluster_tls time:   [110.62 us 114.41 us 118.49 us]                                    
                        change: [+7.7920% +13.561% +19.635%] (p = 0.00 < 0.05)
                        Performance has regressed.

redis_passthrough time:   [90.005 us 93.702 us 97.384 us]                                    
                        change: [-5.9167% -0.5091% +5.7390%] (p = 0.86 > 0.05)
                        No change in performance detected.
Found 17 outliers among 100 measurements (17.00%)
  6 (6.00%) low mild
  5 (5.00%) high mild
  6 (6.00%) high severe

redis_destination_tls                                                                            
                        time:   [93.810 us 97.007 us 100.17 us]
                        change: [-14.776% -11.014% -7.0617%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe
```