### PR TITLE
Cleanup #derives

### DIFF
--- a/shotover-proxy/src/config/mod.rs
+++ b/shotover-proxy/src/config/mod.rs
@@ -1,9 +1,9 @@
 use anyhow::{anyhow, Result};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 pub mod topology;
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct Config {
     pub main_log_level: String,
     pub observability_interface: String,

--- a/shotover-proxy/src/config/topology.rs
+++ b/shotover-proxy/src/config/topology.rs
@@ -8,14 +8,14 @@ use crate::transforms::kafka_destination::KafkaConfig;
 use crate::transforms::mpsc::TeeConfig;
 use crate::transforms::{build_chain_from_config, TransformsConfig};
 use anyhow::{anyhow, Result};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::collections::HashMap;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tokio::sync::oneshot::Sender as OneSender;
 use tokio::sync::watch;
 use tracing::info;
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct Topology {
     pub sources: HashMap<String, SourcesConfig>,
     pub chain_config: HashMap<String, Vec<TransformsConfig>>,
@@ -23,7 +23,7 @@ pub struct Topology {
     pub source_to_chain_mapping: HashMap<String, String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct TopologyConfig {
     pub sources: HashMap<String, SourcesConfig>,
     pub chain_config: HashMap<String, Vec<TransformsConfig>>,
@@ -250,56 +250,5 @@ impl Topology {
             named_topics,
             source_to_chain_mapping,
         }
-    }
-}
-
-#[cfg(test)]
-mod topology_tests {
-    use crate::config::topology::Topology;
-
-    const TEST_STRING: &str = r###"---
-sources:
-  cassandra_prod:
-    Cassandra:
-      bypass_query_processing: false
-      listen_addr: "127.0.0.1:9043"
-      cassandra_ks:
-        system.local:
-          - key
-        test.simple:
-          - pk
-        test.clustering:
-          - pk
-          - clustering
-chain_config:
-  main_chain:
-    - MPSCTee:
-        topic_name: test_topic
-        chain:
-          - KafkaDestination:
-             topic: "test_topic"
-             config_values:
-               bootstrap.servers: "127.0.0.1:9092"
-               message.timeout.ms: "5000"
-    - CassandraCodecDestination:
-        bypass_result_processing: false
-        remote_address: "127.0.0.1:9042"    
-named_topics:
-  test_topic: 1
-source_to_chain_mapping:
-  cassandra_prod: main_chain"###;
-
-    #[test]
-    fn new_test() {
-        let topology = Topology::get_demo_config();
-        println!("{:?}", topology.named_topics);
-        let topology2 = Topology::new_from_yaml(String::from(TEST_STRING));
-        println!("{:?}", topology2.named_topics);
-        assert_eq!(topology2, topology);
-    }
-
-    #[test]
-    fn test_config_parse_format() {
-        Topology::new_from_yaml(String::from(TEST_STRING));
     }
 }

--- a/shotover-proxy/src/message/mod.rs
+++ b/shotover-proxy/src/message/mod.rs
@@ -18,7 +18,7 @@ use std::net::IpAddr;
 
 // TODO: Clippy says this is bad due to large variation - also almost 1k in size on the stack
 // Should move the message type to just be bulk..
-#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct Messages {
     pub messages: Vec<Message>,
 }
@@ -42,14 +42,14 @@ impl IntoIterator for Messages {
     }
 }
 
-#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct Message {
     pub details: MessageDetails,
     pub modified: bool,
     pub original: RawFrame,
 }
 
-#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(PartialEq, Debug, Clone)]
 pub enum MessageDetails {
     Bypass(Box<MessageDetails>),
     Query(QueryMessage),
@@ -180,7 +180,7 @@ impl Messages {
     }
 }
 
-#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct RawMessage {
     pub original: RawFrame,
 }
@@ -228,7 +228,7 @@ impl ASTHolder {
     }
 }
 
