### PR TITLE
redis cache new int test case

### DIFF
--- a/shotover-proxy/examples/cassandra-redis-cache/topology.yaml
+++ b/shotover-proxy/examples/cassandra-redis-cache/topology.yaml
@@ -5,15 +5,20 @@ sources:
       query_processing: true
       listen_addr: "127.0.0.1:9042"
       cassandra_ks:
-        test_cache_keyspace.test_table:
+        test_cache_keyspace_batch_insert.test_table:
+          - id
+        test_cache_keyspace_simple.test_table:
           - id
 chain_config:
   main_chain:
     - RedisCache:
         caching_schema:
-          test_cache_keyspace.test_table:
+          test_cache_keyspace_batch_insert.test_table:
             partition_key: [id]
-            range_key: [test]
+            range_key: [id]
+          test_cache_keyspace_simple.test_table:
+            partition_key: [id]
+            range_key: [id]
         chain:
           - RedisSinkSingle:
               remote_address: "127.0.0.1:6379"

--- a/shotover-proxy/tests/cassandra_int_tests/basic_driver_tests.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/basic_driver_tests.rs
@@ -227,10 +227,7 @@ mod cache {
         test_simple(cassandra_session, redis_connection);
     }
 
-    pub fn test_batch_insert(
-        cassandra_session: &Session,
-        redis_connection: &mut redis::Connection,
-    ) {
+    fn test_batch_insert(cassandra_session: &Session, redis_connection: &mut redis::Connection) {
         redis::cmd("FLUSHDB").execute(redis_connection);
 
         run_query(cassandra_session, "CREATE KEYSPACE test_cache_keyspace_batch_insert WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };");
@@ -292,7 +289,7 @@ mod cache {
         assert_eq!(result, ["dummy_key".to_string()]);
     }
 
-    pub fn test_simple(cassandra_session: &Session, redis_connection: &mut redis::Connection) {
+    fn test_simple(cassandra_session: &Session, redis_connection: &mut redis::Connection) {
         redis::cmd("FLUSHDB").execute(redis_connection);
 
         run_query(cassandra_session, "CREATE KEYSPACE test_cache_keyspace_simple WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };");


### PR DESCRIPTION
Adds a second RedisCache test case that actually manages to store values in redis.

This sets up for the next step which will be changing the stored redis values to a format that can be deserialized back into cassandra values.