### PR TITLE
Update to redis-protocol 4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,9 +48,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.52"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
+checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
 
 [[package]]
 name = "arrayref"
@@ -231,10 +231,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
-name = "cached"
-version = "0.29.0"
+name = "bytes-utils"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "159fb7ae0e3580b5f22f4dbdaf162cd8dfb9542a79e4cdd47436b3f01d2f62f1"
+checksum = "4e314712951c43123e5920a446464929adc667a5eade7f8fb3997776c9df6e54"
+dependencies = [
+ "bytes",
+ "either",
+]
+
+[[package]]
+name = "cached"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4dfac631a8e77b2f327f7852bb6172771f5279c4512efe79fad6067b37be3d"
 dependencies = [
  "async-mutex",
  "async-rwlock",
@@ -300,7 +310,7 @@ dependencies = [
  "num",
  "snap",
  "thiserror",
- "time 0.3.5",
+ "time 0.3.6",
  "uuid",
 ]
 
@@ -439,9 +449,9 @@ checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
 
 [[package]]
 name = "crc32fast"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "738c290dfaea84fc1ca15ad9c168d083b05a714e1efddd8edaab678dc28d2836"
+checksum = "a2209c310e29876f7f0b2721e7e26b84aff178aa3da5d091f9bfbf47669e60e3"
 dependencies = [
  "cfg-if",
 ]
@@ -748,15 +758,15 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
+checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
 
 [[package]]
 name = "fastrand"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779d043b6a0b90cc4c0ed7ee380a6504394cee7efd7db050e3774eee387324b2"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
 ]
@@ -1154,9 +1164,9 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1182,9 +1192,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
 
 [[package]]
 name = "libloading"
