### PR TITLE
Update deps and add deps.rs badge to readme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ dependencies = [
  "serde",
  "snap",
  "syn",
- "time",
+ "time 0.1.43",
  "uuid",
 ]
 
@@ -288,7 +288,7 @@ dependencies = [
  "num-integer",
  "num-traits 0.2.14",
  "serde",
- "time",
+ "time 0.1.43",
  "winapi",
 ]
 
@@ -1267,9 +1267,9 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.0.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata",
 ]
@@ -2782,6 +2782,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99beeb0daeac2bd1e86ac2c21caddecb244b39a093594da1a661ec2060c7aedd"
+dependencies = [
+ "itoa",
+ "libc",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2939,12 +2949,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9965507e507f12c8901432a33e31131222abac31edd90cabbcf85cf544b7127a"
+checksum = "94571df2eae3ed4353815ea5a90974a594a1792d8782ff2cbcc9392d1101f366"
 dependencies = [
- "chrono",
  "crossbeam-channel 0.5.1",
+ "time 0.3.4",
  "tracing-subscriber",
 ]
 
@@ -2981,35 +2991,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
-version = "0.2.25"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+checksum = "80a4ddde70311d8da398062ecf6fc2c309337de6b0f77d6c27aff8d53f6fca52"
 dependencies = [
  "ansi_term",
- "chrono",
  "lazy_static",
  "matchers",
  "regex",
- "serde",
- "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 </p>
 
 [![Rust](https://github.com/shotover/shotover-proxy/workflows/Rust/badge.svg)](https://github.com/shotover/shotover-proxy/actions?query=workflow%3ARust)
+[![dependency status](https://deps.rs/repo/github/shotover/shotover-proxy/status.svg)](https://deps.rs/repo/github/shotover/shotover-proxy)
 
 ## Documentation
 For full documentation please go to [https://docs.shotover.io/](https://docs.shotover.io/)

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -38,17 +38,17 @@ anyhow = "1.0.31"
 sqlparser = "= 0.5.0"
 serde = { version = "1.0.111", features = ["derive"] }
 serde_json = "1.0"
-serde_yaml = "0.8"
+serde_yaml = "0.8.21"
 bincode = "1.3.1"
 
 #Observability
 metrics = "0.17.0"
 metrics-exporter-prometheus = "0.6.0"
 tracing = { version = "0.1.15", features = ["release_max_level_info"] }
-tracing-subscriber = { version = "0.2.11", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.1", features = ["env-filter"] }
 tracing-log = { version = "0.1.1", features = ["env_logger"] }
-tracing-appender = "0.1.1"
-hyper = { version = "0.14.2", features = ["server"] }
+tracing-appender = "0.2.0"
+hyper = { version = "0.14.14", features = ["server"] }
 halfbrown = "0.1.11"
 
 # Transform dependencies


### PR DESCRIPTION
I've been waiting to be able to finally add this badge!

Its a bit unfortunate that the versions in the Cargo.lock are not enough to avoid the insecure warnings and we need to manually update the Cargo.toml, but I think its still super valuable to get insight into this.