### PR TITLE
Fix benchmark CI

### DIFF
--- a/.github/workflows/create_comment.yml
+++ b/.github/workflows/create_comment.yml
@@ -38,6 +38,9 @@ jobs:
             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "comment_info"
             })[0];
+            if (!matchArtifact) {
+              throw 'comment_info artifact was not produced by the previous workflow';
+            }
             var download = await github.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
@@ -53,7 +56,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             var fs = require('fs');
-            if (fs.exists('./issue_number.txt')) {
+            if (fs.existsSync('./issue_number.txt')) {
               var issue_number = Number(fs.readFileSync('./issue_number.txt'));
               var message = fs.readFileSync('./message.txt');
               await github.issues.createComment({

--- a/shotover-proxy/tests/scripts/bench_against_master.sh
+++ b/shotover-proxy/tests/scripts/bench_against_master.sh
@@ -29,3 +29,6 @@ if [ "$COUNT" != "0" ]; then
   echo "$COUNT benchmarks reported regressed performance. Please check the benchmark workflow logs for details: $LOG_PAGE" > comment_info/message.txt
   echo "$GITHUB_EVENT_NUMBER" > ./comment_info/issue_number.txt
 fi
+
+# Need to manually exit with 0 otherwise we get the return value of the if statement which can be 1 or 0 depending on if it executes the branch or not.
+exit 0


### PR DESCRIPTION
* raises an exception when we dont get a matchArtifact, I have only seen this happen when the bench pr workflow fails, but the comment workflow should not run when the previous workflow fails :shrug:  At least this provides a more informative error for a case that we dont particularly care about.
* exists does not do what we want, we should have used existsSync: https://nodejs.org/api/fs.html#fs_fs_existssync_path