### PR TITLE
Fix hang in RedisSinkSingle when wrapper.messages.is_empty()

### DIFF
--- a/shotover-proxy/src/transforms/redis/sink_single.rs
+++ b/shotover-proxy/src/transforms/redis/sink_single.rs
@@ -60,6 +60,12 @@ impl Transform for RedisSinkSingle {
     }
 
     async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> ChainResponse {
+        // Return immediately if we have no messages.
+        // If we tried to send no messages we would block forever waiting for a reply that will will never come.
+        if message_wrapper.messages.is_empty() {
+            return Ok(message_wrapper.messages);
+        }
+
         if self.outbound.is_none() {
             let tcp_stream = TcpStream::connect(self.address.clone()).await.unwrap();
             let generic_stream = if let Some(tls) = self.tls.as_mut() {


### PR DESCRIPTION
Every other sink already handles this case as a noop, so we should do the same for RedisSinkSingle.
Note that the other sinks dont explicitly handle the case, its just that the async abstractions they use dont have this problem.

Although this case is currently impossible to hit in shotover usage, handling it is beneficial because:
* This hang was very confusing to debug and by handling it we prevent future shotover developers from hitting this large time sink.
* I would like to make use of this property in https://github.com/shotover/shotover-proxy/pull/389
