### PR TITLE
rewrite CI, fixing caching and failing on warnings

### DIFF
--- a/.github/workflows/bench_run.yml
+++ b/.github/workflows/bench_run.yml
@@ -18,23 +18,22 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v2
+    - uses: actions-rs/toolchain@v1
       with:
-        path: |
-          ./cache
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          # `toolchain: stable` results in the latest stable toolchain being installed.
+          # However as soon as we use cargo the real version specified in rust-toolchain.toml replaces the stable toolchain.
+          #
+          # When something like https://github.com/actions-rs/toolchain/pull/184 lands we can delete this line and get a nice speedup
+          profile: minimal
+          toolchain: stable
+    - uses: Swatinem/rust-cache@v1
+      with:
+        # Unique key is used to avoid collisions with the Testing workflow
+        key: 'Benchmark'
     - name: Install ubuntu packages
       run: |
         sudo apt-get update
         sudo apt-get install -y gnuplot libpcap-dev
-    - name: Install latest stable
-      uses: actions-rs/toolchain@v1
-      with:
-          toolchain: stable
-          override: true
     - name: Run benchmarks
       run: shotover-proxy/tests/scripts/bench_against_master.sh ${{ github.event.number }}
     - name: Upload comment artifact
@@ -42,5 +41,3 @@ jobs:
       with:
         name: comment_info
         path: comment_info/
-    - name: Cleanup docker
-      run: shotover-proxy/tests/scripts/teardown.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Install latest stable
-        uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
-          override: true
+            # `toolchain: stable` results in the latest stable toolchain being installed.
+            # However as soon as we use cargo the real version specified in rust-toolchain.toml replaces the stable toolchain.
+            #
+            # When something like https://github.com/actions-rs/toolchain/pull/184 lands we can delete this line and get a nice speedup
+            profile: minimal
+            toolchain: stable
       - name: Build & test
         run: |
           shotover-proxy/build/build_release.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,6 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTC_WRAPPER: sccache
   RUST_BACKTRACE: 1
 
 jobs:
@@ -29,47 +28,36 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v2
+    - uses: actions-rs/toolchain@v1
       with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo2-${{ hashFiles('**/Cargo.lock') }}
-    - name: Install latest stable
-      uses: actions-rs/toolchain@v1
-      with:
+          # `toolchain: stable` results in the latest stable toolchain being installed.
+          # However as soon as we use cargo the real version specified in rust-toolchain.toml replaces the stable toolchain.
+          #
+          # When something like https://github.com/actions-rs/toolchain/pull/184 lands we can delete this line and get a nice speedup
+          profile: minimal
           toolchain: stable
-          override: true
-    - name: Install sccache
-      env:
-        LINK: https://github.com/mozilla/sccache/releases/download
-        SCCACHE_VERSION: 0.2.12
-      run: |
-        curl -L "$LINK/$SCCACHE_VERSION/sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl.tar.gz" | tar xz
-        echo "$PWD/sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl/" >> $GITHUB_PATH
+    - uses: Swatinem/rust-cache@v1
+      with:
+        # rust-cache already handles all the sane defaults for caching rust builds.
+        # However because we are running seperate debug/release builds in parallel,
+        # we also need to add Debug or Release to the key so that a seperate cache is used.
+        # Otherwise only the last build to finish would get saved to the cache.
+        key: ${{ matrix.name }}
     - name: Install ubuntu packages
       run: |
         sudo apt-get update
         sudo apt-get install -y libpcap-dev
-    - name: Start sccache
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        SCCACHE_BUCKET: shotover-build-caches
-        SCCACHE_IDLE_TIMEOUT: 0
-      run: sccache --start-server
-    - name: Configure sscache
-      run: echo "" >> .cargo/config && echo "[build]" >> .cargo/config && echo "rustc-wrapper = \"$(which sccache)\"" >> .cargo/config && cat .cargo/config
+    - name: Install cargo-hack
+      run: cargo install cargo-hack --version 0.5.8
     - name: Check `cargo fmt` was run
       run: cargo fmt --all -- --check
