### PR TITLE
Fix transform names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2524,6 +2524,7 @@ dependencies = [
  "serial_test",
  "sodiumoxide",
  "sqlparser",
+ "strum_macros",
  "test-helpers",
  "thiserror",
  "threadpool",
@@ -2630,6 +2631,18 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum_macros"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339f799d8b549e3744c7ac7feb216383e4005d94bdb22561b3ab8f3b808ae9fb"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subprocess"

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -61,6 +61,7 @@ sodiumoxide = "0.2.5"
 rusoto_kms = "0.47.0"
 rusoto_signature = "0.47.0"
 csv = "1.1.6"
+strum_macros = "0.22.0"
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["async_tokio", "html_reports"] }

--- a/shotover-proxy/src/config/topology.rs
+++ b/shotover-proxy/src/config/topology.rs
@@ -528,7 +528,7 @@ redis_chain:
     async fn test_validate_chain_invalid_subchain_parallel_map() {
         let expected = r#"Topology errors
 redis_chain:
-  SequentialMap:
+  ParallelMap:
     test-parallel-map:
       Terminating transform "Null" is not last in chain. Terminating transform must be last in chain.
 "#;

--- a/shotover-proxy/src/sources/cassandra_source.rs
+++ b/shotover-proxy/src/sources/cassandra_source.rs
@@ -68,7 +68,7 @@ impl CassandraSource {
         connection_limit: Option<usize>,
         hard_connection_limit: Option<bool>,
     ) -> CassandraSource {
-        let name = "Cassandra Source";
+        let name = "CassandraSource";
 
         info!("Starting Cassandra source on [{}]", listen_addr);
 

--- a/shotover-proxy/src/sources/redis_source.rs
+++ b/shotover-proxy/src/sources/redis_source.rs
@@ -63,7 +63,7 @@ impl RedisSource {
         tls: Option<TlsConfig>,
     ) -> Result<RedisSource> {
         info!("Starting Redis source on [{}]", listen_addr);
-        let name = "Redis Source";
+        let name = "RedisSource";
 
         let mut listener = TcpCodecListener::new(
             chain.clone(),

--- a/shotover-proxy/src/transforms/cassandra/sink_single.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_single.rs
@@ -153,10 +153,6 @@ impl Transform for CassandraSinkSingle {
         self.send_message(message_wrapper.messages).await
     }
 
-    fn get_name(&self) -> &'static str {
-        "CassandraSinkSingle"
-    }
-
     fn is_terminating(&self) -> bool {
         true
     }

--- a/shotover-proxy/src/transforms/coalesce.rs
+++ b/shotover-proxy/src/transforms/coalesce.rs
@@ -75,10 +75,6 @@ impl Transform for Coalesce {
             )])
         }
     }
-
-    fn get_name(&self) -> &'static str {
-        "Coalesce"
-    }
 }
 
 #[cfg(test)]

--- a/shotover-proxy/src/transforms/debug_printer.rs
+++ b/shotover-proxy/src/transforms/debug_printer.rs
@@ -30,8 +30,4 @@ impl Transform for DebugPrinter {
         info!("Response content: {:?}", response);
         response
     }
-
-    fn get_name(&self) -> &'static str {
-        "DebugPrinter"
-    }
 }

--- a/shotover-proxy/src/transforms/distributed/consistent_scatter.rs
+++ b/shotover-proxy/src/transforms/distributed/consistent_scatter.rs
@@ -117,7 +117,11 @@ fn resolve_fragments(fragments: &mut Vec<QueryResponse>) -> Option<QueryResponse
     }
 }
 
-impl ConsistentScatter {}
+impl ConsistentScatter {
+    fn get_name(&self) -> &'static str {
+        "ConsistentScatter"
+    }
+}
 
 #[async_trait]
 impl Transform for ConsistentScatter {
@@ -236,10 +240,6 @@ impl Transform for ConsistentScatter {
         }
 
         errors
-    }
-
-    fn get_name(&self) -> &'static str {
-        "ConsistentScatter"
     }
 }
 

--- a/shotover-proxy/src/transforms/filter.rs
+++ b/shotover-proxy/src/transforms/filter.rs
@@ -35,10 +35,6 @@ impl Transform for QueryTypeFilter {
         });
         message_wrapper.call_next_transform().await
     }
