### PR TITLE
Cassandra Peers rewrite

### DIFF
--- a/shotover-proxy/examples/cassandra-rewrite-peers/docker-compose.yml
+++ b/shotover-proxy/examples/cassandra-rewrite-peers/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.3"
+services:
+  cassandra-one:
+    image: library/cassandra:4.0.0
+    ports:
+      - "9043:9042"
+    healthcheck:
+      test: [ "CMD", "cqlsh", "-e", "describe keyspaces" ]
+      interval: 5s
+      timeout: 5s
+      retries: 60
+    environment: &environment
+      CASSANDRA_SEEDS: "cassandra-one,cassandra-two"
+      CASSANDRA_CLUSTER_NAME: SolarSystem
+      CASSANDRA_DC: Mars
+      CASSANDRA_RACK: West
+      CASSANDRA_ENDPOINT_SNITCH: GossipingPropertyFileSnitch
+      CASSANDRA_NUM_TOKENS: 128
+  cassandra-two:
+    image: library/cassandra:4.0.0
+    ports:
+      - "9044:9042"
+    healthcheck:
+      test: [ "CMD", "cqlsh", "-e", "describe keyspaces" ]
+      interval: 5s
+      timeout: 5s
+      retries: 60
+    environment: *environment
+    depends_on:
+      - cassandra-one

--- a/shotover-proxy/examples/cassandra-rewrite-peers/docker-compose.yml
+++ b/shotover-proxy/examples/cassandra-rewrite-peers/docker-compose.yml
@@ -16,6 +16,9 @@ services:
       CASSANDRA_RACK: West
       CASSANDRA_ENDPOINT_SNITCH: GossipingPropertyFileSnitch
       CASSANDRA_NUM_TOKENS: 128
+      MAX_HEAP_SIZE: "128M"
+      MIN_HEAP_SIZE: "128M"
+      HEAP_NEWSIZE: "24M"
   cassandra-two:
     image: library/cassandra:4.0.0
     ports:

--- a/shotover-proxy/examples/cassandra-rewrite-peers/topology.yaml
+++ b/shotover-proxy/examples/cassandra-rewrite-peers/topology.yaml
@@ -15,9 +15,10 @@ sources:
 chain_config:
   main_chain:
     - CassandraPeersRewrite:
-        emulate_single_node: true
+        new_port: 9041
+        emulate_single_node: false
     - CassandraCodecDestination:
-        bypass_result_processing: true
+        bypass_result_processing: false
         remote_address: "172.18.0.2:9042"
 source_to_chain_mapping:
   cassandra_prod: main_chain

--- a/shotover-proxy/examples/cassandra-rewrite-peers/topology.yaml
+++ b/shotover-proxy/examples/cassandra-rewrite-peers/topology.yaml
@@ -1,0 +1,23 @@
+---
+sources:
+  cassandra_prod:
+    Cassandra:
+      bypass_query_processing: false
+      listen_addr: "127.0.0.1:9042"
+      cassandra_ks:
+        system.local:
+          - key
+        test.simple:
+          - pk
+        test.clustering:
+          - pk
+          - clustering
+chain_config:
+  main_chain:
+    - CassandraPeersRewrite:
+        emulate_single_node: true
+    - CassandraCodecDestination:
+        bypass_result_processing: true
+        remote_address: "172.18.0.2:9042"
+source_to_chain_mapping:
+  cassandra_prod: main_chain

