### PR TITLE
Update redis-proto dependency to be closer to master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,15 @@ dependencies = [
 
 [[package]]
 name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
@@ -42,6 +51,12 @@ name = "anyhow"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "async-mutex"
@@ -61,15 +76,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "atoi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616896e05fc0e2649463a93a15183c6a16bf03413a7af88ef1285ddedfa9cda5"
-dependencies = [
- "num-traits 0.2.14",
 ]
 
 [[package]]
@@ -118,6 +124,18 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "bitvec"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "block-buffer"
@@ -329,9 +347,9 @@ dependencies = [
 
 [[package]]
 name = "cookie-factory"
-version = "0.2.4"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98a479f8099cc5ac64915a3dd76c87be27f929ba406ad705aacb13f19b791207"
+checksum = "396de984970346b0d9e93d1415082923c679e5ae5c3ee3dcbd104f5610af126b"
 
 [[package]]
 name = "core-foundation"
@@ -699,6 +717,19 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
@@ -738,6 +769,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 
 [[package]]
+name = "float-cmp"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
+dependencies = [
+ "num-traits 0.2.14",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,6 +813,12 @@ name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
@@ -1141,6 +1187,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lexical-core"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "cfg-if 1.0.0",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1409,6 +1468,19 @@ dependencies = [
 
 [[package]]
 name = "nom"
+version = "6.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
+dependencies = [
+ "bitvec",
+ "funty",
+ "lexical-core",
+ "memchr",
+ "version_check",
+]
+
+[[package]]
+name = "nom"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffd9d26838a953b4af82cbeb9f1592c6798916983959be223a7124e992742c1"
@@ -1424,7 +1496,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007e042d4414938f8bed4f97b8e358b215e06c5aa80ce237decab36807aa95eb"
 dependencies = [
- "nom",
+ "nom 7.0.0",
  "nom-derive-impl",
  "rustversion",
 ]
@@ -1714,7 +1786,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb6dd3070cf6f4d7cfb77aade4509979246a245b8a356eec51803ba92c7d21e6"
 dependencies = [
- "nom",
+ "nom 7.0.0",
  "serde",
 ]
 
@@ -1751,6 +1823,18 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "pretty_env_logger"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed8d1e63042e889b85228620629b51c011d380eed2c7e0015f8a644def280c28"
+dependencies = [
+ "ansi_term 0.11.0",
+ "chrono",
+ "env_logger 0.5.13",
+ "log",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -1846,6 +1930,12 @@ checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "radix_trie"
@@ -2032,16 +2122,16 @@ dependencies = [
 
 [[package]]
 name = "redis-protocol"
-version = "1.0.0"
-source = "git+https://github.com/shotover/redis-protocol.rs?branch=remove-parser#39f5775b14a2075cb04a295786c5f46c12bc01cd"
+version = "3.0.0"
+source = "git+https://github.com/shotover/redis-protocol.rs?branch=shotover_fork#0e2fcf46165e90291ca962f6d64f8ca41c741d34"
 dependencies = [
- "anyhow",
- "atoi",
  "bytes",
  "cookie-factory",
  "crc16 0.3.4",
+ "float-cmp",
  "log",
- "serde",
+ "nom 6.1.2",
+ "pretty_env_logger",
 ]
 
 [[package]]
@@ -2196,7 +2286,7 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65c52377bb2288aa522a0c8208947fada1e0c76397f108cc08f57efe6077b50d"
 dependencies = [
- "nom",
+ "nom 7.0.0",
 ]
 
 [[package]]
@@ -2515,6 +2605,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2552,6 +2648,12 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -2684,7 +2786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "409206e2de64edbf7ea99a44ac31680daf9ef1a57895fb3c5bd738a903691be0"
 dependencies = [
  "enum_primitive",
- "nom",
+ "nom 7.0.0",
  "nom-derive",
  "phf",
  "phf_codegen",
@@ -2845,7 +2947,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
 dependencies = [
- "env_logger",
+ "env_logger 0.7.1",
  "lazy_static",
  "log",
  "tracing-core",
@@ -2867,7 +2969,7 @@ version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd0568dbfe3baf7048b7908d2b32bca0d81cd56bec6d2a8f894b01d74f86be3"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.12.1",
  "chrono",
  "lazy_static",
  "matchers",
@@ -3091,6 +3193,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "xml-rs"

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -49,8 +49,7 @@ hyper = { version = "0.14.2", features = ["server"] }
 halfbrown = "0.1.11"
 
 # Transform dependencies
-redis-protocol = { git = "https://github.com/shotover/redis-protocol.rs", branch = "remove-parser" }
-
+redis-protocol = { git = "https://github.com/shotover/redis-protocol.rs", branch = "shotover_fork" }
 cassandra-proto = { git = "https://github.com/shotover/cassandra-proto", branch = "move-to-bytes", features = ["v4"]}
 rdkafka = { version = "0.26", features = ["cmake-build"] }
 crc16 = { version = "0.4.0"}

--- a/shotover-proxy/src/message/mod.rs
+++ b/shotover-proxy/src/message/mod.rs
@@ -9,7 +9,7 @@ use cassandra_proto::types::data_serialization_types::{
 use cassandra_proto::types::CBytes;
 use chrono::serde::ts_nanoseconds::serialize as to_nano_ts;
 use chrono::{DateTime, TimeZone, Utc};
-use redis_protocol::types::Frame;
+use redis_protocol::resp2::types::Frame;
 use serde::{Deserialize, Serialize};
 use sqlparser::ast::Statement;
 use std::collections::HashMap;
@@ -401,12 +401,6 @@ impl From<Frame> for Value {
             Frame::Integer(i) => Value::Integer(i),
             Frame::BulkString(b) => Value::Bytes(b),
             Frame::Array(a) => Value::List(a.iter().cloned().map(Value::from).collect()),
-            Frame::Moved { slot, host, port } => {
-                Value::Strings(format!("MOVED {} {}:{}", slot, host, port))
-            }
-            Frame::Ask { slot, host, port } => {
-                Value::Strings(format!("ASK {} {}:{}", slot, host, port))
-            }
             Frame::Null => Value::NULL,
         }
     }
@@ -419,12 +413,6 @@ impl From<&Frame> for Value {
             Frame::Integer(i) => Value::Integer(i),
             Frame::BulkString(b) => Value::Bytes(b),
             Frame::Array(a) => Value::List(a.iter().cloned().map(Value::from).collect()),
-            Frame::Moved { slot, host, port } => {
-                Value::Strings(format!("MOVED {} {}:{}", slot, host, port))
-            }
-            Frame::Ask { slot, host, port } => {
-                Value::Strings(format!("ASK {} {}:{}", slot, host, port))
-            }
             Frame::Null => Value::NULL,
         }
     }

--- a/shotover-proxy/src/protocols/mod.rs
+++ b/shotover-proxy/src/protocols/mod.rs
@@ -2,7 +2,7 @@ pub mod cassandra_protocol2;
 pub mod redis_codec;
 
 pub use cassandra_proto::frame::Frame as CassandraFrame;
-pub use redis_protocol::prelude::Frame as RedisFrame;
+pub use redis_protocol::resp2::prelude::Frame as RedisFrame;
 
 use anyhow::Result;
 use bytes::Bytes;
@@ -513,13 +513,6 @@ pub fn process_redis_frame(frame: &RedisFrame, response: bool) -> Result<Message
         RedisFrame::SimpleString(s) => handle_redis_string(s, decode_as_request),
         RedisFrame::BulkString(bs) => handle_redis_bulkstring(bs, decode_as_request),
         RedisFrame::Array(frames) => handle_redis_array(frames, decode_as_request),
-        RedisFrame::Moved { slot, host, port } => handle_redis_string(
-            format!("MOVED {} {}:{}", slot, host, port),
-            decode_as_request,
-        ),
-        RedisFrame::Ask { slot, host, port } => {
-            handle_redis_string(format!("ASK {} {}:{}", slot, host, port), decode_as_request)
-        }
         RedisFrame::Integer(i) => handle_redis_integer(i, decode_as_request),
         RedisFrame::Error(s) => handle_redis_error(s, decode_as_request),
         RedisFrame::Null => {

--- a/shotover-proxy/src/transforms/redis_transforms/redis_cluster_slot_rewrite.rs
+++ b/shotover-proxy/src/transforms/redis_transforms/redis_cluster_slot_rewrite.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
-pub use redis_protocol::prelude::Frame;
+use redis_protocol::resp2::prelude::Frame;
 use serde::Deserialize;
 
 use crate::config::topology::TopicHolder;
@@ -70,9 +70,9 @@ fn rewrite_port(frame: &mut RawFrame, new_port: u16) -> Result<()> {
                             [Frame::BulkString(_ip), Frame::Integer(port), ..] => {
                                 *port = new_port.into();
                             }
-                            _ => bail!("expected host-port in slot map but was: {}", frame),
+                            _ => bail!("expected host-port in slot map but was: {:?}", frame),
                         },
-                        _ => bail!("unexpected value in slot map: {}", frame),
+                        _ => bail!("unexpected value in slot map: {:?}", frame),
                     }
                 }
             };


### PR DESCRIPTION
This PR is a step towards https://github.com/shotover/shotover-proxy/issues/223
It swaps the redis-protocol git dependency to:
https://github.com/shotover/redis-protocol.rs/commits/shotover_fork
from:
https://github.com/shotover/redis-protocol.rs/commits/remove-parser

The actual changes to shotover_fork are to be reviewed in this PR https://github.com/shotover/redis-protocol.rs/pull/1

The changes in the new git dependency are a lot simpler and closer to master than the old dependency.
Please review the shotover/redis-protocol shotover_fork branch as part of this PR.

The only difference between redis-protocol master and the new branch is to change usages of `Vec<u8>` to `Bytes`.
Once this PR is merged, the next step will be to investigate if we should upstream the shotover_fork branch or if we should adapt shotover to work with `Vec<u8>` instead.

The benchmarks do not indicate any difference in performance.

I think one of the reviewers should be ben because he might have some insight into the code that was in the remove-parser fork that I am throwing away without reading.