### PR TITLE
fix test_cluster_tls

### DIFF
--- a/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
+++ b/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
@@ -742,27 +742,27 @@ async fn test_pass_through() {
     run_all(&mut connection).await;
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
-fn test_cluster_tls() {
+async fn test_cluster_tls() {
     let _compose = DockerCompose::new("examples/redis-cluster-tls/docker-compose.yml")
         .wait_for_n("Cluster state changed", 6);
     let shotover_manager =
         ShotoverManager::from_topology_file("examples/redis-cluster-tls/topology.yaml");
 
-    let mut connection = shotover_manager.redis_connection(6379);
+    let mut connection = shotover_manager.redis_connection_async(6379).await;
     let connection = &mut connection;
 
-    test_pipeline_error(connection);
-    run_all_cluster_safe(connection);
+    test_pipeline_error(connection).await;
+    run_all_cluster_safe(connection).await;
 
     for _i in 0..1999 {
-        test_script(connection);
+        test_script(connection).await;
     }
 
-    test_cluster_script(connection);
-    test_script(connection);
-    test_cluster_script(connection);
+    test_cluster_script(connection).await;
+    test_script(connection).await;
+    test_cluster_script(connection).await;
 
     // TODO: use all test cases in test_cluster_redis
 }


### PR DESCRIPTION
github only runs CI against PRs at the time they are pushed so we managed to merge broken changes.
To avoid this issue large projects generally use something like https://github.com/bors-ng/bors-ng to enforce rerunning CI before merging a PR.