-
-    fn get_name(&self) -> &'static str {
-        "QueryType Filter"
-    }
 }
 
 #[cfg(test)]

--- a/shotover-proxy/src/transforms/internal_debug_transforms.rs
+++ b/shotover-proxy/src/transforms/internal_debug_transforms.rs
@@ -23,10 +23,6 @@ impl Transform for DebugReturnerTransform {
         }
     }
 
-    fn get_name(&self) -> &'static str {
-        "returner"
-    }
-
     fn is_terminating(&self) -> bool {
         true
     }
@@ -49,9 +45,5 @@ impl Transform for DebugRandomDelayTransform {
         }
         tokio::time::sleep(delay).await;
         message_wrapper.call_next_transform().await
-    }
-
-    fn get_name(&self) -> &'static str {
-        "RandomDelay"
     }
 }

--- a/shotover-proxy/src/transforms/kafka_sink.rs
+++ b/shotover-proxy/src/transforms/kafka_sink.rs
@@ -100,8 +100,4 @@ impl Transform for KafkaSink {
         }
         Ok(responses)
     }
-
-    fn get_name(&self) -> &'static str {
-        "Kafka"
-    }
 }

--- a/shotover-proxy/src/transforms/load_balance.rs
+++ b/shotover-proxy/src/transforms/load_balance.rs
@@ -82,10 +82,6 @@ impl Transform for ConnectionBalanceAndPool {
     fn is_terminating(&self) -> bool {
         true
     }
-
-    fn get_name(&self) -> &'static str {
-        "PoolConnections"
-    }
 }
 
 #[cfg(test)]

--- a/shotover-proxy/src/transforms/loopback.rs
+++ b/shotover-proxy/src/transforms/loopback.rs
@@ -27,10 +27,6 @@ impl Transform for Loopback {
             .collect())
     }
 
-    fn get_name(&self) -> &'static str {
-        "Loopback"
-    }
-
     fn is_terminating(&self) -> bool {
         true
     }

--- a/shotover-proxy/src/transforms/noop.rs
+++ b/shotover-proxy/src/transforms/noop.rs
@@ -22,8 +22,4 @@ impl Transform for NoOp {
     async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> ChainResponse {
         message_wrapper.call_next_transform().await
     }
-
-    fn get_name(&self) -> &'static str {
-        "NoOp"
-    }
 }

--- a/shotover-proxy/src/transforms/null.rs
+++ b/shotover-proxy/src/transforms/null.rs
@@ -20,8 +20,4 @@ impl Transform for Null {
             RawFrame::None,
         )])
     }
-
-    fn get_name(&self) -> &'static str {
-        "Null"
-    }
 }

--- a/shotover-proxy/src/transforms/parallel_map.rs
+++ b/shotover-proxy/src/transforms/parallel_map.rs
@@ -82,6 +82,12 @@ impl ParallelMapConfig {
     }
 }
 
+impl ParallelMap {
+    fn get_name(&self) -> &'static str {
+        "ParallelMap"
+    }
+}
+
 #[async_trait]
 impl Transform for ParallelMap {
     async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> ChainResponse {
@@ -109,10 +115,6 @@ impl Transform for ParallelMap {
             );
         }
         Ok(results)
-    }
-
-    fn get_name(&self) -> &'static str {
-        "SequentialMap"
     }
 
     fn is_terminating(&self) -> bool {
@@ -168,7 +170,7 @@ mod parallel_map_tests {
         assert_eq!(
             transform.validate(),
             vec![
-                "SequentialMap:",
+                "ParallelMap:",
                 "  test-chain-2:",
                 "    Chain cannot be empty"
             ]

--- a/shotover-proxy/src/transforms/protect/mod.rs
+++ b/shotover-proxy/src/transforms/protect/mod.rs
@@ -252,10 +252,6 @@ impl Transform for Protect {
         // todo: destructure the above bracket mountain as below
         Ok(result)
     }
-
-    fn get_name(&self) -> &'static str {
-        "protect"
-    }
 }
 
 #[cfg(test)]

--- a/shotover-proxy/src/transforms/query_counter.rs
+++ b/shotover-proxy/src/transforms/query_counter.rs
@@ -64,10 +64,6 @@ impl Transform for QueryCounter {
 
         message_wrapper.call_next_transform().await
     }
-
-    fn get_name(&self) -> &'static str {
-        "QueryCounter"
-    }
 }
 
 impl QueryCounterConfig {

--- a/shotover-proxy/src/transforms/redis/cache.rs
+++ b/shotover-proxy/src/transforms/redis/cache.rs
@@ -57,6 +57,10 @@ pub struct SimpleRedisCache {
 }
 
 impl SimpleRedisCache {
+    fn get_name(&self) -> &'static str {
+        "SimpleRedisCache"
+    }
+
     async fn get_or_update_from_cache(&mut self, mut messages: Messages) -> ChainResponse {
         for message in &mut messages {
             match &mut message.details {
@@ -374,10 +378,6 @@ impl Transform for SimpleRedisCache {
             );
             upstream
         }
-    }
-
-    fn get_name(&self) -> &'static str {
-        "SimpleRedisCache"
     }
 }
 

