### PR TITLE
Bump version to v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2434,7 +2434,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "shotover-proxy"
-version = "0.0.23"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shotover-proxy"
-version = "0.0.23"
+version = "0.1.0"
 authors = ["Ben <ben@instaclustr.com>"]
 edition = "2021"
 rust-version = "1.56"


### PR DESCRIPTION
A new release is needed with functionality from #275 for INS-15988. I am bumping the minor version, roughly following SemVer, although we're being flexible with pre-1.0 in regards to the definition of a 'breaking change'.