### PR TITLE
Add Wrapper::flush flag

### DIFF
--- a/shotover-proxy/src/server.rs
+++ b/shotover-proxy/src/server.rs
@@ -247,18 +247,17 @@ impl<C: Codec + 'static> TcpCodecListener<C> {
     pub async fn shutdown(&mut self) {
         match self
             .chain
-            .shutdown(Wrapper::new_with_chain_name(
-                vec![],
-                self.chain.name.clone(),
-            ))
+            .process_request(
+                Wrapper::flush_with_chain_name(self.chain.name.clone()),
+                "".into(),
+            )
             .await
         {
-            Ok(()) => {
-                info!("source {} was shutdown", self.source_name);
-            }
-            Err(e) => {
-                error!("shutdown chain processing error - {}", e);
-            }
+            Ok(_) => info!("source {} was shutdown", self.source_name),
+            Err(e) => error!(
+                "source {} encountered an error when flushing the chain for shutdown: {}",
+                self.source_name, e
+            ),
         }
     }
 

--- a/shotover-proxy/src/sources/cassandra_source.rs
+++ b/shotover-proxy/src/sources/cassandra_source.rs
@@ -90,7 +90,7 @@ impl CassandraSource {
                         }
                     }
                     _ = trigger_shutdown_rx.changed() => {
-                        info!("cassandra source shutting down")
+                        listener.shutdown().await;
                     }
                 }
             }

--- a/shotover-proxy/src/sources/mpsc_source.rs
+++ b/shotover-proxy/src/sources/mpsc_source.rs
@@ -13,8 +13,7 @@ use std::time::Instant;
 use tokio::runtime::Handle;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
-use tracing::info;
-use tracing::warn;
+use tracing::{error, info, warn};
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct AsyncMpscConfig {
@@ -129,6 +128,11 @@ impl AsyncMpsc {
                         }
                     }
                 }
+            }
+            let w = Wrapper::new_with_chain_name(vec![], main_chain.name.clone());
+            match main_chain.shutdown(w).await {
+                Ok(()) => info!("source AsyncMpsc was shutdown"),
+                Err(e) => error!("process_request chain processing error - {}", e),
             }
             Ok(())
         });

--- a/shotover-proxy/src/sources/redis_source.rs
+++ b/shotover-proxy/src/sources/redis_source.rs
@@ -82,8 +82,8 @@ impl RedisSource {
                             error!(cause = %err, "failed to accept connection");
                         }
                     }
-                    _ =  trigger_shutdown_rx.changed() => {
-                        info!("redis source shutting down")
+                    _ = trigger_shutdown_rx.changed() => {
+                        listener.shutdown().await;
                     }
                 }
             }

--- a/shotover-proxy/src/transforms/chain.rs
+++ b/shotover-proxy/src/transforms/chain.rs
@@ -156,15 +156,16 @@ impl TransformChain {
                 );
 
                 match chain
-                    .shutdown(Wrapper::new_with_chain_name(vec![], chain.name.clone()))
+                    .process_request(
+                        Wrapper::flush_with_chain_name(chain.name.clone()),
+                        "".into(),
+                    )
                     .await
                 {
-                    Ok(()) => {
-                        info!("Buffered chain {} was shutdown", chain.name)
-                    }
+                    Ok(_) => info!("Buffered chain {} was shutdown", chain.name),
                     Err(e) => error!(
-                        "Internal error in buffered chain when shutting down: {:?}",
-                        e
+                        "Buffered chain {} encountered an error when flushing the chain for shutdown: {}",
+                        chain.name, e
                     ),
                 }
             }
@@ -266,11 +267,6 @@ impl TransformChain {
         }
         histogram!("shotover_chain_latency", start.elapsed(),  "chain" => self.name.clone(), "client_details" => client_details);
         result
-    }
-
-    pub async fn shutdown(&mut self, mut wrapper: Wrapper<'_>) -> Result<()> {
-        wrapper.reset(self.chain.iter_mut().collect_vec());
-        wrapper.call_next_shutdown().await
     }
 }
 

