### PR TITLE
Test infrastructure uses debug! instead of info!

### DIFF
--- a/test-helpers/src/docker_compose.rs
+++ b/test-helpers/src/docker_compose.rs
@@ -6,7 +6,6 @@ use std::thread;
 use std::time;
 use subprocess::{Exec, Redirection};
 use tracing::debug;
-use tracing::info;
 
 /// Runs a command and returns the output as a string.
 ///
@@ -65,8 +64,7 @@ impl DockerCompose {
 
         DockerCompose::clean_up(file_path).unwrap();
 
-        let result = run_command("docker-compose", &["-f", file_path, "up", "-d"]).unwrap();
-        info!("Starting {}: {}", file_path, result);
+        run_command("docker-compose", &["-f", file_path, "up", "-d"]).unwrap();
 
         DockerCompose {
             file_path: file_path.to_string(),
@@ -101,7 +99,7 @@ impl DockerCompose {
     /// * If `count` occurrences of `log_text` is not found in the log within 60 seconds.
     ///
     pub fn wait_for_n(self, log_text: &str, count: usize) -> Self {
-        info!("wait_for_n: '{}' {}", log_text, count);
+        debug!("wait_for_n: '{}' {}", log_text, count);
         let args = ["-f", &self.file_path, "logs"];
         let re = Regex::new(log_text).unwrap();
         let sys_time = time::Instant::now();
@@ -113,7 +111,7 @@ impl DockerCompose {
             debug!("wait_for_n: looping");
             result = run_command("docker-compose", &args).unwrap();
         }
-        info!("wait_for_n: found '{}' {} times", log_text, count);
+        debug!("wait_for_n: found '{}' {} times", log_text, count);
         self
     }
 
@@ -122,7 +120,7 @@ impl DockerCompose {
     /// # Arguments
     /// * `file_path` - The path to the docker-compose yaml file that was used to start docker.
     fn clean_up(file_path: &str) -> Result<()> {
-        info!("bringing down docker compose {}", file_path);
+        debug!("bringing down docker compose {}", file_path);
 
         run_command("docker-compose", &["-f", file_path, "down", "-v"])?;
         run_command("docker-compose", &["-f", file_path, "rm", "-f", "-s", "-v"])?;


### PR DESCRIPTION
I changed them to debug! to help reduce the noise levels when running `cargo test`/`cargo bench`.
The info! logs in shotover itself could probably do with a cleanup but im not sure which ones are important or not.
The problem of shotovers logs could probably do with some more thought both from the perspective of shotover users trying to understand shotovers internal state and from developers trying to not drown in logs.

The info! logs in test infrastructure are of much more dubious value.
Unless your actively working on a test then you dont want to see test infrastructure logging at all.

The docker-compose log is outright removed because we already log the output of that command when the command fails which is the only time we would want to see it anyway. This is the noisiest log taking up ~20 lines for a single log sometimes. So if we want to leave the others as info! we should at least get rid of this one.