### PR TITLE
Register metrics on startup

### DIFF
--- a/shotover-proxy/examples/null-redis/topology.yaml
+++ b/shotover-proxy/examples/null-redis/topology.yaml
@@ -5,6 +5,8 @@ sources:
       listen_addr: "127.0.0.1:6379"
 chain_config:
   redis_chain:
+    - QueryCounter:
+        name: redis-chain
     - Null
 named_topics:
   testtopic: 5

--- a/shotover-proxy/examples/redis-cluster/topology.yaml
+++ b/shotover-proxy/examples/redis-cluster/topology.yaml
@@ -5,6 +5,8 @@ sources:
       listen_addr: "127.0.0.1:6379"
 chain_config:
   redis_chain:
+    - QueryCounter:
+        name: redis-chain
     - RedisSinkCluster:
         first_contact_points: ["127.0.0.1:2220", "127.0.0.1:2221", "127.0.0.1:2222", "127.0.0.1:2223", "127.0.0.1:2224", "127.0.0.1:2225"]
 named_topics:

--- a/shotover-proxy/examples/redis-cluster/topology.yaml
+++ b/shotover-proxy/examples/redis-cluster/topology.yaml
@@ -5,8 +5,6 @@ sources:
       listen_addr: "127.0.0.1:6379"
 chain_config:
   redis_chain:
-    - QueryCounter:
-        name: redis-chain
     - RedisSinkCluster:
         first_contact_points: ["127.0.0.1:2220", "127.0.0.1:2221", "127.0.0.1:2222", "127.0.0.1:2223", "127.0.0.1:2224", "127.0.0.1:2225"]
 named_topics:

