### PR TITLE
Fix formatting on bench comments

### DIFF
--- a/shotover-proxy/tests/scripts/bench_against_master.sh
+++ b/shotover-proxy/tests/scripts/bench_against_master.sh
@@ -36,8 +36,19 @@ if [[ "$COUNT_REGRESS" != "0" || "$COUNT_IMPROVE" != "0" ]]; then
 
   # grep returns non zero exit code when it doesnt find anything so we need to disable -e
   set +e
-  # Kind of brittle but -B5 includes the 5 lines prior which always happens to includes the bench name + results
-  grep -B5 "Performance has regressed." benches_log.txt >> comment_info/message.txt
-  grep -B5 "Performance has improved." benches_log.txt >> comment_info/message.txt
+
+  if [[ "$COUNT_REGRESS" != "0" ]]; then
+    echo "\`\`\`" >> comment_info/message.txt
+    # Kind of brittle but -B5 includes the 5 lines prior which always happens to includes the bench name + results
+    grep -B5 "Performance has regressed." benches_log.txt >> comment_info/message.txt
+    echo "\`\`\`" >> comment_info/message.txt
+  fi
+
+  if [[ "$COUNT_IMPROVE" != "0" ]]; then
+    echo "\`\`\`" >> comment_info/message.txt
+    grep -B5 "Performance has improved." benches_log.txt >> comment_info/message.txt
+    echo "\`\`\`" >> comment_info/message.txt
+  fi
+
   set -e
 fi


### PR DESCRIPTION
grep will output a `--` between results which markdown interprets to mean the above lines are headings.
We can stop grep from outputting those by doing: `grep --no-group-separator`

However we are better off just adding ``` around the log output because it also keeps the monospaced spacing in tact.
So that is what this PR does.