-#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct QueryMessage {
     pub query_string: String,
     pub namespace: Vec<String>,
@@ -236,7 +236,6 @@ pub struct QueryMessage {
     pub query_values: Option<HashMap<String, Value>>,
     pub projection: Option<Vec<String>>,
     pub query_type: QueryType,
-    #[serde(skip)]
     pub ast: Option<ASTHolder>,
 }
 
@@ -284,7 +283,7 @@ impl QueryMessage {
     }
 }
 
-#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct QueryResponse {
     pub matching_query: Option<QueryMessage>,
     pub result: Option<Value>,
@@ -362,7 +361,7 @@ impl QueryResponse {
     }
 }
 
-#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(PartialEq, Debug, Clone, Deserialize)]
 pub enum QueryType {
     Read,
     Write,

--- a/shotover-proxy/src/protocols/mod.rs
+++ b/shotover-proxy/src/protocols/mod.rs
@@ -7,12 +7,11 @@ pub use redis_protocol::prelude::Frame as RedisFrame;
 use anyhow::Result;
 use bytes::Bytes;
 use itertools::Itertools;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::message::{ASTHolder, MessageDetails, QueryMessage, QueryResponse, QueryType, Value};
 
-#[derive(Eq, PartialEq, Debug, Clone, Hash, Serialize, Deserialize)]
+#[derive(PartialEq, Debug, Clone)]
 pub enum RawFrame {
     Cassandra(CassandraFrame),
     Redis(RedisFrame),

--- a/shotover-proxy/src/sources/cassandra_source.rs
+++ b/shotover-proxy/src/sources/cassandra_source.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use tokio::runtime::Handle;
 use tokio::sync::{mpsc, watch, Semaphore};
 use tokio::task::JoinHandle;
@@ -15,7 +15,7 @@ use crate::server::TcpCodecListener;
 use crate::sources::{Sources, SourcesFromConfig};
 use crate::transforms::chain::TransformChain;
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct CassandraConfig {
     pub listen_addr: String,
     pub cassandra_ks: HashMap<String, Vec<String>>,

--- a/shotover-proxy/src/sources/mod.rs
+++ b/shotover-proxy/src/sources/mod.rs
@@ -4,7 +4,7 @@ use crate::sources::mpsc_source::{AsyncMpsc, AsyncMpscConfig};
 use crate::sources::redis_source::{RedisConfig, RedisSource};
 use crate::transforms::chain::TransformChain;
 use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use tokio::sync::{mpsc, watch};
 use tokio::task::JoinHandle;
 
@@ -50,7 +50,7 @@ impl Sources {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone)]
 pub enum SourcesConfig {
     Cassandra(CassandraConfig),
     Mpsc(AsyncMpscConfig),

--- a/shotover-proxy/src/sources/mpsc_source.rs
+++ b/shotover-proxy/src/sources/mpsc_source.rs
@@ -9,7 +9,7 @@ use crate::transforms::coalesce::CoalesceBehavior;
 use crate::transforms::Wrapper;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::time::Instant;
 use tokio::runtime::Handle;
 use tokio::sync::{mpsc, watch};
@@ -17,7 +17,7 @@ use tokio::task::JoinHandle;
 use tracing::info;
 use tracing::warn;
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct AsyncMpscConfig {
     pub topic_name: String,
     pub coalesce_behavior: Option<CoalesceBehavior>,

--- a/shotover-proxy/src/sources/redis_source.rs
+++ b/shotover-proxy/src/sources/redis_source.rs
@@ -6,14 +6,14 @@ use crate::tls::{TlsAcceptor, TlsConfig};
 use crate::transforms::chain::TransformChain;
 use anyhow::Result;
 use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::sync::Arc;
 use tokio::runtime::Handle;
 use tokio::sync::{mpsc, watch, Semaphore};
 use tokio::task::JoinHandle;
 use tracing::{error, info};
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct RedisConfig {
     pub listen_addr: String,
     pub batch_size_hint: u64,

--- a/shotover-proxy/src/tls.rs
+++ b/shotover-proxy/src/tls.rs
@@ -9,7 +9,7 @@ use tokio::net::TcpStream;
 use tokio_openssl::SslStream;
 use tracing::warn;
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct TlsConfig {
     /// Path to the certificate authority in PEM format
     pub certificate_authority_path: String,

--- a/shotover-proxy/src/transforms/cassandra/cassandra_codec_destination.rs
+++ b/shotover-proxy/src/transforms/cassandra/cassandra_codec_destination.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 use crate::config::topology::TopicHolder;
 use crate::message::{Message, Messages, QueryResponse};
@@ -20,7 +20,7 @@ use anyhow::{anyhow, Result};
 use std::time::Duration;
 use tokio::sync::oneshot::Receiver;
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct CassandraCodecConfiguration {
     #[serde(rename = "remote_address")]
     pub address: String,

--- a/shotover-proxy/src/transforms/coalesce.rs
+++ b/shotover-proxy/src/transforms/coalesce.rs
@@ -5,7 +5,7 @@ use crate::protocols::RawFrame;
 use crate::transforms::{Transform, Transforms, TransformsFromConfig, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::time::Instant;
 
 #[derive(Debug, Clone)]
@@ -16,14 +16,14 @@ pub struct Coalesce {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone)]
 pub enum CoalesceBehavior {
     COUNT(usize),
     WAIT_MS(u128),
     COUNT_OR_WAIT(usize, u128),
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct CoalesceConfig {
     pub max_behavior: CoalesceBehavior,
 }

--- a/shotover-proxy/src/transforms/distributed/tunable_consistency_scatter.rs
+++ b/shotover-proxy/src/transforms/distributed/tunable_consistency_scatter.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use futures::stream::FuturesUnordered;
 use itertools::Itertools;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use tokio_stream::StreamExt;
 use tracing::{debug, trace, warn};
 
@@ -28,7 +28,7 @@ pub struct TunableConsistency {
     count: u32,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct TunableConsistencyConfig {
     pub route_map: HashMap<String, Vec<TransformsConfig>>,
     pub write_consistency: i32,

--- a/shotover-proxy/src/transforms/filter.rs
+++ b/shotover-proxy/src/transforms/filter.rs
@@ -4,14 +4,14 @@ use crate::message::{MessageDetails, QueryType};
 use crate::transforms::{Transform, Transforms, TransformsFromConfig, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 #[derive(Debug, Clone)]
 pub struct QueryTypeFilter {
     filter: QueryType,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct QueryTypeFilterConfig {
     pub filter: QueryType,
 }

--- a/shotover-proxy/src/transforms/kafka_destination.rs
+++ b/shotover-proxy/src/transforms/kafka_destination.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use rdkafka::config::ClientConfig;
 use rdkafka::producer::{FutureProducer, FutureRecord};
 use rdkafka::util::Timeout;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 use crate::config::topology::TopicHolder;
 use crate::error::ChainResponse;
@@ -19,7 +19,7 @@ pub struct KafkaDestination {
     pub topic: String,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct KafkaConfig {
     #[serde(rename = "config_values")]
     pub keys: HashMap<String, String>,

--- a/shotover-proxy/src/transforms/load_balance.rs
+++ b/shotover-proxy/src/transforms/load_balance.rs
@@ -6,11 +6,11 @@ use crate::transforms::{
 };
 use anyhow::Result;
 use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct ConnectionBalanceAndPoolConfig {
     pub name: String,
     pub parallelism: usize,

--- a/shotover-proxy/src/transforms/mod.rs
+++ b/shotover-proxy/src/transforms/mod.rs
@@ -5,7 +5,7 @@ use std::pin::Pin;
 use anyhow::Result;
 use async_trait::async_trait;
 use futures::Future;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 use crate::config::topology::TopicHolder;
 use crate::error::ChainResponse;
@@ -171,7 +171,7 @@ impl Transforms {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone)]
 pub enum TransformsConfig {
     CassandraCodecDestination(CassandraCodecConfiguration),
     RedisDestination(RedisCodecConfiguration),

--- a/shotover-proxy/src/transforms/mpsc.rs
+++ b/shotover-proxy/src/transforms/mpsc.rs
@@ -10,7 +10,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use itertools::Itertools;
 use metrics::counter;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use tracing::trace;
 
 /*
@@ -27,7 +27,7 @@ pub struct Buffer {
     pub timeout: Option<u64>,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct BufferConfig {
     pub async_mode: bool,
     pub chain: Vec<TransformsConfig>,
@@ -109,14 +109,14 @@ pub struct Tee {
     pub timeout: Option<u64>,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone)]
 pub enum ConsistencyBehavior {
     IGNORE,
     FAIL,
     LOG { fail_chain: Vec<TransformsConfig> },
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct TeeConfig {
     pub behavior: Option<ConsistencyBehavior>,
     pub timeout_micros: Option<u64>,

--- a/shotover-proxy/src/transforms/parallel_map.rs
+++ b/shotover-proxy/src/transforms/parallel_map.rs
@@ -11,7 +11,7 @@ use futures::stream::{FuturesOrdered, FuturesUnordered};
 use futures::task::{Context, Poll};
 use futures::Stream;
 use itertools::Itertools;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::future::Future;
 use std::pin::Pin;
 use tokio_stream::StreamExt;
@@ -61,7 +61,7 @@ where
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct ParallelMapConfig {
     pub name: String,
     pub parallelism: u32,

--- a/shotover-proxy/src/transforms/protect/key_management.rs
+++ b/shotover-proxy/src/transforms/protect/key_management.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use cached::proc_macro::cached;
 use rusoto_kms::KmsClient;
 use rusoto_signature::Region;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use sodiumoxide::crypto::secretbox::Key;
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -22,7 +22,7 @@ pub enum KeyManager {
     Local(LocalKeyManagement),
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone)]
 pub enum KeyManagerConfig {
     AWSKms {
         region: String,

--- a/shotover-proxy/src/transforms/protect/mod.rs
+++ b/shotover-proxy/src/transforms/protect/mod.rs
@@ -41,7 +41,7 @@ pub struct KeyMaterial {
     pub plaintext: Key,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize)]
 pub struct ProtectConfig {
     pub keyspace_table_columns: HashMap<String, HashMap<String, Vec<String>>>,
     pub key_manager: KeyManagerConfig,
@@ -51,7 +51,7 @@ pub struct ProtectConfig {
 // https://doc.libsodium.org/secret-key_cryptography/secretbox
 // This all relies on crypto_secretbox_easy which takes care of
 // all padding, copying and timing issues associated with crypto
-#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub enum Protected {
     Plaintext(Value),
     Ciphertext {

--- a/shotover-proxy/src/transforms/query_counter.rs
+++ b/shotover-proxy/src/transforms/query_counter.rs
@@ -6,7 +6,7 @@ use crate::transforms::{Transform, Transforms, TransformsFromConfig, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
 use metrics::counter;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use sqlparser::ast::Statement;
 
 #[derive(Debug, Clone)]
@@ -14,7 +14,7 @@ pub struct QueryCounter {
     counter_name: String,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct QueryCounterConfig {
     pub name: String,
 }

--- a/shotover-proxy/src/transforms/redis_transforms/redis_cache.rs
+++ b/shotover-proxy/src/transforms/redis_transforms/redis_cache.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 use crate::config::topology::TopicHolder;
 use crate::error::ChainResponse;
@@ -21,13 +21,13 @@ use std::borrow::Borrow;
 const TRUE: [u8; 1] = [0x1];
 const FALSE: [u8; 1] = [0x0];
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct RedisConfig {
     pub caching_schema: HashMap<String, PrimaryKey>,
     pub chain: Vec<TransformsConfig>,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct PrimaryKey {
     partition_key: Vec<String>,
     range_key: Vec<String>,

--- a/shotover-proxy/src/transforms/redis_transforms/redis_cluster.rs
+++ b/shotover-proxy/src/transforms/redis_transforms/redis_cluster.rs
@@ -10,7 +10,7 @@ use metrics::counter;
 use rand::prelude::SmallRng;
 use rand::SeedableRng;
 use redis_protocol::types::Frame;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::oneshot;
 use tokio::time::timeout;
@@ -36,7 +36,7 @@ const SLOT_SIZE: usize = 16384;
 
 type ChannelMap = HashMap<String, Vec<UnboundedSender<Request>>>;
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct RedisClusterConfig {
     pub first_contact_points: Vec<String>,
     pub tls: Option<TlsConfig>,

--- a/shotover-proxy/src/transforms/redis_transforms/redis_cluster_slot_rewrite.rs
+++ b/shotover-proxy/src/transforms/redis_transforms/redis_cluster_slot_rewrite.rs
@@ -1,14 +1,14 @@
 use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
 pub use redis_protocol::prelude::Frame;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 use crate::config::topology::TopicHolder;
 use crate::error::ChainResponse;
 use crate::protocols::RawFrame;
 use crate::transforms::{Transform, Transforms, TransformsFromConfig, Wrapper};
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct RedisClusterSlotRewriteConfig {
     pub new_port: u16,
 }

--- a/shotover-proxy/src/transforms/redis_transforms/redis_codec_destination.rs
+++ b/shotover-proxy/src/transforms/redis_transforms/redis_codec_destination.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use futures::{FutureExt, SinkExt};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::pin::Pin;
 use tokio::net::TcpStream;
 use tokio_stream::StreamExt;
@@ -15,7 +15,7 @@ use crate::protocols::redis_codec::RedisCodec;
 use crate::tls::{AsyncStream, TlsConfig, TlsConnector};
 use crate::transforms::{Transform, Transforms, TransformsFromConfig, Wrapper};
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct RedisCodecConfiguration {
     #[serde(rename = "remote_address")]
     pub address: String,

--- a/shotover-proxy/src/transforms/redis_transforms/timestamp_tagging.rs
+++ b/shotover-proxy/src/transforms/redis_transforms/timestamp_tagging.rs
@@ -7,7 +7,7 @@ use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
 use itertools::Itertools;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::{debug, trace};
@@ -15,7 +15,7 @@ use tracing::{debug, trace};
 #[derive(Clone, Default)]
 pub struct RedisTimestampTagger {}
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct RedisTimestampTaggerConfig {}
 
 impl RedisTimestampTagger {

--- a/shotover-proxy/tests/codec/util/packet_parse.rs
+++ b/shotover-proxy/tests/codec/util/packet_parse.rs
@@ -9,11 +9,11 @@ use pktparse::*;
 use std::string::ToString;
 use tls_parser::TlsMessage;
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 pub struct PacketParse {}
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize)]
 pub enum PacketHeader {
     Tls(TlsType),
     Dns(DnsPacket),
@@ -25,7 +25,7 @@ pub enum PacketHeader {
     Arp(ArpPacket),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct ParsedPacket {
     pub len: u32,
     pub timestamp: String,
@@ -44,7 +44,7 @@ impl ParsedPacket {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize)]
 pub enum TlsType {
     Handshake,
     ChangeCipherSpec,
@@ -54,7 +54,7 @@ pub enum TlsType {
     EncryptedData,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize)]
 pub struct DnsPacket {
     questions: Vec<String>,
     answers: Vec<String>,


### PR DESCRIPTION
having less #derives will improve iterative build times a little and allows us to be more flexible in the types that we store.

The test was deleted as we are testing the topology config deserialization quite thoroughly already with out integration tests and removing it lets us remove a lot of PartialEq derives