### PR TITLE
Fix testing on ubuntu 18.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,12 +20,17 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: Release
+          - name: Ubuntu 18.04 - Release
+            runner: ubuntu-18.04
             cargo_profile: --release
-          - name: Debug
+          - name: Ubuntu 18.04 - Debug
+            runner: ubuntu-18.04
+            cargo_profile:
+          - name: Ubuntu 20.04 - Debug
+            runner: ubuntu-20.04
             cargo_profile:
     name: ${{ matrix.name }}
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.runner }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
@@ -62,4 +67,4 @@ jobs:
       run: |
         cargo install --locked cargo-deny
         cargo deny check licenses
-      if: ${{ matrix.name == 'Debug' }}
+      if: ${{ matrix.name == 'Ubuntu 20.04 - Debug' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,15 +328,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmake"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b858541263efe664aead4a5209a4ae5c5d2811167d4ed4ee0944503f8d2089"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "combine"
 version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2049,7 +2040,6 @@ version = "4.1.0+1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e212ccf56a2d4e0b9f874a1cad295495769e0cdbabe60e02b4f654d369a2d6a1"
 dependencies = [
- "cmake",
  "libc",
  "libz-sys",
  "num_enum 0.5.4",

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -53,7 +53,7 @@ halfbrown = "0.1.11"
 # Transform dependencies
 redis-protocol = "3.0.1"
 cassandra-proto = { git = "https://github.com/shotover/cassandra-proto", branch = "move-to-bytes", features = ["v4"] }
-rdkafka = { version = "0.27", features = ["cmake-build"] }
+rdkafka = { version = "0.27" }
 crc16 = { version = "0.4.0" }
 
 #Crypto

--- a/shotover-proxy/build/build_release.sh
+++ b/shotover-proxy/build/build_release.sh
@@ -6,6 +6,7 @@ SCRIPT_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 cd $SCRIPT_DIR/../..
 
+cargo test --release
 cargo build --release
 
 # Make glibc version

--- a/shotover-proxy/src/transforms/redis/cache.rs
+++ b/shotover-proxy/src/transforms/redis/cache.rs
@@ -593,8 +593,6 @@ mod test {
         let expected = build_redis_query_frame("ZRANGEBYLEX 1 [124 ]998");
 
         assert_eq!(expected, query);
-
-        println!("{:#?}", query);
     }
 
     #[test]


### PR DESCRIPTION
The section named "Build & Test" in the GA tagged-release workflow didnt actually do any testing!
This change fixes that, but also moves our test workflows to primarily use 18.04 as that is where our binary is built but also includes an extra 20.04 workflow so that we dont find ourselves stuck when 18.04 is EoL.

In order to fix building on ubuntu 18.04 we had to change rdkafka to build with mklove instead of cmake.
Not sure why we were using cmake in the first place as mklove seems to be shipped with rdkafka.