### PR TITLE
Fix warnings that trigger in fridays upcoming rust 1.57 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,16 +724,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dns-parser"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4d33be9473d06f75f58220f71f7a9317aca647dc061dbd3c361b0bef505fbea"
-dependencies = [
- "byteorder",
- "quick-error",
-]
-
-[[package]]
 name = "dtoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2603,7 +2593,6 @@ dependencies = [
  "criterion",
  "csv",
  "derivative",
- "dns-parser",
  "futures",
  "futures-core",
  "halfbrown",

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -68,7 +68,6 @@ criterion = { version = "0.3", features = ["async_tokio", "html_reports"] }
 redis = { version = "0.21.0", features = ["tokio-comp", "cluster"] }
 pcap = "0.9.0"
 pktparse = {version = "0.7.0", features = ["serde"]}
-dns-parser = "0.8"
 tls-parser = "0.11.0"
 threadpool = "1.0"
 tokio-io-timeout = "1.1.1"

--- a/shotover-proxy/src/message/mod.rs
+++ b/shotover-proxy/src/message/mod.rs
@@ -87,14 +87,15 @@ pub struct RawMessage {
 
 #[derive(PartialEq, Debug, Clone)]
 pub enum ASTHolder {
-    SQL(Statement),
+    // Statement is boxed because Statement takes up a lot more stack space than Value.
+    SQL(Box<Statement>),
     Commands(Value), // A flexible representation of a structured query that will naturally convert into the required type via into/from traits
 }
 
 impl ASTHolder {
     pub fn get_command(&self) -> String {
         match self {
-            ASTHolder::SQL(statement) => match statement {
+            ASTHolder::SQL(statement) => match **statement {
                 Statement::Query(_) => "SELECT",
                 Statement::Insert { .. } => "INSERT",
                 Statement::Update { .. } => "UPDATE",

--- a/shotover-proxy/src/protocols/cassandra_protocol2.rs
+++ b/shotover-proxy/src/protocols/cassandra_protocol2.rs
@@ -310,7 +310,7 @@ impl CassandraCodec2 {
             ..
         } = message
         {
-            match ast {
+            match &mut **ast {
                 Statement::Query(query) => {
                     if let SetExpr::Select(select) = &mut query.body {
                         let Select {
@@ -525,7 +525,7 @@ impl CassandraCodec2 {
                             query_values: parsed_string.colmap,
                             projection: parsed_string.projection,
                             query_type: QueryType::Read,
-                            ast: parsed_string.ast.map(ASTHolder::SQL),
+                            ast: parsed_string.ast.map(|x| ASTHolder::SQL(Box::new(x))),
                         }),
                         false,
                         RawFrame::Cassandra(frame),
@@ -849,52 +849,54 @@ mod cassandra_protocol_tests {
                 )])),
                 projection: Some(vec!["*".into()]),
                 query_type: QueryType::Read,
-                ast: Some(ASTHolder::SQL(Statement::Query(Box::new(Query {
-                    with: None,
-                    body: SetExpr::Select(Box::new(Select {
-                        distinct: false,
-                        top: None,
-                        projection: vec![SelectItem::Wildcard],
-                        from: vec![TableWithJoins {
-                            relation: TableFactor::Table {
-                                name: ObjectName(vec![
-                                    Ident {
-                                        value: "system".into(),
-                                        quote_style: None,
-                                    },
-                                    Ident {
-                                        value: "local".into(),
-                                        quote_style: None,
-                                    },
-                                ]),
-                                alias: None,
-                                args: vec![],
-                                with_hints: vec![],
-                            },
-                            joins: vec![],
-                        }],
-                        lateral_views: vec![],
-                        selection: Some(BinaryOp {
-                            left: Box::new(Expr::Identifier(Ident {
-                                value: "key".into(),
-                                quote_style: None,
-                            })),
-                            op: BinaryOperator::Eq,
-                            right: Box::new(Expr::Value(SQLValue::SingleQuotedString(
-                                "local".into(),
-                            ))),
-                        }),
-                        group_by: vec![],
-                        cluster_by: vec![],
-                        distribute_by: vec![],
-                        sort_by: vec![],
-                        having: None,
-                    })),
-                    order_by: vec![],
-                    limit: None,
-                    offset: None,
-                    fetch: None,
-                })))),
+                ast: Some(ASTHolder::SQL(Box::new(Statement::Query(Box::new(
+                    Query {
+                        with: None,
+                        body: SetExpr::Select(Box::new(Select {
+                            distinct: false,
+                            top: None,
+                            projection: vec![SelectItem::Wildcard],
+                            from: vec![TableWithJoins {
+                                relation: TableFactor::Table {
+                                    name: ObjectName(vec![
+                                        Ident {
+                                            value: "system".into(),
+                                            quote_style: None,
+                                        },
+                                        Ident {
+                                            value: "local".into(),
+                                            quote_style: None,
+                                        },
+                                    ]),
+                                    alias: None,
+                                    args: vec![],
+                                    with_hints: vec![],
+                                },
+                                joins: vec![],
+                            }],
+                            lateral_views: vec![],
+                            selection: Some(BinaryOp {
+                                left: Box::new(Expr::Identifier(Ident {
+                                    value: "key".into(),
+                                    quote_style: None,
+                                })),
+                                op: BinaryOperator::Eq,
+                                right: Box::new(Expr::Value(SQLValue::SingleQuotedString(
+                                    "local".into(),
+                                ))),
+                            }),
+                            group_by: vec![],
+                            cluster_by: vec![],
+                            distribute_by: vec![],
+                            sort_by: vec![],
+                            having: None,
+                        })),
+                        order_by: vec![],
+                        limit: None,
+                        offset: None,
+                        fetch: None,
+                    },
+                ))))),
             }),
             modified: false,
             original: RawFrame::Cassandra(Frame {

--- a/shotover-proxy/src/transforms/distributed/consistent_scatter.rs
+++ b/shotover-proxy/src/transforms/distributed/consistent_scatter.rs
@@ -66,7 +66,7 @@ fn get_timestamp(frag: &QueryResponse) -> i64 {
 }
 
 fn get_size(frag: &QueryResponse) -> usize {
-    frag.result.as_ref().map_or(0, |v| std::mem::size_of_val(v))
+    frag.result.as_ref().map_or(0, std::mem::size_of_val)
 }
 
 fn resolve_fragments(fragments: &mut Vec<QueryResponse>) -> Option<QueryResponse> {

--- a/shotover-proxy/src/transforms/query_counter.rs
+++ b/shotover-proxy/src/transforms/query_counter.rs
@@ -42,7 +42,7 @@ impl Transform for QueryCounter {
             {
                 match ast {
                     ASTHolder::SQL(statement) => {
-                        let query_type = match statement {
+                        let query_type = match **statement {
                             Statement::Query(_) => "SELECT",
                             Statement::Insert { .. } => "INSERT",
                             Statement::Copy { .. } => "COPY",

--- a/shotover-proxy/src/transforms/redis/cache.rs
+++ b/shotover-proxy/src/transforms/redis/cache.rs
@@ -241,9 +241,9 @@ fn build_redis_ast_from_sql(
     query_values: &Option<HashMap<String, ShotoverValue>>,
 ) -> Result<ASTHolder> {
     match &mut ast {
-        ASTHolder::SQL(sql) => match sql {
-            Statement::Query(ref mut q) => match q.body {
-                SetExpr::Select(ref mut s) if s.selection.is_some() => {
+        ASTHolder::SQL(sql) => match &mut **sql {
+            Statement::Query(q) => match &mut q.body {
+                SetExpr::Select(s) if s.selection.is_some() => {
                     let expr = s.selection.as_mut().unwrap();
                     let mut commands_buffer: Vec<ShotoverValue> = Vec::new();
                     let mut min: Vec<u8> = vec![b'-'];
@@ -402,7 +402,7 @@ mod test {
         pk_col_map: &HashMap<String, Vec<String>>,
     ) -> (ASTHolder, Option<HashMap<String, Value>>) {
         let res = CassandraCodec2::parse_query_string(query_string, pk_col_map);
-        (ASTHolder::SQL(res.ast.unwrap()), res.colmap)
+        (ASTHolder::SQL(Box::new(res.ast.unwrap())), res.colmap)
     }
 
     fn build_redis_query_frame(query: &str) -> ASTHolder {

--- a/shotover-proxy/src/transforms/redis/mod.rs
+++ b/shotover-proxy/src/transforms/redis/mod.rs
@@ -25,7 +25,7 @@ pub enum RedisError {
 
 impl RedisError {
     fn from_message(error: &str) -> RedisError {
-        match error.splitn(2, ' ').next() {
+        match error.split_once(' ').map(|x| x.0) {
             Some("NOAUTH") => RedisError::NotAuthenticated,
             Some("NOPERM") => RedisError::NotAuthorized,
             Some("WRONGPASS") => RedisError::BadCredentials,

--- a/shotover-proxy/tests/cassandra_int_tests/basic_driver_tests.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/basic_driver_tests.rs
@@ -46,7 +46,7 @@ fn test_cluster() {
         "examples/cassandra-cluster/topology3.yaml",
     ]
     .into_iter()
-    .map(|s| ShotoverManager::from_topology_file_without_observability(s))
+    .map(ShotoverManager::from_topology_file_without_observability)
     .collect();
 
     test_create_keyspace(cassandra_connection("127.0.0.1", 9042));

--- a/shotover-proxy/tests/helpers/mod.rs
+++ b/shotover-proxy/tests/helpers/mod.rs
@@ -170,9 +170,7 @@ pub struct ShotoverProcess {
 impl ShotoverProcess {
     #[allow(unused)]
     pub fn new(topology_path: &str) -> ShotoverProcess {
-        // TODO: this will be nicer when --profile is stabilized
-        //let all_args = ["run", "--profile", env!("PROFILE"), "--", "-t", topology_path];
-
+        // Set in build.rs from PROFILE listed in https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts
         let all_args = if env!("PROFILE") == "release" {
             vec!["run", "--release", "--", "-t", topology_path]
         } else {


### PR DESCRIPTION
You can see the warnings yourself by setting `channel = "beta"` in rust-toolchain.toml

I'm not sure why we have such an extensive packet parser just for one single test.
The fields on DnsPacket are giving unused warnings, the test doesnt make use of the dns parser so DnsPacket should just be entirely removed.
Although maybe we do want such powerful parsing in the future and the whole parser should be moved into a separate crate?

I removed the comment in `shotover-proxy/tests/helpers/mod.rs` I was expecting shotover-proxy/tests/helpers/mod.rs to make this code simpler but it didnt end up helping due to a mismatch in the values used by the PROFILE env var and the values accepted by `--profile`.