### PR TITLE
redis_timestamp_tagger bench uses better test data to avoid skipping unwrap_response

### DIFF
--- a/shotover-proxy/benches/chain_benches.rs
+++ b/shotover-proxy/benches/chain_benches.rs
@@ -5,6 +5,7 @@ use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use shotover_proxy::message::{Message, QueryMessage, QueryType};
 use shotover_proxy::protocols::RawFrame;
 use shotover_proxy::transforms::chain::TransformChain;
+use shotover_proxy::transforms::debug::returner::{DebugReturner, Response};
 use shotover_proxy::transforms::null::Null;
 use shotover_proxy::transforms::redis::cluster_ports_rewrite::RedisClusterPortsRewrite;
 use shotover_proxy::transforms::redis::timestamp_tagging::RedisTimestampTagger;
@@ -54,7 +55,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let chain = TransformChain::new_no_shared_state(
             vec![
                 Transforms::RedisTimestampTagger(RedisTimestampTagger::new()),
-                Transforms::Null(Null::default()),
+                Transforms::DebugReturner(DebugReturner::new(Response::Redis("a".into()))),
             ],
             "bench".to_string(),
         );


### PR DESCRIPTION
returning a null message causes this logic to be skipped:
https://github.com/shotover/shotover-proxy/blob/1ceb040ce09736ba1cd8a274316c95982ebcdcef/shotover-proxy/src/transforms/redis/timestamp_tagging.rs#L98