### PR TITLE
Set Cassandra maximum heap size

### DIFF
--- a/shotover-proxy/examples/cass-redis-kafka/docker-compose.yml
+++ b/shotover-proxy/examples/cass-redis-kafka/docker-compose.yml
@@ -8,6 +8,10 @@ services:
     image: library/cassandra:3.11.6
     ports:
       - "9043:9042"
+    environment:
+      MAX_HEAP_SIZE: "128M"
+      MIN_HEAP_SIZE: "128M"
+      HEAP_NEWSIZE: "24M"
   zookeeper-one:
     image: wurstmeister/zookeeper
     ports:

--- a/shotover-proxy/examples/cassandra-standalone/docker-compose.yml
+++ b/shotover-proxy/examples/cassandra-standalone/docker-compose.yml
@@ -4,3 +4,7 @@ services:
     image: library/cassandra:3.11.10
     ports:
       - "9043:9042"
+    environment:
+      MAX_HEAP_SIZE: "128M"
+      MIN_HEAP_SIZE: "128M"
+      HEAP_NEWSIZE: "24M"

--- a/shotover-proxy/examples/null-cassandra/config.yaml
+++ b/shotover-proxy/examples/null-cassandra/config.yaml
@@ -1,3 +1,0 @@
----
-main_log_level: "info,shotover_proxy=info"
-observability_interface: "0.0.0.0:9001"

--- a/shotover-proxy/examples/null-redis/config.yaml
+++ b/shotover-proxy/examples/null-redis/config.yaml
@@ -1,3 +1,0 @@
----
-main_log_level: "info,shotover_proxy=info"
-observability_interface: "0.0.0.0:9001"


### PR DESCRIPTION
- Save some resources when running the Cassandra docker containers by setting the maximum heap size. Does not affect anything as the containers will run fine with the amount I've set.
- Remove some unused config files in `null-redis` and `null-cassandra`