### PR TITLE
Fix bench reporting

### DIFF
--- a/.github/workflows/create_comment.yml
+++ b/.github/workflows/create_comment.yml
@@ -58,7 +58,7 @@ jobs:
             var fs = require('fs');
             if (fs.existsSync('./issue_number.txt')) {
               var issue_number = Number(fs.readFileSync('./issue_number.txt'));
-              var message = fs.readFileSync('./message.txt');
+              var message = fs.readFileSync('./message.txt', 'utf8');
               await github.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,


### PR DESCRIPTION
readFileSync only returns a string when an encoding is specified as the second arg.
https://nodejs.org/api/fs.html#fs_fs_readfilesync_path_options