### PR TITLE
Refactor TcpCodecListener

### DIFF
--- a/shotover-proxy/src/server.rs
+++ b/shotover-proxy/src/server.rs
@@ -38,16 +38,16 @@ pub struct TcpCodecListener<C: Codec> {
     ///
     /// This is a wrapper around an `Arc`. This enables `db` to be cloned and
     /// passed into the per connection state (`Handler`).
-    pub chain: TransformChain,
+    chain: TransformChain,
 
-    pub source_name: String,
+    source_name: String,
 
     /// TCP listener supplied by the `run` caller.
-    pub listener: Option<TcpListener>,
-    pub listen_addr: String,
-    pub hard_connection_limit: bool,
+    listener: Option<TcpListener>,
+    listen_addr: String,
+    hard_connection_limit: bool,
 
-    pub codec: C,
+    codec: C,
 
     /// Limit the max number of connections.
     ///
@@ -57,7 +57,7 @@ pub struct TcpCodecListener<C: Codec> {
     ///
     /// When handlers complete processing a connection, the permit is returned
     /// to the semaphore.
-    pub limit_connections: Arc<Semaphore>,
+    limit_connections: Arc<Semaphore>,
 
     /// Broadcasts a shutdown signal to all active connections.
     ///
@@ -67,16 +67,41 @@ pub struct TcpCodecListener<C: Codec> {
     /// handle. When a graceful shutdown is initiated, a `true` value is sent via
     /// the watch::Sender. Each active connection receives it, reaches a
     /// safe terminal state, and completes the task.
-    pub trigger_shutdown_rx: watch::Receiver<bool>,
+    trigger_shutdown_rx: watch::Receiver<bool>,
 
     /// Used as part of the graceful shutdown process to wait for client
     /// connections to complete processing.
-    pub shutdown_complete_tx: mpsc::Sender<()>,
+    shutdown_complete_tx: mpsc::Sender<()>,
 
-    pub tls: Option<TlsAcceptor>,
+    tls: Option<TlsAcceptor>,
 }
 
 impl<C: Codec + 'static> TcpCodecListener<C> {
+    pub fn new(
+        chain: TransformChain,
+        source_name: String,
+        listen_addr: String,
+        hard_connection_limit: bool,
+        codec: C,
+        limit_connections: Arc<Semaphore>,
+        trigger_shutdown_rx: watch::Receiver<bool>,
+        shutdown_complete_tx: mpsc::Sender<()>,
+        tls: Option<TlsAcceptor>,
+    ) -> Self {
+        TcpCodecListener {
+            chain,
+            source_name,
+            listener: None,
+            listen_addr,
+            hard_connection_limit,
+            codec,
+            limit_connections,
+            trigger_shutdown_rx,
+            shutdown_complete_tx,
+            tls,
+        }
+    }
+
     /// Run the server
     ///
     /// Listen for inbound connections. For each inbound connection, spawn a

--- a/shotover-proxy/src/sources/cassandra_source.rs
+++ b/shotover-proxy/src/sources/cassandra_source.rs
@@ -72,18 +72,17 @@ impl CassandraSource {
 
         info!("Starting Cassandra source on [{}]", listen_addr);
 
-        let mut listener = TcpCodecListener {
-            chain: chain.clone(),
-            source_name: name.to_string(),
-            listener: None,
-            listen_addr: listen_addr.clone(),
-            hard_connection_limit: hard_connection_limit.unwrap_or(false),
-            codec: CassandraCodec2::new(cassandra_ks, !query_processing),
-            limit_connections: Arc::new(Semaphore::new(connection_limit.unwrap_or(512))),
-            trigger_shutdown_rx: trigger_shutdown_rx.clone(),
+        let mut listener = TcpCodecListener::new(
+            chain.clone(),
+            name.to_string(),
+            listen_addr.clone(),
+            hard_connection_limit.unwrap_or(false),
+            CassandraCodec2::new(cassandra_ks, !query_processing),
+            Arc::new(Semaphore::new(connection_limit.unwrap_or(512))),
+            trigger_shutdown_rx.clone(),
             shutdown_complete_tx,
-            tls: None,
-        };
+            None,
+        );
 
         let join_handle = Handle::current().spawn(async move {
             // Check we didn't receive a shutdown signal before the receiver was created

--- a/shotover-proxy/src/sources/redis_source.rs
+++ b/shotover-proxy/src/sources/redis_source.rs
@@ -65,18 +65,17 @@ impl RedisSource {
         info!("Starting Redis source on [{}]", listen_addr);
         let name = "Redis Source";
 
-        let mut listener = TcpCodecListener {
-            chain: chain.clone(),
-            source_name: name.to_string(),
-            listener: None,
-            listen_addr: listen_addr.clone(),
-            hard_connection_limit: hard_connection_limit.unwrap_or(false),
-            codec: RedisCodec::new(DecodeType::Query),
-            limit_connections: Arc::new(Semaphore::new(connection_limit.unwrap_or(512))),
-            trigger_shutdown_rx: trigger_shutdown_rx.clone(),
+        let mut listener = TcpCodecListener::new(
+            chain.clone(),
+            name.to_string(),
+            listen_addr.clone(),
+            hard_connection_limit.unwrap_or(false),
+            RedisCodec::new(DecodeType::Query),
+            Arc::new(Semaphore::new(connection_limit.unwrap_or(512))),
+            trigger_shutdown_rx.clone(),
             shutdown_complete_tx,
-            tls: tls.map(TlsAcceptor::new).transpose()?,
-        };
+            tls.map(TlsAcceptor::new).transpose()?,
+        );
 
         let join_handle = Handle::current().spawn(async move {
             // Check we didn't receive a shutdown signal before the receiver was created


### PR DESCRIPTION
This is a pre-req for my fix for #295 as I need use a `new` method to register metric recorders for the listener when it's created.