### PR TITLE
Get the query type for a message by a common get_query_type method

### DIFF
--- a/shotover-proxy/src/message/mod.rs
+++ b/shotover-proxy/src/message/mod.rs
@@ -104,6 +104,16 @@ impl Message {
             },
         }
     }
+
+    /// Gets the `QueryType` for a message.
+    /// First checks the `details` of the message and then falls back to the `original` message.
+    pub fn get_query_type(&self) -> QueryType {
+        if let MessageDetails::Query(query) = &self.details {
+            query.query_type.clone()
+        } else {
+            self.original.get_query_type()
+        }
+    }
 }
 
 #[derive(PartialEq, Debug, Clone)]

--- a/shotover-proxy/src/transforms/distributed/consistent_scatter.rs
+++ b/shotover-proxy/src/transforms/distributed/consistent_scatter.rs
@@ -9,7 +9,7 @@ use tracing::{debug, error, trace, warn};
 
 use crate::config::topology::TopicHolder;
 use crate::error::ChainResponse;
-use crate::message::{Message, MessageDetails, QueryMessage, QueryResponse, QueryType, Value};
+use crate::message::{Message, MessageDetails, QueryResponse, QueryType, Value};
 use crate::protocols::RawFrame;
 use crate::transforms::chain::BufferedChain;
 use crate::transforms::{
@@ -128,16 +128,10 @@ impl Transform for ConsistentScatter {
             .map(|m| {
                 m.generate_message_details_query();
 
-                match &m.details {
-                    MessageDetails::Query(QueryMessage {
-                        query_type: QueryType::Read,
-                        ..
-                    }) => self.read_consistency,
-                    MessageDetails::Query(QueryMessage { .. }) => self.write_consistency,
-                    _ if matches!(m.original.get_query_type(), QueryType::Read) => {
-                        self.read_consistency
-                    }
-                    _ => self.write_consistency,
+                if m.get_query_type() == QueryType::Read {
+                    self.read_consistency
+                } else {
+                    self.write_consistency
                 }
             })
             .collect();

--- a/shotover-proxy/src/transforms/filter.rs
+++ b/shotover-proxy/src/transforms/filter.rs
@@ -1,5 +1,5 @@
 use crate::error::ChainResponse;
-use crate::message::{Message, MessageDetails, QueryType};
+use crate::message::{Message, QueryType};
 use crate::transforms::{Transform, Transforms, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -30,13 +30,7 @@ impl Transform for QueryTypeFilter {
             .messages
             .iter()
             .enumerate()
-            .filter(|(_, m)| {
-                if let MessageDetails::Query(qm) = &m.details {
-                    qm.query_type == self.filter
-                } else {
-                    m.original.get_query_type() == self.filter
-                }
-            })
+            .filter(|(_, m)| m.get_query_type() == self.filter)
             .map(|(i, m)| (i, m.to_filtered_reply()))
             .collect();
 

--- a/shotover-proxy/src/transforms/redis/cache.rs
+++ b/shotover-proxy/src/transforms/redis/cache.rs
@@ -349,10 +349,8 @@ impl Transform for SimpleRedisCache {
                 }) = &m.original
                 {
                     m.generate_message_details_query();
-                    if let MessageDetails::Query(qm) = &m.details {
-                        if qm.query_type == QueryType::Write {
-                            updates += 1;
-                        }
+                    if m.get_query_type() == QueryType::Write {
+                        updates += 1;
                     }
                 }
             }


### PR DESCRIPTION
Refactor towards getting RedisCache working.

Simplifies and unifies the implementation of various transforms