### PR TITLE
rust 2021 🎉🦀

### DIFF
--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -2,7 +2,8 @@
 name = "shotover-proxy"
 version = "0.0.23"
 authors = ["Ben <ben@instaclustr.com>"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/test-helpers/Cargo.toml
+++ b/test-helpers/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "test-helpers"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html
The new rust-version field mean developers get a nice message when their rust version is unsupported.