### PR TITLE
Fix get_source methods

### DIFF
--- a/shotover-proxy/src/server.rs
+++ b/shotover-proxy/src/server.rs
@@ -77,6 +77,7 @@ pub struct TcpCodecListener<C: Codec> {
 }
 
 impl<C: Codec + 'static> TcpCodecListener<C> {
+    #![allow(clippy::too_many_arguments)]
     pub fn new(
         chain: TransformChain,
         source_name: String,

--- a/shotover-proxy/src/transforms/cassandra/sink_single.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_single.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
 use serde::Deserialize;
 
-use crate::config::topology::TopicHolder;
 use crate::message::{Message, Messages, QueryResponse};
 use crate::protocols::cassandra_protocol2::CassandraCodec2;
 use crate::transforms::{Transform, Transforms, Wrapper};
@@ -28,7 +27,7 @@ pub struct CassandraSinkSingleConfig {
 }
 
 impl CassandraSinkSingleConfig {
-    pub async fn get_source(&self, _: &TopicHolder) -> Result<Transforms> {
+    pub async fn get_source(&self) -> Result<Transforms> {
         Ok(Transforms::CassandraSinkSingle(CassandraSinkSingle::new(
             self.address.clone(),
             self.result_processing,

--- a/shotover-proxy/src/transforms/coalesce.rs
+++ b/shotover-proxy/src/transforms/coalesce.rs
@@ -1,4 +1,3 @@
-use crate::config::topology::TopicHolder;
 use crate::error::ChainResponse;
 use crate::message::{Message, MessageDetails, Messages, QueryResponse};
 use crate::protocols::RawFrame;
@@ -28,7 +27,7 @@ pub struct CoalesceConfig {
 }
 
 impl CoalesceConfig {
-    pub async fn get_source(&self, _topics: &TopicHolder) -> Result<Transforms> {
+    pub async fn get_source(&self) -> Result<Transforms> {
         let hint = match self.max_behavior {
             CoalesceBehavior::Count(c) => Some(c),
             CoalesceBehavior::CountOrWait(c, _) => Some(c),

--- a/shotover-proxy/src/transforms/filter.rs
+++ b/shotover-proxy/src/transforms/filter.rs
@@ -1,4 +1,3 @@
-use crate::config::topology::TopicHolder;
 use crate::error::ChainResponse;
 use crate::message::{MessageDetails, QueryType};
 use crate::transforms::{Transform, Transforms, Wrapper};
@@ -17,7 +16,7 @@ pub struct QueryTypeFilterConfig {
 }
 
 impl QueryTypeFilterConfig {
-    pub async fn get_source(&self, _topics: &TopicHolder) -> Result<Transforms> {
+    pub async fn get_source(&self) -> Result<Transforms> {
         Ok(Transforms::QueryTypeFilter(QueryTypeFilter {
             filter: self.filter.clone(),
         }))

--- a/shotover-proxy/src/transforms/kafka_sink.rs
+++ b/shotover-proxy/src/transforms/kafka_sink.rs
@@ -7,7 +7,6 @@ use rdkafka::producer::{FutureProducer, FutureRecord};
 use rdkafka::util::Timeout;
 use serde::Deserialize;
 
-use crate::config::topology::TopicHolder;
 use crate::error::ChainResponse;
 use crate::message::{Message, MessageDetails, QueryResponse};
 use crate::protocols::RawFrame;
@@ -27,7 +26,7 @@ pub struct KafkaSinkConfig {
 }
 
 impl KafkaSinkConfig {
-    pub async fn get_source(&self, _topics: &TopicHolder) -> Result<Transforms> {
+    pub async fn get_source(&self) -> Result<Transforms> {
         Ok(Transforms::KafkaSink(KafkaSink::new_from_config(
             &self.keys,
             self.topic.clone(),

--- a/shotover-proxy/src/transforms/mod.rs
+++ b/shotover-proxy/src/transforms/mod.rs
@@ -252,25 +252,25 @@ impl TransformsConfig {
     /// Return a new instance of the transform that the config is specifying.
     pub async fn get_transforms(&self, topics: &TopicHolder) -> Result<Transforms> {
         match self {
-            TransformsConfig::CassandraSinkSingle(c) => c.get_source(topics).await,
-            TransformsConfig::KafkaSink(k) => k.get_source(topics).await,
+            TransformsConfig::CassandraSinkSingle(c) => c.get_source().await,
+            TransformsConfig::KafkaSink(k) => k.get_source().await,
             TransformsConfig::RedisCache(r) => r.get_source(topics).await,
             TransformsConfig::Tee(t) => t.get_source(topics).await,
-            TransformsConfig::RedisSinkSingle(r) => r.get_source(topics).await,
+            TransformsConfig::RedisSinkSingle(r) => r.get_source().await,
             TransformsConfig::ConsistentScatter(c) => c.get_source(topics).await,
             TransformsConfig::RedisTimestampTagger => {
                 Ok(Transforms::RedisTimestampTagger(RedisTimestampTagger::new()))
             }
-            TransformsConfig::RedisClusterPortsRewrite(r) => r.get_source(topics).await,
+            TransformsConfig::RedisClusterPortsRewrite(r) => r.get_source().await,
             TransformsConfig::DebugPrinter => Ok(Transforms::DebugPrinter(DebugPrinter::new())),
             TransformsConfig::Null => Ok(Transforms::Null(Null::default())),
             TransformsConfig::Loopback => Ok(Transforms::Loopback(Loopback::default())),
-            TransformsConfig::RedisSinkCluster(r) => r.get_source(topics).await,
+            TransformsConfig::RedisSinkCluster(r) => r.get_source().await,
             TransformsConfig::ParallelMap(s) => s.get_source(topics).await,
             //TransformsConfig::PoolConnections(s) => s.get_source(topics).await,
-            TransformsConfig::Coalesce(s) => s.get_source(topics).await,
-            TransformsConfig::QueryTypeFilter(s) => s.get_source(topics).await,
-            TransformsConfig::QueryCounter(s) => s.get_source(topics).await,
+            TransformsConfig::Coalesce(s) => s.get_source().await,
+            TransformsConfig::QueryTypeFilter(s) => s.get_source().await,
+            TransformsConfig::QueryCounter(s) => s.get_source().await,
         }
     }
 }

--- a/shotover-proxy/src/transforms/query_counter.rs
+++ b/shotover-proxy/src/transforms/query_counter.rs
@@ -1,4 +1,3 @@
-use crate::config::topology::TopicHolder;
 use crate::error::ChainResponse;
 use crate::message::Value::List;
 use crate::message::{ASTHolder, MessageDetails, QueryMessage};
@@ -72,7 +71,7 @@ impl Transform for QueryCounter {
 }
 
 impl QueryCounterConfig {
-    pub async fn get_source(&self, _topics: &TopicHolder) -> Result<Transforms> {
+    pub async fn get_source(&self) -> Result<Transforms> {
         Ok(Transforms::QueryCounter(QueryCounter {
             counter_name: self.name.clone(),
         }))

--- a/shotover-proxy/src/transforms/redis/cluster_ports_rewrite.rs
+++ b/shotover-proxy/src/transforms/redis/cluster_ports_rewrite.rs
@@ -3,7 +3,6 @@ use async_trait::async_trait;
 use redis_protocol::resp2::prelude::Frame;
 use serde::Deserialize;
 
-use crate::config::topology::TopicHolder;
 use crate::error::ChainResponse;
 use crate::protocols::RawFrame;
 use crate::transforms::{Transform, Transforms, Wrapper};
@@ -14,7 +13,7 @@ pub struct RedisClusterPortsRewriteConfig {
 }
 
 impl RedisClusterPortsRewriteConfig {
-    pub async fn get_source(&self, _topics: &TopicHolder) -> Result<Transforms> {
+    pub async fn get_source(&self) -> Result<Transforms> {
         Ok(Transforms::RedisClusterPortsRewrite(
             RedisClusterPortsRewrite {
                 new_port: self.new_port,

--- a/shotover-proxy/src/transforms/redis/sink_cluster.rs
+++ b/shotover-proxy/src/transforms/redis/sink_cluster.rs
@@ -18,7 +18,6 @@ use tokio::time::Duration;
 use tracing::{debug, error, info, trace, warn};
 
 use crate::concurrency::FuturesOrdered;
-use crate::config::topology::TopicHolder;
 use crate::error::ChainResponse;
 use crate::message::{Message, MessageDetails, Messages, QueryResponse};
 use crate::protocols::redis_codec::{DecodeType, RedisCodec};
@@ -44,7 +43,7 @@ pub struct RedisSinkClusterConfig {
 }
 
 impl RedisSinkClusterConfig {
-    pub async fn get_source(&self, _topics: &TopicHolder) -> Result<Transforms> {
+    pub async fn get_source(&self) -> Result<Transforms> {
         let authenticator = RedisAuthenticator {};
 
         let connection_pool = ConnectionPool::new_with_auth(

--- a/shotover-proxy/src/transforms/redis/sink_single.rs
+++ b/shotover-proxy/src/transforms/redis/sink_single.rs
@@ -9,7 +9,6 @@ use tokio::net::TcpStream;
 use tokio_stream::StreamExt;
 use tokio_util::codec::Framed;
 
-use crate::config::topology::TopicHolder;
 use crate::error::ChainResponse;
 use crate::protocols::redis_codec::{DecodeType, RedisCodec};
 use crate::tls::{AsyncStream, TlsConfig, TlsConnector};
@@ -23,7 +22,7 @@ pub struct RedisSinkSingleConfig {
 }
 
 impl RedisSinkSingleConfig {
-    pub async fn get_source(&self, _: &TopicHolder) -> Result<Transforms> {
+    pub async fn get_source(&self) -> Result<Transforms> {
         let tls = self.tls.clone().map(TlsConnector::new).transpose()?;
         Ok(Transforms::RedisSinkSingle(RedisSinkSingle::new(
             self.address.clone(),

--- a/shotover-proxy/src/transforms/redis/timestamp_tagging.rs
+++ b/shotover-proxy/src/transforms/redis/timestamp_tagging.rs
@@ -1,5 +1,3 @@
-use crate::config::topology::TopicHolder;
-
 use crate::error::ChainResponse;
 use crate::message::{ASTHolder, MessageDetails, QueryMessage, QueryResponse, Value};
 use crate::transforms::{Transform, Transforms, Wrapper};
@@ -26,7 +24,7 @@ impl RedisTimestampTagger {
 }
 
 impl RedisTimestampTaggerConfig {
-    pub async fn get_source(&self, _topics: &TopicHolder) -> Result<Transforms> {
+    pub async fn get_source(&self) -> Result<Transforms> {
         Ok(Transforms::RedisTimestampTagger(RedisTimestampTagger {}))
     }
 }


### PR DESCRIPTION
We don't need these unused parameters since `get_source` no longer belongs to a trait.