### PR TITLE
Allow Cassandra passthrough to be configured in docker-compose.yml 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -199,3 +199,6 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+
+The file shotover-proxy/examples/cassandra-passthrough/docker-entrypoint.sh originally came from https://github.com/docker-library/cassandra is copyright 2021 Docker, Inc and provided under the Apache v2 license; modified by Instacluster, Inc.

--- a/shotover-proxy/examples/cassandra-passthrough/docker-compose.yml
+++ b/shotover-proxy/examples/cassandra-passthrough/docker-compose.yml
@@ -8,3 +8,7 @@ services:
       MAX_HEAP_SIZE: "128M"
       MIN_HEAP_SIZE: "128M"
       HEAP_NEWSIZE: "24M"
+      CASSANDRA_ENABLE_SCRIPTED_USER_DEFINED_FUNCTIONS: "true"
+      CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS: "true"
+    volumes:
+      - ./docker-entrypoint.sh:/usr/local/bin/docker-entrypoint.sh

--- a/shotover-proxy/examples/cassandra-passthrough/docker-entrypoint.sh
+++ b/shotover-proxy/examples/cassandra-passthrough/docker-entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+###  https://github.com/docker-library/cassandra/blob/master/3.11/docker-entrypoint.sh
+###  This file has been copied from the above link and modified to include enable_user_defined_functions and enable_scripted_user_defined_functions to the for yaml in \ loop
+###  so extra cassandra config options can be modified from the docker-compose.yml
+
 # first arg is `-f` or `--some-option`
 # or there are no args
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then

--- a/shotover-proxy/examples/cassandra-passthrough/docker-entrypoint.sh
+++ b/shotover-proxy/examples/cassandra-passthrough/docker-entrypoint.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+set -e
+
+# first arg is `-f` or `--some-option`
+# or there are no args
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+	set -- cassandra -f "$@"
+fi
+
+# allow the container to be started with `--user`
+if [ "$1" = 'cassandra' -a "$(id -u)" = '0' ]; then
+	find "$CASSANDRA_CONF" /var/lib/cassandra /var/log/cassandra \
+		\! -user cassandra -exec chown cassandra '{}' +
+	exec gosu cassandra "$BASH_SOURCE" "$@"
+fi
+
+_ip_address() {
+	# scrape the first non-localhost IP address of the container
+	# in Swarm Mode, we often get two IPs -- the container IP, and the (shared) VIP, and the container IP should always be first
+	ip address | awk '
+		$1 != "inet" { next } # only lines with ip addresses
+		$NF == "lo" { next } # skip loopback devices
+		$2 ~ /^127[.]/ { next } # skip loopback addresses
+		$2 ~ /^169[.]254[.]/ { next } # skip link-local addresses
+		{
+			gsub(/\/.+$/, "", $2)
+			print $2
+			exit
+		}
+	'
+}
+
+# "sed -i", but without "mv" (which doesn't work on a bind-mounted file, for example)
+_sed-in-place() {
+	local filename="$1"; shift
+	local tempFile
+	tempFile="$(mktemp)"
+	sed "$@" "$filename" > "$tempFile"
+	cat "$tempFile" > "$filename"
+	rm "$tempFile"
+}
+
+if [ "$1" = 'cassandra' ]; then
+	: ${CASSANDRA_RPC_ADDRESS='0.0.0.0'}
+
+	: ${CASSANDRA_LISTEN_ADDRESS='auto'}
+	if [ "$CASSANDRA_LISTEN_ADDRESS" = 'auto' ]; then
+		CASSANDRA_LISTEN_ADDRESS="$(_ip_address)"
+	fi
+
+	: ${CASSANDRA_BROADCAST_ADDRESS="$CASSANDRA_LISTEN_ADDRESS"}
+
+	if [ "$CASSANDRA_BROADCAST_ADDRESS" = 'auto' ]; then
+		CASSANDRA_BROADCAST_ADDRESS="$(_ip_address)"
+	fi
+	: ${CASSANDRA_BROADCAST_RPC_ADDRESS:=$CASSANDRA_BROADCAST_ADDRESS}
+
+	if [ -n "${CASSANDRA_NAME:+1}" ]; then
+		: ${CASSANDRA_SEEDS:="cassandra"}
+	fi
+	: ${CASSANDRA_SEEDS:="$CASSANDRA_BROADCAST_ADDRESS"}
+
+	_sed-in-place "$CASSANDRA_CONF/cassandra.yaml" \
+		-r 's/(- seeds:).*/\1 "'"$CASSANDRA_SEEDS"'"/'
+
+	for yaml in \
+		broadcast_address \
+		broadcast_rpc_address \
+		cluster_name \
+		endpoint_snitch \
+		listen_address \
+		num_tokens \
+		rpc_address \
+		start_rpc \
+		enable_user_defined_functions \
+		enable_scripted_user_defined_functions \
+	; do
+		var="CASSANDRA_${yaml^^}"
+		val="${!var}"
+		if [ "$val" ]; then
+			_sed-in-place "$CASSANDRA_CONF/cassandra.yaml" \
+				-r 's/^(# )?('"$yaml"':).*/\2 '"$val"'/'
+		fi
+	done
+
+	for rackdc in dc rack; do
+		var="CASSANDRA_${rackdc^^}"
+		val="${!var}"
+		if [ "$val" ]; then
+			_sed-in-place "$CASSANDRA_CONF/cassandra-rackdc.properties" \
+				-r 's/^('"$rackdc"'=).*/\1 '"$val"'/'
+		fi
+	done
+fi
+
+exec "$@"