@@ -1616,6 +1626,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71a1eb3a36534514077c1e079ada2fb170ef30c47d203aa6916138cf882ecd52"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1922,9 +1941,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
@@ -2072,11 +2091,12 @@ dependencies = [
 
 [[package]]
 name = "redis-protocol"
-version = "3.1.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb7023bcb2073713373c72c4096ec4fee06819b3047991b8c187e8c00072d3"
+checksum = "d5545304be6e60d4521e9a4f7354362cd8f9f9a419abc54af7af289bfab540ec"
 dependencies = [
  "bytes",
+ "bytes-utils",
  "cookie-factory",
  "crc16",
  "log",
@@ -2354,9 +2374,9 @@ checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"
-version = "1.0.133"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
+checksum = "2cf9235533494ea2ddcdb794665461814781c53f19d87b76e571a1c35acbad2b"
 dependencies = [
  "serde_derive",
 ]
@@ -2373,9 +2393,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.133"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
+checksum = "8dcde03d87d4c973c04be249e7d8f0b35db1c848c487bd43032808e59dd8328d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2384,9 +2404,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.75"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c059c05b48c5c0067d4b4b2b4f0732dd65feb52daf7e0ea09cd87e7dadc1af79"
+checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -2493,6 +2513,7 @@ dependencies = [
  "bincode",
  "byteorder",
  "bytes",
+ "bytes-utils",
  "cached",
  "cassandra-cpp",
  "cassandra-protocol",
@@ -2601,9 +2622,9 @@ checksum = "45456094d1983e2ee2a18fdfebce3189fa451699d0502cb8e3b49dba5ba41451"
 
 [[package]]
 name = "socket2"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
+checksum = "0f82496b90c36d70af5fcd482edaa2e0bd16fade569de1330405fecbbdac736b"
 dependencies = [
  "libc",
  "winapi",
@@ -2673,9 +2694,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2786,12 +2807,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
+checksum = "c8d54b9298e05179c335de2b9645d061255bcd5155f843b3e328d2cfe0a5b413"
 dependencies = [
- "itoa 0.4.8",
+ "itoa 1.0.1",
  "libc",
+ "num_threads",
  "time-macros",
 ]
 
@@ -2963,7 +2985,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94571df2eae3ed4353815ea5a90974a594a1792d8782ff2cbcc9392d1101f366"
 dependencies = [
  "crossbeam-channel",
- "time 0.3.5",
+ "time 0.3.6",
  "tracing-subscriber",
 ]
 
@@ -3128,15 +3150,15 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.3+wasi-snapshot-preview1"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a2e384a3f170b0c7543787a91411175b71afd56ba4d3a0ae5678d4e2243c0e"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3144,9 +3166,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3159,9 +3181,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
+checksum = "2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3171,9 +3193,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3181,9 +3203,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3194,15 +3216,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
 
 [[package]]
 name = "web-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -13,6 +13,7 @@ tokio = { version = "1.14.0", features = ["full", "macros"] }
 tokio-util = { version = "0.6.1", features = ["full"] }
 tokio-stream = "0.1.2"
 bytes = "1.0.0"
+bytes-utils = "0.1.1"
 futures = "0.3.12"
 futures-core = "0.3.1"
 async-trait = "0.1.30"
@@ -22,7 +23,7 @@ derivative = "2.1.1"
 itertools = "0.10.1"
 rand = { version = "0.8.4" }
 rand_distr = "0.4.1"
-cached = "0.29"
+cached = "0.30"
 pin-project-lite = "0.2"
 tokio-openssl = "0.6.2"
 openssl = { version = "0.10.36", features = ["vendored"] }
@@ -53,7 +54,7 @@ hyper = { version = "0.14.14", features = ["server"] }
 halfbrown = "0.1.11"
 
 # Transform dependencies
-redis-protocol = "3.0.1"
+redis-protocol = { version = "4.0.1", features = ["decode-mut"] }
 cassandra-protocol = { git = "https://github.com/krojew/cdrs-tokio" }
 rdkafka = "0.28"
 crc16 = "0.4.0"

--- a/shotover-proxy/benches/chain_benches.rs
+++ b/shotover-proxy/benches/chain_benches.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use bytes::Bytes;
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 
 use shotover_proxy::message::{Message, QueryMessage, QueryType};
@@ -61,9 +62,9 @@ fn criterion_benchmark(c: &mut Criterion) {
         );
         let wrapper = Wrapper::new_with_chain_name(
             vec![Message::new_raw(RawFrame::Redis(RedisFrame::Array(vec![
-                RedisFrame::BulkString(b"SET".to_vec()),
-                RedisFrame::BulkString(b"foo".to_vec()),
-                RedisFrame::BulkString(b"bar".to_vec()),
+                RedisFrame::BulkString(Bytes::from_static(b"SET")),
+                RedisFrame::BulkString(Bytes::from_static(b"foo")),
+                RedisFrame::BulkString(Bytes::from_static(b"bar")),
             ])))],
             chain.name.clone(),
         );
@@ -92,9 +93,9 @@ fn criterion_benchmark(c: &mut Criterion) {
         );
         let wrapper = Wrapper::new_with_chain_name(
             vec![Message::new_raw(RawFrame::Redis(RedisFrame::Array(vec![
-                RedisFrame::BulkString(b"SET".to_vec()),
-                RedisFrame::BulkString(b"foo".to_vec()),
-                RedisFrame::BulkString(b"bar".to_vec()),
+                RedisFrame::BulkString(Bytes::from_static(b"SET")),
+                RedisFrame::BulkString(Bytes::from_static(b"foo")),
+                RedisFrame::BulkString(Bytes::from_static(b"bar")),
             ])))],
             chain.name.clone(),
         );

--- a/shotover-proxy/src/transforms/debug/returner.rs
+++ b/shotover-proxy/src/transforms/debug/returner.rs
@@ -52,7 +52,7 @@ impl Transform for DebugReturner {
                 .map(|_| Message {
                     details: MessageDetails::Unknown,
                     modified: false,
-                    original: RawFrame::Redis(RedisFrame::BulkString(string.clone().into_bytes())),
+                    original: RawFrame::Redis(RedisFrame::BulkString(string.to_string().into())),
                 })
                 .collect()),
             Response::Fail => Err(anyhow!("Intentional Fail")),

--- a/shotover-proxy/src/transforms/redis/cluster_ports_rewrite.rs
+++ b/shotover-proxy/src/transforms/redis/cluster_ports_rewrite.rs
@@ -1,6 +1,7 @@
 use crate::protocols::RedisFrame;
 use anyhow::{anyhow, bail, Context, Result};
 use async_trait::async_trait;
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::Deserialize;
 
 use crate::error::ChainResponse;
@@ -103,7 +104,7 @@ fn rewrite_port_slot(frame: &mut RawFrame, new_port: u16) -> Result<()> {
 }
 
 /// Get a mutable reference to the CSV string inside a response to CLUSTER NODES or REPLICAS
-fn get_buffer(frame: &mut RawFrame) -> Result<&mut Vec<u8>> {
+fn get_buffer(frame: &mut RawFrame) -> Result<&mut Bytes> {
     // CLUSTER NODES
     if let RawFrame::Redis(RedisFrame::BulkString(ref mut buf)) = frame {
         return Ok(buf);
@@ -125,48 +126,50 @@ fn get_buffer(frame: &mut RawFrame) -> Result<&mut Vec<u8>> {
 fn rewrite_port_node(frame: &mut RawFrame, new_port: u16) -> Result<()> {
     let buf = get_buffer(frame)?;
 
-    let read_cursor = std::io::Cursor::new(buf.clone());
+    let mut bytes_writer = BytesMut::new().writer();
 
-    buf.clear();
-    let write_cursor = std::io::Cursor::new(buf);
+    {
+        let read_cursor = std::io::Cursor::new(&buf);
 
-    let mut reader = csv::ReaderBuilder::new()
-        .delimiter(b' ')
-        .has_headers(false)
-        .flexible(true) // flexible because the last fields is an arbitrary number of tokens
-        .from_reader(read_cursor);
+        let mut reader = csv::ReaderBuilder::new()
+            .delimiter(b' ')
+            .has_headers(false)
+            .flexible(true) // flexible because the last fields is an arbitrary number of tokens
+            .from_reader(read_cursor);
 
-    let mut writer = csv::WriterBuilder::new()
-        .delimiter(b' ')
-        .flexible(true)
-        .from_writer(write_cursor);
+        let mut writer = csv::WriterBuilder::new()
+            .delimiter(b' ')
+            .flexible(true)
+            .from_writer(&mut bytes_writer);
 
-    for result in reader.records() {
-        let record = result?;
-        let mut record_iter = record.into_iter();
+        for result in reader.records() {
+            let record = result?;
+            let mut record_iter = record.into_iter();
 
-        // Write the id field
-        let id = record_iter
-            .next()
-            .ok_or_else(|| anyhow!("CLUSTER NODES response missing id field"))?;
-        writer.write_field(id)?;
+            // Write the id field
+            let id = record_iter
+                .next()
+                .ok_or_else(|| anyhow!("CLUSTER NODES response missing id field"))?;
+            writer.write_field(id)?;
 
-        // Modify and rewrite the port field
-        let ip = record_iter
-            .next()
-            .ok_or_else(|| anyhow!("CLUSTER NODES response missing address field"))?;
+            // Modify and rewrite the port field
+            let ip = record_iter
+                .next()
+                .ok_or_else(|| anyhow!("CLUSTER NODES response missing address field"))?;
 
-        let split = ip.split(|c| c == ':' || c == '@').collect::<Vec<&str>>();
+            let split = ip.split(|c| c == ':' || c == '@').collect::<Vec<&str>>();
 
-        let new_ip = format!("{}:{}@{}", split[0], new_port, split[2]);
+            let new_ip = format!("{}:{}@{}", split[0], new_port, split[2]);
 
-        writer.write_field(&*new_ip)?;
+            writer.write_field(&*new_ip)?;
 
-        // Write the last of the record
-        writer.write_record(record_iter)?;
+            // Write the last of the record
+            writer.write_record(record_iter)?;
+        }
+        writer.flush()?;
     }
 
-    writer.flush()?;
+    *buf = bytes_writer.into_inner().freeze();
 
     Ok(())
 }
@@ -231,13 +234,13 @@ mod test {
 
         for msg in cluster_messages {
             let frame = RawFrame::Redis(RedisFrame::Array(vec![RedisFrame::BulkString(
-                msg.to_vec(),
+                Bytes::from_static(msg),
             )]));
             assert!(is_cluster_message(&frame));
         }
 
         let frame = RawFrame::Redis(RedisFrame::Array(vec![RedisFrame::BulkString(
-            b"notcluster".to_vec(),
+            Bytes::from_static(b"notcluster"),
         )]));
         assert!(!is_cluster_message(&frame));
     }
@@ -253,15 +256,15 @@ mod test {
 
         for combo in combos {
             let frame = RawFrame::Redis(RedisFrame::Array(vec![
-                RedisFrame::BulkString(combo.0.to_vec()),
-                RedisFrame::BulkString(combo.1.to_vec()),
+                RedisFrame::BulkString(Bytes::from_static(combo.0)),
+                RedisFrame::BulkString(Bytes::from_static(combo.1)),
             ]));
             assert!(is_cluster_slots(&frame));
         }
 
         let frame = RawFrame::Redis(RedisFrame::Array(vec![
-            RedisFrame::BulkString(b"GET".to_vec()),
-            RedisFrame::BulkString(b"key1".to_vec()),
+            RedisFrame::BulkString(Bytes::from_static(b"GET")),
+            RedisFrame::BulkString(Bytes::from_static(b"key1")),
         ]));
 
         assert!(!is_cluster_slots(&frame));
@@ -284,15 +287,15 @@ mod test {
 
         for combo in combos {
             let frame = RawFrame::Redis(RedisFrame::Array(vec![
-                RedisFrame::BulkString(combo.0.to_vec()),
-                RedisFrame::BulkString(combo.1.to_vec()),
+                RedisFrame::BulkString(Bytes::from_static(combo.0)),
+                RedisFrame::BulkString(Bytes::from_static(combo.1)),
             ]));
             assert!(is_cluster_nodes(&frame));
         }
 
         let frame = RawFrame::Redis(RedisFrame::Array(vec![
-            RedisFrame::BulkString(b"GET".to_vec()),
-            RedisFrame::BulkString(b"key1".to_vec()),
+            RedisFrame::BulkString(Bytes::from_static(b"GET")),
+            RedisFrame::BulkString(Bytes::from_static(b"key1")),
         ]));
 
         assert!(!is_cluster_nodes(&frame));
@@ -368,7 +371,8 @@ c852007a1c3b726534e6866456c1f2002fc442d9 172.31.0.6:1234@16379 myself,master - 0
 f9553ea7fc23905476efec1f949b4b3e41a44103 :1234@0 slave,noaddr c852007a1c3b726534e6866456c1f2002fc442d9 1634273478445 1634273478445 3 disconnected
 ";
 
-        let mut raw_frame = RawFrame::Redis(RedisFrame::BulkString(bulk_string.to_vec()));
+        let mut raw_frame =
+            RawFrame::Redis(RedisFrame::BulkString(Bytes::from_static(bulk_string)));
         rewrite_port_node(&mut raw_frame, 1234).unwrap();
 
         let rewritten = if let RawFrame::Redis(RedisFrame::BulkString(string)) = raw_frame.clone() {
@@ -377,6 +381,6 @@ f9553ea7fc23905476efec1f949b4b3e41a44103 :1234@0 slave,noaddr c852007a1c3b726534
             panic!("bad input: {raw_frame:?}")
         };
 
-        assert_eq!(rewritten, expected_string);
+        assert_eq!(rewritten, Bytes::from_static(expected_string));
     }
 }


### PR DESCRIPTION
The only change in 4.0.0 was to replace String with StrMut and Vec<u8> with BytesMut https://github.com/aembke/redis-protocol.rs/pull/17

I think the `Frame` fields should be using `Bytes`/`Str` instead of `BytesMut`/`StrMut`.
I raised an issue https://github.com/aembke/redis-protocol.rs/issues/18 for this.
In the mean time we should upgrade to ensure that when we reason about performance implications we are working from the current state of the library.