### PR TITLE
Use upstream cassandra-protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,21 +273,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eadde404d13254d8592f8aaa946a1fb7a2769c137df56ed29a3be5996973a156"
 
 [[package]]
-name = "cassandra-proto"
-version = "0.1.2"
-source = "git+https://github.com/shotover/cassandra-proto?branch=OPTION_fix#6527d6148c85be77d4eb324e5344be86ebba4fa9"
+name = "cassandra-protocol"
+version = "1.0.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6bcea031b58e1e74da299f6307d175ee37b581fe1b3488cf2fd6b2ab8c47376"
 dependencies = [
- "byteorder",
- "bytes",
- "cbytes_macro_derive",
- "log",
- "num_enum 0.4.3",
- "quote",
- "rand 0.4.6",
- "serde",
+ "arrayref",
+ "bitflags",
+ "chrono",
+ "derive_more",
+ "float_eq",
+ "lz4_flex",
+ "num",
  "snap",
- "syn",
- "time 0.1.43",
+ "thiserror",
+ "time 0.3.4",
  "uuid",
 ]
 
@@ -291,17 +297,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
 dependencies = [
- "rustc_version",
-]
-
-[[package]]
-name = "cbytes_macro_derive"
-version = "0.1.0"
-source = "git+https://github.com/shotover/cassandra-proto?branch=OPTION_fix#6527d6148c85be77d4eb324e5344be86ebba4fa9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -332,6 +328,7 @@ dependencies = [
  "num-integer",
  "num-traits 0.2.14",
  "serde",
+ "time 0.1.43",
  "winapi",
 ]
 
@@ -390,6 +387,12 @@ dependencies = [
  "tokio",
  "tokio-util",
 ]
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cookie-factory"
@@ -694,6 +697,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.3.3",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,6 +845,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 
 [[package]]
+name = "float_eq"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa334a728fecaf0922f5735ede5f27c08fefc7c4e5b04c5efe02a3861b512f2e"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,12 +880,6 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "funty"
@@ -1311,6 +1327,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827b976d911b5d2e42b2ccfc7c0d2461a1414e8280436885218762fc529b3f8"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1579,12 +1604,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits 0.2.14",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits 0.2.14",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
+dependencies = [
+ "num-traits 0.2.14",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
+ "num-traits 0.2.14",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits 0.2.14",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
  "num-traits 0.2.14",
 ]
 
@@ -1619,34 +1701,12 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca565a7df06f3d4b485494f25ba05da1435950f4dc263440eda7a6fa9b8e36e4"
-dependencies = [
- "derivative",
- "num_enum_derive 0.4.3",
-]
-
-[[package]]
-name = "num_enum"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9bd055fb730c4f8f4f57d45d35cd6b3f0980535b056dc7ff119cee6a66ed6f"
 dependencies = [
  "derivative",
- "num_enum_derive 0.5.4",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa5a33ddddfee04c0283a7653987d634e880347e96b5b2ed64de07efb59db9d"
-dependencies = [
- "proc-macro-crate 0.1.5",
- "proc-macro2",
- "quote",
- "syn",
+ "num_enum_derive",
 ]
 
 [[package]]
@@ -1655,7 +1715,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "486ea01961c4a818096de679a8b740b26d9033146ac5291b1c98557658f8cdd9"
 dependencies = [
- "proc-macro-crate 1.1.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -1800,6 +1860,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
 name = "phf"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1825,7 +1894,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared",
- "rand 0.8.4",
+ "rand",
 ]
 
 [[package]]
@@ -1898,15 +1967,6 @@ name = "ppv-lite86"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
-
-[[package]]
-name = "proc-macro-crate"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
-dependencies = [
- "toml",
-]
 
 [[package]]
 name = "proc-macro-crate"
@@ -2012,26 +2072,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.3",
+ "rand_core",
  "rand_hc",
 ]
 
@@ -2042,23 +2089,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -2076,7 +2108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "964d548f8e7d12e102ef183a0de7e98180c9f8729f555897a857b96e48122d2f"
 dependencies = [
  "num-traits 0.2.14",
- "rand 0.8.4",
+ "rand",
 ]
 
 [[package]]
