### PR TITLE
force netlify to always deploy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,3 +2,4 @@
 base = "docs"
 publish = "book"
 command = "curl -L https://github.com/rust-lang/mdBook/releases/download/v0.4.13/mdbook-v0.4.13-x86_64-unknown-linux-gnu.tar.gz | tar xvz && ./mdbook build"
+ignore = "/bin/false"


### PR DESCRIPTION
fixes the issue where someone pushes a cleanup commit to a docs PR that doesnt change the output and then the netlify preview can no longer be seen due to matching the previous deploy.
e.g. https://app.netlify.com/sites/elegant-joliot-4fcb9b/deploys/6184d3c90542d1000734a86f

I have never seen this problem before so I think it is be caused by mdbook being deterministic while mkdocs is not deterministic.
You can go back to old PRs before we switched to mdbook and see that this never occurred.