### PR TITLE
Reuse wait for socket implementation across cassandra and redis

### DIFF
--- a/shotover-proxy/tests/cassandra_int_tests/basic_driver_tests.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/basic_driver_tests.rs
@@ -1,7 +1,7 @@
 use crate::helpers::ShotoverManager;
 use test_helpers::docker_compose::DockerCompose;
 
-use crate::cassandra_int_tests::new_with_points;
+use crate::cassandra_int_tests::cassandra_connection;
 use cassandra_cpp::{stmt, Session};
 use serial_test::serial;
 use tracing::debug;
@@ -60,5 +60,5 @@ fn test_basic_connection() {
     .map(|s| ShotoverManager::from_topology_file_without_observability(*s))
     .collect();
 
-    test_create_keyspace(new_with_points("127.0.0.1"));
+    test_create_keyspace(cassandra_connection("127.0.0.1", 9042));
 }

--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -1,58 +1,14 @@
-use cassandra_cpp::{stmt, Cluster, Session};
-use std::thread::sleep;
-use std::time::Duration;
-use tracing::info;
+use cassandra_cpp::{Cluster, Session};
 
 mod basic_driver_tests;
 
-pub fn new_with_points(contact_points: &str) -> Session {
-    new_with_points_and_port(contact_points, 9042)
-}
-
-pub fn new_with_points_and_port(contact_points: &str, port: u16) -> Session {
+pub fn cassandra_connection(contact_points: &str, port: u16) -> Session {
+    for contact_point in contact_points.split(',') {
+        crate::helpers::wait_for_socket_to_open(contact_point, port);
+    }
     let mut cluster = Cluster::default();
     cluster.set_contact_points(contact_points).unwrap();
     cluster.set_port(port).ok();
     cluster.set_load_balance_round_robin();
-    let mut session;
-    //let query = stmt!("SELECT keyspace_name FROM system_schema.keyspaces;");
-    let query = stmt!("SELECT release_version FROM system.local");
-
-    let attempts = 30;
-    let mut current_attempt = 0;
-
-    loop {
-        current_attempt += 1;
-        info!("attempt {}", current_attempt);
-        if current_attempt > attempts {
-            panic!("Could not connect!")
-        }
-        let millisecond = Duration::from_millis(100 * current_attempt);
-
-        match cluster.connect() {
-            Ok(conn) => {
-                session = conn;
-                match session.execute(&query).wait() {
-                    Ok(_) => {
-                        break;
-                    }
-                    Err(e) => {
-                        info!(
-                            "Could not execute dummy query {}, retrying again - retries {}",
-                            e, current_attempt
-                        );
-                        sleep(millisecond);
-                    }
-                }
-            }
-            Err(e) => {
-                info!(
-                    "Could not connect {}, retrying again - retries {}",
-                    e, current_attempt
-                );
-                sleep(millisecond);
-            }
-        }
-    }
-    session
+    cluster.connect().unwrap()
 }


### PR DESCRIPTION
Changes cassandra tests to use the wait_for_socket_to_open implementation that redis uses instead of the current cassandra level protocol level wait/retry system.

wait_for_socket_to_open has a few advantages:
* its simpler
* its reusable across different protocols
* it only fails if the port is closed. This is important because if shotover can be in a state where the port is open but the connection fails then the test should fail!