@@ -2085,7 +2117,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
- "rand_core 0.6.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -2147,17 +2179,8 @@ checksum = "e212ccf56a2d4e0b9f874a1cad295495769e0cdbabe60e02b4f654d369a2d6a1"
 dependencies = [
  "libc",
  "libz-sys",
- "num_enum 0.5.4",
+ "num_enum",
  "pkg-config",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2175,7 +2198,7 @@ dependencies = [
  "itoa",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.8.4",
+ "rand",
  "sha1",
  "tokio",
  "tokio-util",
@@ -2302,7 +2325,7 @@ dependencies = [
  "log",
  "rusoto_credential",
  "rusoto_signature",
- "rustc_version",
+ "rustc_version 0.4.0",
  "serde",
  "serde_json",
  "tokio",
@@ -2361,7 +2384,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rusoto_credential",
- "rustc_version",
+ "rustc_version 0.4.0",
  "serde",
  "sha2",
  "tokio",
@@ -2381,11 +2404,20 @@ checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
 name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver",
+ "semver 1.0.4",
 ]
 
 [[package]]
@@ -2459,9 +2491,27 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -2596,7 +2646,7 @@ dependencies = [
  "bytes",
  "cached",
  "cassandra-cpp",
- "cassandra-proto",
+ "cassandra-protocol",
  "clap 3.0.0-beta.5",
  "clap_derive",
  "crc16",
@@ -2618,7 +2668,7 @@ dependencies = [
  "pcap",
  "pin-project-lite",
  "pktparse",
- "rand 0.8.4",
+ "rand",
  "rand_distr",
  "rdkafka",
  "redis",
@@ -2695,13 +2745,9 @@ checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "snap"
-version = "0.2.5"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95d697d63d44ad8b78b8d235bf85b34022a78af292c8918527c5f0cffdde7f43"
-dependencies = [
- "byteorder",
- "lazy_static",
-]
+checksum = "45456094d1983e2ee2a18fdfebce3189fa451699d0502cb8e3b49dba5ba41451"
 
 [[package]]
 name = "socket2"
@@ -2799,7 +2845,7 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "rand 0.8.4",
+ "rand",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
@@ -2898,7 +2944,14 @@ checksum = "99beeb0daeac2bd1e86ac2c21caddecb244b39a093594da1a661ec2060c7aedd"
 dependencies = [
  "itoa",
  "libc",
+ "time-macros",
 ]
+
+[[package]]
+name = "time-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6"
 
 [[package]]
 name = "tinytemplate"
@@ -3124,10 +3177,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "twox-hash"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "static_assertions",
+]
+
+[[package]]
 name = "typenum"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicase"
@@ -3188,10 +3257,6 @@ name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom",
- "serde",
-]
 
 [[package]]
 name = "vcpkg"

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -52,9 +52,9 @@ halfbrown = "0.1.11"
 
 # Transform dependencies
 redis-protocol = "3.0.1"
-cassandra-proto = { git = "https://github.com/shotover/cassandra-proto", branch = "OPTION_fix", features = ["v4"]}
-rdkafka = { version = "0.27" }
-crc16 = { version = "0.4.0" }
+cassandra-protocol = "=1.0.0-beta.2"
+rdkafka = "0.27"
+crc16 = "0.4.0"
 
 #Crypto
 sodiumoxide = "0.2.5"

--- a/shotover-proxy/src/message/mod.rs
+++ b/shotover-proxy/src/message/mod.rs
@@ -1,11 +1,11 @@
 use crate::protocols::RawFrame;
 use bytes::Bytes;
-use cassandra_proto::frame::frame_result::{ColSpec, ColType};
-use cassandra_proto::types::data_serialization_types::{
-    decode_ascii, decode_bigint, decode_boolean, decode_decimal, decode_double, decode_float,
-    decode_inet, decode_int, decode_smallint, decode_tinyint, decode_varchar, decode_varint,
+use cassandra_protocol::frame::frame_result::{ColSpec, ColType};
+use cassandra_protocol::types::data_serialization_types::{
+    decode_ascii, decode_bigint, decode_boolean, decode_double, decode_float, decode_inet,
+    decode_int, decode_smallint, decode_tinyint, decode_varchar,
 };
-use cassandra_proto::types::CBytes;
+use cassandra_protocol::types::CBytes;
 use redis_protocol::resp2::types::Frame;
 use serde::{Deserialize, Serialize};
 use sqlparser::ast::Statement;
@@ -347,13 +347,13 @@ impl Value {
                 ColType::Blob => Value::Bytes(Bytes::copy_from_slice(actual_bytes)),
                 ColType::Boolean => Value::Boolean(decode_boolean(actual_bytes).unwrap()),
                 ColType::Counter => Value::Integer(decode_int(actual_bytes).unwrap() as i64),
-                ColType::Decimal => Value::Float(decode_decimal(actual_bytes).unwrap().as_plain()),
+                ColType::Decimal => unimplemented!("We dont have a decimal type yet"),
                 ColType::Double => Value::Float(decode_double(actual_bytes).unwrap()),
                 ColType::Float => Value::Float(decode_float(actual_bytes).unwrap() as f64),
                 ColType::Int => Value::Integer(decode_int(actual_bytes).unwrap() as i64),
                 ColType::Uuid => Value::Bytes(Bytes::copy_from_slice(actual_bytes)),
                 ColType::Varchar => Value::Strings(decode_varchar(actual_bytes).unwrap()),
-                ColType::Varint => Value::Integer(decode_varint(actual_bytes).unwrap()),
+                ColType::Varint => unimplemented!("We dont have a varint type yet"),
                 ColType::Timeuuid => Value::Bytes(Bytes::copy_from_slice(actual_bytes)),
                 ColType::Inet => Value::Inet(decode_inet(actual_bytes).unwrap()),
                 ColType::Timestamp => Value::NULL,
@@ -406,22 +406,22 @@ impl Value {
     }
 }
 
-impl From<Value> for cassandra_proto::types::value::Bytes {
-    fn from(value: Value) -> cassandra_proto::types::value::Bytes {
+impl From<Value> for cassandra_protocol::types::value::Bytes {
+    fn from(value: Value) -> cassandra_protocol::types::value::Bytes {
         match value {
             Value::NULL => (-1).into(),
-            Value::None => cassandra_proto::types::value::Bytes::new(vec![]),
-            Value::Bytes(b) => cassandra_proto::types::value::Bytes::new(b.to_vec()),
+            Value::None => cassandra_protocol::types::value::Bytes::new(vec![]),
+            Value::Bytes(b) => cassandra_protocol::types::value::Bytes::new(b.to_vec()),
             Value::Strings(s) => s.into(),
             Value::Integer(i) => i.into(),
             Value::Float(f) => f.into(),
             Value::Boolean(b) => b.into(),
-            Value::List(l) => cassandra_proto::types::value::Bytes::from(l),
-            Value::Rows(r) => cassandra_proto::types::value::Bytes::from(r),
-            Value::NamedRows(n) => cassandra_proto::types::value::Bytes::from(n),
-            Value::Document(d) => cassandra_proto::types::value::Bytes::from(d),
+            Value::List(l) => cassandra_protocol::types::value::Bytes::from(l),
+            Value::Rows(r) => cassandra_protocol::types::value::Bytes::from(r),
+            Value::NamedRows(n) => cassandra_protocol::types::value::Bytes::from(n),
+            Value::Document(d) => cassandra_protocol::types::value::Bytes::from(d),
             Value::Inet(i) => i.into(),
-            Value::FragmentedResponse(l) => cassandra_proto::types::value::Bytes::from(l),
+            Value::FragmentedResponse(l) => cassandra_protocol::types::value::Bytes::from(l),
         }
     }
 }

--- a/shotover-proxy/src/protocols/cassandra_protocol2.rs
+++ b/shotover-proxy/src/protocols/cassandra_protocol2.rs
@@ -747,6 +747,27 @@ mod cassandra_protocol_tests {
     }
 
     #[test]
+    fn test_codec_options() {
+        let mut codec = new_codec();
+        let bytes = hex!("040000000500000000");
+        let messages = vec![Message {
+            details: MessageDetails::Unknown,
+            modified: false,
+            original: RawFrame::Cassandra(Frame {
+                version: Version::V4,
+                direction: Direction::Request,
+                flags: Flags::empty(),
+                opcode: Opcode::Options,
+                stream: 0,
+                body: vec![],
+                tracing_id: None,
+                warnings: vec![],
+            }),
+        }];
+        test_frame_codec_roundtrip(&mut codec, &bytes, messages);
+    }
+
+    #[test]
     fn test_codec_ready() {
         let mut codec = new_codec();
         let bytes = hex!("840000000200000000");

--- a/shotover-proxy/src/protocols/mod.rs
+++ b/shotover-proxy/src/protocols/mod.rs
@@ -1,7 +1,7 @@
 pub mod cassandra_protocol2;
 pub mod redis_codec;
 
-pub use cassandra_proto::frame::Frame as CassandraFrame;
+pub use cassandra_protocol::frame::Frame as CassandraFrame;
 pub use redis_protocol::resp2::prelude::Frame as RedisFrame;
 
 use anyhow::Result;

--- a/shotover-proxy/src/transforms/protect/mod.rs
+++ b/shotover-proxy/src/transforms/protect/mod.rs
@@ -260,8 +260,8 @@ mod protect_transform_tests {
 
     use anyhow::{anyhow, Result};
 
-    use cassandra_proto::consistency::Consistency;
-    use cassandra_proto::frame::Frame;
+    use cassandra_protocol::consistency::Consistency;
+    use cassandra_protocol::frame::{Flags, Frame, Version};
     use sodiumoxide::crypto::secretbox;
 
     use crate::message::{Message, MessageDetails, QueryMessage, QueryResponse, QueryType, Value};
@@ -366,12 +366,14 @@ mod protect_transform_tests {
                             .to_string(),
                         Consistency::LocalQuorum,
                         None,
+                        false,
                         None,
                         None,
                         None,
                         None,
-                        None,
-                        vec![],
+                        Flags::empty(),
+                        false,
+                        Version::V4,
                     );
 
                     let mut colk_map: HashMap<String, Vec<String>> = HashMap::new();
@@ -540,12 +542,14 @@ mod protect_transform_tests {
                         .to_string(),
                     Consistency::LocalQuorum,
                     None,
+                    false,
                     None,
                     None,
                     None,
                     None,
-                    None,
-                    vec![],
+                    Flags::empty(),
+                    false,
+                    Version::V4,
                 );
 
                 let mut colk_map: HashMap<String, Vec<String>> = HashMap::new();

--- a/shotover-proxy/src/transforms/redis/cache.rs
+++ b/shotover-proxy/src/transforms/redis/cache.rs
@@ -13,7 +13,7 @@ use crate::transforms::{
     build_chain_from_config, Transform, Transforms, TransformsConfig, Wrapper,
 };
 use bytes::{BufMut, Bytes, BytesMut};
-use cassandra_proto::frame::{Frame, Opcode};
+use cassandra_protocol::frame::{Frame, Opcode};
 use itertools::Itertools;
 use sqlparser::ast::{BinaryOperator, Expr, SetExpr, Statement, Value};
 use std::borrow::Borrow;
@@ -344,13 +344,8 @@ impl Transform for SimpleRedisCache {
         {
             for m in &mut message_wrapper.messages {
                 if let RawFrame::Cassandra(Frame {
-                    version: _,
-                    flags: _,
                     opcode: Opcode::Query,
-                    stream: _,
-                    body: _,
-                    tracing_id: _,
-                    warnings: _,
+                    ..
                 }) = &m.original
                 {
                     m.generate_message_details_query();

--- a/shotover-proxy/src/transforms/util/mod.rs
+++ b/shotover-proxy/src/transforms/util/mod.rs
@@ -12,7 +12,7 @@ pub mod unordered_cluster_connection_pool;
 pub struct Request {
     pub messages: Message,
     pub return_chan: Option<tokio::sync::oneshot::Sender<Response>>,
-    pub message_id: Option<u16>,
+    pub message_id: Option<i16>,
 }
 
 pub type Response = (Message, ChainResponse);

--- a/shotover-proxy/src/transforms/util/unordered_cluster_connection_pool.rs
+++ b/shotover-proxy/src/transforms/util/unordered_cluster_connection_pool.rs
@@ -113,10 +113,10 @@ async fn rx_process<C: CodecReadHalf>(
     codec: C,
 ) -> Result<()> {
     let mut in_r = FramedRead::new(read, codec);
-    let mut return_channel_map: HashMap<u16, (tokio::sync::oneshot::Sender<Response>, Message)> =
+    let mut return_channel_map: HashMap<i16, (tokio::sync::oneshot::Sender<Response>, Message)> =
         HashMap::new();
 
-    let mut return_message_map: HashMap<u16, Message> = HashMap::new();
+    let mut return_message_map: HashMap<i16, Message> = HashMap::new();
 
     // let foo = timeout(Duration::from_millis(10), )
 


### PR DESCRIPTION
Doesnt yet compile.
Still a lot of upstreaming required.

The current upstream parser API requires an extra allocation.
I think the best path forward is to just accept that extra allocation for now and then we can properly investigate a solution that works for all parties once we are on upstream. This is very similar to the approach we took for redis-proto.

TODO before this can be merged:
- [x] Split out cassandra-protocol from cdrs-tokio <-- https://github.com/krojew/cdrs-tokio/pull/41
- [x] Add missing PartialEq implementations
- [x] Upstream response encoding
- [x] Upstream query decoding
- [x] Upstream sync frame parser
- [x] Upstream error serializing
- [x] Logic issues - currently failing on some version issue

Edit:
Now ready for review!