### PR TITLE
Always pass chain name into Wrapper

### DIFF
--- a/shotover-proxy/benches/chain_benches.rs
+++ b/shotover-proxy/benches/chain_benches.rs
@@ -19,19 +19,22 @@ fn criterion_benchmark(c: &mut Criterion) {
             vec![Transforms::Null(Null::default())],
             "bench".to_string(),
         );
-        let wrapper = Wrapper::new(vec![Message::new_query(
-            QueryMessage {
-                query_string: "".to_string(),
-                namespace: vec![],
-                primary_key: HashMap::new(),
-                query_values: None,
-                projection: None,
-                query_type: QueryType::Write,
-                ast: None,
-            },
-            true,
-            RawFrame::None,
-        )]);
+        let wrapper = Wrapper::new_with_chain_name(
+            vec![Message::new_query(
+                QueryMessage {
+                    query_string: "".to_string(),
+                    namespace: vec![],
+                    primary_key: HashMap::new(),
+                    query_values: None,
+                    projection: None,
+                    query_type: QueryType::Write,
+                    ast: None,
+                },
+                true,
+                RawFrame::None,
+            )],
+            chain.name.clone(),
+        );
 
         group.bench_function("null", |b| {
             b.to_async(&rt).iter_batched(
@@ -55,11 +58,14 @@ fn criterion_benchmark(c: &mut Criterion) {
             ],
             "bench".to_string(),
         );
-        let wrapper = Wrapper::new(vec![Message::new_raw(RawFrame::Redis(Frame::Array(vec![
-            Frame::BulkString(b"SET".to_vec()),
-            Frame::BulkString(b"foo".to_vec()),
-            Frame::BulkString(b"bar".to_vec()),
-        ])))]);
+        let wrapper = Wrapper::new_with_chain_name(
+            vec![Message::new_raw(RawFrame::Redis(Frame::Array(vec![
+                Frame::BulkString(b"SET".to_vec()),
+                Frame::BulkString(b"foo".to_vec()),
+                Frame::BulkString(b"bar".to_vec()),
+            ])))],
+            chain.name.clone(),
+        );
 
         group.bench_function("redis_timestamp_tagger", |b| {
             b.to_async(&rt).iter_batched(
@@ -83,11 +89,14 @@ fn criterion_benchmark(c: &mut Criterion) {
             ],
             "bench".to_string(),
         );
-        let wrapper = Wrapper::new(vec![Message::new_raw(RawFrame::Redis(Frame::Array(vec![
-            Frame::BulkString(b"SET".to_vec()),
-            Frame::BulkString(b"foo".to_vec()),
-            Frame::BulkString(b"bar".to_vec()),
-        ])))]);
+        let wrapper = Wrapper::new_with_chain_name(
+            vec![Message::new_raw(RawFrame::Redis(Frame::Array(vec![
+                Frame::BulkString(b"SET".to_vec()),
+                Frame::BulkString(b"foo".to_vec()),
+                Frame::BulkString(b"bar".to_vec()),
+            ])))],
+            chain.name.clone(),
+        );
 
         group.bench_function("redis_cluster_ports_rewrite", |b| {
             b.to_async(&rt).iter_batched(

--- a/shotover-proxy/src/server.rs
+++ b/shotover-proxy/src/server.rs
@@ -434,7 +434,11 @@ impl<C: Codec + 'static> Handler<C> {
             match self
                 .chain
                 .process_request(
-                    Wrapper::new_with_client_details(frame, self.client_details.clone()),
+                    Wrapper::new_with_client_details(
+                        frame,
+                        self.client_details.clone(),
+                        self.chain.name.clone(),
+                    ),
                     self.client_details.clone(),
                 )
                 .await

--- a/shotover-proxy/src/sources/mpsc_source.rs
+++ b/shotover-proxy/src/sources/mpsc_source.rs
@@ -115,7 +115,7 @@ impl AsyncMpsc {
                                 _ => {}
                             }
                             std::mem::swap(&mut buffer, &mut messages);
-                            let w: Wrapper = Wrapper::new(messages);
+                            let w = Wrapper::new_with_chain_name(messages, main_chain.name.clone());
                             info!("Flushing {} commands", w.messages.len());
 
                             if let Err(e) =
@@ -126,7 +126,7 @@ impl AsyncMpsc {
                         }
                     }
                     Some(tx) => {
-                        let w: Wrapper = Wrapper::new(messages);
+                        let w = Wrapper::new_with_chain_name(messages, main_chain.name.clone());
                         if let Err(e) =
                             tx.send(main_chain.process_request(w, "AsyncMpsc".to_string()).await)
                         {

--- a/shotover-proxy/src/transforms/mod.rs
+++ b/shotover-proxy/src/transforms/mod.rs
@@ -341,6 +341,7 @@ impl<'a> Wrapper<'a> {
         result
     }
 
+    #[cfg(test)]
     pub fn new(m: Messages) -> Self {
         Wrapper {
             messages: m,
@@ -359,21 +360,16 @@ impl<'a> Wrapper<'a> {
         }
     }
 
-    pub fn new_with_client_details(m: Messages, client_details: String) -> Self {
+    pub fn new_with_client_details(
+        m: Messages,
+        client_details: String,
+        chain_name: String,
+    ) -> Self {
         Wrapper {
             messages: m,
             transforms: vec![],
             client_details,
-            chain_name: "".to_string(),
-        }
-    }
-
-    pub fn new_with_next_transform(m: Messages, _next_transform: usize) -> Self {
-        Wrapper {
-            messages: m,
-            transforms: vec![],
-            client_details: "".to_string(),
-            chain_name: "".to_string(),
+            chain_name,
         }
     }
 

--- a/shotover-proxy/src/transforms/parallel_map.rs
+++ b/shotover-proxy/src/transforms/parallel_map.rs
@@ -97,9 +97,10 @@ impl Transform for ParallelMap {
             let mut future = UOFutures::new(self.ordered);
             for chain in self.chains.iter_mut() {
                 if let Some(message) = message_iter.next() {
-                    future.push(
-                        chain.process_request(Wrapper::new(vec![message]), "Parallel".to_string()),
-                    );
+                    future.push(chain.process_request(
+                        Wrapper::new_with_chain_name(vec![message], chain.name.clone()),
+                        "Parallel".to_string(),
+                    ));
                 }
             }
             // We do this gnarly functional chain to unwrap each individual result and pop an error on the first one

--- a/shotover-proxy/src/transforms/redis/cache.rs
+++ b/shotover-proxy/src/transforms/redis/cache.rs
@@ -90,7 +90,10 @@ impl SimpleRedisCache {
         }
 
         self.cache_chain
-            .process_request(Wrapper::new(messages), "cliebntdetailstodo".to_string())
+            .process_request(
+                Wrapper::new_with_chain_name(messages, self.cache_chain.name.clone()),
+                "cliebntdetailstodo".to_string(),
+            )
             .await
     }
 }


### PR DESCRIPTION
We wouldn't want to create a `Wrapper` outside of a chain unless testing so I have restricted the use of `new` to tests only. The other 2 `new_xxx` methods ensure that `Wrapper` should always be given a chain name.  