--- a/shotover-proxy/src/server.rs
+++ b/shotover-proxy/src/server.rs
@@ -90,6 +90,7 @@ impl<C: Codec + 'static> TcpCodecListener<C> {
         tls: Option<TlsAcceptor>,
     ) -> Self {
         register_gauge!("shotover_available_connections", Unit::Count, "source" => source_name.clone());
+        gauge!("shotover_available_connections", limit_connections.available_permits() as f64, "source" => source_name.clone());
 
         TcpCodecListener {
             chain,

--- a/shotover-proxy/src/server.rs
+++ b/shotover-proxy/src/server.rs
@@ -4,7 +4,7 @@ use crate::transforms::chain::TransformChain;
 use crate::transforms::Wrapper;
 use anyhow::{anyhow, Result};
 use futures::StreamExt;
-use metrics::gauge;
+use metrics::{gauge, register_gauge, Unit};
 use std::sync::Arc;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::{TcpListener, TcpStream};
@@ -89,6 +89,8 @@ impl<C: Codec + 'static> TcpCodecListener<C> {
         shutdown_complete_tx: mpsc::Sender<()>,
         tls: Option<TlsAcceptor>,
     ) -> Self {
+        register_gauge!("shotover_available_connections", Unit::Count, "source" => source_name.clone());
+
         TcpCodecListener {
             chain,
             source_name,

--- a/shotover-proxy/src/transforms/chain.rs
+++ b/shotover-proxy/src/transforms/chain.rs
@@ -171,12 +171,12 @@ impl TransformChain {
     pub fn new(transform_list: Vec<Transforms>, name: String) -> Self {
         register_counter!("shotover_chain_total", Unit::Count, "chain" => name.clone());
         register_counter!("shotover_chain_failures", Unit::Count, "chain" => name.clone());
-        register_histogram!("shotover_chain_latency", Unit::Count, "chain" => name.clone());
+        register_histogram!("shotover_chain_latency", Unit::Seconds, "chain" => name.clone());
 
         for transform in &transform_list {
             register_counter!("shotover_transform_total", Unit::Count, "transform" => transform.get_name());
             register_counter!("shotover_transform_failures", Unit::Count, "transform" => transform.get_name());
-            register_histogram!("shotover_transform_latency", Unit::Seconds, "transform"=> transform.get_name());
+            register_histogram!("shotover_transform_latency", Unit::Seconds, "transform" => transform.get_name());
         }
 
         TransformChain {

--- a/shotover-proxy/src/transforms/query_counter.rs
+++ b/shotover-proxy/src/transforms/query_counter.rs
@@ -4,7 +4,7 @@ use crate::message::{ASTHolder, MessageDetails, QueryMessage};
 use crate::transforms::{Transform, Transforms, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
-use metrics::counter;
+use metrics::{counter, register_counter, Unit};
 use serde::Deserialize;
 use sqlparser::ast::Statement;
 
@@ -16,6 +16,14 @@ pub struct QueryCounter {
 #[derive(Deserialize, Debug, Clone)]
 pub struct QueryCounterConfig {
     pub name: String,
+}
+
+impl QueryCounter {
+    pub fn new(counter_name: String) -> Self {
+        register_counter!("query_count", Unit::Count, "name" => counter_name.clone());
+
+        QueryCounter { counter_name }
+    }
 }
 
 #[async_trait]
@@ -72,8 +80,8 @@ impl Transform for QueryCounter {
 
 impl QueryCounterConfig {
     pub async fn get_source(&self) -> Result<Transforms> {
-        Ok(Transforms::QueryCounter(QueryCounter {
-            counter_name: self.name.clone(),
-        }))
+        Ok(Transforms::QueryCounter(QueryCounter::new(
+            self.name.clone(),
+        )))
     }
 }

--- a/shotover-proxy/tests/runner/observability_int_tests.rs
+++ b/shotover-proxy/tests/runner/observability_int_tests.rs
@@ -1,55 +1,41 @@
 use crate::helpers::ShotoverManager;
 use serial_test::serial;
-use test_helpers::docker_compose::DockerCompose;
 
 async fn http_request_metrics() -> String {
-    let client = hyper::Client::new();
-    let uri = "http://localhost:9001/metrics".parse().unwrap();
-    let res = client.get(uri).await.unwrap();
-    let body_bytes = hyper::body::to_bytes(res.into_body()).await.unwrap();
-    String::from_utf8(body_bytes.to_vec()).unwrap()
+    let url = "http://localhost:9001/metrics";
+    reqwest::get(url).await.unwrap().text().await.unwrap()
+}
+
+fn assert_array_elems(expected: &[&str], result: String) {
+    for s in expected {
+        if !result.contains(s) {
+            panic!("{} missing from response: \n{}", s, result);
+        }
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn test_metrics() {
-    let _compose = DockerCompose::new("examples/redis-cluster/docker-compose.yml")
-        .wait_for_n("Cluster state changed", 6);
-    let shotover_manager =
-        ShotoverManager::from_topology_file("examples/redis-cluster/topology.yaml");
-
+    let shotover_manager = ShotoverManager::from_topology_file("examples/null-redis/topology.yaml");
     let mut connection = shotover_manager.redis_connection_async(6379).await;
 
-    let expected = [
-        // transform counter
-        r#"# TYPE shotover_transform_total counter"#,
-        r#"shotover_transform_total{transform="RedisSinkCluster"}"#,
-        r#"shotover_transform_total{transform="QueryCounter"}"#,
-        // chain counter
+    let expected = vec![
+        r#"# TYPE query_count counter"#,
+        r#"query_count{name="redis-chain"}"#,
         r#"# TYPE shotover_chain_total counter"#,
         r#"shotover_chain_total{chain="redis_chain"}"#,
-        // chain failures
+        r#"# TYPE shotover_transform_total counter"#,
+        r#"shotover_transform_total{transform="QueryCounter"}"#,
+        r#"shotover_transform_total{transform="Null"}"#,
         r#"# TYPE shotover_chain_failures counter"#,
         r#"shotover_chain_failures{chain="redis_chain"}"#,
-        r#"shotover_transform_failures{transform="RedisSinkCluster"}"#,
-        // transform failures
         r#"# TYPE shotover_transform_failures counter"#,
-        r#"shotover_transform_failures{transform="RedisSinkCluster"}"#,
-        // available connections
+        r#"shotover_transform_failures{transform="Null"}"#,
+        r#"shotover_transform_failures{transform="QueryCounter"}"#,
         r#"# TYPE shotover_available_connections gauge"#,
         r#"shotover_available_connections{source="Redis Source"}"#,
-        // redis sink cluster  latency summary
         r#"# TYPE shotover_transform_latency summary"#,
-        r#"shotover_transform_latency{transform="RedisSinkCluster",quantile="0"}"#,
-        r#"shotover_transform_latency{transform="RedisSinkCluster",quantile="0.5"}"#,
-        r#"shotover_transform_latency{transform="RedisSinkCluster",quantile="0.9"}"#,
-        r#"shotover_transform_latency{transform="RedisSinkCluster",quantile="0.95"}"#,
-        r#"shotover_transform_latency{transform="RedisSinkCluster",quantile="0.99"}"#,
-        r#"shotover_transform_latency{transform="RedisSinkCluster",quantile="0.999"}"#,
-        r#"shotover_transform_latency{transform="RedisSinkCluster",quantile="1"}"#,
-        r#"shotover_transform_latency_sum{transform="RedisSinkCluster"}"#,
-        r#"shotover_transform_latency_count{transform="RedisSinkCluster"}"#,
-        // query counter latency summary
         r#"shotover_transform_latency{transform="QueryCounter",quantile="0"}"#,
         r#"shotover_transform_latency{transform="QueryCounter",quantile="0.5"}"#,
         r#"shotover_transform_latency{transform="QueryCounter",quantile="0.9"}"#,
@@ -59,7 +45,15 @@ async fn test_metrics() {
         r#"shotover_transform_latency{transform="QueryCounter",quantile="1"}"#,
         r#"shotover_transform_latency_sum{transform="QueryCounter"}"#,
         r#"shotover_transform_latency_count{transform="QueryCounter"}"#,
-        // chain latency
+        r#"shotover_transform_latency{transform="Null",quantile="0"}"#,
+        r#"shotover_transform_latency{transform="Null",quantile="0.5"}"#,
+        r#"shotover_transform_latency{transform="Null",quantile="0.9"}"#,
+        r#"shotover_transform_latency{transform="Null",quantile="0.95"}"#,
+        r#"shotover_transform_latency{transform="Null",quantile="0.99"}"#,
+        r#"shotover_transform_latency{transform="Null",quantile="0.999"}"#,
+        r#"shotover_transform_latency{transform="Null",quantile="1"}"#,
+        r#"shotover_transform_latency_sum{transform="Null"}"#,
+        r#"shotover_transform_latency_count{transform="Null"}"#,
         r#"# TYPE shotover_chain_latency summary"#,
         r#"shotover_chain_latency{chain="redis_chain",quantile="0"}"#,
         r#"shotover_chain_latency{chain="redis_chain",quantile="0.5"}"#,
@@ -73,15 +67,13 @@ async fn test_metrics() {
     ];
 
     // check we get the metrics on startup
-
     let mut body = http_request_metrics().await;
 
-    for s in expected {
-        assert!(body.contains(s));
-    }
+    let lines = body.lines().count();
+
+    assert_array_elems(&expected, body);
 
     // Check we still get the metrics after sending a couple requests
-
     redis::cmd("SET")
         .arg("the_key")
         .arg(42)
@@ -96,9 +88,30 @@ async fn test_metrics() {
         .await
         .unwrap();
 
+    redis::cmd("GET")
+        .arg("the_key")
+        .query_async::<_, ()>(&mut connection)
+        .await
+        .unwrap();
+
     body = http_request_metrics().await;
 
-    for s in expected {
-        assert!(body.contains(s));
-    }
+    //TODO we dont assert the contents of metrics response yet,
+    // due to the randomized order of the labels. Will need to parse the prometheus output
+
+    let new_lines = vec![
+        r#"shotover_chain_latency{chain="redis_chain",client_details="127.0.0.1",quantile="0"}"#,
+        r#"shotover_chain_latency{chain="redis_chain",client_details="127.0.0.1",quantile="0.5"}"#,
+        r#"shotover_chain_latency{chain="redis_chain",client_details="127.0.0.1",quantile="0.9"}"#,
+        r#"shotover_chain_latency{chain="redis_chain",client_details="127.0.0.1",quantile="0.95"}"#,
+        r#"shotover_chain_latency{chain="redis_chain",client_details="127.0.0.1",quantile="0.99"}"#,
+        r#"shotover_chain_latency{chain="redis_chain",client_details="127.0.0.1",quantile="0.999"}"#,
+        r#"shotover_chain_latency{chain="redis_chain",client_details="127.0.0.1",quantile="1"}"#,
+        r#"shotover_chain_latency_sum{chain="redis_chain",client_details="127.0.0.1"}"#,
+        r#"shotover_chain_latency_count{chain="redis_chain",client_details="127.0.0.1"}"#,
+    ];
+
+    assert_eq!(lines + new_lines.len(), body.lines().count());
+
+    assert_array_elems(&expected, body);
 }

--- a/shotover-proxy/tests/runner/observability_int_tests.rs
+++ b/shotover-proxy/tests/runner/observability_int_tests.rs
@@ -2,15 +2,85 @@ use crate::helpers::ShotoverManager;
 use serial_test::serial;
 use test_helpers::docker_compose::DockerCompose;
 
+async fn http_request_metrics() -> String {
+    let client = hyper::Client::new();
+    let uri = "http://localhost:9001/metrics".parse().unwrap();
+    let res = client.get(uri).await.unwrap();
+    let body_bytes = hyper::body::to_bytes(res.into_body()).await.unwrap();
+    String::from_utf8(body_bytes.to_vec()).unwrap()
+}
+
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn test_metrics() {
-    let _compose = DockerCompose::new("examples/redis-passthrough/docker-compose.yml")
-        .wait_for("Ready to accept connections");
+    let _compose = DockerCompose::new("examples/redis-cluster/docker-compose.yml")
+        .wait_for_n("Cluster state changed", 6);
     let shotover_manager =
-        ShotoverManager::from_topology_file("examples/redis-passthrough/topology.yaml");
+        ShotoverManager::from_topology_file("examples/redis-cluster/topology.yaml");
 
     let mut connection = shotover_manager.redis_connection_async(6379).await;
+
+    let expected = [
+        // transform counter
+        r#"# TYPE shotover_transform_total counter"#,
+        r#"shotover_transform_total{transform="RedisSinkCluster"}"#,
+        r#"shotover_transform_total{transform="QueryCounter"}"#,
+        // chain counter
+        r#"# TYPE shotover_chain_total counter"#,
+        r#"shotover_chain_total{chain="redis_chain"}"#,
+        // chain failures
+        r#"# TYPE shotover_chain_failures counter"#,
+        r#"shotover_chain_failures{chain="redis_chain"}"#,
+        r#"shotover_transform_failures{transform="RedisSinkCluster"}"#,
+        // transform failures
+        r#"# TYPE shotover_transform_failures counter"#,
+        r#"shotover_transform_failures{transform="RedisSinkCluster"}"#,
+        // available connections
+        r#"# TYPE shotover_available_connections gauge"#,
+        r#"shotover_available_connections{source="Redis Source"}"#,
+        // redis sink cluster  latency summary
+        r#"# TYPE shotover_transform_latency summary"#,
+        r#"shotover_transform_latency{transform="RedisSinkCluster",quantile="0"}"#,
+        r#"shotover_transform_latency{transform="RedisSinkCluster",quantile="0.5"}"#,
+        r#"shotover_transform_latency{transform="RedisSinkCluster",quantile="0.9"}"#,
+        r#"shotover_transform_latency{transform="RedisSinkCluster",quantile="0.95"}"#,
+        r#"shotover_transform_latency{transform="RedisSinkCluster",quantile="0.99"}"#,
+        r#"shotover_transform_latency{transform="RedisSinkCluster",quantile="0.999"}"#,
+        r#"shotover_transform_latency{transform="RedisSinkCluster",quantile="1"}"#,
+        r#"shotover_transform_latency_sum{transform="RedisSinkCluster"}"#,
+        r#"shotover_transform_latency_count{transform="RedisSinkCluster"}"#,
+        // query counter latency summary
+        r#"shotover_transform_latency{transform="QueryCounter",quantile="0"}"#,
+        r#"shotover_transform_latency{transform="QueryCounter",quantile="0.5"}"#,
+        r#"shotover_transform_latency{transform="QueryCounter",quantile="0.9"}"#,
+        r#"shotover_transform_latency{transform="QueryCounter",quantile="0.95"}"#,
+        r#"shotover_transform_latency{transform="QueryCounter",quantile="0.99"}"#,
+        r#"shotover_transform_latency{transform="QueryCounter",quantile="0.999"}"#,
+        r#"shotover_transform_latency{transform="QueryCounter",quantile="1"}"#,
+        r#"shotover_transform_latency_sum{transform="QueryCounter"}"#,
+        r#"shotover_transform_latency_count{transform="QueryCounter"}"#,
+        // chain latency
+        r#"# TYPE shotover_chain_latency summary"#,
+        r#"shotover_chain_latency{chain="redis_chain",quantile="0"}"#,
+        r#"shotover_chain_latency{chain="redis_chain",quantile="0.5"}"#,
+        r#"shotover_chain_latency{chain="redis_chain",quantile="0.9"}"#,
+        r#"shotover_chain_latency{chain="redis_chain",quantile="0.95"}"#,
+        r#"shotover_chain_latency{chain="redis_chain",quantile="0.99"}"#,
+        r#"shotover_chain_latency{chain="redis_chain",quantile="0.999"}"#,
+        r#"shotover_chain_latency{chain="redis_chain",quantile="1"}"#,
+        r#"shotover_chain_latency_sum{chain="redis_chain"}"#,
+        r#"shotover_chain_latency_count{chain="redis_chain"}"#,
+    ];
+
+    // check we get the metrics on startup
+
+    let mut body = http_request_metrics().await;
+
+    for s in expected {
+        assert!(body.contains(s));
+    }
+
+    // Check we still get the metrics after sending a couple requests
 
     redis::cmd("SET")
         .arg("the_key")
@@ -26,16 +96,9 @@ async fn test_metrics() {
         .await
         .unwrap();
 
-    let client = hyper::Client::new();
-    let uri = "http://localhost:9001/metrics".parse().unwrap();
-    let res = client.get(uri).await.unwrap();
-    let body_bytes = hyper::body::to_bytes(res.into_body()).await.unwrap();
-    let body = String::from_utf8(body_bytes.to_vec()).unwrap();
+    body = http_request_metrics().await;
 
-    // If the body contains these substrings, we can assume metrics are working
-    assert!(body.contains("# TYPE shotover_transform_total counter"));
-    assert!(body.contains("# TYPE shotover_chain_total counter"));
-    assert!(body.contains("# TYPE shotover_available_connections gauge"));
-    assert!(body.contains("# TYPE shotover_transform_latency summary"));
-    assert!(body.contains("# TYPE shotover_chain_latency summary"));
+    for s in expected {
+        assert!(body.contains(s));
+    }
 }


### PR DESCRIPTION
Register all metrics on startup so they can be retrieved from the metrics endpoint without any needed to be actually be recorded yet.