### PR TITLE
Update sqlparser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2613,9 +2613,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.5.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ac1f0f284146472a721eb7b5cb4615e314c781f5f7be41d27aa98d9e0a1ff9"
+checksum = "760e624412a15d5838ae04fad01037beeff1047781431d74360cddd6b3c1c784"
 dependencies = [
  "log",
 ]

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -34,7 +34,7 @@ thiserror = "1.0"
 anyhow = "1.0.31"
 
 # Parsers
-sqlparser = "= 0.5.0"
+sqlparser = "0.12"
 serde = { version = "1.0.111", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.8.21"

--- a/shotover-proxy/src/protocols/cassandra_protocol2.rs
+++ b/shotover-proxy/src/protocols/cassandra_protocol2.rs
@@ -69,12 +69,8 @@ impl CassandraCodec2 {
         CassandraCodec2::rebuild_query_string_from_ast(&mut query);
         let QueryMessage {
             query_string,
-            namespace: _,
-            primary_key: _,
             query_values,
-            projection: _,
-            query_type: _,
-            ast: _,
+            ..
         } = query;
 
         let values: Option<QueryValues> = Some(QueryValues::SimpleValues(
@@ -117,7 +113,7 @@ impl CassandraCodec2 {
                                 )),
                                 name: CString::new(x.clone()),
                                 col_type: ColTypeOption {
-                                    id: ColType::Ascii, // todo: get types working
+                                    id: ColType::Ascii, // TODO: get types working
                                     value: None,
                                 },
                             }
@@ -128,8 +124,6 @@ impl CassandraCodec2 {
                         flags: 0,
                         columns_count: count,
                         paging_state: None,
-                        // global_table_space: Some(query.namespace.iter()
-                        //     .map(|x| CString::new(x.clone())).collect()),
                         global_table_space: None,
                         col_specs: col_spec,
                     };
@@ -143,15 +137,11 @@ impl CassandraCodec2 {
                                     let rb: CBytes = CBytes::new(match j {
                                         Value::NULL => (-1_i32).into_cbytes(),
                                         Value::Bytes(x) => x.to_vec(),
-                                        Value::Strings(x) => {
-                                            Vec::from(x.as_bytes())
-                                            // CString::new(x.clone()).into_cbytes()
-                                        }
+                                        Value::Strings(x) => Vec::from(x.as_bytes()),
                                         Value::Integer(x) => {
                                             let mut temp: Vec<u8> = Vec::new();
                                             let _ = temp.write_i64::<BigEndian>(*x).unwrap();
                                             temp
-                                            // Decimal::new(*x, 0).into_cbytes()
                                         }
                                         Value::Float(x) => {
                                             let mut temp: Vec<u8> = Vec::new();
@@ -162,7 +152,6 @@ impl CassandraCodec2 {
                                             let mut temp: Vec<u8> = Vec::new();
                                             let _ = temp.write_i32::<BigEndian>(*x as i32).unwrap();
                                             temp
-                                            // (x.clone() as CInt).into_cbytes()
                                         }
                                         _ => unreachable!(),
                                     });
@@ -199,7 +188,7 @@ impl CassandraCodec2 {
     fn value_to_expr(v: &Value) -> SQLValue {
         match v {
             Value::NULL => SQLValue::Null,
-            Value::Bytes(b) => SQLValue::SingleQuotedString(String::from_utf8(b.to_vec()).unwrap()), // todo: this is definitely wrong
+            Value::Bytes(b) => SQLValue::SingleQuotedString(String::from_utf8(b.to_vec()).unwrap()), // TODO: this is definitely wrong
             Value::Strings(s) => SQLValue::SingleQuotedString(s.clone()),
             Value::Integer(i) => SQLValue::Number(i.to_string(), false),
             Value::Float(f) => SQLValue::Number(f.to_string(), false),
@@ -302,12 +291,8 @@ impl CassandraCodec2 {
     pub fn rebuild_query_string_from_ast(message: &mut QueryMessage) {
         if let QueryMessage {
             query_string,
-            namespace: _,
-            primary_key: _,
-            query_values: _,
-            projection: _,
-            query_type: _,
             ast: Some(ASTHolder::SQL(ast)),
+            ..
         } = message
         {
             let new_query_string = format!("{}", ast);
@@ -317,25 +302,20 @@ impl CassandraCodec2 {
 
     pub fn rebuild_ast_in_message(message: &mut QueryMessage) {
         if let QueryMessage {
-            query_string: _,
             namespace,
-            primary_key: _,
             query_values: Some(query_values),
             projection: Some(qm_projection),
-            query_type: _,
             ast: Some(ASTHolder::SQL(ast)),
+            ..
         } = message
         {
             match ast {
                 Statement::Query(query) => {
                     if let SetExpr::Select(select) = &mut query.body {
                         let Select {
-                            distinct: _,
                             projection,
                             from,
                             selection,
-                            group_by: _,
-                            having: _,
                             ..
                         } = select.deref_mut();
 
@@ -352,23 +332,14 @@ impl CassandraCodec2 {
 
                         // Rebuild namespace
                         if let Some(table_ref) = from.get_mut(0) {
-                            if let TableFactor::Table {
-                                name,
-                                alias: _,
-                                args: _,
-                                with_hints: _,
-                            } = &mut table_ref.relation
-                            {
+                            if let TableFactor::Table { name, .. } = &mut table_ref.relation {
                                 let _ = std::mem::replace(
                                     name,
                                     ObjectName {
                                         0: namespace
-                                            .clone()
                                             .iter()
-                                            .map(|a| sqlparser::ast::Ident {
-                                                value: a.to_string(),
-                                                quote_style: None,
-                                            })
+                                            .cloned()
+                                            .map(sqlparser::ast::Ident::new)
                                             .collect(),
                                     },
                                 );
@@ -391,7 +362,7 @@ impl CassandraCodec2 {
     }
 
     pub(crate) fn parse_query_string(
-        query_string: String,
+        query_string: &str,
         pk_col_map: &HashMap<String, Vec<String>>,
     ) -> ParsedCassandraQueryString {
         let dialect = GenericDialect {}; //TODO write CQL dialect
@@ -400,10 +371,9 @@ impl CassandraCodec2 {
         let mut projection: Vec<String> = Vec::new();
         let mut primary_key: HashMap<String, Value> = HashMap::new();
         let mut ast: Option<Statement> = None;
-        let parsed_sql = Parser::parse_sql(&dialect, &query_string);
-        //TODO handle pks
-        // println!("{:#?}", foo);
+        let parsed_sql = Parser::parse_sql(&dialect, query_string);
 
+        //TODO handle pks
         //TODO: We absolutely don't handle multiple statements despite this loop indicating otherwise
         // for statement in ast_list.iter() {
         if let Ok(ast_list) = parsed_sql {
@@ -413,14 +383,10 @@ impl CassandraCodec2 {
                     Statement::Query(q) => {
                         if let SetExpr::Select(s) = q.body.borrow() {
                             projection = s.projection.iter().map(|s| s.to_string()).collect();
-                            if let TableFactor::Table {
-                                name,
-                                alias: _,
-                                args: _,
-                                with_hints: _,
-                            } = &s.from.get(0).unwrap().relation
+                            if let TableFactor::Table { name, .. } =
+                                &s.from.get(0).unwrap().relation
                             {
-                                namespace = name.0.clone().iter().map(|a| a.to_string()).collect();
+                                namespace = name.0.iter().map(|a| a.value.clone()).collect();
                             }
                             if let Some(sel) = &s.selection {
                                 CassandraCodec2::binary_ops_to_hashmap(sel, colmap.borrow_mut());
@@ -442,10 +408,10 @@ impl CassandraCodec2 {
                         source,
                         ..
                     } => {
-                        namespace = table_name.0.clone().iter().map(|a| a.to_string()).collect();
+                        namespace = table_name.0.iter().map(|a| a.value.clone()).collect();
                         let values = CassandraCodec2::get_column_values(&source.body);
                         for (i, c) in columns.iter().enumerate() {
-                            projection.push(c.clone().to_string());
+                            projection.push(c.value.clone());
                             if let Some(v) = values.get(i) {
                                 colmap.insert(c.to_string(), Value::Strings(v.clone()));
                             }
@@ -466,27 +432,25 @@ impl CassandraCodec2 {
                         assignments,
                         selection,
                     } => {
-                        namespace = table_name.0.clone().iter().map(|a| a.to_string()).collect();
+                        namespace = table_name.0.iter().map(|a| a.value.clone()).collect();
                         for assignment in assignments {
                             if let Expr::Value(v) = assignment.clone().value {
                                 let converted_value = CassandraCodec2::expr_to_value(v.borrow());
-                                colmap.insert(assignment.id.clone().to_string(), converted_value);
+                                colmap.insert(assignment.id.value.clone(), converted_value);
                             }
                         }
                         if let Some(s) = selection {
                             CassandraCodec2::binary_ops_to_hashmap(s, &mut primary_key);
                         }
-                        // projection = ;
                     }
                     Delete {
                         table_name,
                         selection,
                     } => {
-                        namespace = table_name.0.clone().iter().map(|a| a.to_string()).collect();
+                        namespace = table_name.0.iter().map(|a| a.value.clone()).collect();
                         if let Some(s) = selection {
                             CassandraCodec2::binary_ops_to_hashmap(s, &mut primary_key);
                         }
-                        // projection = None;
                     }
                     _ => {}
                 }
@@ -554,10 +518,8 @@ impl CassandraCodec2 {
         match frame.opcode {
             Opcode::Query => {
                 if let Ok(ResponseBody::Query(body)) = frame.get_body() {
-                    let parsed_string = CassandraCodec2::parse_query_string(
-                        body.query.clone().into_plain(),
-                        &self.pk_col_map,
-                    );
+                    let parsed_string =
+                        CassandraCodec2::parse_query_string(body.query.as_str(), &self.pk_col_map);
                     if parsed_string.ast.is_none() {
                         // TODO: Currently this will probably catch schema changes that don't match
                         // what the SQL parser expects
@@ -601,10 +563,6 @@ impl CassandraCodec2 {
     }
 
     fn decode_raw(&mut self, src: &mut BytesMut) -> Result<Option<Frame>> {
-        // while src.remaining() != 0 {
-        //
-        // }
-
         trace!("Parsing C* frame");
         let v = parser::parse_frame(src, &self.compressor, &self.current_head);
         match v {

--- a/shotover-proxy/src/transforms/redis/cache.rs
+++ b/shotover-proxy/src/transforms/redis/cache.rs
@@ -101,7 +101,7 @@ struct ValueHelper(Value);
 impl ValueHelper {
     fn as_bytes(&self) -> &[u8] {
         match &self.0 {
-            Value::Number(v) => v.as_bytes(),
+            Value::Number(v, false) => v.as_bytes(),
             Value::SingleQuotedString(v) => v.as_bytes(),
             Value::NationalStringLiteral(v) => v.as_bytes(),
             Value::HexStringLiteral(v) => v.as_bytes(),
@@ -112,9 +112,6 @@ impl ValueHelper {
                     &FALSE
                 }
             }
-            Value::Date(v) => v.as_bytes(),
-            Value::Time(v) => v.as_bytes(),
-            Value::Timestamp(v) => v.as_bytes(),
             Value::Null => &[],
             _ => unreachable!(),
         }
@@ -147,7 +144,7 @@ fn build_redis_commands(
         Expr::BinaryOp { left, op, right } => {
             // first check if this is a related to PK
             if let Expr::Identifier(i) = left.borrow() {
-                if pks.iter().any(|v| v == i) {
+                if pks.iter().any(|v| *v == i.to_string()) {
                     //Ignore this as we build the pk constraint elsewhere
                     return Ok(());
                 }

--- a/shotover-proxy/src/transforms/redis/cache.rs
+++ b/shotover-proxy/src/transforms/redis/cache.rs
@@ -144,7 +144,7 @@ fn build_redis_commands(
         Expr::BinaryOp { left, op, right } => {
             // first check if this is a related to PK
             if let Expr::Identifier(i) = left.borrow() {
-                if pks.iter().any(|v| *v == i.to_string()) {
+                if pks.iter().any(|v| *v == i.value) {
                     //Ignore this as we build the pk constraint elsewhere
                     return Ok(());
                 }
@@ -398,7 +398,7 @@ mod test {
         query_string: &str,
         pk_col_map: &HashMap<String, Vec<String>>,
     ) -> (ASTHolder, Option<HashMap<String, Value>>) {
-        let res = CassandraCodec2::parse_query_string(query_string.to_string(), pk_col_map);
+        let res = CassandraCodec2::parse_query_string(query_string, pk_col_map);
         (ASTHolder::SQL(res.ast.unwrap()), res.colmap)
     }
 


### PR DESCRIPTION
Similar to #325, I've removed our handling of Timestamp until we implement it properly

...and sqlparser moved it from their [Value enum](https://docs.rs/sqlparser/0.5.0/src/sqlparser/ast/value.rs.html#19-60) to [DataType](https://docs.rs/sqlparser/0.12.0/sqlparser/ast/enum.DataType.html#variant.Timestamp.)