### PR TITLE
Fix docker_compose wait_for panic message

### DIFF
--- a/test-helpers/src/docker_compose.rs
+++ b/test-helpers/src/docker_compose.rs
@@ -126,10 +126,11 @@ impl DockerCompose {
         while my_count < count {
             if sys_time.elapsed().as_secs() > time {
                 panic!(
-                    "wait_for: {} second timer expired. Found {}  instances of '{}' in the log",
+                    "wait_for: {} second timer expired. Found {} instances of '{}' in the log\n{}",
                     time,
                     re.find_iter(&result).count(),
-                    log_text
+                    log_text,
+                    result
                 );
             }
             debug!("wait_for_n: {:?} looping {}/{}", log_text, my_count, count);


### PR DESCRIPTION
The actual log contents was accidentally removed in https://github.com/shotover/shotover-proxy/pull/331