### PR TITLE
Redis cache doesnt blow up when the cache path is taken

### DIFF
--- a/shotover-proxy/examples/cassandra-redis-cache/topology.yaml
+++ b/shotover-proxy/examples/cassandra-redis-cache/topology.yaml
@@ -5,19 +5,14 @@ sources:
       query_processing: true
       listen_addr: "127.0.0.1:9042"
       cassandra_ks:
-        system.local:
-          - key
-        test.simple:
-          - pk
-        test.clustering:
-          - pk
-          - clustering
+        test_cache_keyspace.test_table:
+          - id
 chain_config:
   main_chain:
     - RedisCache:
         caching_schema:
           test_cache_keyspace.test_table:
-            partition_key: [test]
+            partition_key: [id]
             range_key: [test]
         chain:
           - RedisSinkSingle:

--- a/shotover-proxy/tests/cassandra_int_tests/basic_driver_tests.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/basic_driver_tests.rs
@@ -259,12 +259,19 @@ mod cache {
             ],
         );
 
-        // TODO: This triggers a panic in transforms/redis/cache.rs
-        // assert_query_result(
-        //     session,
-        //     "SELECT id, x, name FROM test_cache_keyspace.test_table WHERE x=400",
-        //     &[],
-        // );
+        // query against the primary key
+        assert_query_result(
+            session,
+            "SELECT id, x, name FROM test_cache_keyspace.test_table WHERE id=1",
+            &[],
+        );
+
+        // query against some other field
+        assert_query_result(
+            session,
+            "SELECT id, x, name FROM test_cache_keyspace.test_table WHERE x=11",
+            &[],
+        );
 
         // Insert a dummy key to ensure the keys command is working correctly, we can remove this later.
         redis_connection


### PR DESCRIPTION
The integration test now actually takes the cache path.
This revealed the issue that we actually attempt to directly return the redis messages as cassandra messages, this naturally causes the decoder to error out.
In order to get the integration test passing I made a dummy redis-cache to cassandra message conversion that just ignores the redis message and generates an empty cassandra message.
This logic will be completely replaced later on but it will be really useful to have a test checked in that actually takes the cache path.

There is a separate testcase for queries against the PK and against some other field because they take different codepaths and the 2nd case currently sends an invalid query to redis, as can be seen by the output of `info!("Received reply from redis cache {:?}", message);`

After staring at the code for a while it seems we can only cache queries that have an equality check against a primary key.
Is that an intentional restriction or have we just not yet implemented handling for other cases?