### PR TITLE
Remove MessageDetails::Bypass

### DIFF
--- a/shotover-proxy/src/message/mod.rs
+++ b/shotover-proxy/src/message/mod.rs
@@ -23,7 +23,6 @@ pub struct Message {
 
 #[derive(PartialEq, Debug, Clone)]
 pub enum MessageDetails {
-    Bypass(Box<MessageDetails>),
     Query(QueryMessage),
     Response(QueryResponse),
     Unknown,
@@ -58,14 +57,6 @@ impl Message {
         Self::new(MessageDetails::Response(qr), modified, original)
     }
 
-    pub fn new_bypass(raw_frame: RawFrame) -> Self {
-        Self::new(
-            MessageDetails::Bypass(Box::new(MessageDetails::Unknown)),
-            false,
-            raw_frame,
-        )
-    }
-
     pub fn new_raw(raw_frame: RawFrame) -> Self {
         Self::new(MessageDetails::Unknown, false, raw_frame)
     }
@@ -75,18 +66,6 @@ impl Message {
             details,
             modified,
             original: RawFrame::None,
-        }
-    }
-
-    pub fn into_bypass(self) -> Self {
-        if let MessageDetails::Bypass(_) = &self.details {
-            self
-        } else {
-            Message {
-                details: MessageDetails::Bypass(Box::new(self.details)),
-                modified: false,
-                original: self.original,
-            }
         }
     }
 }

--- a/shotover-proxy/src/protocols/cassandra_protocol2.rs
+++ b/shotover-proxy/src/protocols/cassandra_protocol2.rs
@@ -655,11 +655,6 @@ impl CassandraCodec2 {
             get_cassandra_frame(item.original)?
         } else {
             match item.details {
-                MessageDetails::Bypass(message) => self.encode_message(Message {
-                    details: *message,
-                    modified: item.modified,
-                    original: item.original,
-                })?,
                 MessageDetails::Query(qm) => {
                     CassandraCodec2::build_cassandra_query_frame(qm, Consistency::LocalQuorum)
                 }

--- a/shotover-proxy/src/protocols/redis_codec.rs
+++ b/shotover-proxy/src/protocols/redis_codec.rs
@@ -471,11 +471,6 @@ impl RedisCodec {
             get_redis_frame(item.original)?
         } else {
             match item.details {
-                MessageDetails::Bypass(message) => self.encode_message(Message {
-                    details: *message,
-                    modified: item.modified,
-                    original: item.original,
-                })?,
                 MessageDetails::Query(qm) => RedisCodec::build_redis_query_frame(qm),
                 MessageDetails::Response(qr) => RedisCodec::build_redis_response_frame(qr),
                 MessageDetails::Unknown => get_redis_frame(item.original)?,

--- a/shotover-proxy/src/transforms/kafka_sink.rs
+++ b/shotover-proxy/src/transforms/kafka_sink.rs
@@ -74,7 +74,6 @@ impl Transform for KafkaSink {
         let mut responses = vec![];
         for message in message_wrapper.messages {
             match message.details {
-                MessageDetails::Bypass(_) => {}
                 MessageDetails::Query(qm) => {
                     if let Some(ref key) = qm.get_namespaced_primary_key() {
                         if let Some(values) = qm.query_values {

--- a/shotover-proxy/src/transforms/redis/sink_cluster.rs
+++ b/shotover-proxy/src/transforms/redis/sink_cluster.rs
@@ -752,7 +752,7 @@ async fn receive_frame_response(
 #[inline(always)]
 fn send_frame_response(one_tx: oneshot::Sender<Response>, frame: Frame) -> Result<(), Response> {
     one_tx.send((
-        Message::new_bypass(RawFrame::None),
+        Message::new_raw(RawFrame::None),
         Ok(vec![Message::new(
             MessageDetails::Response(QueryResponse::empty()),
             false,
@@ -804,7 +804,7 @@ impl Transform for RedisSinkCluster {
             trace!("Got resp {:?}", s);
             let (original, response) = s.or_else(|_| -> Result<(_, _)> {
                 Ok((
-                    Message::new_bypass(RawFrame::None),
+                    Message::new_raw(RawFrame::None),
                     Ok(vec![Message::new(
                         MessageDetails::Response(QueryResponse::empty()),
                         false,


### PR DESCRIPTION
From what I can see it is only created in `redis/sink_cluster.rs` and I cant see any reason we would want to bypass something here.
Would appreciate a thorough review to make sure i'm not missing anything here.