### PR TITLE
various fixes to improve CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tests/soaktest-*
 output.txt
 **/.DS_Store
 /.project
+/test_data

--- a/shotover-proxy/src/protocols/cassandra_protocol2.rs
+++ b/shotover-proxy/src/protocols/cassandra_protocol2.rs
@@ -815,9 +815,6 @@ mod cassandra_protocol_tests {
                     ast: Some(ASTHolder::SQL(ast)),
                     ..
                 }) => {
-                    println!("{}", query_string);
-                    println!("{}", ast);
-
                     assert_eq!(
                         query_string.replace(char::is_whitespace, ""),
                         ast.to_string().replace(char::is_whitespace, ""),

--- a/shotover-proxy/src/transforms/redis/cache.rs
+++ b/shotover-proxy/src/transforms/redis/cache.rs
@@ -569,9 +569,6 @@ mod test {
 
         let query_two = build_redis_ast_from_sql(ast, &pks, &pk_holder, &query_values).unwrap();
 
-        println!("{:#?}", query_one);
-        println!("{:#?}", query_two);
-
         // Semantically databases treat the order of AND clauses differently, Cassandra however requires clustering key predicates be in order
         // So here we will just expect the order is correct in the query. TODO: we may need to revisit this as support for other databases is added
         assert_ne!(query_one, query_two);
@@ -625,8 +622,6 @@ mod test {
         let expected = build_redis_query_frame("ZRANGEBYLEX 1 [123 ]999");
 
         assert_eq!(expected, query);
-
-        println!("{:#?}", query);
     }
 
     #[test]
@@ -648,8 +643,6 @@ mod test {
         let expected = build_redis_query_frame("ZRANGEBYLEX 1 - +");
 
         assert_eq!(expected, query);
-
-        println!("{:#?}", query);
     }
 
     #[test]
@@ -673,8 +666,6 @@ mod test {
         let expected = build_redis_query_frame("ZRANGEBYLEX 12 - +");
 
         assert_eq!(expected, query);
-
-        println!("{:#?}", query);
     }
 
     #[test]
@@ -709,8 +700,6 @@ mod test {
         let expected = build_redis_query_frame("ZRANGEBYLEX 1 - ]123");
 
         assert_eq!(expected, query);
-
-        println!("{:#?}", query);
     }
 
     #[tokio::test]

--- a/shotover-proxy/tests/codec/cassandra.rs
+++ b/shotover-proxy/tests/codec/cassandra.rs
@@ -42,10 +42,10 @@ async fn check_vec_of_bytes(packet_stream: Vec<Bytes>) {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_cassandra_packet_capture() {
-    let test_data = std::path::PathBuf::from("../target/test_data");
+    let test_data = std::path::PathBuf::from("../test_data");
     let cql_mixed = test_data.join("cql_mixed.pcap");
     if !test_data.exists() {
-        std::fs::create_dir_all("../target/test_data").unwrap();
+        std::fs::create_dir_all(test_data).unwrap();
 
         let url = "https://shotover-test-captures.s3.us-east-1.amazonaws.com/cql_mixed.pcap";
         let data = reqwest::get(url).await.unwrap().bytes().await.unwrap();


### PR DESCRIPTION
* Moving the test_data directory outside of target reduces our cache usage by 1GB which is a sizeable portion of the 5GB GA cache limit. AFAIK this limit can not yet be increased with paid plans.
* Deleted a bunch of println's that add noise to the logs