### PR TITLE
Bench CI improvements

### DIFF
--- a/.github/workflows/bench_run.yml
+++ b/.github/workflows/bench_run.yml
@@ -1,4 +1,4 @@
-name: Benchmark Run
+name: Benchmarks
 
 on:
   pull_request:
@@ -14,8 +14,9 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  build:
+  benchmarks:
     runs-on: ubuntu-20.04
+    name: Benchmarks
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1

--- a/shotover-proxy/benches/redis_benches.rs
+++ b/shotover-proxy/benches/redis_benches.rs
@@ -8,6 +8,7 @@ use helpers::ShotoverManager;
 fn redis(c: &mut Criterion) {
     let mut group = c.benchmark_group("redis");
     group.throughput(criterion::Throughput::Elements(1));
+    group.noise_threshold(2.0);
 
     {
         let mut state = None;


### PR DESCRIPTION
* change in bench_run.yml fixes the name used when github actions reports failures
* redis_benches.rs change bumps up the threshold at which failures are detected to 200%
  + Basically I dont believe these tests can be made to give useful results for benchmarking so im giving them absurdly high values so we dont have to worry about them for now. I'm not deleting them yet, as they could be useful as measures of throughput in the future.
* bench_against_master.sh changes are to report the names of the benches that regressed and improved.
   + If this ever breaks I'm rewriting this whole thing as a rust tool. I hate bash.