### PR TITLE
Fix CI benchmark alert comments

### DIFF
--- a/.github/workflows/create_comment.yml
+++ b/.github/workflows/create_comment.yml
@@ -11,7 +11,7 @@ name: Create Comment
 
 on:
   workflow_run:
-    workflows: [ "Benchmark Run" ]
+    workflows: [ "Benchmarks" ]
 
 # Cancel already running jobs
 concurrency:


### PR DESCRIPTION
I thought the benchmark comments were suspiciously quiet so I checked https://github.com/shotover/shotover-proxy/actions/workflows/create_comment.yml and found that its been broken since 3 months ago.

I tracked the problem down to https://github.com/shotover/shotover-proxy/pull/340 - the create_comment workflow wasnt adjusted to the new name of the benchmarks workflow.
This PR fixes that issue.