### PR TITLE
Cleanup RedisCodec

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
       # * clippy --all-targets causes clippy to run against tests and examples which it doesnt do by default.
       run: cargo hack --feature-powerset clippy --all-targets --locked ${{ matrix.cargo_profile }} -- -D warnings
     - name: Ensure that tests pass
-      run: cargo test ${{ matrix.cargo_profile }} -- --include-ignored --show-output
+      run: cargo test ${{ matrix.cargo_profile }} -- --include-ignored --show-output --test-threads 1
       # can not run tests if cpp driver not installed
       if: ${{ matrix.runner == 'ubuntu-18.04' }}
     - name: License Check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
       # * clippy --all-targets causes clippy to run against tests and examples which it doesnt do by default.
       run: cargo hack --feature-powerset clippy --all-targets --locked ${{ matrix.cargo_profile }} -- -D warnings
     - name: Ensure that tests pass
-      run: cargo test ${{ matrix.cargo_profile }} -- --include-ignored --show-output --test-threads 1
+      run: cargo test ${{ matrix.cargo_profile }} -- --include-ignored --show-output
       # can not run tests if cpp driver not installed
       if: ${{ matrix.runner == 'ubuntu-18.04' }}
     - name: License Check

--- a/shotover-proxy/src/protocols/redis_codec.rs
+++ b/shotover-proxy/src/protocols/redis_codec.rs
@@ -5,13 +5,13 @@ use crate::message::{
 use crate::protocols::Frame;
 use crate::protocols::RedisFrame;
 use anyhow::{anyhow, Result};
-use bytes::{Buf, Bytes, BytesMut};
+use bytes::{Bytes, BytesMut};
 use itertools::Itertools;
 use redis_protocol::resp2::prelude::decode_mut;
 use redis_protocol::resp2::prelude::encode_bytes;
 use std::collections::{BTreeMap, HashMap};
 use tokio_util::codec::{Decoder, Encoder};
-use tracing::{debug, info, trace, warn};
+use tracing::{debug, trace, warn};
 
 /// Redis doesn't have an explicit "Response" type as part of the protocol.
 /// So it is up to the code to know whether it is processing queries or responses.
@@ -24,7 +24,6 @@ pub enum DecodeType {
 #[derive(Debug, Clone)]
 pub struct RedisCodec {
     decode_type: DecodeType,
-    current_frames: Vec<RedisFrame>,
     enable_metadata: bool,
 }
 
@@ -493,38 +492,30 @@ impl RedisCodec {
     pub fn new(decode_type: DecodeType) -> RedisCodec {
         RedisCodec {
             decode_type,
-            current_frames: vec![],
             enable_metadata: false,
         }
     }
 
-    pub fn process_redis_bulk(&self, frames: Vec<RedisFrame>) -> Result<Messages> {
-        trace!("processing bulk response {:?}", frames);
-        frames
-            .into_iter()
-            .map(|frame| {
-                if self.enable_metadata {
-                    Ok(Message::new(
-                        match self.decode_type {
-                            DecodeType::Response => {
-                                MessageDetails::Response(process_redis_frame_response(&frame)?)
-                            }
-                            DecodeType::Query => {
-                                MessageDetails::Query(process_redis_frame_query(&frame)?)
-                            }
-                        },
-                        false,
-                        Frame::Redis(frame),
-                    ))
-                } else {
-                    Ok(Message::new(
-                        MessageDetails::Unknown,
-                        false,
-                        Frame::Redis(frame),
-                    ))
-                }
-            })
-            .collect()
+    pub fn frame_to_message(&self, frame: RedisFrame) -> Result<Message> {
+        trace!("processing bulk response {:?}", frame);
+        if self.enable_metadata {
+            Ok(Message::new(
+                match self.decode_type {
+                    DecodeType::Response => {
+                        MessageDetails::Response(process_redis_frame_response(&frame)?)
+                    }
+                    DecodeType::Query => MessageDetails::Query(process_redis_frame_query(&frame)?),
+                },
+                false,
+                Frame::Redis(frame),
+            ))
+        } else {
+            Ok(Message::new(
+                MessageDetails::Unknown,
+                false,
+                Frame::Redis(frame),
+            ))
+        }
     }
 
     fn build_redis_response_frame(resp: QueryResponse) -> RedisFrame {
@@ -548,40 +539,6 @@ impl RedisCodec {
         }
     }
 
-    fn decode_raw(&mut self, src: &mut BytesMut) -> Result<Option<Vec<RedisFrame>>> {
-        while src.remaining() != 0 {
-            trace!("remaining {}", src.remaining());
-
-            match decode_mut(src).map_err(|e| {
-                info!("Error decoding redis frame {:?}", e);
-                anyhow!("Error decoding redis frame {}", e)
-            })? {
-                Some((frame, size, _bytes)) => {
-                    trace!("Got frame {:?} of {}", frame, size);
-                    self.current_frames.push(frame);
-                }
-                None => {
-                    if src.remaining() == 0 {
-                        break;
-                    } else {
-                        return Ok(None);
-                    }
-                }
-            }
-        }
-        trace!(
-            "frames {:?} - remaining {}",
-            self.current_frames,
-            src.remaining()
-        );
-
-        if self.current_frames.is_empty() {
-            Ok(None)
-        } else {
-            Ok(Some(std::mem::take(&mut self.current_frames)))
-        }
-    }
-
     fn encode_raw(&mut self, item: RedisFrame, dst: &mut BytesMut) -> Result<()> {
         encode_bytes(dst, &item)
             .map(|_| ())
@@ -593,26 +550,30 @@ impl Decoder for RedisCodec {
     type Item = Messages;
     type Error = anyhow::Error;
 
-    fn decode(
-        &mut self,
-        src: &mut BytesMut,
-    ) -> std::result::Result<Option<Self::Item>, Self::Error> {
-        Ok(match self.decode_raw(src)? {
-            None => None,
-            Some(f) => Some(self.process_redis_bulk(f)?),
-        })
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>> {
+        let mut messages = vec![];
+        loop {
+            match decode_mut(src).map_err(|e| anyhow!("Error decoding redis frame {}", e))? {
+                Some((frame, _size, _bytes)) => {
+                    messages.push(self.frame_to_message(frame)?);
+                }
+                None => {
+                    if messages.is_empty() {
+                        return Ok(None);
+                    } else {
+                        return Ok(Some(messages));
+                    }
+                }
+            }
+        }
     }
 }
 
 impl Encoder<Messages> for RedisCodec {
     type Error = anyhow::Error;
 
-    fn encode(
-        &mut self,
-        item: Messages,
-        dst: &mut BytesMut,
-    ) -> std::result::Result<(), Self::Error> {
-        item.into_iter().try_for_each(|m: Message| {
+    fn encode(&mut self, item: Messages, dst: &mut BytesMut) -> Result<()> {
+        item.into_iter().try_for_each(|m| {
             let frame = self.encode_message(m)?;
             self.encode_raw(frame, dst)
         })


### PR DESCRIPTION
This change is functionally equivalent but:
* is simpler
* allocates less
* is a step towards the message details rewrite storing the raw redis Bytes in the message to skip encoding in same cases.