### PR TITLE
Use upstream redis-proto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,15 +30,6 @@ dependencies = [
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
@@ -250,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
+checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
 
 [[package]]
 name = "cfg-if"
@@ -375,12 +366,6 @@ checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "crc16"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a65c4797332f3e3a5945e0377875afc79b1bdc87082a4f98ac1ef15b47e2dd"
 
 [[package]]
 name = "crc16"
@@ -717,19 +702,6 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
@@ -767,15 +739,6 @@ name = "event-listener"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
-
-[[package]]
-name = "float-cmp"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
-dependencies = [
- "num-traits 0.2.14",
-]
 
 [[package]]
 name = "fnv"
@@ -937,9 +900,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f3675cfef6a30c8031cf9e6493ebdc3bb3272a3fea3923c4210d1830e6a472"
+checksum = "6c06815895acec637cd6ed6e9662c935b866d20a106f8361892893a7d9234964"
 dependencies = [
  "bytes",
  "fnv",
@@ -1400,9 +1363,9 @@ dependencies = [
 
 [[package]]
 name = "minimal-lexical"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c835948974f68e0bd58636fc6c5b1fbff7b297e3046f11b3b3c18bbac012c6d"
+checksum = "9c64630dcdd71f1a64c435f54885086a0de5d6a12d104d69b165fb7d5286d677"
 
 [[package]]
 name = "mio"
@@ -1455,9 +1418,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7555d6c7164cc913be1ce7f95cbecdabda61eb2ccd89008524af306fb7f5031"
+checksum = "d3bb9a13fa32bc5aeb64150cd3f32d6cf4c748f8f8a417cce5d2eb976a8370ba"
 dependencies = [
  "bitflags",
  "cc",
@@ -1825,18 +1788,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
-name = "pretty_env_logger"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed8d1e63042e889b85228620629b51c011d380eed2c7e0015f8a644def280c28"
-dependencies = [
- "ansi_term 0.11.0",
- "chrono",
- "env_logger 0.5.13",
- "log",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,9 +1875,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
 ]
@@ -2107,7 +2058,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "combine",
- "crc16 0.4.0",
+ "crc16",
  "dtoa",
  "futures-util",
  "itoa",
@@ -2122,16 +2073,15 @@ dependencies = [
 
 [[package]]
 name = "redis-protocol"
-version = "3.0.0"
-source = "git+https://github.com/shotover/redis-protocol.rs?branch=shotover_fork#0e2fcf46165e90291ca962f6d64f8ca41c741d34"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26f7b2ced88925385105caeba1157cb8098d4c4923812bd8b86736b35216c1f5"
 dependencies = [
  "bytes",
  "cookie-factory",
- "crc16 0.3.4",
- "float-cmp",
+ "crc16",
  "log",
  "nom 6.1.2",
- "pretty_env_logger",
 ]
 
 [[package]]
@@ -2478,7 +2428,7 @@ dependencies = [
  "chrono",
  "clap 3.0.0-beta.4",
  "clap_derive",
- "crc16 0.4.0",
+ "crc16",
  "criterion",
  "derivative",
  "dns-parser",
@@ -2640,9 +2590,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.77"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5239bc68e0fef57495900cfea4e8dc75596d9a319d7e16b1e0a440d24e6fe0a0"
+checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2825,9 +2775,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
+checksum = "154794c8f499c2619acd19e839294703e9e32e7630ef5f46ea80d4ef0fbee5eb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2900,9 +2850,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f96e095c0c82419687c20ddf5cb3eadb61f4e1405923c9dc8e53a1adacbda8"
+checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
@@ -2923,9 +2873,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.16"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98863d0dd09fa59a1b79c6750ad80dbda6b75f4e71c437a6a1a8cb91a8bcbd77"
+checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2934,9 +2884,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46125608c26121c81b0c6d693eab5a420e416da7e43c426d2e8f7df8da8a3acf"
+checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 dependencies = [
  "lazy_static",
 ]
@@ -2947,7 +2897,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
 dependencies = [
- "env_logger 0.7.1",
+ "env_logger",
  "lazy_static",
  "log",
  "tracing-core",
@@ -2965,11 +2915,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.24"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd0568dbfe3baf7048b7908d2b32bca0d81cd56bec6d2a8f894b01d74f86be3"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
 dependencies = [
- "ansi_term 0.12.1",
+ "ansi_term",
  "chrono",
  "lazy_static",
  "matchers",

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -50,7 +50,7 @@ hyper = { version = "0.14.2", features = ["server"] }
 halfbrown = "0.1.11"
 
 # Transform dependencies
-redis-protocol = { git = "https://github.com/shotover/redis-protocol.rs", branch = "shotover_fork" }
+redis-protocol = "3.0.1"
 cassandra-proto = { git = "https://github.com/shotover/cassandra-proto", branch = "move-to-bytes", features = ["v4"] }
 rdkafka = { version = "0.26", features = ["cmake-build"] }
 crc16 = { version = "0.4.0" }

--- a/shotover-proxy/src/message/mod.rs
+++ b/shotover-proxy/src/message/mod.rs
@@ -399,7 +399,7 @@ impl From<Frame> for Value {
             Frame::SimpleString(s) => Value::Strings(s),
             Frame::Error(e) => Value::Strings(e),
             Frame::Integer(i) => Value::Integer(i),
-            Frame::BulkString(b) => Value::Bytes(b),
+            Frame::BulkString(b) => Value::Bytes(Bytes::from(b)),
             Frame::Array(a) => Value::List(a.iter().cloned().map(Value::from).collect()),
             Frame::Null => Value::NULL,
         }
@@ -411,7 +411,7 @@ impl From<&Frame> for Value {
             Frame::SimpleString(s) => Value::Strings(s),
             Frame::Error(e) => Value::Strings(e),
             Frame::Integer(i) => Value::Integer(i),
-            Frame::BulkString(b) => Value::Bytes(b),
+            Frame::BulkString(b) => Value::Bytes(Bytes::from(b)),
             Frame::Array(a) => Value::List(a.iter().cloned().map(Value::from).collect()),
             Frame::Null => Value::NULL,
         }
@@ -423,7 +423,7 @@ impl From<Value> for Frame {
         match value {
             Value::NULL => Frame::Null,
             Value::None => unimplemented!(),
-            Value::Bytes(b) => Frame::BulkString(b),
+            Value::Bytes(b) => Frame::BulkString(b.to_vec()),
             Value::Strings(s) => Frame::SimpleString(s),
             Value::Integer(i) => Frame::Integer(i),
             Value::Float(f) => Frame::SimpleString(f.to_string()),

--- a/shotover-proxy/src/protocols/redis_codec.rs
+++ b/shotover-proxy/src/protocols/redis_codec.rs
@@ -419,11 +419,14 @@ fn handle_redis_string(string: String, decode_as_response: bool) -> Result<Messa
     }
 }
 
-fn handle_redis_bulkstring(bulkstring: Bytes, decode_as_response: bool) -> Result<MessageDetails> {
+fn handle_redis_bulkstring(
+    bulkstring: Vec<u8>,
+    decode_as_response: bool,
+) -> Result<MessageDetails> {
     if decode_as_response {
         Ok(MessageDetails::Response(QueryResponse {
             matching_query: None,
-            result: Some(Value::Bytes(bulkstring)),
+            result: Some(Value::Bytes(Bytes::from(bulkstring))),
             error: None,
             response_meta: None,
         }))

--- a/shotover-proxy/src/transforms/redis_transforms/redis_cluster.rs
+++ b/shotover-proxy/src/transforms/redis_transforms/redis_cluster.rs
@@ -5,7 +5,6 @@ use async_trait::async_trait;
 use derivative::Derivative;
 use futures::stream::FuturesUnordered;
 use futures::{Future, StreamExt, TryFutureExt};
-use hyper::body::Bytes;
 use metrics::counter;
 use rand::prelude::SmallRng;
 use rand::SeedableRng;
@@ -644,8 +643,8 @@ async fn get_topology_from_node(
     let return_chan_rx = send_frame_request(
         &sender,
         Frame::Array(vec![
-            Frame::BulkString(Bytes::from("CLUSTER")),
-            Frame::BulkString(Bytes::from("SLOTS")),
+            Frame::BulkString(b"CLUSTER".to_vec()),
+            Frame::BulkString(b"SLOTS".to_vec()),
         ]),
     )?;
 
@@ -843,11 +842,11 @@ impl Transform for RedisCluster {
 #[derive(Clone, PartialEq, Eq, Hash, Derivative)]
 #[derivative(Debug)]
 pub struct UsernamePasswordToken {
-    pub username: Option<Bytes>,
+    pub username: Option<Vec<u8>>,
 
     // Reduce risk of logging passwords.
     #[derivative(Debug = "ignore")]
-    pub password: Bytes,
+    pub password: Vec<u8>,
 }
 
 #[derive(Clone)]
@@ -862,7 +861,7 @@ impl Authenticator<UsernamePasswordToken> for RedisAuthenticator {
         sender: &mut UnboundedSender<Request>,
         token: &UsernamePasswordToken,
     ) -> Result<(), TransformError> {
-        let mut auth_args = vec![Frame::BulkString(Bytes::from("AUTH"))];
+        let mut auth_args = vec![Frame::BulkString(b"AUTH".to_vec())];
 
         // Support non-ACL / username-less.
         if let Some(username) = &token.username {

--- a/shotover-proxy/src/transforms/redis_transforms/redis_cluster_slot_rewrite.rs
+++ b/shotover-proxy/src/transforms/redis_transforms/redis_cluster_slot_rewrite.rs
@@ -107,29 +107,28 @@ mod test {
         protocols::redis_codec::RedisCodec,
         transforms::redis_transforms::redis_cluster::parse_slots,
     };
-    use hyper::body::Bytes;
     use tokio_util::codec::Decoder;
 
     #[test]
     fn test_is_cluster_slots() {
         let combos = [
-            ("cluster", "slots"),
-            ("CLUSTER", "SLOTS"),
-            ("cluster", "SLOTS"),
-            ("CLUSTER", "slots"),
+            (b"cluster", b"slots"),
+            (b"CLUSTER", b"SLOTS"),
+            (b"cluster", b"SLOTS"),
+            (b"CLUSTER", b"slots"),
         ];
 
         for combo in combos {
             let frame = RawFrame::Redis(Frame::Array(vec![
-                Frame::BulkString(Bytes::from(combo.0)),
-                Frame::BulkString(Bytes::from(combo.1)),
+                Frame::BulkString(combo.0.to_vec()),
+                Frame::BulkString(combo.1.to_vec()),
             ]));
             assert!(is_cluster_slots(&frame));
         }
 
         let frame = RawFrame::Redis(Frame::Array(vec![
-            Frame::BulkString(Bytes::from("GET")),
-            Frame::BulkString(Bytes::from("key1")),
+            Frame::BulkString(b"GET".to_vec()),
+            Frame::BulkString(b"key1".to_vec()),
         ]));
 
         assert!(!is_cluster_slots(&frame));


### PR DESCRIPTION
closes https://github.com/shotover/shotover-proxy/issues/223

All of the upstreaming PRs I made to https://github.com/aembke/redis-protocol.rs/pulls have been merged and published to crates.io.
So this PR moves shotover to use the 3.0.1 release of redis-protocol.

Performance implications:
* Going from `Vec<u8>` -> `Bytes` should be free. We just need to wrap the heap pointer to heap in a reference counter. [^1]
* Going from Bytes -> Vec<u8> will be expensive as it needs to copy the entire value as the Bytes can not transfer ownership due to being behind a reference counter.

The only benchmark that takes this expensive path is redis_active.
So we should consider this benchmark when evaluating
Possibly this benchmark has a lot of other things getting in the way of evaluating changes here and we should come up with a new benchmark to properly evaluate this change.

Running on main I got:
```
run 1
redis_active            time:   [145.15 us 146.74 us 148.39 us]                         
                        change: [-7.5556% -5.8868% -4.1842%] (p = 0.00 < 0.05)
                        Performance has improved.

run 2
redis_active            time:   [157.02 us 159.20 us 161.26 us]                         
                        change: [+6.1064% +7.9610% +9.9223%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) low mild
```

Running on redis_proto_upstream I got:
```
run 1
redis_active            time:   [139.94 us 143.60 us 147.29 us]                         
                        change: [-7.3755% -5.3071% -3.2769%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) low mild
  
run 2
redis_active            time:   [154.97 us 156.88 us 158.89 us]                         
                        change: [+1.3008% +3.4575% +5.7928%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) low mild
  4 (4.00%) high mild
```

So no observable difference

[^1]: https://docs.rs/bytes/1.1.0/src/bytes/bytes.rs.html#798-803