### PR TITLE
Use metrics handles in transforms

### DIFF
--- a/shotover-proxy/src/server.rs
+++ b/shotover-proxy/src/server.rs
@@ -100,7 +100,6 @@ pub struct TcpCodecListener<C: Codec> {
     /// Keep track of how many messages we have received so we can use it as a request id.
     message_count: u64,
 
-    /// Metric recording shotover available connections
     available_connections_gauge: Gauge,
 }
 

--- a/shotover-proxy/src/server.rs
+++ b/shotover-proxy/src/server.rs
@@ -4,7 +4,7 @@ use crate::transforms::chain::TransformChain;
 use crate::transforms::Wrapper;
 use anyhow::{anyhow, Result};
 use futures::StreamExt;
-use metrics::{gauge, register_gauge};
+use metrics::{register_gauge, Gauge};
 use std::sync::Arc;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::{TcpListener, TcpStream};
@@ -99,6 +99,9 @@ pub struct TcpCodecListener<C: Codec> {
 
     /// Keep track of how many messages we have received so we can use it as a request id.
     message_count: u64,
+
+    /// Metric recording shotover available connections
+    gauge: Gauge,
 }
 
 impl<C: Codec + 'static> TcpCodecListener<C> {
@@ -113,8 +116,9 @@ impl<C: Codec + 'static> TcpCodecListener<C> {
         trigger_shutdown_rx: watch::Receiver<bool>,
         tls: Option<TlsAcceptor>,
     ) -> Self {
-        register_gauge!("shotover_available_connections", "source" => source_name.clone());
-        gauge!("shotover_available_connections", limit_connections.available_permits() as f64, "source" => source_name.clone());
+        let gauge =
+            register_gauge!("shotover_available_connections", "source" => source_name.clone());
+        gauge.set(limit_connections.available_permits() as f64);
 
         TcpCodecListener {
             chain,
@@ -127,6 +131,7 @@ impl<C: Codec + 'static> TcpCodecListener<C> {
             trigger_shutdown_rx,
             tls,
             message_count: 0,
+            gauge,
         }
     }
 
@@ -189,7 +194,8 @@ impl<C: Codec + 'static> TcpCodecListener<C> {
             let socket = self.accept().await?;
 
             debug!("got socket");
-            gauge!("shotover_available_connections", self.limit_connections.available_permits() as f64, "source" => self.source_name.clone());
+            self.gauge
+                .set(self.limit_connections.available_permits() as f64);
 
             let peer = socket
                 .peer_addr()

