### PR TITLE
Optimise Redis cache loop

### DIFF
--- a/shotover-proxy/src/transforms/redis/cache.rs
+++ b/shotover-proxy/src/transforms/redis/cache.rs
@@ -375,23 +375,24 @@ impl Transform for SimpleRedisCache {
     }
 
     async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> ChainResponse {
-        let mut updates = 0_i32;
-        {
-            for m in &mut message_wrapper.messages {
-                if let RawFrame::Cassandra(Frame {
-                    opcode: Opcode::Query,
-                    ..
-                }) = &m.original
-                {
-                    m.generate_message_details_query();
-                    if m.get_query_type() == QueryType::Write {
-                        updates += 1;
-                    }
+        let mut updates = false;
+
+        for m in &mut message_wrapper.messages {
+            if let RawFrame::Cassandra(Frame {
+                opcode: Opcode::Query,
+                ..
+            }) = &m.original
+            {
+                m.generate_message_details_query();
+                if m.get_query_type() == QueryType::Write {
+                    updates = true;
+                    break;
                 }
             }
         }
 
-        if updates == 0 {
+        // If there are no write queries (all queries are reads) we can use the cache
+        if !updates {
             match self
                 .get_or_update_from_cache(message_wrapper.messages.clone())
                 .await


### PR DESCRIPTION
Something I noticed while investigating #448. We can early return from this loop the first time we notice a `QueryType::Write` and not scan through the rest of the messages, and I added a comment to make the logic a little clearer.