### PR TITLE
Improve cassandra redis cache int test + tracing

### DIFF
--- a/shotover-proxy/examples/cassandra-redis-cache/docker-compose.yml
+++ b/shotover-proxy/examples/cassandra-redis-cache/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   redis-one:
     image: library/redis:5.0.9
     ports:
-      - "6378:6379"
+      - "6379:6379"
   cassandra-one:
     image: library/cassandra:3.11.10
     ports:

--- a/shotover-proxy/examples/cassandra-redis-cache/topology.yaml
+++ b/shotover-proxy/examples/cassandra-redis-cache/topology.yaml
@@ -2,6 +2,7 @@
 sources:
   cassandra_prod:
     Cassandra:
+      query_processing: true
       listen_addr: "127.0.0.1:9042"
       cassandra_ks:
         system.local:
@@ -15,7 +16,7 @@ chain_config:
   main_chain:
     - RedisCache:
         caching_schema:
-          test:
+          test_cache_keyspace.test_table:
             partition_key: [test]
             range_key: [test]
         chain:


### PR DESCRIPTION
* Various fixes to the integration test
* Add a cache::test function for testing caching functionality
   + It demonstrates the current working functionality of RedisCache - which is to say it demonstrates that the caching does nothing and no key/values are inserted into redis.
* Various improvements to RedisCache error reporting
    + The changes make it too verbose but that is better than silently ignoring all errors like it used to do
    + We can change the expected failed to cache cases to occur silently once everything is working.
    
I would like to merge this PR as a base to build upon, and then add the fixes to RedisCache in a follow up PR.