--- a/shotover-proxy/src/transforms/redis/cluster_ports_rewrite.rs
+++ b/shotover-proxy/src/transforms/redis/cluster_ports_rewrite.rs
@@ -75,10 +75,6 @@ impl Transform for RedisClusterPortsRewrite {
 
         Ok(response)
     }
-
-    fn get_name(&self) -> &'static str {
-        "RedisClusterPortsRewrite"
-    }
 }
 
 /// Rewrites the ports of a response to a CLUSTER SLOTS message to `new_port`

--- a/shotover-proxy/src/transforms/redis/sink_cluster.rs
+++ b/shotover-proxy/src/transforms/redis/sink_cluster.rs
@@ -833,10 +833,6 @@ impl Transform for RedisSinkCluster {
         }
         Ok(response_buffer)
     }
-
-    fn get_name(&self) -> &'static str {
-        "RedisSinkCluster"
-    }
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Derivative)]

--- a/shotover-proxy/src/transforms/redis/sink_single.rs
+++ b/shotover-proxy/src/transforms/redis/sink_single.rs
@@ -86,10 +86,6 @@ impl Transform for RedisSinkSingle {
             None => Err(anyhow!("couldnt get frame")),
         }
     }
-
-    fn get_name(&self) -> &'static str {
-        "RedisSinkSingle"
-    }
 }
 
 #[cfg(test)]

--- a/shotover-proxy/src/transforms/redis/timestamp_tagging.rs
+++ b/shotover-proxy/src/transforms/redis/timestamp_tagging.rs
@@ -188,8 +188,4 @@ impl Transform for RedisTimestampTagger {
         debug!("response after trying to unwrap -> {:?}", response);
         response
     }
-
-    fn get_name(&self) -> &'static str {
-        "RedisTimestampTagger"
-    }
 }

--- a/shotover-proxy/src/transforms/sampler.rs
+++ b/shotover-proxy/src/transforms/sampler.rs
@@ -27,6 +27,10 @@ impl Sampler {
             sample_chain: TransformChain::new_no_shared_state(vec![], "dummy".to_string()),
         }
     }
+
+    fn get_name(&self) -> &'static str {
+        "Sampler"
+    }
 }
 
 #[async_trait]
@@ -47,9 +51,5 @@ impl Transform for Sampler {
         } else {
             message_wrapper.call_next_transform().await
         }
-    }
-
-    fn get_name(&self) -> &'static str {
-        "Sampler"
     }
 }

--- a/shotover-proxy/src/transforms/tee.rs
+++ b/shotover-proxy/src/transforms/tee.rs
@@ -63,6 +63,12 @@ impl TeeConfig {
     }
 }
 
+impl Tee {
+    fn get_name(&self) -> &'static str {
+        "Tee"
+    }
+}
+
 #[async_trait]
 impl Transform for Tee {
     async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> ChainResponse {
@@ -135,9 +141,5 @@ impl Transform for Tee {
                 Ok(chain_response)
             }
         }
-    }
-
-    fn get_name(&self) -> &'static str {
-        "tee"
     }
 }


### PR DESCRIPTION
Use [`IntoStaticStr`](https://docs.rs/strum/0.22.0/strum/derive.IntoStaticStr.html) to get the name of transforms instead of a method on the `Transform` trait. 

In some places we need access to the transform name from within the transform itself so I have added `get_name` methods directly to the struct. 