--- a/shotover-proxy/src/protocols/cassandra_protocol2.rs
+++ b/shotover-proxy/src/protocols/cassandra_protocol2.rs
@@ -608,10 +608,6 @@ impl CassandraCodec2 {
     }
 
     fn decode_raw(&mut self, src: &mut BytesMut) -> Result<Option<Frame>> {
-        // while src.remaining() != 0 {
-        //
-        // }
-
         trace!("Parsing C* frame");
         let v = parser::parse_frame(src, &self.compressor, &self.current_head);
         match v {

--- a/shotover-proxy/src/transforms/cassandra/cassandra_peers_rewrite.rs
+++ b/shotover-proxy/src/transforms/cassandra/cassandra_peers_rewrite.rs
@@ -1,0 +1,38 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::config::topology::TopicHolder;
+use crate::error::ChainResponse;
+use crate::transforms::{Transform, Transforms, TransformsFromConfig, Wrapper};
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+pub struct CassandraPeersRewriteConfig {}
+
+#[async_trait]
+impl TransformsFromConfig for CassandraPeersRewriteConfig {
+    async fn get_source(&self, _topics: &TopicHolder) -> Result<Transforms> {
+        todo!();
+    }
+}
+
+#[derive(Clone)]
+pub struct CassandraPeersRewrite {}
+
+#[async_trait]
+impl Transform for CassandraPeersRewrite {
+    async fn prep_transform_chain(
+        &mut self,
+        _t: &mut crate::transforms::chain::TransformChain,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    async fn transform<'a>(&'a mut self, _message_wrapper: Wrapper<'a>) -> ChainResponse {
+        todo!()
+    }
+
+    fn get_name(&self) -> &'static str {
+        "CassandraPeersRewrite"
+    }
+}

--- a/shotover-proxy/src/transforms/cassandra/cassandra_peers_rewrite.rs
+++ b/shotover-proxy/src/transforms/cassandra/cassandra_peers_rewrite.rs
@@ -1,23 +1,40 @@
+use crate::{
+    config::topology::TopicHolder,
+    error::ChainResponse,
+    message::MessageDetails,
+    transforms::{Transform, Transforms, TransformsFromConfig, Wrapper},
+};
+use crate::{message::QueryType, protocols::RawFrame};
 use anyhow::Result;
 use async_trait::async_trait;
+use cassandra_proto::{
+    frame::{
+        frame_response::ResponseBody,
+        frame_result::{BodyResResultRows, ResResultBody},
+        Frame, IntoBytes, Opcode, Version,
+    },
+    types::CBytes,
+};
 use serde::{Deserialize, Serialize};
 
-use crate::config::topology::TopicHolder;
-use crate::error::ChainResponse;
-use crate::transforms::{Transform, Transforms, TransformsFromConfig, Wrapper};
-
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-pub struct CassandraPeersRewriteConfig {}
+pub struct CassandraPeersRewriteConfig {
+    pub emulate_single_node: bool,
+}
 
 #[async_trait]
 impl TransformsFromConfig for CassandraPeersRewriteConfig {
     async fn get_source(&self, _topics: &TopicHolder) -> Result<Transforms> {
-        todo!();
+        Ok(Transforms::CassandraPeersRewrite(CassandraPeersRewrite {
+            emulate_single_node: self.emulate_single_node,
+        }))
     }
 }
 
 #[derive(Clone)]
-pub struct CassandraPeersRewrite {}
+pub struct CassandraPeersRewrite {
+    emulate_single_node: bool,
+}
 
 #[async_trait]
 impl Transform for CassandraPeersRewrite {
@@ -28,11 +45,204 @@ impl Transform for CassandraPeersRewrite {
         Ok(())
     }
 
-    async fn transform<'a>(&'a mut self, _message_wrapper: Wrapper<'a>) -> ChainResponse {
-        todo!()
+    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> ChainResponse {
+        // Find the indices of queries to system.peers & system.peers_v2
+        let system_peers = message_wrapper
+            .message
+            .messages
+            .iter()
+            .enumerate()
+            .filter(|(_, m)| is_system_peers(&m.details) || is_system_peers_v2(&m.details))
+            .map(|(i, _)| i)
+            .collect::<Vec<_>>();
+
+        let mut response = message_wrapper.call_next_transform().await?;
+
+        for i in system_peers {
+            if self.emulate_single_node {
+                emulate_single_node(&mut response.messages[i].original);
+            }
+        }
+
+        Ok(response)
     }
 
     fn get_name(&self) -> &'static str {
         "CassandraPeersRewrite"
     }
 }
