### PR TITLE
Join on source task

### DIFF
--- a/shotover-proxy/src/runner.rs
+++ b/shotover-proxy/src/runner.rs
@@ -233,9 +233,8 @@ pub async fn run(
     );
 
     match topology.run_chains(trigger_shutdown_rx).await {
-        Ok((sources, mut shutdown_complete_rx)) => {
+        Ok(sources) => {
             futures::future::join_all(sources.into_iter().map(|x| x.into_join_handle())).await;
-            shutdown_complete_rx.recv().await;
             info!("Shotover was shutdown cleanly.");
             Ok(())
         }

--- a/shotover-proxy/src/runner.rs
+++ b/shotover-proxy/src/runner.rs
@@ -233,7 +233,8 @@ pub async fn run(
     );
 
     match topology.run_chains(trigger_shutdown_rx).await {
-        Ok((_, mut shutdown_complete_rx)) => {
+        Ok((sources, mut shutdown_complete_rx)) => {
+            futures::future::join_all(sources.into_iter().map(|x| x.into_join_handle())).await;
             shutdown_complete_rx.recv().await;
             info!("Shotover was shutdown cleanly.");
             Ok(())

--- a/shotover-proxy/src/sources/mod.rs
+++ b/shotover-proxy/src/sources/mod.rs
@@ -41,11 +41,11 @@ pub enum Sources {
 }
 
 impl Sources {
-    pub fn get_join_handles<T>(&self) -> &JoinHandle<Result<()>> {
+    pub fn into_join_handle(self) -> JoinHandle<Result<()>> {
         match self {
-            Sources::Cassandra(c) => &c.join_handle,
-            Sources::Mpsc(m) => &m.rx_handle,
-            Sources::Redis(r) => &r.join_handle,
+            Sources::Cassandra(c) => c.join_handle,
+            Sources::Mpsc(m) => m.rx_handle,
+            Sources::Redis(r) => r.join_handle,
         }
     }
 }

--- a/shotover-proxy/src/sources/mod.rs
+++ b/shotover-proxy/src/sources/mod.rs
@@ -5,7 +5,7 @@ use crate::sources::redis_source::{RedisConfig, RedisSource};
 use crate::transforms::chain::TransformChain;
 use async_trait::async_trait;
 use serde::Deserialize;
-use tokio::sync::{mpsc, watch};
+use tokio::sync::watch;
 use tokio::task::JoinHandle;
 
 use anyhow::Result;
@@ -63,21 +63,11 @@ impl SourcesConfig {
         chain: &TransformChain,
         topics: &mut TopicHolder,
         trigger_shutdown_rx: watch::Receiver<bool>,
-        shutdown_complete_tx: mpsc::Sender<()>,
     ) -> Result<Vec<Sources>> {
         match self {
-            SourcesConfig::Cassandra(c) => {
-                c.get_source(chain, topics, trigger_shutdown_rx, shutdown_complete_tx)
-                    .await
-            }
-            SourcesConfig::Mpsc(m) => {
-                m.get_source(chain, topics, trigger_shutdown_rx, shutdown_complete_tx)
-                    .await
-            }
-            SourcesConfig::Redis(r) => {
-                r.get_source(chain, topics, trigger_shutdown_rx, shutdown_complete_tx)
-                    .await
-            }
+            SourcesConfig::Cassandra(c) => c.get_source(chain, topics, trigger_shutdown_rx).await,
+            SourcesConfig::Mpsc(m) => m.get_source(chain, topics, trigger_shutdown_rx).await,
+            SourcesConfig::Redis(r) => r.get_source(chain, topics, trigger_shutdown_rx).await,
         }
     }
 }
@@ -89,6 +79,5 @@ pub trait SourcesFromConfig: Send {
         chain: &TransformChain,
         topics: &mut TopicHolder,
         trigger_shutdown_rx: watch::Receiver<bool>,
-        shutdown_complete_tx: mpsc::Sender<()>,
     ) -> Result<Vec<Sources>>;
 }


### PR DESCRIPTION
This PR has two changes:
* Join on the sources task when shotover shutsdown - first commit
    + this is needed to prevent a race condition where shotover ends before the source's task shutsdown. This can be observed by the `redis source shutting down` sometimes not being logged.
* Remove shutdown_complete broadcast channel - second commit
    + now that we are waiting on sources join handle it seems that this is redundant.
    + Having said that I'm a little concerned as to if there is some significance behind mini-redis taking this approach. Maybe shotover has diverged enough from mini-redis that a different approach is warranted?