### PR TITLE
give a nice panic message when there is no terminating transform

### DIFF
--- a/shotover-proxy/src/transforms/mod.rs
+++ b/shotover-proxy/src/transforms/mod.rs
@@ -272,6 +272,9 @@ tokio::task_local! {
 
 impl<'a> Wrapper<'a> {
     pub async fn call_next_transform(mut self) -> ChainResponse {
+        if self.transforms.is_empty() {
+            panic!("The transform chain does not end with a terminating transform. If you want to throw the messages away use a Null transform, otherwise use a Destination transform to send the messages somewhere.");
+        }
         let transform = self.transforms.remove(0);
 
         let transform_name = transform.get_name();
@@ -287,10 +290,6 @@ impl<'a> Wrapper<'a> {
         }
         histogram!("shotover_transform_latency", start.elapsed(),  "transform" => transform_name);
         result
-    }
-
-    pub fn swap_message(&mut self, mut m: Messages) {
-        std::mem::swap(&mut self.message, &mut m);
     }
 
     pub fn new(m: Messages) -> Self {


### PR DESCRIPTION
I hit this while working on benchmarks

This is just a temporary measure, ideally we would detect this when loading the topology.yaml but implementing that will be part of a comprehensive validation solution as per:  https://github.com/shotover/shotover-proxy/issues/254