### PR TITLE
fix shotover panicking when the trigger_shutdown_tx is dropped without first sending a shutdown message

### DIFF
--- a/shotover-proxy/src/runner.rs
+++ b/shotover-proxy/src/runner.rs
@@ -216,7 +216,7 @@ pub struct RunnerSpawned {
 pub async fn run(
     topology: Topology,
     config: Config,
-    trigger_shutdown_tx: watch::Receiver<bool>,
+    trigger_shutdown_rx: watch::Receiver<bool>,
 ) -> Result<()> {
     info!("Starting Shotover {}", crate_version!());
     info!(configuration = ?config);
@@ -232,7 +232,7 @@ pub async fn run(
         std::mem::size_of::<Wrapper<'_>>()
     );
 
-    match topology.run_chains(trigger_shutdown_tx).await {
+    match topology.run_chains(trigger_shutdown_rx).await {
         Ok((_, mut shutdown_complete_rx)) => {
             shutdown_complete_rx.recv().await;
             info!("Shotover was shutdown cleanly.");

--- a/shotover-proxy/src/server.rs
+++ b/shotover-proxy/src/server.rs
@@ -398,7 +398,6 @@ impl<C: Codec + 'static> Handler<C> {
             {
                 Ok(modified_message) => {
                     out_tx.send(modified_message)?;
-                    // let _ = self.chain.lua_runtime.gc_collect(); // TODO is this a good idea??
                 }
                 Err(e) => {
                     error!("chain processing error - {}", e);

--- a/shotover-proxy/src/sources/cassandra_source.rs
+++ b/shotover-proxy/src/sources/cassandra_source.rs
@@ -100,13 +100,6 @@ impl CassandraSource {
                 }
             }
 
-            let TcpCodecListener {
-                shutdown_complete_tx,
-                ..
-            } = listener;
-
-            drop(shutdown_complete_tx);
-
             Ok(())
         });
 

--- a/shotover-proxy/src/sources/redis_source.rs
+++ b/shotover-proxy/src/sources/redis_source.rs
@@ -93,16 +93,8 @@ impl RedisSource {
                     _ =  trigger_shutdown_rx.changed() => {
                         info!("redis source shutting down")
                     }
-
                 }
             }
-
-            let TcpCodecListener {
-                shutdown_complete_tx,
-                ..
-            } = listener;
-
-            drop(shutdown_complete_tx);
 
             Ok(())
         });


### PR DESCRIPTION
If there is a panic in an integration test we may also get a panic in shotover as below:
```
thread 'tokio-runtime-worker' panicked at 'called `Result::unwrap()` on an `Err` value: RecvError(())', shotover-proxy/src/server.rs:473:41
stack backtrace:
   0: rust_begin_unwind
             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panicking.rs:515:5
   1: core::panicking::panic_fmt
             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/panicking.rs:92:14
   2: core::result::unwrap_failed
             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/result.rs:1599:5
   3: core::result::Result<T,E>::unwrap
             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/result.rs:1281:23
   4: shotover_proxy::server::Shutdown::recv::{{closure}}
             at ./src/server.rs:473:13
   5: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/future/mod.rs:80:19
   6: shotover_proxy::server::Handler<C>::run::{{closure}}::{{closure}}
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/macros/select.rs:505:49
   7: <tokio::future::poll_fn::PollFn<F> as core::future::future::Future>::poll
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/future/poll_fn.rs:38:9
   8: shotover_proxy::server::Handler<C>::run::{{closure}}
             at ./src/server.rs:356:25
   9: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/future/mod.rs:80:19
  10: shotover_proxy::server::TcpCodecListener<C>::run::{{closure}}::{{closure}}
             at ./src/server.rs:193:35
  11: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/future/mod.rs:80:19
  12: tokio::runtime::task::core::CoreStage<T>::poll::{{closure}}
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/runtime/task/core.rs:161:17
  13: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/loom/std/unsafe_cell.rs:14:9
  14: tokio::runtime::task::core::CoreStage<T>::poll
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/runtime/task/core.rs:151:13
  15: tokio::runtime::task::harness::poll_future::{{closure}}
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/runtime/task/harness.rs:461:19
  16: <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panic.rs:347:9
  17: std::panicking::try::do_call
             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panicking.rs:401:40
  18: __rust_try
  19: std::panicking::try
             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panicking.rs:365:19
  20: std::panic::catch_unwind
             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panic.rs:434:14
  21: tokio::runtime::task::harness::poll_future
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/runtime/task/harness.rs:449:18
  22: tokio::runtime::task::harness::Harness<T,S>::poll_inner
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/runtime/task/harness.rs:98:27
  23: tokio::runtime::task::harness::Harness<T,S>::poll
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/runtime/task/harness.rs:53:15
  24: tokio::runtime::task::raw::poll
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/runtime/task/raw.rs:113:5
  25: tokio::runtime::task::raw::RawTask::poll
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/runtime/task/raw.rs:70:18
  26: tokio::runtime::task::LocalNotified<S>::run
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/runtime/task/mod.rs:343:9
  27: tokio::runtime::thread_pool::worker::Context::run_task::{{closure}}
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/runtime/thread_pool/worker.rs:420:13
  28: tokio::coop::with_budget::{{closure}}
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/coop.rs:106:9
  29: std::thread::local::LocalKey<T>::try_with
             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/thread/local.rs:399:16
  30: std::thread::local::LocalKey<T>::with
             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/thread/local.rs:375:9
  31: tokio::coop::with_budget
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/coop.rs:99:5
  32: tokio::coop::budget
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/coop.rs:76:5
  33: tokio::runtime::thread_pool::worker::Context::run_task
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/runtime/thread_pool/worker.rs:419:9
  34: tokio::runtime::thread_pool::worker::Context::run
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/runtime/thread_pool/worker.rs:386:24
  35: tokio::runtime::thread_pool::worker::run::{{closure}}
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/runtime/thread_pool/worker.rs:371:17
  36: tokio::macros::scoped_tls::ScopedKey<T>::set
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/macros/scoped_tls.rs:61:9
  37: tokio::runtime::thread_pool::worker::run
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/runtime/thread_pool/worker.rs:368:5
  38: tokio::runtime::thread_pool::worker::Launch::launch::{{closure}}
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/runtime/thread_pool/worker.rs:347:45
  39: <tokio::runtime::blocking::task::BlockingTask<T> as core::future::future::Future>::poll
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/runtime/blocking/task.rs:42:21
  40: tokio::runtime::task::core::CoreStage<T>::poll::{{closure}}
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/runtime/task/core.rs:161:17
  41: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/loom/std/unsafe_cell.rs:14:9
  42: tokio::runtime::task::core::CoreStage<T>::poll
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/runtime/task/core.rs:151:13
  43: tokio::runtime::task::harness::poll_future::{{closure}}
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/runtime/task/harness.rs:461:19
  44: <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panic.rs:347:9
  45: std::panicking::try::do_call
             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panicking.rs:401:40
  46: __rust_try
  47: std::panicking::try
             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panicking.rs:365:19
  48: std::panic::catch_unwind
             at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/panic.rs:434:14
  49: tokio::runtime::task::harness::poll_future
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/runtime/task/harness.rs:449:18
  50: tokio::runtime::task::harness::Harness<T,S>::poll_inner
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/runtime/task/harness.rs:98:27
  51: tokio::runtime::task::harness::Harness<T,S>::poll
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/runtime/task/harness.rs:53:15
  52: tokio::runtime::task::raw::poll
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/runtime/task/raw.rs:113:5
  53: tokio::runtime::task::raw::RawTask::poll
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/runtime/task/raw.rs:70:18
  54: tokio::runtime::task::UnownedTask<S>::run
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/runtime/task/mod.rs:379:9
  55: tokio::runtime::blocking::pool::Inner::run
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/runtime/blocking/pool.rs:265:17
  56: tokio::runtime::blocking::pool::Spawner::spawn_thread::{{closure}}
             at /home/rukai/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.12.0/src/runtime/blocking/pool.rs:245:17
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

This extra panic is quite confusing so this PR prevents that panic from happening by always attempting to shutdown shotover.