### PR TITLE
Fix CI failures when a new benchmark is added

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,14 +455,13 @@ dependencies = [
 [[package]]
 name = "criterion"
 version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
+source = "git+https://github.com/bheisler/criterion.rs?branch=version-0.4#77f1b38906ffdc3b6edc506ea5aeb50beafa63fe"
 dependencies = [
+ "anes",
  "atty",
  "cast",
  "clap 2.34.0",
  "criterion-plot",
- "csv",
  "futures",
  "itertools",
  "lazy_static",
@@ -477,8 +482,7 @@ dependencies = [
 [[package]]
 name = "criterion-plot"
 version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
+source = "git+https://github.com/bheisler/criterion.rs?branch=version-0.4#77f1b38906ffdc3b6edc506ea5aeb50beafa63fe"
 dependencies = [
  "cast",
  "itertools",

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -67,7 +67,7 @@ csv = "1.1.6"
 strum_macros = "0.23"
 
 [dev-dependencies]
-criterion = { version = "0.3", features = ["async_tokio", "html_reports"] }
+criterion = { git = "https://github.com/bheisler/criterion.rs", branch = "version-0.4", version = "0.3", features = ["async_tokio", "html_reports"] }
 redis = { version = "0.21.0", features = ["tokio-comp", "cluster"] }
 pcap = "0.9.0"
 pktparse = {version = "0.7.0", features = ["serde"]}

--- a/shotover-proxy/tests/scripts/bench_against_master.sh
+++ b/shotover-proxy/tests/scripts/bench_against_master.sh
@@ -20,8 +20,8 @@ cargo bench --bench chain_benches -- --save-baseline master --noplot
 
 echo -e "\nBenchmarking PR branch against main as a baseline"
 git checkout $ORIGINAL_REF
-cargo bench --bench redis_benches -- --baseline master --noplot | tee benches_log.txt -a
-cargo bench --bench chain_benches -- --baseline master --noplot | tee benches_log.txt -a
+cargo bench --bench redis_benches -- --baseline-lenient master --noplot | tee benches_log.txt -a
+cargo bench --bench chain_benches -- --baseline-lenient master --noplot | tee benches_log.txt -a
 
 # grep returns non zero exit code when it doesnt find anything so we need to disable pipefail
 set +o pipefail


### PR DESCRIPTION
closes https://github.com/shotover/shotover-proxy/issues/270

~~Waiting on https://github.com/bheisler/criterion.rs/pull/532 to be merged~~

The problem was caused because criterion expects a baseline to exist for every benchmark.
This PR solves the problem by making use of a new criterion feature (https://github.com/bheisler/criterion.rs/pull/532) that silently ignores missing baselines.