+
+fn emulate_single_node(original: &mut RawFrame) {
+    if let RawFrame::Cassandra(ref mut frame) = original {
+        if let Ok(ResponseBody::Result(ResResultBody::Rows(rows))) = frame.get_body() {
+            let new_body = BodyResResultRows {
+                metadata: rows.metadata,
+                rows_count: 0_i32,
+                rows_content: Vec::<Vec<CBytes>>::new(),
+            };
+            let mut body = vec![0, 0, 0, 2];
+            body.extend_from_slice(&new_body.into_cbytes());
+
+            *original = RawFrame::Cassandra(Frame {
+                version: Version::Response,
+                flags: frame.flags.clone(),
+                opcode: Opcode::Result,
+                stream: frame.stream,
+                body,
+                tracing_id: frame.tracing_id,
+                warnings: Vec::new(),
+            });
+        } else {
+            panic!("Expected ResResultBody::Rows");
+        }
+    } else {
+        panic!("Expected RawFrame::Cassandra");
+    }
+}
+
+fn is_system_peers(message_details: &MessageDetails) -> bool {
+    if let MessageDetails::Query(message_details) = &message_details {
+        if QueryType::Read != message_details.query_type {
+            // only want to modify read queries
+            return false;
+        }
+
+        message_details.namespace.eq(&["system", "peers"])
+    } else {
+        false
+    }
+}
+
+fn is_system_peers_v2(message_details: &MessageDetails) -> bool {
+    if let MessageDetails::Query(message_details) = &message_details {
+        if QueryType::Read != message_details.query_type {
+            // only want to modify read queries
+            return false;
+        }
+
+        message_details.namespace.eq(&["system", "peers_v2"])
+    } else {
+        false
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::message::{QueryMessage, QueryType};
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_is_system_peers() {
+        let mut message_details = QueryMessage {
+            query_string: "SELECT * from system.peers".to_string(),
+            namespace: vec!["system".to_string(), "peers".to_string()],
+            primary_key: HashMap::new(),
+            query_values: None,
+            projection: None,
+            query_type: QueryType::Read,
+            ast: None,
+        };
+
+        assert!(is_system_peers(&MessageDetails::Query(
+            message_details.clone()
+        )));
+
+        message_details.namespace = vec!["notsystem".to_string(), "notpeers".to_string()];
+        assert!(!is_system_peers(&MessageDetails::Query(
+            message_details.clone()
+        )));
+
+        message_details.namespace = vec!["system".to_string(), "peers".to_string()];
+        message_details.query_type = QueryType::Write;
+        assert!(!is_system_peers(&MessageDetails::Query(
+            message_details.clone()
+        )));
+
+        message_details.query_type = QueryType::SchemaChange;
+        assert!(!is_system_peers(&MessageDetails::Query(
+            message_details.clone()
+        )));
+
+        message_details.namespace = vec!["system".to_string(), "peers_v2".to_string()];
+        message_details.query_type = QueryType::Read;
+        assert!(!is_system_peers(&MessageDetails::Query(
+            message_details.clone()
+        )));
+    }
+
+    #[test]
+    fn test_is_system_peers_v2() {
+        let mut message_details = QueryMessage {
+            query_string: "SELECT * from system.peers_v2".to_string(),
+            namespace: vec!["system".to_string(), "peers_v2".to_string()],
+            primary_key: HashMap::new(),
+            query_values: None,
+            projection: None,
+            query_type: QueryType::Read,
+            ast: None,
+        };
+
+        assert!(is_system_peers_v2(&MessageDetails::Query(
+            message_details.clone()
+        )));
+
+        message_details.namespace = vec!["notsystem".to_string(), "notpeers".to_string()];
+        assert!(!is_system_peers_v2(&MessageDetails::Query(
+            message_details.clone()
+        )));
+
+        message_details.namespace = vec!["system".to_string(), "peers_v2".to_string()];
+        message_details.query_type = QueryType::Write;
+        assert!(!is_system_peers_v2(&MessageDetails::Query(
+            message_details.clone()
+        )));
+
+        message_details.namespace = vec!["system".to_string(), "peers".to_string()];
+        message_details.query_type = QueryType::Read;
+        assert!(!is_system_peers_v2(&MessageDetails::Query(
+            message_details.clone()
+        )));
+
+        message_details.query_type = QueryType::SchemaChange;
+        assert!(!is_system_peers_v2(&MessageDetails::Query(
+            message_details.clone()
+        )));
+    }
+
+    #[test]
+    fn test_emulate_single_node() {}
+}
+
+// fn rewrite_ip_address(original: &mut RawFrame) -> RawFrame {
+//     if let RawFrame::Cassandra(ref mut frame) = original {
+//         //tracing::info!("{:?}", frame);
+//         frame.body =
+//             if let Ok(ResponseBody::Result(ResResultBody::Rows(ref mut rows))) = frame.get_body() {
+//                 tracing::info!("{:?}", rows);
+//                 for row in rows.rows_content.iter_mut() {
+//                     for cell in row.iter_mut() {
+//                         *cell = cassandra_proto::types::CBytes::new(
+//                             std::net::Ipv4Addr::new(127, 0, 0, 1).octets().to_vec(),
+//                         )
+//                     }
+//                 }
+//                 //tracing::info!("{:?}", rows);
+//                 rows.into_cbytes()
+//             } else {
+//                 panic!("");
+//             };
+
+//         //tracing::info!("{:?}", rows);
+
+//         //frame.body = rows.into_cbytes();
+
+//         //tracing::info!("{:?}", rows.into_cbytes());
+
+//         //tracing::info!("{:?}", frame);
+
+//         return RawFrame::Cassandra(frame.clone());
+//     } else {
+//         panic!("FUG!");
+//     }
+// }

--- a/shotover-proxy/src/transforms/cassandra/mod.rs
+++ b/shotover-proxy/src/transforms/cassandra/mod.rs
@@ -1,1 +1,2 @@
+pub mod peers_rewrite;
 pub mod sink_single;

--- a/shotover-proxy/src/transforms/cassandra/peers_rewrite.rs
+++ b/shotover-proxy/src/transforms/cassandra/peers_rewrite.rs
@@ -2,7 +2,7 @@ use crate::{
     config::topology::TopicHolder,
     error::ChainResponse,
     message::MessageDetails,
-    transforms::{Transform, Transforms, TransformsFromConfig, Wrapper},
+    transforms::{Transform, Transforms, Wrapper},
 };
 use crate::{message::QueryType, protocols::RawFrame};
 use anyhow::Result;
@@ -24,9 +24,8 @@ pub struct CassandraPeersRewriteConfig {
     pub port: Option<u32>,
 }
 
-#[async_trait]
-impl TransformsFromConfig for CassandraPeersRewriteConfig {
-    async fn get_source(&self, _topics: &TopicHolder) -> Result<Transforms> {
+impl CassandraPeersRewriteConfig {
+    pub async fn get_source(&self, _topics: &TopicHolder) -> Result<Transforms> {
         Ok(Transforms::CassandraPeersRewrite(CassandraPeersRewrite {
             emulate_single_node: self.emulate_single_node,
             port: self.port,
@@ -52,7 +51,6 @@ impl Transform for CassandraPeersRewrite {
     async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> ChainResponse {
         // Find the indices of queries to system.peers & system.peers_v2
         let system_peers = message_wrapper
-            .message
             .messages
             .iter()
             .enumerate()
@@ -64,11 +62,11 @@ impl Transform for CassandraPeersRewrite {
 
         for i in system_peers {
             if let Some(new_port) = self.port {
-                rewrite_port(&mut response.messages[i].original, new_port);
+                rewrite_port(&mut response[i].original, new_port);
             }
 
             if self.emulate_single_node {
-                emulate_single_node(&mut response.messages[i].original);
+                emulate_single_node(&mut response[i].original);
             }
         }
 

--- a/shotover-proxy/src/transforms/mod.rs
+++ b/shotover-proxy/src/transforms/mod.rs
@@ -11,7 +11,10 @@ use serde::Deserialize;
 use crate::config::topology::TopicHolder;
 use crate::error::ChainResponse;
 use crate::message::{Message, Messages};
-use crate::transforms::cassandra::sink_single::{CassandraSinkSingle, CassandraSinkSingleConfig};
+use crate::transforms::cassandra::{
+    peers_rewrite::{CassandraPeersRewrite, CassandraPeersRewriteConfig},
+    sink_single::{CassandraSinkSingle, CassandraSinkSingleConfig},
+};
 use metrics::{counter, histogram};
 
 use crate::transforms::chain::TransformChain;
@@ -101,8 +104,9 @@ impl Debug for Transforms {
 impl Transforms {
     async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> ChainResponse {
         match self {
-            Transforms::CassandraCodecDestination(c) => c.transform(message_wrapper).await,
-            Transforms::KafkaDestination(k) => k.transform(message_wrapper).await,
+            Transforms::CassandraSinkSingle(c) => c.transform(message_wrapper).await,
+            Transforms::CassandraPeersRewrite(c) => c.transform(message_wrapper).await,
+            Transforms::KafkaSink(k) => k.transform(message_wrapper).await,
             Transforms::RedisCache(r) => r.transform(message_wrapper).await,
             Transforms::Tee(m) => m.transform(message_wrapper).await,
             Transforms::DebugPrinter(p) => p.transform(message_wrapper).await,
@@ -126,8 +130,9 @@ impl Transforms {
 
     fn get_name(&self) -> &'static str {
         match self {
-            Transforms::CassandraCodecDestination(c) => c.get_name(),
-            Transforms::KafkaDestination(k) => k.get_name(),
+            Transforms::CassandraSinkSingle(c) => c.get_name(),
+            Transforms::CassandraPeersRewrite(c) => c.get_name(),
+            Transforms::KafkaSink(k) => k.get_name(),
             Transforms::RedisCache(r) => r.get_name(),
             Transforms::Tee(m) => m.get_name(),
             Transforms::DebugPrinter(p) => p.get_name(),
@@ -151,9 +156,10 @@ impl Transforms {
 
     async fn _prep_transform_chain(&mut self, t: &mut TransformChain) -> Result<()> {
         match self {
-            Transforms::CassandraCodecDestination(a) => a.prep_transform_chain(t).await,
-            Transforms::RedisCodecDestination(a) => a.prep_transform_chain(t).await,
-            Transforms::KafkaDestination(a) => a.prep_transform_chain(t).await,
+            Transforms::CassandraSinkSingle(a) => a.prep_transform_chain(t).await,
+            Transforms::CassandraPeersRewrite(c) => c.prep_transform_chain(t).await,
+            Transforms::RedisSinkSingle(a) => a.prep_transform_chain(t).await,
+            Transforms::KafkaSink(a) => a.prep_transform_chain(t).await,
             Transforms::RedisCache(a) => a.prep_transform_chain(t).await,
             Transforms::Tee(a) => a.prep_transform_chain(t).await,
             Transforms::DebugPrinter(a) => a.prep_transform_chain(t).await,
@@ -177,6 +183,7 @@ impl Transforms {
     fn validate(&self) -> Vec<String> {
         match self {
             Transforms::CassandraSinkSingle(c) => c.validate(),
+            Transforms::CassandraPeersRewrite(c) => c.validate(),
             Transforms::KafkaSink(k) => k.validate(),
             Transforms::RedisCache(r) => r.validate(),
             Transforms::Tee(t) => t.validate(),
@@ -202,6 +209,7 @@ impl Transforms {
     fn is_terminating(&self) -> bool {
         match self {
             Transforms::CassandraSinkSingle(c) => c.is_terminating(),
+            Transforms::CassandraPeersRewrite(c) => c.is_terminating(),
             Transforms::KafkaSink(k) => k.is_terminating(),
             Transforms::RedisCache(r) => r.is_terminating(),
             Transforms::Tee(t) => t.is_terminating(),
@@ -232,6 +240,7 @@ pub enum TransformsConfig {
     CassandraSinkSingle(CassandraSinkSingleConfig),
     RedisSinkSingle(RedisSinkSingleConfig),
     KafkaSink(KafkaSinkConfig),
+    CassandraPeersRewrite(CassandraPeersRewriteConfig),
     RedisCache(RedisConfig),
     Tee(TeeConfig),
     ConsistentScatter(ConsistentScatterConfig),
@@ -253,8 +262,9 @@ impl TransformsConfig {
     /// Return a new instance of the transform that the config is specifying.
     pub async fn get_transforms(&self, topics: &TopicHolder) -> Result<Transforms> {
         match self {
-            TransformsConfig::CassandraCodecDestination(c) => c.get_source(topics).await,
-            TransformsConfig::KafkaDestination(k) => k.get_source(topics).await,
+            TransformsConfig::CassandraSinkSingle(c) => c.get_source(topics).await,
+            TransformsConfig::CassandraPeersRewrite(c) => c.get_source(topics).await,
+            TransformsConfig::KafkaSink(k) => k.get_source(topics).await,
             TransformsConfig::RedisCache(r) => r.get_source(topics).await,
             TransformsConfig::Tee(t) => t.get_source(topics).await,
             TransformsConfig::RedisSinkSingle(r) => r.get_source(topics).await,

--- a/shotover-proxy/src/transforms/mod.rs
+++ b/shotover-proxy/src/transforms/mod.rs
@@ -72,6 +72,7 @@ pub enum Transforms {
     CassandraSinkSingle(CassandraSinkSingle),
     RedisSinkSingle(RedisSinkSingle),
     KafkaSink(KafkaSink),
+    CassandraPeersRewrite(CassandraPeersRewrite),
     RedisCache(SimpleRedisCache),
     Tee(Tee),
     Null(Null),
@@ -100,8 +101,8 @@ impl Debug for Transforms {
 impl Transforms {
     async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> ChainResponse {
         match self {
-            Transforms::CassandraSinkSingle(c) => c.transform(message_wrapper).await,
-            Transforms::KafkaSink(k) => k.transform(message_wrapper).await,
+            Transforms::CassandraCodecDestination(c) => c.transform(message_wrapper).await,
+            Transforms::KafkaDestination(k) => k.transform(message_wrapper).await,
             Transforms::RedisCache(r) => r.transform(message_wrapper).await,
             Transforms::Tee(m) => m.transform(message_wrapper).await,
             Transforms::DebugPrinter(p) => p.transform(message_wrapper).await,
@@ -125,8 +126,8 @@ impl Transforms {
 
     fn get_name(&self) -> &'static str {
         match self {
-            Transforms::CassandraSinkSingle(c) => c.get_name(),
-            Transforms::KafkaSink(k) => k.get_name(),
+            Transforms::CassandraCodecDestination(c) => c.get_name(),
+            Transforms::KafkaDestination(k) => k.get_name(),
             Transforms::RedisCache(r) => r.get_name(),
             Transforms::Tee(m) => m.get_name(),
             Transforms::DebugPrinter(p) => p.get_name(),
@@ -150,9 +151,9 @@ impl Transforms {
 
     async fn _prep_transform_chain(&mut self, t: &mut TransformChain) -> Result<()> {
         match self {
-            Transforms::CassandraSinkSingle(a) => a.prep_transform_chain(t).await,
-            Transforms::RedisSinkSingle(a) => a.prep_transform_chain(t).await,
-            Transforms::KafkaSink(a) => a.prep_transform_chain(t).await,
+            Transforms::CassandraCodecDestination(a) => a.prep_transform_chain(t).await,
+            Transforms::RedisCodecDestination(a) => a.prep_transform_chain(t).await,
+            Transforms::KafkaDestination(a) => a.prep_transform_chain(t).await,
             Transforms::RedisCache(a) => a.prep_transform_chain(t).await,
             Transforms::Tee(a) => a.prep_transform_chain(t).await,
             Transforms::DebugPrinter(a) => a.prep_transform_chain(t).await,
@@ -252,8 +253,8 @@ impl TransformsConfig {
     /// Return a new instance of the transform that the config is specifying.
     pub async fn get_transforms(&self, topics: &TopicHolder) -> Result<Transforms> {
         match self {
-            TransformsConfig::CassandraSinkSingle(c) => c.get_source(topics).await,
-            TransformsConfig::KafkaSink(k) => k.get_source(topics).await,
+            TransformsConfig::CassandraCodecDestination(c) => c.get_source(topics).await,
+            TransformsConfig::KafkaDestination(k) => k.get_source(topics).await,
             TransformsConfig::RedisCache(r) => r.get_source(topics).await,
             TransformsConfig::Tee(t) => t.get_source(topics).await,
             TransformsConfig::RedisSinkSingle(r) => r.get_source(topics).await,


### PR DESCRIPTION
The functionality of port rewriting and emulating a single node (returning an empty system peers table) is working. Before this can be merged I need to:
- [ ] Fix some issues with the Cassandra driver
- [ ] Reconsider the ergonomics of the config file and setting the variables/using this transform. The current implement is pretty ad-hoc so I can test things.
- [ ] In the case of Shotover emulating a single node, we also need to have Shotover handle request routing to the right Cassandra nodes
- [ ] Add integration tests. This is blocked by #107 

#### Cassandra driver issues: 
* The cause of the hacky 4 magic bytes that needed to be added at the start of the body is because the driver wasn't adding the [byte representing the ResultKind](https://github.com/apache/cassandra/blob/5ee1ba2dfaac0f4424322268912f6714e89904ae/doc/native_protocol_v4.spec#L554) 
* The driver wasn't properly serialising null values. Cassandra parsers [expects a -1](https://github.com/apache/cassandra/blob/5ee1ba2dfaac0f4424322268912f6714e89904ae/doc/native_protocol_v4.spec#L230) when a value is null. The driver was just skipping them altogether.