### PR TITLE
Fix silent failure in server encoder

### DIFF
--- a/shotover-proxy/src/protocols/redis_codec.rs
+++ b/shotover-proxy/src/protocols/redis_codec.rs
@@ -653,7 +653,7 @@ impl RedisCodec {
     fn encode_raw(&mut self, item: Frame, dst: &mut BytesMut) -> Result<()> {
         encode(dst, &item)
             .map(|_| ())
-            .map_err(|e| anyhow!("Uh - oh {} - {:#?}", e, item))
+            .map_err(|e| anyhow!("Redis encoding error: {} - {:#?}", e, item))
     }
 }
 

--- a/shotover-proxy/src/server.rs
+++ b/shotover-proxy/src/server.rs
@@ -314,8 +314,9 @@ fn spawn_read_write_tasks<
 
     tokio::spawn(async move {
         let rx_stream = UnboundedReceiverStream::new(out_rx).map(Ok);
-        let r = rx_stream.forward(writer).await;
-        debug!("Stream ended {:?}", r);
+        if let Err(err) = rx_stream.forward(writer).await {
+            error!("Stream ended with error {:?}", err);
+        }
     });
 }
 


### PR DESCRIPTION
With this PR when the encoder blows up we get an error like below:
```
Sep 30 16:47:46.812 ERROR shotover_proxy::server: Stream ended with error Redis encoding error: Encode Error: Invalid frame kind. - Array(
    [
        SimpleString(
            "OK",
        ),
        SimpleString(
            "OK",
        ),
        Array(
            [
                BulkString(
                    b"42",
                ),
                BulkString(
                    b"43",
                ),
            ],
        ),
    ],
)
```

Previously it just silently stopped sending data :no_mouth: 