### PR TITLE
Fix broken doc links and enforce via mdbook-linkcheck plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ output.txt
 /.project
 /test_data
 /docs/book
+/docs/mdbook_bin

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -4,3 +4,12 @@ language = "en"
 multilingual = false
 src = "src"
 title = "Shotover"
+
+[output.html]
+
+[output.linkcheck]
+# Should we check links on the internet? Enabling this option adds a
+# non-negligible performance impact
+follow-web-links = false
+
+warning-policy = "error"

--- a/docs/mdbook.sh
+++ b/docs/mdbook.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e; set -u
+
+# Setup the the mdbook binaries if they havent already been setup
+if [ ! -d "mdbook_bin" ]; then
+    mkdir -p mdbook_bin
+    pushd mdbook_bin
+    curl -L https://github.com/rust-lang/mdBook/releases/download/v0.4.13/mdbook-v0.4.13-x86_64-unknown-linux-gnu.tar.gz | tar xvz
+    wget https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v0.7.6/mdbook-linkcheck.x86_64-unknown-linux-gnu.zip -O linkcheck.zip
+    unzip linkcheck.zip
+    chmod +x mdbook-linkcheck
+    popd
+fi
+
+# Need to set the PATH so that mdbook can find the mdbook-linkcheck plugin
+PATH="$PATH:$PWD/mdbook_bin"
+
+mdbook "$@"

--- a/docs/serve.sh
+++ b/docs/serve.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-# make sure the version here matches with the version used in netlify.toml
-cargo install mdbook --version "=0.4.13"
-mdbook serve

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -18,8 +18,6 @@ Shotover can be deployed in a number of ways, it will generally be based on the 
 * As a stand alone proxy - If you are building a Service/DBaaS/Common data layer, you can deploy Shotover on standalone hardware and really let it fly.
 * As a sidecar to your database - You can also stick Shotover on the same instance/server as your database is running on, we do it, so we won't judge you.
 
-See the [deployment guide](user-guide/deployment.md) for details.
-
 ## Roadmap
 
 * Support relevant xDS APIs (so Shotover can play nicely with service mesh implementations).

--- a/docs/src/transforms.md
+++ b/docs/src/transforms.md
@@ -219,14 +219,14 @@ Fields are protected using a NaCL secretbox (xsalsa20-poly1305). Modification of
   key_manager
 ```
 
-Currently the Protect transform supports AWS KMS and or using a local Key Encryption Key on disk. See [key management](keys.md)
+Currently the Protect transform supports AWS KMS and or using a local Key Encryption Key on disk.
 
 Note: Currently the data encryption key ID function is just defined as a static string, this will be replaced by a user defined script shortly.
 
 ### QueryCounter
 
 This transform will log the queries that pass through it.
-The log can be accessed via the [Shotover metrics](/user-guide/configuration/#observability_interface)
+The log can be accessed via the [Shotover metrics](user-guide/configuration.md#observability_interface)
 
 ```yaml
 - QueryCounter:

--- a/docs/src/user-guide/concepts.md
+++ b/docs/src/user-guide/concepts.md
@@ -23,6 +23,6 @@ A topology is how you configure Shotover. You define your sources, your transfor
 
 ## Topics
 
-Shotover has a basic, built-in topic based messaging capability. A transform can access topic channels to publish messages on to. To receive messages, there is a message source that you can assign a chain to. This allows for complex routing and asynchronous passing of messages between transform chains in a topology. See [the cassandra and kafka example](/examples/cass-redis-kafka) as an example.
+Shotover has a basic, built-in topic based messaging capability. A transform can access topic channels to publish messages on to. To receive messages, there is a message source that you can assign a chain to. This allows for complex routing and asynchronous passing of messages between transform chains in a topology.
 
 Generally if you want to build blocking behaviour in your chain, you will use transforms that have sub chains. For non-blocking behaviour (e.g. copying a query to a Kafka queue while sending it the upstream service) use topic based transforms.

--- a/docs/src/user-guide/configuration.md
+++ b/docs/src/user-guide/configuration.md
@@ -172,5 +172,3 @@ This mapping would effectively create a solution that:
 * All Redis requests are first batched and then sent to a remote Redis cluster in another region. This happens asynchronously and if the remote Redis cluster is unavailable it will not block operations to the current cluster.
 * Subsequently, all Redis actions get identified based on command type, counted and provided as a set of metrics.
 * The Redis request is then transform into a cluster aware request and routed to the correct node
-
-The entire example configuration can be found [here](/examples/redis-cluster-dr/topology.yaml).

--- a/docs/src/user-guide/introduction.md
+++ b/docs/src/user-guide/introduction.md
@@ -38,11 +38,13 @@ Shotover prioritises the following principals in the order listed:
 
 Shotover provides a set of predefined transforms that can modify, route and control queries from any number of sources to a similar number of sinks. As the user you can construct chains of these transforms to achieve the behaviour required. Each chain can then be attached to a "source" that speaks the native protocol of you chosen database. The transform chain will process each request with access to a unified/simplified representation of a generic query, the original raw query and optionally (for SQL like protocols) a parsed AST representing the query.
 
+<!--
 You can also implement your own transforms natively with Rust. For concrete examples of what you can achieve with shotover-proxy, see the following examples:
 
 * [Multi-region, active-active redis](../examples/redis-multi)
 * [Cassandra query caching in redis, with a query audit trail sent to kafka](../examples/cass-redis-kafka)
 * [Field level, "In Application" encryption for Apache Cassandra with AWS Key Management Service](../examples/cassandra-encryption)
+-->
 
 Shotover proxy currently supports the following protocols as sources:
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
 base = "docs"
-publish = "book"
-command = "curl -L https://github.com/rust-lang/mdBook/releases/download/v0.4.13/mdbook-v0.4.13-x86_64-unknown-linux-gnu.tar.gz | tar xvz && ./mdbook build"
+publish = "book/html"
+command = "./mdbook.sh test && ./mdbook.sh build"
 ignore = "/bin/false"


### PR DESCRIPTION
The setup script is adjusted to run for both netlify and local usage (previously just local usage)

I opted to delete most of the dead-links but im happy to comment them out if we want to keep them around until we bring back the pages they link to.