--- a/shotover-proxy/src/transforms/cassandra/sink_single.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_single.rs
@@ -43,9 +43,7 @@ pub struct CassandraSinkSingle {
     cassandra_ks: HashMap<String, Vec<String>>,
     bypass: bool,
     chain_name: String,
-
-    /// Metric recording failed requests
-    counter: Counter,
+    failed_requests: Counter,
 }
 
 impl Clone for CassandraSinkSingle {
@@ -56,7 +54,7 @@ impl Clone for CassandraSinkSingle {
 
 impl CassandraSinkSingle {
     pub fn new(address: String, bypass: bool, chain_name: String) -> CassandraSinkSingle {
-        let counter = register_counter!("failed_requests", "chain" => chain_name.clone(), "transform" => "CassandraSinkSingle");
+        let failed_requests = register_counter!("failed_requests", "chain" => chain_name.clone(), "transform" => "CassandraSinkSingle");
 
         CassandraSinkSingle {
             address,
@@ -64,7 +62,7 @@ impl CassandraSinkSingle {
             cassandra_ks: HashMap::new(),
             bypass,
             chain_name,
-            counter,
+            failed_requests,
         }
     }
 }
@@ -127,7 +125,7 @@ impl CassandraSinkSingle {
                                                 ..
                                             }) = &message.original
                                             {
-                                                self.counter.increment(1);
+                                                self.failed_requests.increment(1);
                                             }
                                         }
                                         responses.append(&mut resp);

--- a/shotover-proxy/src/transforms/redis/sink_single.rs
+++ b/shotover-proxy/src/transforms/redis/sink_single.rs
@@ -40,8 +40,6 @@ pub struct RedisSinkSingle {
     tls: Option<TlsConnector>,
     outbound: Option<Framed<Pin<Box<dyn AsyncStream + Send + Sync>>, RedisCodec>>,
     chain_name: String,
-
-    /// Metric recording failed requests
     failed_requests: Counter,
 }
 

--- a/shotover-proxy/src/transforms/redis/sink_single.rs
+++ b/shotover-proxy/src/transforms/redis/sink_single.rs
@@ -4,7 +4,7 @@ use crate::protocols::RedisFrame;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use futures::{FutureExt, SinkExt};
-use metrics::{counter, register_counter};
+use metrics::{register_counter, Counter};
 use serde::Deserialize;
 use std::pin::Pin;
 use tokio::net::TcpStream;
@@ -40,6 +40,9 @@ pub struct RedisSinkSingle {
     tls: Option<TlsConnector>,
     outbound: Option<Framed<Pin<Box<dyn AsyncStream + Send + Sync>>, RedisCodec>>,
     chain_name: String,
+
+    /// Metric recording failed requests
+    counter: Counter,
 }
 
 impl Clone for RedisSinkSingle {
@@ -54,19 +57,15 @@ impl Clone for RedisSinkSingle {
 
 impl RedisSinkSingle {
     pub fn new(address: String, tls: Option<TlsConnector>, chain_name: String) -> RedisSinkSingle {
-        let redis_sink = RedisSinkSingle {
+        let counter = register_counter!("failed_requests", "chain" => chain_name.clone(), "transform" => "RedisSinkSingle");
+
+        RedisSinkSingle {
             address,
             tls,
             outbound: None,
-            chain_name: chain_name.clone(),
-        };
-        register_counter!("failed_requests", "chain" => chain_name, "transform" => redis_sink.get_name());
-
-        redis_sink
-    }
-
-    fn get_name(&self) -> &'static str {
-        "RedisSinkSingle"
+            chain_name,
+            counter,
+        }
     }
 }
 
@@ -109,7 +108,7 @@ impl Transform for RedisSinkSingle {
                 if let Ok(ref messages) = a {
                     for message in messages {
                         if let RawFrame::Redis(RedisFrame::Error(_)) = message.original {
-                            counter!("failed_requests", 1, "chain" => self.chain_name.clone(), "transform" => self.get_name());
+                            self.counter.increment(1);
                         }
                     }
                 }

--- a/shotover-proxy/src/transforms/redis/sink_single.rs
+++ b/shotover-proxy/src/transforms/redis/sink_single.rs
@@ -42,7 +42,7 @@ pub struct RedisSinkSingle {
     chain_name: String,
 
     /// Metric recording failed requests
-    counter: Counter,
+    failed_requests: Counter,
 }
 
 impl Clone for RedisSinkSingle {
@@ -57,14 +57,14 @@ impl Clone for RedisSinkSingle {
 
 impl RedisSinkSingle {
     pub fn new(address: String, tls: Option<TlsConnector>, chain_name: String) -> RedisSinkSingle {
-        let counter = register_counter!("failed_requests", "chain" => chain_name.clone(), "transform" => "RedisSinkSingle");
+        let failed_requests = register_counter!("failed_requests", "chain" => chain_name.clone(), "transform" => "RedisSinkSingle");
 
         RedisSinkSingle {
             address,
             tls,
             outbound: None,
             chain_name,
-            counter,
+            failed_requests,
         }
     }
 }
@@ -108,7 +108,7 @@ impl Transform for RedisSinkSingle {
                 if let Ok(ref messages) = a {
                     for message in messages {
                         if let RawFrame::Redis(RedisFrame::Error(_)) = message.original {
-                            self.counter.increment(1);
+                            self.failed_requests.increment(1);
                         }
                     }
                 }


### PR DESCRIPTION
- Using metrics handles in transforms is pretty simple. 
- Using handles instead of the macros in `TransformChain` and `Wrapper` will require more complex changes. Will see if it's worth re-architecting things to do this.