### PR TITLE
Test some untested examples

### DIFF
--- a/shotover-proxy/examples/cass-redis-kafka/docker-compose.yml
+++ b/shotover-proxy/examples/cass-redis-kafka/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - "6378:6379"
   cassandra-one:
-    image: library/cassandra:3.11.6
+    image: library/cassandra:3.11.10
     ports:
       - "9043:9042"
     environment:

--- a/shotover-proxy/examples/cass-redis-kafka/topology.yaml
+++ b/shotover-proxy/examples/cass-redis-kafka/topology.yaml
@@ -21,17 +21,29 @@ chain_config:
   redis_chain:
     - Tee:
         topic_name: testtopic
+        chain:
+          - Null
     - RedisSinkSingle:
         remote_address: "127.0.0.1:6378"
   main_chain:
     - Tee:
         topic_name: testtopic
+        chain:
+          - Null
     - RedisCache:
         config_values: "redis://127.0.0.1/"
+        caching_schema:
+          test:
+            partition_key: [test]
+            range_key: [test]
+        chain:
+          - Null
     - CassandraSinkSingle:
         remote_address: "127.0.0.1:9043"
+        result_processing: false
   async_chain:
     - KafkaSink:
+        topic: testtopic
         config_values:
           bootstrap.servers: "127.0.0.1:9092"
           message.timeout.ms: "5000"

--- a/shotover-proxy/tests/test_examples.rs
+++ b/shotover-proxy/tests/test_examples.rs
@@ -1,0 +1,25 @@
+mod helpers;
+
+use helpers::ShotoverManager;
+use serial_test::serial;
+use test_helpers::docker_compose::DockerCompose;
+
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn test_cass_redis_kafka_topology_valid() {
+    let _compose = DockerCompose::new("examples/cass-redis-kafka/docker-compose.yml")
+        .wait_for_n("Startup complete", 1);
+
+    let _shotover_proxy =
+        ShotoverManager::from_topology_file("examples/cass-redis-kafka/topology.yaml");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn test_cassandra_standalone() {
+    let _compose = DockerCompose::new("examples/cassandra-standalone/docker-compose.yml")
+        .wait_for_n("Startup complete", 1);
+
+    let _shotover_proxy =
+        ShotoverManager::from_topology_file("examples/cassandra-standalone/topology.yaml");
+}

--- a/test-helpers/src/docker_compose.rs
+++ b/test-helpers/src/docker_compose.rs
@@ -107,7 +107,7 @@ impl DockerCompose {
         let sys_time = time::Instant::now();
         let mut result = run_command("docker-compose", &args).unwrap();
         while re.find_iter(&result).count() < count {
-            if sys_time.elapsed().as_secs() > 30 {
+            if sys_time.elapsed().as_secs() > 90 {
                 panic!("wait_for_n timer expired. Log output: {}", result);
             }
             debug!("wait_for_n: looping");


### PR DESCRIPTION
Add 2 small tests that check Shotover will work with `cass-redis-kafka` and `cassandra-standalone`, which were previously untested.

Also pull in some work from #256 needed to check that Cassandra containers have started. 