### PR TITLE
Run cargo udeps

### DIFF
--- a/shotover-proxy/src/protocols/cassandra_protocol2.rs
+++ b/shotover-proxy/src/protocols/cassandra_protocol2.rs
@@ -37,7 +37,6 @@ use anyhow::{anyhow, Result};
 pub struct CassandraCodec2 {
     compressor: NoCompression,
     current_head: Option<FrameHeader>,
-    current_frames: Vec<Frame>,
     pk_col_map: HashMap<String, Vec<String>>,
     bypass: bool,
 }
@@ -55,7 +54,6 @@ impl CassandraCodec2 {
         CassandraCodec2 {
             compressor: NoCompression::new(),
             current_head: None,
-            current_frames: Vec::new(),
             pk_col_map,
             bypass,
         }

--- a/shotover-proxy/src/transforms/mod.rs
+++ b/shotover-proxy/src/transforms/mod.rs
@@ -271,11 +271,6 @@ pub async fn build_chain_from_config(
     Ok(TransformChain::new(transforms, name))
 }
 
-#[derive(Debug, Clone)]
-struct QueryData {
-    query: String,
-}
-
 /// The [`Wrapper`] struct is passed into each transform and contains a list of mutable references to the
 /// remaining transforms that will process the messages attached to this [`Wrapper`].
 /// Most [`Transform`] authors will only be interested in [`Wrapper.messages`].
@@ -376,11 +371,6 @@ impl<'a> Wrapper<'a> {
     pub fn reset(&mut self, transforms: Vec<&'a mut Transforms>) {
         self.transforms = transforms;
     }
-}
-
-#[derive(Debug)]
-struct ResponseData {
-    response: Messages,
 }
 
 /// This trait is the primary extension point for Shotover-proxy.

--- a/shotover-proxy/src/transforms/protect/mod.rs
+++ b/shotover-proxy/src/transforms/protect/mod.rs
@@ -25,7 +25,6 @@ mod pkcs_11;
 
 #[derive(Clone)]
 pub struct Protect {
-    name: &'static str,
     keyspace_table_columns: HashMap<String, HashMap<String, Vec<String>>>,
     key_source: KeyManager,
     // TODO this should be a function to create key_ids based on "something", e.g. primary key
@@ -148,7 +147,6 @@ impl Protected {
 impl ProtectConfig {
     pub async fn get_source(&self) -> Result<Transforms> {
         Ok(Transforms::Protect(Protect {
-            name: "protect",
             keyspace_table_columns: self.keyspace_table_columns.clone(),
             key_source: self.key_manager.build()?,
             key_id: "XXXXXXX".to_string(),


### PR DESCRIPTION
The aftermath of running `cargo udeps` on our codebase.

If properly implementing `timeout` and `count` into `ConsistentScatter` is something we want to do I can open a ticket for it.  