### PR TITLE
Refactor getting started docs

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,6 @@
 # Contributing to Shotover
 
-This guide contains tips and tricks for working on Shotover Proxy itself. See [transform-development](transforms/transforms.md) for details on writing your own transforms.
+This guide contains tips and tricks for working on Shotover Proxy itself. See [transform-development](transform-development.md) for details on writing your own transforms.
 
 ## Building Shotover
 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -6,10 +6,10 @@
 2. **Run** - cd into the extracted `shotover` folder and run `./shotover-proxy`. Shotover will launch and display some logs.
 3. **Examine Config** - Shotover has two configuration files:
     * `config/config.yaml` - This is used to configure logging and metrics.
-    * `config/topology.yaml` - This defines how shotover receives, transforms and delivers messages.
+    * `config/topology.yaml` - This defines how Shotover receives, transforms and delivers messages.
 4. **Configure topology** - Open `topology.yaml` in your text editor and edit it to define the sources and transforms you need, the comments in the file will direct you to suitable documentation. Alternatively you can refer to the [Deployment Scenarios](#deployment-scenarios) section for full `topology.yaml` examples.
-5. **Rerun** - Shutover currently doesn't support hot-reloading config, so first shut it down with ctrl-c. Then rerun `./shotover-proxy` for your new config to take effect.
-6. **Test** - Send a message to shotover as per your configuration and observe it delivered to its configured destination database.
+5. **Rerun** - Shotover currently doesn't support hot-reloading config, so first shut it down with ctrl-c. Then rerun `./shotover-proxy` for your new config to take effect.
+6. **Test** - Send a message to Shotover as per your configuration and observe it is delivered to it's configured destination database.
 
 To see Shotover's command line arguments run: `./shotover-proxy --help`
 


### PR DESCRIPTION
I deleted some lines that say something that only makes sense to someone who already knows that.
e.g. "you may choose to place it in your path", if you know what it means to place something in your path then you already know that shotover could be placed in your path

I tried to make sure that starting from the getting-started page, the user can go from knowing nothing about shotover to having shotover setup with the configuration they need.