### PR TITLE
Add must_use attribute to test helpers

### DIFF
--- a/shotover-proxy/tests/helpers/mod.rs
+++ b/shotover-proxy/tests/helpers/mod.rs
@@ -14,6 +14,7 @@ use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tokio_io_timeout::TimeoutStream;
 
+#[must_use]
 pub struct ShotoverManager {
     pub runtime: Option<Runtime>,
     pub runtime_handle: RuntimeHandle,

--- a/shotover-proxy/tests/runner/runner_int_tests.rs
+++ b/shotover-proxy/tests/runner/runner_int_tests.rs
@@ -28,7 +28,9 @@ fn test_runtime_create() {
 #[test]
 #[serial]
 fn test_early_shutdown_cassandra_source() {
-    ShotoverManager::from_topology_file("examples/null-cassandra/topology.yaml");
+    std::mem::drop(ShotoverManager::from_topology_file(
+        "examples/null-cassandra/topology.yaml",
+    ));
 }
 
 #[test]

--- a/test-helpers/src/docker_compose.rs
+++ b/test-helpers/src/docker_compose.rs
@@ -36,6 +36,7 @@ fn run_command(command: &str, args: &[&str]) -> Result<String> {
     }
 }
 
+#[must_use]
 pub struct DockerCompose {
     file_path: String,
 }


### PR DESCRIPTION
This will give a warning on code like this that drops the compose in a non-obvious way:
```rust

    let _compose = DockerCompose::new("examples/redis-passthrough/docker-compose.yml");
    _compose.wait_for("Ready to accept connections");
```

Example warning:
![image](https://user-images.githubusercontent.com/5120858/141083458-a932cf43-0b02-4a69-8bbe-f482491335f6.png)
