### PR TITLE
Filter Read messages in Tee

### DIFF
--- a/docs/src/user-guide/configuration.md
+++ b/docs/src/user-guide/configuration.md
@@ -127,8 +127,6 @@ chain_config:
         buffer_size: 10000
         #The child chain, that Tee will asynchronously pass requests to
         chain:
-          - QueryTypeFilter:
-              filter: Read
           - Coalesce:
               max_behavior:
                 Count: 2000

--- a/shotover-proxy/examples/redis-cluster-dr/topology.yaml
+++ b/shotover-proxy/examples/redis-cluster-dr/topology.yaml
@@ -11,8 +11,6 @@ chain_config:
         behavior: Ignore
         buffer_size: 10000
         chain:
-          - QueryTypeFilter:
-              filter: Read
           - Coalesce:
               max_behavior:
                 Count: 2000

--- a/shotover-proxy/tests/test-topologies/tee/fail.yaml
+++ b/shotover-proxy/tests/test-topologies/tee/fail.yaml
@@ -10,8 +10,6 @@ chain_config:
         behavior: FailOnMismatch
         buffer_size: 10000
         chain:
-          - QueryTypeFilter:
-              filter: Read
           - DebugReturner:
               Redis: "42"
     - DebugReturner:

--- a/shotover-proxy/tests/test-topologies/tee/fail_with_mismatch.yaml
+++ b/shotover-proxy/tests/test-topologies/tee/fail_with_mismatch.yaml
@@ -10,8 +10,6 @@ chain_config:
         behavior: FailOnMismatch
         buffer_size: 10000
         chain:
-          - QueryTypeFilter:
-              filter: Read
           - DebugReturner:
               Redis: "41"
     - DebugReturner:

--- a/shotover-proxy/tests/test-topologies/tee/ignore.yaml
+++ b/shotover-proxy/tests/test-topologies/tee/ignore.yaml
@@ -10,8 +10,6 @@ chain_config:
         behavior: Ignore
         buffer_size: 10000
         chain:
-          - QueryTypeFilter:
-              filter: Read
           - DebugReturner:
               Redis: "42"
     - DebugReturner:

--- a/shotover-proxy/tests/test-topologies/tee/ignore_with_mismatch.yaml
+++ b/shotover-proxy/tests/test-topologies/tee/ignore_with_mismatch.yaml
@@ -10,8 +10,6 @@ chain_config:
         behavior: Ignore
         buffer_size: 10000
         chain:
-          - QueryTypeFilter:
-              filter: Read
           - DebugReturner:
               Redis: "41"
     - DebugReturner:

--- a/shotover-proxy/tests/test-topologies/tee/subchain.yaml
+++ b/shotover-proxy/tests/test-topologies/tee/subchain.yaml
@@ -9,8 +9,6 @@ chain_config:
     - Tee:
         behavior:
           SubchainOnMismatch:
-            - QueryTypeFilter:
-                filter: Read
             - RedisSinkSingle:
                 remote_address: "127.0.0.1:1111"
         buffer_size: 10000

--- a/shotover-proxy/tests/test-topologies/tee/subchain_with_mismatch.yaml
+++ b/shotover-proxy/tests/test-topologies/tee/subchain_with_mismatch.yaml
@@ -10,13 +10,9 @@ chain_config:
         buffer_size: 10000
         behavior:
           SubchainOnMismatch:
-            - QueryTypeFilter:
-                filter: Read
             - RedisSinkSingle:
                 remote_address: "127.0.0.1:1111"
         chain:
-          - QueryTypeFilter:
-              filter: Read
           - DebugReturner:
               Redis: "41"
     - DebugReturner:


### PR DESCRIPTION
Filter out all "Read" messages in Tee. Removes the need to put a `QueryTypeFilter::Read` in front of Tee for it to function correctly.

Last of the fixes for #281