### PR TITLE
Replace CoalesceBehaviour with individual fields in Coalesce.

### DIFF
--- a/docs/src/transforms.md
+++ b/docs/src/transforms.md
@@ -64,21 +64,17 @@ Note: this will just pass the query to the remote node. No cluster discovery or 
 ### Coalesce
 
 This transform holds onto messages until some requirement is met and then sends them batched together.
+Validation will fail if none of the `flush_when_` fields are provided, as this would otherwise result in a Coalesce transform that never flushes.
 
 ```yaml
 - Coalesce:
-    max_behavior:
-      # Messages are held until the specified number of messages have been received.
-      Count: 2000
-      # alternatively:
-      #
-      # Wait until 100ms have passed
-      # Messages are held until the specified number of milliseconds has passed
-      # WaitMs(100)
-      #
-      # Messages are held until the specified number of messages have been received
-      # or the specified number of milliseconds has passed.
-      # CountOrWait(2000, 100)
+    # When this field is provided a flush will occur when the specified number of messages are currently held in the buffer.
+    flush_when_buffered_message_count: 2000
+
+    # When this field is provided a flush will occur when the following occurs in sequence:
+    # 1. the specified number of milliseconds have passed since the last flush ocurred
+    # 2. a new message is received
+    flush_when_millis_since_last_flush: 10000
 ```
 
 ### ConsistentScatter
@@ -91,9 +87,9 @@ Upon receiving the configured number of responses, the transform will attempt to
 
 ```yaml
 - ConsistentScatter:
-    # write_consistency - The number of chains to wait for a "write" response on.
+    # The number of chains to wait for a "write" response on.
     write_consistency: 2
-    # read_consistency - The number of chains to wait for a "read" response on.
+    # The number of chains to wait for a "read" response on.
     read_consistency: 2
     # A map of named chains. All chains will be used in each request.
     route_map:

--- a/docs/src/user-guide/configuration.md
+++ b/docs/src/user-guide/configuration.md
@@ -130,8 +130,7 @@ chain_config:
           - QueryTypeFilter:
               filter: Read
           - Coalesce:
-              max_behavior:
-                Count: 2000
+              flush_when_buffered_message_count: 2000
           - QueryCounter:
               name: "DR chain"
           - RedisSinkCluster:

--- a/shotover-proxy/examples/redis-cluster-dr/topology.yaml
+++ b/shotover-proxy/examples/redis-cluster-dr/topology.yaml
@@ -14,8 +14,8 @@ chain_config:
           - QueryTypeFilter:
               filter: Read
           - Coalesce:
-              max_behavior:
-                Count: 2000
+              flush_when_buffered_message_count: 2000
+              flush_when_millis_since_last_flush: 10000
           - QueryCounter:
               name: "DR chain"
           - RedisSinkCluster:

--- a/shotover-proxy/src/sources/mpsc_source.rs
+++ b/shotover-proxy/src/sources/mpsc_source.rs
@@ -4,7 +4,6 @@ use tokio::sync::mpsc::Receiver;
 use crate::config::topology::{ChannelMessage, TopicHolder};
 use crate::server::Shutdown;
 use crate::sources::{Sources, SourcesFromConfig};
-use crate::transforms::coalesce::CoalesceBehavior;
 use crate::transforms::Wrapper;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -14,6 +13,13 @@ use tokio::runtime::Handle;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
+
+#[derive(Deserialize, Debug, Clone)]
+pub enum CoalesceBehavior {
+    Count(usize),
+    WaitMs(u128),
+    CountOrWait(usize, u128),
+}
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct AsyncMpscConfig {


### PR DESCRIPTION
Using enums in configuration to make it impossible to represent invalid states is really powerful.
I think the `tls` field in RedisSink is a good example of where this works really well.

However in the case of the `max_behaviour` field in Coalesce I think the benefit tips the other way and we are better off with separate fields.
Conceptually we have two separate optional values that we want to configure: flush by timeout and flush by message count.
But we are currently combining both into one enum to avoid the invalid state where none of these values are provided.
This gives us a really awkward 3rd variant: CountOrWait that is both difficult to document and difficult to use.
The current CountOrWait implementation could be improved by replacing it with a `CountOrWait { count: usize, wait: u128 }`
But I think that would still be pretty confusing.

I propose we split the enum into two fields and maintain the same safety by adding an equivalent validation check.
This will make the API simpler to use and the documentation easier to understand.
Incidentally it makes the implementation a bit simpler too.