### PR TITLE
Fix QueryTypeFilter on main chain

### DIFF
--- a/docs/src/transforms.md
+++ b/docs/src/transforms.md
@@ -238,8 +238,6 @@ The log can be accessed via the [Shotover metrics](user-guide/configuration.md#o
 
 This transform will drop messages that match the specified filter.
 
-TODO: This doesnt send a reply for some messages, does this break the transform invariants?
-
 ```yaml
 - QueryTypeFilter:
     # drop messages that are read

--- a/shotover-proxy/src/message/mod.rs
+++ b/shotover-proxy/src/message/mod.rs
@@ -82,7 +82,9 @@ impl Message {
             details: MessageDetails::Unknown,
             modified: true,
             original: match &self.original {
-                RawFrame::Redis(_) => RawFrame::Redis(Frame::Null),
+                RawFrame::Redis(_) => RawFrame::Redis(Frame::Error(
+                    "ERR Message was filtered out by shotover".into(),
+                )),
                 RawFrame::Cassandra(frame) => RawFrame::Cassandra(CassandraFrame {
                     version: frame.version,
                     direction: Direction::Response,

--- a/shotover-proxy/src/transforms/debug/returner.rs
+++ b/shotover-proxy/src/transforms/debug/returner.rs
@@ -43,14 +43,18 @@ impl DebugReturner {
 
 #[async_trait]
 impl Transform for DebugReturner {
-    async fn transform<'a>(&'a mut self, _message_wrapper: Wrapper<'a>) -> ChainResponse {
+    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> ChainResponse {
         match &self.response {
             Response::Message(message) => Ok(message.clone()),
-            Response::Redis(string) => Ok(vec![Message {
-                details: MessageDetails::Unknown,
-                modified: false,
-                original: RawFrame::Redis(Frame::BulkString(string.clone().into_bytes())),
-            }]),
+            Response::Redis(string) => Ok(message_wrapper
+                .messages
+                .iter()
+                .map(|_| Message {
+                    details: MessageDetails::Unknown,
+                    modified: false,
+                    original: RawFrame::Redis(Frame::BulkString(string.clone().into_bytes())),
+                })
+                .collect()),
             Response::Fail => Err(anyhow!("Intentional Fail")),
         }
     }

--- a/shotover-proxy/tests/test-topologies/query_type_filter/simple.yaml
+++ b/shotover-proxy/tests/test-topologies/query_type_filter/simple.yaml
@@ -1,0 +1,16 @@
+---
+sources:
+  redis_prod:
+    Redis:
+      listen_addr: "127.0.0.1:6379"
+      connection_limit: 3000000
+chain_config:
+  redis_chain:
+    - QueryTypeFilter:
+        filter: Write
+    - DebugReturner:
+        Redis: "42"
+named_topics:
+  example: 10
+source_to_chain_mapping:
+  redis_prod: redis_chain

--- a/shotover-proxy/tests/transforms/mod.rs
+++ b/shotover-proxy/tests/transforms/mod.rs
@@ -1,1 +1,2 @@
+pub mod query_type_filter;
 pub mod tee;

--- a/shotover-proxy/tests/transforms/query_type_filter.rs
+++ b/shotover-proxy/tests/transforms/query_type_filter.rs
@@ -1,0 +1,30 @@
+use crate::helpers::ShotoverManager;
+use serial_test::serial;
+
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn test_query_type_filter() {
+    let shotover_manager =
+        ShotoverManager::from_topology_file("tests/test-topologies/query_type_filter/simple.yaml");
+
+    let mut connection = shotover_manager.redis_connection_async(6379).await;
+
+    for _ in 0..100 {
+        // Because this is a write it should be filtered out and replaced with redis null
+        let result = redis::cmd("SET")
+            .arg("key")
+            .arg("myvalue")
+            .query_async::<_, Option<i32>>(&mut connection)
+            .await
+            .unwrap();
+        assert_eq!(None, result);
+
+        // Because this is a read it should not be filtered out and gets the DebugReturner value of 42
+        let result = redis::cmd("GET")
+            .arg("key")
+            .query_async::<_, String>(&mut connection)
+            .await
+            .unwrap();
+        assert_eq!("42", result);
+    }
+}

--- a/shotover-proxy/tests/transforms/query_type_filter.rs
+++ b/shotover-proxy/tests/transforms/query_type_filter.rs
@@ -9,22 +9,68 @@ async fn test_query_type_filter() {
 
     let mut connection = shotover_manager.redis_connection_async(6379).await;
 
+    // using individual queries tests QueryTypeFilter with a MessageWrapper containing a single message at a time.
     for _ in 0..100 {
-        // Because this is a write it should be filtered out and replaced with redis null
+        // Because this is a write it should be filtered out and replaced with an error
         let result = redis::cmd("SET")
             .arg("key")
             .arg("myvalue")
-            .query_async::<_, Option<i32>>(&mut connection)
+            .query_async::<_, ()>(&mut connection)
             .await
-            .unwrap();
-        assert_eq!(None, result);
+            .unwrap_err()
+            .to_string();
+        assert_eq!(
+            "An error was signalled by the server: Message was filtered out by shotover",
+            result
+        );
 
         // Because this is a read it should not be filtered out and gets the DebugReturner value of 42
-        let result = redis::cmd("GET")
+        let result: String = redis::cmd("GET")
             .arg("key")
-            .query_async::<_, String>(&mut connection)
+            .query_async(&mut connection)
             .await
             .unwrap();
         assert_eq!("42", result);
+    }
+
+    // using a pipeline tests QueryTypeFilter with a MessageWrapper containing multiple messages at a time.
+    for _ in 0..100 {
+        // Because there is a set which is a write it should be filtered out and replaced with an error and the entire pipeline will fail as a result
+        let result = redis::pipe()
+            .cmd("SET")
+            .arg("some_key")
+            .arg("some_value")
+            .arg("some_key")
+            .ignore()
+            .cmd("GET")
+            .arg("some_key")
+            .ignore()
+            .cmd("GET")
+            .arg("some_key")
+            .query_async::<_, ()>(&mut connection)
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert_eq!(
+            "An error was signalled by the server: Message was filtered out by shotover",
+            result
+        );
+
+        // Because this is all GETs which are reads, no messages will be filtered out and the entire pipeline will succeed
+        let result: Vec<String> = redis::pipe()
+            .cmd("GET")
+            .arg("some_key")
+            .ignore()
+            .cmd("GET")
+            .arg("some_key")
+            .ignore()
+            .cmd("GET")
+            .arg("some_key")
+            .query_async(&mut connection)
+            .await
+            .unwrap();
+
+        assert_eq!(result, vec!("42".to_string()));
     }
 }


### PR DESCRIPTION
Fix QueryTypeFilter and DebugReturner so that they always return the same number of messages that they receive.
The only reason this hasnt been a problem yet is because in production we only use QueryTypeFilter in an ignore tee branch where breaking this invariant has no consequences.

DebugReturner's Response::Message case could also cause this problem but thats only used internally for unit tests and this PR is large enough already so it should be investigated separately.