### PR TITLE
Clean up BufferedChain API

### DIFF
--- a/shotover-proxy/src/transforms/chain.rs
+++ b/shotover-proxy/src/transforms/chain.rs
@@ -40,18 +40,16 @@ impl BufferedChain {
     pub async fn process_request(
         &mut self,
         wrapper: Wrapper<'_>,
-        client_details: String,
         buffer_timeout_micros: Option<u64>,
     ) -> ChainResponse {
-        self.process_request_with_receiver(wrapper, client_details, buffer_timeout_micros)
+        self.process_request_with_receiver(wrapper, buffer_timeout_micros)
             .await?
             .await?
     }
 
-    pub async fn process_request_with_receiver(
+    async fn process_request_with_receiver(
         &mut self,
         wrapper: Wrapper<'_>,
-        _client_details: String,
         buffer_timeout_micros: Option<u64>,
     ) -> Result<OneReceiver<ChainResponse>> {
         let (one_tx, one_rx) = tokio::sync::oneshot::channel::<ChainResponse>();
@@ -79,7 +77,6 @@ impl BufferedChain {
     pub async fn process_request_no_return(
         &mut self,
         wrapper: Wrapper<'_>,
-        _client_details: String,
         buffer_timeout_micros: Option<u64>,
     ) -> Result<()> {
         match buffer_timeout_micros {

--- a/shotover-proxy/src/transforms/distributed/consistent_scatter.rs
+++ b/shotover-proxy/src/transforms/distributed/consistent_scatter.rs
@@ -151,11 +151,7 @@ impl Transform for ConsistentScatter {
 
         //TODO: FuturesUnordered does bias to polling the first submitted task - this will bias all requests
         for chain in self.route_map.iter_mut() {
-            rec_fu.push(chain.process_request(
-                message_wrapper.clone(),
-                "ConsistentScatter".to_string(),
-                None,
-            ));
+            rec_fu.push(chain.process_request(message_wrapper.clone(), None));
         }
 
         let mut results = Vec::new();

--- a/shotover-proxy/src/transforms/load_balance.rs
+++ b/shotover-proxy/src/transforms/load_balance.rs
@@ -69,11 +69,7 @@ impl Transform for ConnectionBalanceAndPool {
         self.active_connection
             .as_mut()
             .unwrap()
-            .process_request(
-                message_wrapper,
-                "Connection Balance and Pooler".to_string(),
-                None,
-            )
+            .process_request(message_wrapper, None)
             .await
     }
 


### PR DESCRIPTION
- We never use the client details in `BufferedChain` so I have removed it
- Make an inner method private so it's clear you should use the other 2 only