--- a/shotover-proxy/src/transforms/coalesce.rs
+++ b/shotover-proxy/src/transforms/coalesce.rs
@@ -50,13 +50,16 @@ impl Transform for Coalesce {
     async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> ChainResponse {
         self.buffer.append(&mut message_wrapper.messages);
 
-        if match self.max_behavior {
-            CoalesceBehavior::Count(c) => self.buffer.len() >= c,
-            CoalesceBehavior::WaitMs(w) => self.last_write.elapsed().as_millis() >= w,
-            CoalesceBehavior::CountOrWait(c, w) => {
-                self.last_write.elapsed().as_millis() >= w || self.buffer.len() >= c
-            }
-        } {
+        let flush_buffer = message_wrapper.flush
+            || match self.max_behavior {
+                CoalesceBehavior::Count(c) => self.buffer.len() >= c,
+                CoalesceBehavior::WaitMs(w) => self.last_write.elapsed().as_millis() >= w,
+                CoalesceBehavior::CountOrWait(c, w) => {
+                    self.last_write.elapsed().as_millis() >= w || self.buffer.len() >= c
+                }
+            };
+
+        if flush_buffer {
             //this could be done in the if statement above, but for the moment lets keep the
             //evaluation logic separate from the update
             match self.max_behavior {
@@ -74,11 +77,6 @@ impl Transform for Coalesce {
                 RawFrame::None,
             )])
         }
-    }
-
-    async fn shutdown<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<()> {
-        message_wrapper.messages.append(&mut self.buffer);
-        message_wrapper.call_next_shutdown().await
     }
 }
 

--- a/shotover-proxy/src/transforms/coalesce.rs
+++ b/shotover-proxy/src/transforms/coalesce.rs
@@ -75,6 +75,11 @@ impl Transform for Coalesce {
             )])
         }
     }
+
+    async fn shutdown<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<()> {
+        message_wrapper.messages.append(&mut self.buffer);
+        message_wrapper.call_next_shutdown().await
+    }
 }
 
 #[cfg(test)]

--- a/shotover-proxy/src/transforms/mod.rs
+++ b/shotover-proxy/src/transforms/mod.rs
@@ -280,7 +280,9 @@ pub struct Wrapper<'a> {
     transforms: Vec<&'a mut Transforms>,
     pub client_details: String,
     chain_name: String,
-    /// When true transforms must flush any buffered messages into the messages field
+    /// When true transforms must flush any buffered messages into the messages field.
+    /// This can occur at any time but will always occur before the transform is destroyed due to either
+    /// shotover or the transform's chain shutting down.
     pub flush: bool,
 }
 
@@ -435,7 +437,8 @@ pub trait Transform: Send {
     /// messages to an external system or generates its own response to the query e.g.
     /// [`crate::transforms::cassandra::cassandra_sink_single::CassandraSinkSingle`]. This type of transform
     /// is called a Terminating transform (as no subsequent transforms in the chain will be called).
-    /// * _Message count_ - Your transform should return the same number of responses as messages it receives. Transforms that
+    /// * _Message count_ - message_wrapper.messages will contain 0 or more messages.
+    /// Your transform should return the same number of responses as messages received in message_wrapper.messages. Transforms that
     /// don't do this explicitly for each call, should return the same number of responses as messages it receives over the lifetime
     /// of the transform chain. A good example of this is the [`crate::transforms::coalesce::Coalesce`] transform. The
     /// [`crate::transforms::sampler::Sampler`] transform is also another example of this, with a slightly different twist.


### PR DESCRIPTION
This is a step towards https://github.com/shotover/shotover-proxy/issues/385

This PR adds:
* A flush flag in Wrapper which indicates to transforms that they should immediately flush all buffered messages.
    + Support for this flag is added to the Coalesce transform
* coalesce shutdown logic that flushes all buffered messages.
*  Shutdown logic for sources and buffered chains that flushes all messages before dropping all their objects.

I originally planned to have a separate `Transform::shutdown` method that handles this but I had to ditch this approach because it required each transform to reimplement a lot of logic from their `Transform::transform` implementation. If for example the QueryTypeFilter transform was just simply passing on messages without filtering them that would introduce all sorts of bugs.