### PR TITLE
Skip container setup when skipping benchmark

### DIFF
--- a/shotover-proxy/benches/redis_benches.rs
+++ b/shotover-proxy/benches/redis_benches.rs
@@ -5,106 +5,126 @@ use test_helpers::docker_compose::DockerCompose;
 mod helpers;
 use helpers::ShotoverManager;
 
-fn redis_active(c: &mut Criterion) {
-    let _compose = DockerCompose::new("examples/redis-multi/docker-compose.yml")
-        .wait_for_n("Ready to accept connections", 3);
-    let shotover_manager =
-        ShotoverManager::from_topology_file("examples/redis-multi/topology.yaml");
+fn redis(c: &mut Criterion) {
+    let mut group = c.benchmark_group("redis");
+    group.throughput(criterion::Throughput::Elements(1));
 
-    let mut connection = shotover_manager.redis_connection(6379);
-    redis::cmd("FLUSHDB").execute(&mut connection);
+    {
+        let mut state = None;
+        group.bench_function("active", move |b| {
+            b.iter(|| {
+                let state = state.get_or_insert_with(|| {
+                    let compose = DockerCompose::new("examples/redis-multi/docker-compose.yml")
+                        .wait_for_n("Ready to accept connections", 3);
+                    let shotover_manager =
+                        ShotoverManager::from_topology_file("examples/redis-multi/topology.yaml");
+                    BenchResources::new(shotover_manager, compose)
+                });
+                redis::cmd("SET")
+                    .arg("foo")
+                    .arg(42)
+                    .execute(&mut state.connection);
+            })
+        });
+    }
 
-    c.bench_function("redis_active", move |b| {
-        b.iter(|| {
-            redis::cmd("SET")
-                .arg("foo")
-                .arg(42)
-                .execute(&mut connection);
-        })
-    });
+    {
+        let mut state = None;
+        group.bench_function("cluster", move |b| {
+            b.iter(|| {
+                let state = state.get_or_insert_with(|| {
+                    let compose = DockerCompose::new("examples/redis-cluster/docker-compose.yml")
+                        .wait_for_n("Cluster state changed", 6);
+                    let shotover_manager =
+                        ShotoverManager::from_topology_file("examples/redis-cluster/topology.yaml");
+                    BenchResources::new(shotover_manager, compose)
+                });
+                redis::cmd("SET")
+                    .arg("foo")
+                    .arg(42)
+                    .execute(&mut state.connection);
+            })
+        });
+    }
+
+    {
+        let mut state = None;
+        group.bench_function("passthrough", move |b| {
+            let state = state.get_or_insert_with(|| {
+                let compose = DockerCompose::new("examples/redis-passthrough/docker-compose.yml")
+                    .wait_for("Ready to accept connections");
+                let shotover_manager =
+                    ShotoverManager::from_topology_file("examples/redis-passthrough/topology.yaml");
+                BenchResources::new(shotover_manager, compose)
+            });
+            b.iter(|| {
+                redis::cmd("SET")
+                    .arg("foo")
+                    .arg(42)
+                    .execute(&mut state.connection);
+            })
+        });
+    }
+
+    {
+        let mut state = None;
+        group.bench_function("destination_tls", move |b| {
+            b.iter(|| {
+                let state = state.get_or_insert_with(|| {
+                    let compose = DockerCompose::new("examples/redis-tls/docker-compose.yml")
+                        .wait_for("Ready to accept connections");
+                    let shotover_manager =
+                        ShotoverManager::from_topology_file("examples/redis-tls/topology.yaml");
+                    BenchResources::new(shotover_manager, compose)
+                });
+                redis::cmd("SET")
+                    .arg("foo")
+                    .arg(42)
+                    .execute(&mut state.connection);
+            })
+        });
+    }
+
+    {
+        let mut state = None;
+        group.bench_function("cluster_tls", move |b| {
+            b.iter(|| {
+                let state = state.get_or_insert_with(|| {
+                    let compose =
+                        DockerCompose::new("examples/redis-cluster-tls/docker-compose.yml")
+                            .wait_for_n("Cluster state changed", 6);
+                    let shotover_manager = ShotoverManager::from_topology_file(
+                        "examples/redis-cluster-tls/topology.yaml",
+                    );
+                    BenchResources::new(shotover_manager, compose)
+                });
+                redis::cmd("SET")
+                    .arg("foo")
+                    .arg(42)
+                    .execute(&mut state.connection);
+            })
+        });
+    }
 }
 
-fn redis_cluster(c: &mut Criterion) {
-    let _compose = DockerCompose::new("examples/redis-cluster/docker-compose.yml")
-        .wait_for_n("Cluster state changed", 6);
-    let shotover_manager =
-        ShotoverManager::from_topology_file("examples/redis-cluster/topology.yaml");
-
-    let mut connection = shotover_manager.redis_connection(6379);
-    redis::cmd("FLUSHDB").execute(&mut connection);
-
-    c.bench_function("redis_cluster", move |b| {
-        b.iter(|| {
-            redis::cmd("SET")
-                .arg("foo")
-                .arg(42)
-                .execute(&mut connection);
-        })
-    });
-}
-
-fn redis_passthrough(c: &mut Criterion) {
-    let _compose = DockerCompose::new("examples/redis-passthrough/docker-compose.yml")
-        .wait_for("Ready to accept connections");
-    let shotover_manager =
-        ShotoverManager::from_topology_file("examples/redis-passthrough/topology.yaml");
-
-    let mut connection = shotover_manager.redis_connection(6379);
-    redis::cmd("FLUSHDB").execute(&mut connection);
-
-    c.bench_function("redis_passthrough", move |b| {
-        b.iter(|| {
-            redis::cmd("SET")
-                .arg("foo")
-                .arg(42)
-                .execute(&mut connection);
-        })
-    });
-}
-
-fn redis_destination_tls(c: &mut Criterion) {
-    let _compose = DockerCompose::new("examples/redis-tls/docker-compose.yml")
-        .wait_for("Ready to accept connections");
-    let shotover_manager = ShotoverManager::from_topology_file("examples/redis-tls/topology.yaml");
-
-    let mut connection = shotover_manager.redis_connection(6379);
-    redis::cmd("FLUSHDB").execute(&mut connection);
-
-    c.bench_function("redis_destination_tls", move |b| {
-        b.iter(|| {
-            redis::cmd("SET")
-                .arg("foo")
-                .arg(42)
-                .execute(&mut connection);
-        })
-    });
-}
-
-fn redis_cluster_tls(c: &mut Criterion) {
-    let _compose = DockerCompose::new("examples/redis-cluster-tls/docker-compose.yml")
-        .wait_for_n("Cluster state changed", 6);
-    let shotover_manager =
-        ShotoverManager::from_topology_file("examples/redis-cluster-tls/topology.yaml");
-
-    let mut connection = shotover_manager.redis_connection(6379);
-    redis::cmd("FLUSHDB").execute(&mut connection);
-
-    c.bench_function("redis_cluster_tls", move |b| {
-        b.iter(|| {
-            redis::cmd("SET")
-                .arg("foo")
-                .arg(42)
-                .execute(&mut connection);
-        })
-    });
-}
-
-criterion_group!(
-    benches,
-    redis_cluster,
-    redis_passthrough,
-    redis_active,
-    redis_destination_tls,
-    redis_cluster_tls,
-);
+criterion_group!(benches, redis);
 criterion_main!(benches);
+
+struct BenchResources {
+    _compose: DockerCompose,
+    _shotover_manager: ShotoverManager,
+    connection: redis::Connection,
+}
+
+impl BenchResources {
+    fn new(shotover_manager: ShotoverManager, compose: DockerCompose) -> Self {
+        let mut connection = shotover_manager.redis_connection(6379);
+        redis::cmd("FLUSHDB").execute(&mut connection);
+
+        Self {
+            _compose: compose,
+            _shotover_manager: shotover_manager,
+            connection,
+        }
+    }
+}


### PR DESCRIPTION
Currently every bench mark runs its init code regardless of if the actual benchmark is run or not. e.g. via cargo bench some_bench_name
This is making it very difficult for me to investigate benchmark issues and to write new benchmarks.

To solve this issue I moved the init code to run in the first iteration of the benchmark.
Although this completely destroys the time to complete for the first iteration, this seems to have no effect on the result as it is ignored as an outlier.

A preferred solution would be to have criterion to provide some kind of one time setup abstraction https://github.com/bheisler/criterion.rs/issues/514
But I dont think implementing that is a great idea atm, because I suspect criterion might not be the best way to measure these large integration tests anyway.

As a bonus I enabled `group.throughput(criterion::Throughput::Elements(1));` which shows request throughput in the final results.