### PR TITLE
Implement test_cassandra_redis_cache integration test

### DIFF
--- a/docs/src/transforms.md
+++ b/docs/src/transforms.md
@@ -116,7 +116,6 @@ This transform will log the query/message at an info level, then call the down-c
 - DebugPrinter
 ```
 
-
 ### DebugReturner
 
 This transform will drop any messages it receives and return the supplied response.
@@ -261,12 +260,15 @@ This transform will attempt to cache values for a given primary key in a Redis h
 
 ```yaml
 - RedisCache:
-    # The redis connection url. E.g. `config_values: "redis://127.0.0.1/"`
-    config_values: "redis://127.0.0.1/"
+    caching_schema:
+      test:
+        partition_key: [test]
+        range_key: [test]
     chain:
-      - QueryTypeFilter:
-          filter: Read
-      - Null
+      # The chain can contain anything but must end in a Redis sink
+      - RedisSinkSingle:
+          # The IP address and port of the upstream redis node/service.
+          remote_address: "127.0.0.1:6379"
 ```
 
 ### RedisClusterPortsRewrite

--- a/shotover-proxy/examples/cassandra-redis-cache/docker-compose.yml
+++ b/shotover-proxy/examples/cassandra-redis-cache/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3.3"
+services:
+  redis-one:
+    image: library/redis:5.0.9
+    ports:
+      - "6378:6379"
+  cassandra-one:
+    image: library/cassandra:3.11.10
+    ports:
+      - "9043:9042"
+    environment:
+      MAX_HEAP_SIZE: "128M"
+      MIN_HEAP_SIZE: "128M"
+      HEAP_NEWSIZE: "24M"
+      CASSANDRA_ENABLE_SCRIPTED_USER_DEFINED_FUNCTIONS: "true"
+      CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS: "true"
+    volumes:
+      - ./docker-entrypoint.sh:/usr/local/bin/docker-entrypoint.sh

--- a/shotover-proxy/examples/cassandra-redis-cache/docker-entrypoint.sh
+++ b/shotover-proxy/examples/cassandra-redis-cache/docker-entrypoint.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+set -e
+
+###  https://github.com/docker-library/cassandra/blob/master/3.11/docker-entrypoint.sh
+###  This file has been copied from the above link and modified to include enable_user_defined_functions and enable_scripted_user_defined_functions to the for yaml in \ loop
+###  so extra cassandra config options can be modified from the docker-compose.yml
+
+# first arg is `-f` or `--some-option`
+# or there are no args
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+	set -- cassandra -f "$@"
+fi
+
+# allow the container to be started with `--user`
+if [ "$1" = 'cassandra' -a "$(id -u)" = '0' ]; then
+	find "$CASSANDRA_CONF" /var/lib/cassandra /var/log/cassandra \
+		\! -user cassandra -exec chown cassandra '{}' +
+	exec gosu cassandra "$BASH_SOURCE" "$@"
+fi
+
+_ip_address() {
+	# scrape the first non-localhost IP address of the container
+	# in Swarm Mode, we often get two IPs -- the container IP, and the (shared) VIP, and the container IP should always be first
+	ip address | awk '
+		$1 != "inet" { next } # only lines with ip addresses
+		$NF == "lo" { next } # skip loopback devices
+		$2 ~ /^127[.]/ { next } # skip loopback addresses
+		$2 ~ /^169[.]254[.]/ { next } # skip link-local addresses
+		{
+			gsub(/\/.+$/, "", $2)
+			print $2
+			exit
+		}
+	'
+}
+
+# "sed -i", but without "mv" (which doesn't work on a bind-mounted file, for example)
+_sed-in-place() {
+	local filename="$1"; shift
+	local tempFile
+	tempFile="$(mktemp)"
+	sed "$@" "$filename" > "$tempFile"
+	cat "$tempFile" > "$filename"
+	rm "$tempFile"
+}
+
+if [ "$1" = 'cassandra' ]; then
+	: ${CASSANDRA_RPC_ADDRESS='0.0.0.0'}
+
+	: ${CASSANDRA_LISTEN_ADDRESS='auto'}
+	if [ "$CASSANDRA_LISTEN_ADDRESS" = 'auto' ]; then
+		CASSANDRA_LISTEN_ADDRESS="$(_ip_address)"
+	fi
+
+	: ${CASSANDRA_BROADCAST_ADDRESS="$CASSANDRA_LISTEN_ADDRESS"}
+
+	if [ "$CASSANDRA_BROADCAST_ADDRESS" = 'auto' ]; then
+		CASSANDRA_BROADCAST_ADDRESS="$(_ip_address)"
+	fi
+	: ${CASSANDRA_BROADCAST_RPC_ADDRESS:=$CASSANDRA_BROADCAST_ADDRESS}
+
+	if [ -n "${CASSANDRA_NAME:+1}" ]; then
+		: ${CASSANDRA_SEEDS:="cassandra"}
+	fi
+	: ${CASSANDRA_SEEDS:="$CASSANDRA_BROADCAST_ADDRESS"}
+
+	_sed-in-place "$CASSANDRA_CONF/cassandra.yaml" \
+		-r 's/(- seeds:).*/\1 "'"$CASSANDRA_SEEDS"'"/'
+
+	for yaml in \
+		broadcast_address \
+		broadcast_rpc_address \
+		cluster_name \
+		endpoint_snitch \
+		listen_address \
+		num_tokens \
+		rpc_address \
+		start_rpc \
+		enable_user_defined_functions \
+		enable_scripted_user_defined_functions \
+	; do
+		var="CASSANDRA_${yaml^^}"
+		val="${!var}"
+		if [ "$val" ]; then
+			_sed-in-place "$CASSANDRA_CONF/cassandra.yaml" \
+				-r 's/^(# )?('"$yaml"':).*/\2 '"$val"'/'
+		fi
+	done
+
+	for rackdc in dc rack; do
+		var="CASSANDRA_${rackdc^^}"
+		val="${!var}"
+		if [ "$val" ]; then
+			_sed-in-place "$CASSANDRA_CONF/cassandra-rackdc.properties" \
+				-r 's/^('"$rackdc"'=).*/\1 '"$val"'/'
+		fi
+	done
+fi
+
+exec "$@"

--- a/shotover-proxy/examples/cassandra-redis-cache/topology.yaml
+++ b/shotover-proxy/examples/cassandra-redis-cache/topology.yaml
@@ -1,0 +1,30 @@
+---
+sources:
+  cassandra_prod:
+    Cassandra:
+      listen_addr: "127.0.0.1:9042"
+      cassandra_ks:
+        system.local:
+          - key
+        test.simple:
+          - pk
+        test.clustering:
+          - pk
+          - clustering
+chain_config:
+  main_chain:
+    - RedisCache:
+        caching_schema:
+          test:
+            partition_key: [test]
+            range_key: [test]
+        chain:
+          - RedisSinkSingle:
+              remote_address: "127.0.0.1:6379"
+    - CassandraSinkSingle:
+        remote_address: "127.0.0.1:9043"
+        result_processing: false
+named_topics:
+  testtopic: 5
+source_to_chain_mapping:
+  cassandra_prod: main_chain

--- a/shotover-proxy/tests/cassandra_int_tests/basic_driver_tests.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/basic_driver_tests.rs
@@ -254,3 +254,20 @@ fn test_passthrough() {
     udt::test(&connection);
     functions::test(&connection);
 }
+
+#[test]
+#[serial]
+fn test_cassandra_redis_cache() {
+    let _compose = DockerCompose::new("examples/cassandra-redis-cache/docker-compose.yml")
+        .wait_for_n_t("Startup complete", 1, 90);
+
+    let _shotover_manager =
+        ShotoverManager::from_topology_file("examples/cassandra-redis-cache/topology.yaml");
+
+    let connection = cassandra_connection("127.0.0.1", 9042);
+
+    keyspace::test(&connection);
+    table::test(&connection);
+    udt::test(&connection);
+    functions::test(&connection);
+}


### PR DESCRIPTION
The test currently demonstrates that the RedisCache transform can at least pass on messages to cassandra without issues.

Still need to test that the cache actually caches something.
We can do that by manually modifying the cache and checking we get the modified version back.
But that should go in a follow up PR.