--- a/test-helpers/src/docker_compose.rs
+++ b/test-helpers/src/docker_compose.rs
@@ -1,9 +1,6 @@
 use anyhow::{anyhow, Result};
 use regex::Regex;
-use std::env::{current_dir, set_current_dir};
-use std::fs::metadata;
 use std::io::ErrorKind;
-use std::path::Path;
 use std::process::Command;
 use std::thread;
 use std::time;
@@ -51,8 +48,6 @@ impl DockerCompose {
     /// # Notes:
     /// * Does not sleep - Calling processes should sleep or use `wait_for()` to delay until the
     /// containers are ready.
-    /// * Switches to the directory containing the docker-compose.yml so any volume mounting relying on
-    /// the process being in that directory functions correctly. Switches to the previous dir when complete.
     ///
     /// # Arguments
     /// * `file_path` - The path to the docker-compose yaml file.
@@ -61,9 +56,6 @@ impl DockerCompose {
     /// * Will panic if docker-compose is not installed
     ///
     pub fn new(file_path: &str) -> Self {
-        // Assert that the path given was a file
-        assert!(metadata(file_path).unwrap().is_file());
-
         if let Err(ErrorKind::NotFound) = Command::new("docker-compose")
             .output()
             .map_err(|e| e.kind())
@@ -73,18 +65,7 @@ impl DockerCompose {
 
         DockerCompose::clean_up(file_path).unwrap();
 
-        // Save the current directory to go back to later
-        let current = current_dir().unwrap();
-
-        // Get the containing directory of the docker-compose file and switch to it
-        let example_dir_path = Path::new(file_path).parent().unwrap();
-        set_current_dir(example_dir_path).unwrap();
-
-        // Start the docker compose services
-        run_command("docker-compose", &["up", "-d"]).unwrap();
-
-        // Return to the starting dir
-        set_current_dir(&current).unwrap();
+        run_command("docker-compose", &["-f", file_path, "up", "-d"]).unwrap();
 
         DockerCompose {
             file_path: file_path.to_string(),


### PR DESCRIPTION
This change allows us to use docker compose volume mounting for files the example directory. 

E.g. We can just mount the PWD in `docker-compose.yml`

```YAML
volumes:
    - ./docker-entrypoint.sh:/usr/local/bin/docker-entrypoint.sh
```

I've also included the change to the `cassandra-passthrough` example that I needed this change for. User defined functions need to be enabled in Cassandra to test them but they can't be set from the docker-compose so we need to modify the `docker-entrypoint.sh` to do this.

The `docker-entrypoint.sh` is mostly the same as the [default](https://github.com/docker-library/cassandra/blob/master/3.11/docker-entrypoint.sh) but I added `enable_user_defined_functions` and `enable_scripted_user_defined_functions` to the `for yaml in \` loop.

I considered opening a PR to enable this on the official docker image but I found this [comment](https://github.com/docker-library/cassandra/pull/122#issuecomment-426774071) explaining why they don't want to enable this.