-    - name: Build
-      run: cargo build ${{ matrix.cargo_profile }} --all-targets
-    - name: Run tests
+    - name: Ensure that all crates compile and have no warnings under every possible combination of features
+      # some things to explicitly point out:
+      # * clippy also reports rustc warnings and errors
+      # * clippy --all-targets causes clippy to run against tests and examples which it doesnt do by default.
+      run: cargo hack --feature-powerset clippy --all-targets --locked ${{ matrix.cargo_profile }} -- -D warnings
+    - name: Ensure that tests pass
       run: cargo test ${{ matrix.cargo_profile }} -- --include-ignored --show-output
-      timeout-minutes: 30
-    - name: Cleanup docker
-      run: shotover-proxy/tests/scripts/teardown.sh
     - name: License Check
       run: |
         cargo install --locked cargo-deny

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.56"
 components = [ "rustfmt", "clippy" ]

--- a/shotover-proxy/src/transforms/load_balance.rs
+++ b/shotover-proxy/src/transforms/load_balance.rs
@@ -120,7 +120,7 @@ mod test {
                 .clone()
                 .process_request(Wrapper::new(Messages::new()), "test_client".to_string())
                 .await;
-            assert_eq!(r.is_ok(), true);
+            assert!(r.is_ok());
         }
 
         match chain.chain.remove(0) {

--- a/shotover-proxy/src/transforms/protect/mod.rs
+++ b/shotover-proxy/src/transforms/protect/mod.rs
@@ -270,7 +270,6 @@ mod protect_transform_tests {
     use cassandra_proto::frame::Frame;
     use sodiumoxide::crypto::secretbox;
 
-    use crate::config::topology::TopicHolder;
     use crate::message::{Message, MessageDetails, QueryMessage, QueryResponse, QueryType, Value};
     use crate::protocols::cassandra_protocol2::CassandraCodec2;
     use crate::protocols::RawFrame;

--- a/shotover-proxy/tests/codec/cassandra.rs
+++ b/shotover-proxy/tests/codec/cassandra.rs
@@ -21,22 +21,20 @@ async fn check_vec_of_bytes(packet_stream: Vec<Bytes>) {
     let stream = tokio_stream::iter(
         packet_stream
             .into_iter()
-            .map(|b| Ok(b))
+            .map(Ok)
             .collect::<Vec<anyhow::Result<Bytes, std::io::Error>>>(),
     );
 
     let byte_stream = StreamReader::new(stream);
     let mut reader = FramedRead::new(byte_stream, codec);
 
-    for frame in reader.next().await {
-        if let Ok(frame) = frame {
-            let recv_buffer = BufWriter::new(Vec::new());
-            let mut writer = FramedWrite::new(recv_buffer, write_codec.clone());
-            writer.send(frame).await.unwrap();
-            let results = Bytes::from(writer.into_inner().into_inner());
-            let orig_bytes = comparator_iter.next().expect("packet count mismatch");
-            assert_eq!(orig_bytes, results);
-        }
+    for frame in reader.next().await.into_iter().flatten() {
+        let recv_buffer = BufWriter::new(Vec::new());
+        let mut writer = FramedWrite::new(recv_buffer, write_codec.clone());
+        writer.send(frame).await.unwrap();
+        let results = Bytes::from(writer.into_inner().into_inner());
+        let orig_bytes = comparator_iter.next().expect("packet count mismatch");
+        assert_eq!(orig_bytes, results);
     }
 }
 
@@ -52,19 +50,17 @@ async fn test_cassandra_packet_capture() {
         std::fs::write(&cql_mixed, &data).unwrap();
     }
 
-    let mut capture = crate::codec::util::packet_capture::PacketCapture::new();
+    let mut capture = crate::codec::util::packet_capture::PacketCapture::default();
     let packets = capture.parse_from_file(&cql_mixed, None);
     let mut client_packets = Vec::new();
     let mut server_packets = Vec::new();
-    for packet in packets {
-        if let Ok(packet) = packet {
-            let (_src_address, src_port, _dst_addr, dst_port, protocol, _length, _timestamp) =
-                capture.get_packet_details(&packet);
-            match (src_port.as_str(), dst_port.as_str(), protocol.as_str()) {
-                ("9042", _, "Tcp") => server_packets.push(Bytes::from(packet.remaining)),
-                (_, "9042", "Tcp") => client_packets.push(Bytes::from(packet.remaining)),
-                _ => {}
-            }
+    for packet in packets.into_iter().flatten() {
+        let (_src_address, src_port, _dst_addr, dst_port, protocol, _length, _timestamp) =
+            capture.get_packet_details(&packet);
+        match (src_port.as_str(), dst_port.as_str(), protocol.as_str()) {
+            ("9042", _, "Tcp") => server_packets.push(Bytes::from(packet.remaining)),
+            (_, "9042", "Tcp") => client_packets.push(Bytes::from(packet.remaining)),
+            _ => {}
         }
     }
     check_vec_of_bytes(client_packets).await;

--- a/shotover-proxy/tests/codec/util/packet_capture.rs
+++ b/shotover-proxy/tests/codec/util/packet_capture.rs
@@ -7,15 +7,12 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 use threadpool::ThreadPool;
 
+#[derive(Default)]
 pub struct PacketCapture {
     err_count: u64,
 }
 
 impl PacketCapture {
-    pub fn new() -> PacketCapture {
-        PacketCapture { err_count: 0 }
-    }
-
     pub fn list_devices() {
         let devices: Vec<String> = Device::list()
             .unwrap()
@@ -55,7 +52,7 @@ impl PacketCapture {
                 &packet.header.ts.tv_sec, &packet.header.ts.tv_usec
             );
 
-            let packet_parse = PacketParse::new();
+            let packet_parse = PacketParse::default();
             let parsed_packet = packet_parse.parse_packet(data, len, ts);
             match parsed_packet {
                 Ok(parsed_packet) => {
@@ -112,7 +109,7 @@ impl PacketCapture {
     }
 
     pub fn print_packet(&self, parsed_packet: &ParsedPacket) {
-        let (src_addr, src_port, dst_addr, dst_port) = self.get_packet_meta(&parsed_packet);
+        let (src_addr, src_port, dst_addr, dst_port) = self.get_packet_meta(parsed_packet);
         let protocol = &parsed_packet.headers[0].to_string();
         let length = &parsed_packet.len;
         let ts = &parsed_packet.timestamp;
@@ -126,7 +123,7 @@ impl PacketCapture {
         &self,
         parsed_packet: &ParsedPacket,
     ) -> (String, String, String, String, String, u32, String) {
-        let (src_addr, src_port, dst_addr, dst_port) = self.get_packet_meta(&parsed_packet);
+        let (src_addr, src_port, dst_addr, dst_port) = self.get_packet_meta(parsed_packet);
         let protocol = parsed_packet.headers[0].to_string();
         let length = parsed_packet.len;
         let ts = parsed_packet.timestamp.clone();
@@ -161,7 +158,7 @@ impl PacketCapture {
             let packets = packets.clone();
 
             pool.execute(move || {
-                let packet_parse = PacketParse::new();
+                let packet_parse = PacketParse::default();
                 let parsed_packet = packet_parse.parse_packet(data, len, ts);
 
                 packets.lock().unwrap().push(parsed_packet);

--- a/shotover-proxy/tests/codec/util/packet_parse.rs
+++ b/shotover-proxy/tests/codec/util/packet_parse.rs
@@ -11,6 +11,7 @@ use tls_parser::TlsMessage;
 
 use serde::Deserialize;
 
+#[derive(Default)]
 pub struct PacketParse {}
 
 #[derive(Debug, Deserialize)]
@@ -25,23 +26,12 @@ pub enum PacketHeader {
     Arp(ArpPacket),
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Default)]
 pub struct ParsedPacket {
     pub len: u32,
     pub timestamp: String,
     pub headers: Vec<PacketHeader>,
     pub remaining: Vec<u8>,
-}
-
-impl ParsedPacket {
-    pub fn new() -> ParsedPacket {
-        ParsedPacket {
-            len: 0,
-            timestamp: "".to_string(),
-            headers: vec![],
-            remaining: vec![],
-        }
-    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -109,7 +99,7 @@ impl PacketParse {
     }
 
     pub fn parse_link_layer(&self, content: &[u8]) -> Result<ParsedPacket, String> {
-        let mut pack = ParsedPacket::new();
+        let mut pack = ParsedPacket::default();
         match ethernet::parse_ethernet_frame(content) {
             Ok((content, headers)) => {
                 match headers.ethertype {

--- a/shotover-proxy/tests/helpers/mod.rs
+++ b/shotover-proxy/tests/helpers/mod.rs
@@ -115,9 +115,7 @@ impl ShotoverManager {
     fn shutdown_shotover(&mut self) -> Result<()> {
         self.trigger_shutdown_tx.send(true)?;
         let _enter_guard = self.runtime_handle.enter();
-        Ok(futures::executor::block_on(
-            self.join_handle.take().unwrap(),
-        )??)
+        futures::executor::block_on(self.join_handle.take().unwrap())?
     }
 }
 

--- a/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
+++ b/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
@@ -486,7 +486,7 @@ async fn test_pipeline_reuse_query_clear(connection: &mut Connection) {
         .unwrap();
     pl.clear();
 
-    assert_eq!(k1, false);
+    assert!(!k1);
     assert_eq!(k2, 45);
 }
 
@@ -653,8 +653,8 @@ async fn test_nice_hash_api(connection: &mut Connection) {
     }
 
     assert_eq!(found.len(), 2);
-    assert_eq!(found.contains(&("f3".to_string(), 4)), true);
-    assert_eq!(found.contains(&("f4".to_string(), 8)), true);
+    assert!(found.contains(&("f3".to_string(), 4)));
+    assert!(found.contains(&("f4".to_string(), 8)));
 }
 
 async fn test_nice_list_api(connection: &mut Connection) {
@@ -981,10 +981,7 @@ async fn get_master_id(connection: &mut Connection) -> String {
         for result in reader.records() {
             let record = result.unwrap();
 
-            let is_master = record[2]
-                .split(",")
-                .collect::<Vec<&str>>()
-                .contains(&"master");
+            let is_master = record[2].split(',').any(|x| x == "master");
 
             if is_master {
                 return record[0].to_string();
@@ -1059,7 +1056,7 @@ fn assert_cluster_ports_rewrite_nodes(res: Value, new_port: u16) {
     for result in reader.records() {
         let record = result.unwrap();
 
-        let port: Vec<&str> = record[1].split(":").collect();
+        let port: Vec<&str> = record[1].split(':').collect();
         assert_eq!(port[1], format!("{}@16379", new_port));
         assertion_run = true;
     }


### PR DESCRIPTION
closes https://github.com/shotover/shotover-proxy/issues/323
My conclusion here is that the AWS + sccache solution would be a bit better, but using the GA cache is easier to setup and manage.
So if we find the GA cache limiting we can investigate going back to AWS + sccache.

The other changes are:
* failing on clippy warnings
  + we can do this because we are now specifying a rust version in the rust-toolchain.toml and we already have our Cargo.lock checked in so there is no way for our build to break due to warnings being added.
     - The expectation here is that we will update the rust-toolchain.toml every time a new rust version comes out to take advantage of the speed ups and UX improvements not to mention new features.
* changes the toolchain installer to be a little more efficient and added a comment explaining why we are still wasting some time installing a toolchain we dont use.
* installs [cargo-hack](https://github.com/taiki-e/cargo-hack) so that we can use it for the clippy check allowing us to test every possible feature combination.
* removes the manual docker cleanup - not sure why this existed ... surely the whole VM gets destroyed when we finish anyway.

All the actual code changes are to fix clippy warnings that we weren't hitting locally due to not including `--all-targets`.