### PR TITLE
Remove new no state method from TransformChain

### DIFF
--- a/shotover-proxy/benches/chain_benches.rs
+++ b/shotover-proxy/benches/chain_benches.rs
@@ -17,10 +17,8 @@ fn criterion_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("transform");
 
     {
-        let chain = TransformChain::new_no_shared_state(
-            vec![Transforms::Null(Null::default())],
-            "bench".to_string(),
-        );
+        let chain =
+            TransformChain::new(vec![Transforms::Null(Null::default())], "bench".to_string());
         let wrapper = Wrapper::new_with_chain_name(
             vec![Message::new_query(
                 QueryMessage {
@@ -53,7 +51,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     {
         use shotover_proxy::protocols::RedisFrame;
-        let chain = TransformChain::new_no_shared_state(
+        let chain = TransformChain::new(
             vec![
                 Transforms::RedisTimestampTagger(RedisTimestampTagger::new()),
                 Transforms::DebugReturner(DebugReturner::new(Response::Redis("a".into()))),
@@ -84,7 +82,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     {
         use shotover_proxy::protocols::RedisFrame;
-        let chain = TransformChain::new_no_shared_state(
+        let chain = TransformChain::new(
             vec![
                 Transforms::RedisClusterPortsRewrite(RedisClusterPortsRewrite::new(2004)),
                 Transforms::Null(Null::default()),

--- a/shotover-proxy/src/transforms/chain.rs
+++ b/shotover-proxy/src/transforms/chain.rs
@@ -15,32 +15,6 @@ use tracing::{debug, error, info, trace, Instrument};
 
 type InnerChain = Vec<Transforms>;
 
-/// Stores metrics for this transform chain. `histogram` metrics cannot be stored in this because they cannot be registered without knowing the client details
-#[derive(Clone)]
-struct TransformChainMetrics {
-    chain_total: Counter,
-    chain_failures: Counter,
-}
-
-impl TransformChainMetrics {
-    pub fn new(chain_name: String) -> Self {
-        TransformChainMetrics {
-            chain_total: register_counter!("shotover_chain_total", "chain" => chain_name.clone()),
-            chain_failures: register_counter!("shotover_chain_failures", "chain" => chain_name),
-        }
-    }
-
-    /// Increment the chain_total metric
-    pub fn increment_chain_total(&self, value: u64) {
-        self.chain_total.increment(value);
-    }
-
-    /// Increment the chain_failures metric
-    pub fn increment_chain_failures(&self, value: u64) {
-        self.chain_failures.increment(value);
-    }
-}
-
 //TODO explore running the transform chain on a LocalSet for better locality to a given OS thread
 //Will also mean we can have `!Send` types  in our transform chain
 

--- a/shotover-proxy/src/transforms/chain.rs
+++ b/shotover-proxy/src/transforms/chain.rs
@@ -15,6 +15,32 @@ use tracing::{debug, error, info, trace, Instrument};
 
 type InnerChain = Vec<Transforms>;
 
+/// Stores metrics for this transform chain. `histogram` metrics cannot be stored in this because they cannot be registered without knowing the client details
+#[derive(Clone)]
+struct TransformChainMetrics {
+    chain_total: Counter,
+    chain_failures: Counter,
+}
+
+impl TransformChainMetrics {
+    pub fn new(chain_name: String) -> Self {
+        TransformChainMetrics {
+            chain_total: register_counter!("shotover_chain_total", "chain" => chain_name.clone()),
+            chain_failures: register_counter!("shotover_chain_failures", "chain" => chain_name),
+        }
+    }
+
+    /// Increment the chain_total metric
+    pub fn increment_chain_total(&self, value: u64) {
+        self.chain_total.increment(value);
+    }
+
+    /// Increment the chain_failures metric
+    pub fn increment_chain_failures(&self, value: u64) {
+        self.chain_failures.increment(value);
+    }
+}
+
 //TODO explore running the transform chain on a LocalSet for better locality to a given OS thread
 //Will also mean we can have `!Send` types  in our transform chain
 

--- a/shotover-proxy/src/transforms/chain.rs
+++ b/shotover-proxy/src/transforms/chain.rs
@@ -189,25 +189,6 @@ impl TransformChain {
         }
     }
 
-    pub fn new_no_shared_state(transform_list: Vec<Transforms>, name: String) -> Self {
-        for transform in &transform_list {
-            register_counter!("shotover_transform_total", "transform" => transform.get_name());
-            register_counter!("shotover_transform_failures", "transform" => transform.get_name());
-            register_histogram!("shotover_transform_latency", "transform" => transform.get_name());
-        }
-
-        let chain_total = register_counter!("shotover_chain_total", "chain" => name.clone());
-        let chain_failures = register_counter!("shotover_chain_failures", "chain" => name.clone());
-        register_histogram!("shotover_chain_latency", "chain" => name.clone());
-
-        TransformChain {
-            name,
-            chain: transform_list,
-            chain_total,
-            chain_failures,
-        }
-    }
-
     pub fn new(transform_list: Vec<Transforms>, name: String) -> Self {
         for transform in &transform_list {
             register_counter!("shotover_transform_total", "transform" => transform.get_name());
@@ -302,7 +283,7 @@ mod chain_tests {
 
     #[tokio::test]
     async fn test_validate_invalid_chain() {
-        let chain = TransformChain::new_no_shared_state(vec![], "test-chain".to_string());
+        let chain = TransformChain::new(vec![], "test-chain".to_string());
         assert_eq!(
             chain.validate(),
             vec!["test-chain:", "  Chain cannot be empty"]
@@ -311,7 +292,7 @@ mod chain_tests {
 
     #[tokio::test]
     async fn test_validate_valid_chain() {
-        let chain = TransformChain::new_no_shared_state(
+        let chain = TransformChain::new(
             vec![
                 Transforms::DebugPrinter(DebugPrinter::new()),
                 Transforms::DebugPrinter(DebugPrinter::new()),

--- a/shotover-proxy/src/transforms/distributed/consistent_scatter.rs
+++ b/shotover-proxy/src/transforms/distributed/consistent_scatter.rs
@@ -360,7 +360,7 @@ mod scatter_transform_tests {
 
     #[tokio::test]
     async fn test_validate_invalid_chain() {
-        let chain_1 = TransformChain::new_no_shared_state(
+        let chain_1 = TransformChain::new(
             vec![
                 Transforms::DebugPrinter(DebugPrinter::new()),
                 Transforms::DebugPrinter(DebugPrinter::new()),
@@ -368,7 +368,7 @@ mod scatter_transform_tests {
             ],
             "test-chain-1".to_string(),
         );
-        let chain_2 = TransformChain::new_no_shared_state(vec![], "test-chain-2".to_string());
+        let chain_2 = TransformChain::new(vec![], "test-chain-2".to_string());
 
         let transform = ConsistentScatter {
             route_map: vec![
@@ -391,7 +391,7 @@ mod scatter_transform_tests {
 
     #[tokio::test]
     async fn test_validate_valid_chain() {
-        let chain_1 = TransformChain::new_no_shared_state(
+        let chain_1 = TransformChain::new(
             vec![
                 Transforms::DebugPrinter(DebugPrinter::new()),
                 Transforms::DebugPrinter(DebugPrinter::new()),
@@ -399,7 +399,7 @@ mod scatter_transform_tests {
             ],
             "test-chain-1".to_string(),
         );
-        let chain_2 = TransformChain::new_no_shared_state(
+        let chain_2 = TransformChain::new(
             vec![
                 Transforms::DebugPrinter(DebugPrinter::new()),
                 Transforms::DebugPrinter(DebugPrinter::new()),

--- a/shotover-proxy/src/transforms/parallel_map.rs
+++ b/shotover-proxy/src/transforms/parallel_map.rs
@@ -152,7 +152,7 @@ mod parallel_map_tests {
 
     #[tokio::test]
     async fn test_validate_invalid_chain() {
-        let chain_1 = TransformChain::new_no_shared_state(
+        let chain_1 = TransformChain::new(
             vec![
                 Transforms::DebugPrinter(DebugPrinter::new()),
                 Transforms::DebugPrinter(DebugPrinter::new()),
@@ -160,7 +160,7 @@ mod parallel_map_tests {
             ],
             "test-chain-1".to_string(),
         );
-        let chain_2 = TransformChain::new_no_shared_state(vec![], "test-chain-2".to_string());
+        let chain_2 = TransformChain::new(vec![], "test-chain-2".to_string());
 
         let transform = ParallelMap {
             chains: vec![chain_1, chain_2],
@@ -179,7 +179,7 @@ mod parallel_map_tests {
 
     #[tokio::test]
     async fn test_validate_valid_chain() {
-        let chain_1 = TransformChain::new_no_shared_state(
+        let chain_1 = TransformChain::new(
             vec![
                 Transforms::DebugPrinter(DebugPrinter::new()),
                 Transforms::DebugPrinter(DebugPrinter::new()),
@@ -187,7 +187,7 @@ mod parallel_map_tests {
             ],
             "test-chain-1".to_string(),
         );
-        let chain_2 = TransformChain::new_no_shared_state(
+        let chain_2 = TransformChain::new(
             vec![
                 Transforms::DebugPrinter(DebugPrinter::new()),
                 Transforms::DebugPrinter(DebugPrinter::new()),

--- a/shotover-proxy/src/transforms/redis/cache.rs
+++ b/shotover-proxy/src/transforms/redis/cache.rs
@@ -781,7 +781,7 @@ mod test {
 
     #[tokio::test]
     async fn test_validate_invalid_chain() {
-        let chain = TransformChain::new_no_shared_state(vec![], "test-chain".to_string());
+        let chain = TransformChain::new(vec![], "test-chain".to_string());
         let transform = SimpleRedisCache {
             cache_chain: chain,
             caching_schema: HashMap::new(),
@@ -799,7 +799,7 @@ mod test {
 
     #[tokio::test]
     async fn test_validate_valid_chain() {
-        let chain = TransformChain::new_no_shared_state(
+        let chain = TransformChain::new(
             vec![
                 Transforms::DebugPrinter(DebugPrinter::new()),
                 Transforms::DebugPrinter(DebugPrinter::new()),

--- a/shotover-proxy/src/transforms/sampler.rs
+++ b/shotover-proxy/src/transforms/sampler.rs
@@ -24,7 +24,7 @@ impl Sampler {
         Sampler {
             numerator: 1,
             denominator: 100,
-            sample_chain: TransformChain::new_no_shared_state(vec![], "dummy".to_string()),
+            sample_chain: TransformChain::new(vec![], "dummy".to_string()),
         }
     }
 


### PR DESCRIPTION
As mentioned on https://github.com/shotover/shotover-proxy/pull/469: 

The `new_no_shared_state` function on `TransformChain` does nothing different to the `new` function so this PR removes it. 