### PR TITLE
Rename RawFrame -> Frame

### DIFF
--- a/shotover-proxy/benches/chain_benches.rs
+++ b/shotover-proxy/benches/chain_benches.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 
 use shotover_proxy::message::{Message, QueryMessage, QueryType};
-use shotover_proxy::protocols::RawFrame;
+use shotover_proxy::protocols::Frame;
 use shotover_proxy::transforms::chain::TransformChain;
 use shotover_proxy::transforms::debug::returner::{DebugReturner, Response};
 use shotover_proxy::transforms::null::Null;
@@ -31,7 +31,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     ast: None,
                 },
                 true,
-                RawFrame::None,
+                Frame::None,
             )],
             chain.name.clone(),
         );
@@ -59,7 +59,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             "bench".to_string(),
         );
         let wrapper = Wrapper::new_with_chain_name(
-            vec![Message::new_raw(RawFrame::Redis(RedisFrame::Array(vec![
+            vec![Message::new_raw(Frame::Redis(RedisFrame::Array(vec![
                 RedisFrame::BulkString(Bytes::from_static(b"SET")),
                 RedisFrame::BulkString(Bytes::from_static(b"foo")),
                 RedisFrame::BulkString(Bytes::from_static(b"bar")),
@@ -90,7 +90,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             "bench".to_string(),
         );
         let wrapper = Wrapper::new_with_chain_name(
-            vec![Message::new_raw(RawFrame::Redis(RedisFrame::Array(vec![
+            vec![Message::new_raw(Frame::Redis(RedisFrame::Array(vec![
                 RedisFrame::BulkString(Bytes::from_static(b"SET")),
                 RedisFrame::BulkString(Bytes::from_static(b"foo")),
                 RedisFrame::BulkString(Bytes::from_static(b"bar")),

--- a/shotover-proxy/src/message/mod.rs
+++ b/shotover-proxy/src/message/mod.rs
@@ -1,5 +1,5 @@
 use crate::protocols::CassandraFrame;
-use crate::protocols::RawFrame;
+use crate::protocols::Frame;
 use crate::protocols::RedisFrame;
 use bigdecimal::BigDecimal;
 use bytes::Bytes;
@@ -30,7 +30,7 @@ pub struct Message {
     pub details: MessageDetails,
     pub modified: bool,
     /// The frame in the format defined by the protocol.
-    pub original: RawFrame,
+    pub original: Frame,
 }
 
 #[derive(PartialEq, Debug, Clone)]
@@ -44,7 +44,7 @@ pub enum MessageDetails {
 }
 
 impl Message {
-    pub fn new(details: MessageDetails, modified: bool, original: RawFrame) -> Self {
+    pub fn new(details: MessageDetails, modified: bool, original: Frame) -> Self {
         Message {
             details,
             modified,
@@ -64,15 +64,15 @@ impl Message {
         }
     }
 
-    pub fn new_query(qm: QueryMessage, modified: bool, original: RawFrame) -> Self {
+    pub fn new_query(qm: QueryMessage, modified: bool, original: Frame) -> Self {
         Self::new(MessageDetails::Query(qm), modified, original)
     }
 
-    pub fn new_response(qr: QueryResponse, modified: bool, original: RawFrame) -> Self {
+    pub fn new_response(qr: QueryResponse, modified: bool, original: Frame) -> Self {
         Self::new(MessageDetails::Response(qr), modified, original)
     }
 
-    pub fn new_raw(raw_frame: RawFrame) -> Self {
+    pub fn new_raw(raw_frame: Frame) -> Self {
         Self::new(MessageDetails::Unknown, false, raw_frame)
     }
 
@@ -80,7 +80,7 @@ impl Message {
         Message {
             details,
             modified,
-            original: RawFrame::None,
+            original: Frame::None,
         }
     }
 
@@ -90,10 +90,10 @@ impl Message {
             details: MessageDetails::Unknown,
             modified: true,
             original: match &self.original {
-                RawFrame::Redis(_) => RawFrame::Redis(RedisFrame::Error(
+                Frame::Redis(_) => Frame::Redis(RedisFrame::Error(
                     "ERR Message was filtered out by shotover".into(),
                 )),
-                RawFrame::Cassandra(frame) => RawFrame::Cassandra(CassandraFrame {
+                Frame::Cassandra(frame) => Frame::Cassandra(CassandraFrame {
                     version: frame.version,
                     direction: Direction::Response,
                     flags: Flags::empty(),
@@ -108,7 +108,7 @@ impl Message {
                     tracing_id: None,
                     warnings: vec![],
                 }),
-                RawFrame::None => RawFrame::None,
+                Frame::None => Frame::None,
             },
         }
     }
@@ -126,7 +126,7 @@ impl Message {
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct RawMessage {
-    pub original: RawFrame,
+    pub original: Frame,
 }
 
 // Transforms should not try to directly serialize the AST - it's purely an in-memory representation

--- a/shotover-proxy/src/protocols/mod.rs
+++ b/shotover-proxy/src/protocols/mod.rs
@@ -9,39 +9,39 @@ use anyhow::Result;
 use crate::message::{MessageDetails, QueryType};
 
 #[derive(PartialEq, Debug, Clone)]
-pub enum RawFrame {
+pub enum Frame {
     Cassandra(CassandraFrame),
     Redis(RedisFrame),
     None,
 }
 
-impl RawFrame {
+impl Frame {
     pub fn build_message_response(&self) -> Result<MessageDetails> {
         match self {
-            RawFrame::Cassandra(_c) => Ok(MessageDetails::Unknown),
-            RawFrame::Redis(frame) => {
+            Frame::Cassandra(_c) => Ok(MessageDetails::Unknown),
+            Frame::Redis(frame) => {
                 redis_codec::process_redis_frame_response(frame).map(MessageDetails::Response)
             }
-            RawFrame::None => Ok(MessageDetails::Unknown),
+            Frame::None => Ok(MessageDetails::Unknown),
         }
     }
 
     pub fn build_message_query(&self) -> Result<MessageDetails> {
         match self {
-            RawFrame::Cassandra(_c) => Ok(MessageDetails::Unknown),
-            RawFrame::Redis(frame) => {
+            Frame::Cassandra(_c) => Ok(MessageDetails::Unknown),
+            Frame::Redis(frame) => {
                 redis_codec::process_redis_frame_query(frame).map(MessageDetails::Query)
             }
-            RawFrame::None => Ok(MessageDetails::Unknown),
+            Frame::None => Ok(MessageDetails::Unknown),
         }
     }
 
     #[inline]
     pub fn get_query_type(&self) -> QueryType {
         match self {
-            RawFrame::Cassandra(_) => QueryType::ReadWrite,
-            RawFrame::Redis(frame) => redis_codec::redis_query_type(frame),
-            RawFrame::None => QueryType::ReadWrite,
+            Frame::Cassandra(_) => QueryType::ReadWrite,
+            Frame::Redis(frame) => redis_codec::redis_query_type(frame),
+            Frame::None => QueryType::ReadWrite,
         }
     }
 }

--- a/shotover-proxy/src/protocols/redis_codec.rs
+++ b/shotover-proxy/src/protocols/redis_codec.rs
@@ -2,7 +2,7 @@ use crate::message::{
     ASTHolder, IntSize, Message, MessageDetails, Messages, QueryMessage, QueryResponse, QueryType,
     Value,
 };
-use crate::protocols::RawFrame;
+use crate::protocols::Frame;
 use crate::protocols::RedisFrame;
 use anyhow::{anyhow, Result};
 use bytes::{Buf, Bytes, BytesMut};
@@ -460,8 +460,8 @@ pub fn process_redis_frame_query(frame: &RedisFrame) -> Result<QueryMessage> {
 }
 
 #[inline]
-fn get_redis_frame(rf: RawFrame) -> Result<RedisFrame> {
-    if let RawFrame::Redis(frame) = rf {
+fn get_redis_frame(rf: Frame) -> Result<RedisFrame> {
+    if let Frame::Redis(frame) = rf {
         Ok(frame)
     } else {
         warn!("Unsupported Frame detected - Dropping Frame {:?}", rf);
@@ -508,13 +508,13 @@ impl RedisCodec {
                             }
                         },
                         modified: false,
-                        original: RawFrame::Redis(frame),
+                        original: Frame::Redis(frame),
                     })
                 } else {
                     Ok(Message {
                         details: MessageDetails::Unknown,
                         modified: false,
-                        original: RawFrame::Redis(frame),
+                        original: Frame::Redis(frame),
                     })
                 }
             })

--- a/shotover-proxy/src/transforms/cassandra/sink_single.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_single.rs
@@ -3,7 +3,7 @@ use crate::error::ChainResponse;
 use crate::message;
 use crate::message::{Message, Messages, QueryResponse};
 use crate::protocols::cassandra_codec::CassandraCodec;
-use crate::protocols::RawFrame;
+use crate::protocols::Frame;
 use crate::transforms::util::unordered_cluster_connection_pool::OwnedUnorderedConnectionPool;
 use crate::transforms::util::Request;
 use crate::transforms::{Transform, Transforms, Wrapper};
@@ -94,7 +94,7 @@ impl CassandraSinkSingle {
                             .map(|m| {
                                 let (return_chan_tx, return_chan_rx) =
                                     tokio::sync::oneshot::channel();
-                                let stream = if let RawFrame::Cassandra(frame) = &m.original {
+                                let stream = if let Frame::Cassandra(frame) = &m.original {
                                     frame.stream_id
                                 } else {
                                     info!("no cassandra frame found");
@@ -120,7 +120,7 @@ impl CassandraSinkSingle {
                                 match prelim? {
                                     (_, Ok(mut resp)) => {
                                         for message in &resp {
-                                            if let RawFrame::Cassandra(CassandraFrame {
+                                            if let Frame::Cassandra(CassandraFrame {
                                                 opcode: cassandra_protocol::frame::Opcode::Error,
                                                 ..
                                             }) = &message.original

--- a/shotover-proxy/src/transforms/coalesce.rs
+++ b/shotover-proxy/src/transforms/coalesce.rs
@@ -1,6 +1,6 @@
 use crate::error::ChainResponse;
 use crate::message::{Message, MessageDetails, Messages, QueryResponse};
-use crate::protocols::RawFrame;
+use crate::protocols::Frame;
 use crate::transforms::{Transform, Transforms, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -57,7 +57,7 @@ impl Transform for Coalesce {
             Ok(vec![Message::new(
                 MessageDetails::Response(QueryResponse::empty()),
                 true,
-                RawFrame::None,
+                Frame::None,
             )])
         }
     }
@@ -85,7 +85,7 @@ impl Transform for Coalesce {
 #[cfg(test)]
 mod test {
     use crate::message::{Message, QueryMessage};
-    use crate::protocols::RawFrame;
+    use crate::protocols::Frame;
     use crate::transforms::coalesce::Coalesce;
     use crate::transforms::loopback::Loopback;
     use crate::transforms::{Transform, Transforms, Wrapper};
@@ -104,7 +104,7 @@ mod test {
         let mut loopback = Transforms::Loopback(Loopback::default());
 
         let messages: Vec<_> = (0..25)
-            .map(|_| Message::new_query(QueryMessage::empty(), true, RawFrame::None))
+            .map(|_| Message::new_query(QueryMessage::empty(), true, Frame::None))
             .collect();
 
         let mut message_wrapper = Wrapper::new(messages.clone());
@@ -142,7 +142,7 @@ mod test {
         let mut loopback = Transforms::Loopback(Loopback::default());
 
         let messages: Vec<_> = (0..25)
-            .map(|_| Message::new_query(QueryMessage::empty(), true, RawFrame::None))
+            .map(|_| Message::new_query(QueryMessage::empty(), true, Frame::None))
             .collect();
 
         let mut message_wrapper = Wrapper::new(messages.clone());
@@ -180,7 +180,7 @@ mod test {
         let mut loopback = Transforms::Loopback(Loopback::default());
 
         let messages: Vec<_> = (0..25)
-            .map(|_| Message::new_query(QueryMessage::empty(), true, RawFrame::None))
+            .map(|_| Message::new_query(QueryMessage::empty(), true, Frame::None))
             .collect();
 
         let mut message_wrapper = Wrapper::new(messages.clone());

--- a/shotover-proxy/src/transforms/debug/returner.rs
+++ b/shotover-proxy/src/transforms/debug/returner.rs
@@ -1,6 +1,6 @@
 use crate::error::ChainResponse;
 use crate::message::{Message, MessageDetails, Messages};
-use crate::protocols::RawFrame;
+use crate::protocols::Frame;
 use crate::protocols::RedisFrame;
 use crate::transforms::Transforms;
 use crate::transforms::{Transform, Wrapper};
@@ -52,7 +52,7 @@ impl Transform for DebugReturner {
                 .map(|_| Message {
                     details: MessageDetails::Unknown,
                     modified: false,
-                    original: RawFrame::Redis(RedisFrame::BulkString(string.to_string().into())),
+                    original: Frame::Redis(RedisFrame::BulkString(string.to_string().into())),
                 })
                 .collect()),
             Response::Fail => Err(anyhow!("Intentional Fail")),

--- a/shotover-proxy/src/transforms/distributed/consistent_scatter.rs
+++ b/shotover-proxy/src/transforms/distributed/consistent_scatter.rs
@@ -10,7 +10,7 @@ use tracing::{debug, error, trace, warn};
 use crate::config::topology::TopicHolder;
 use crate::error::ChainResponse;
 use crate::message::{Message, MessageDetails, QueryResponse, QueryType, Value};
-use crate::protocols::RawFrame;
+use crate::protocols::Frame;
 use crate::transforms::chain::BufferedChain;
 use crate::transforms::{
     build_chain_from_config, Transform, Transforms, TransformsConfig, Wrapper,
@@ -178,7 +178,7 @@ impl Transform for ConsistentScatter {
                             "Not enough responses".to_string(),
                         ))),
                         true,
-                        RawFrame::None,
+                        Frame::None,
                     )
                 })
                 .collect()
@@ -195,7 +195,7 @@ impl Transform for ConsistentScatter {
                         }
                     }
                     resolve_fragments(&mut collated_results)
-                        .map(|qr| Message::new_response(qr, true, RawFrame::None))
+                        .map(|qr| Message::new_response(qr, true, Frame::None))
                 })
                 // We do this as we are pop'ing from the end of the results in the filter_map above
                 .rev()
@@ -238,7 +238,7 @@ mod scatter_transform_tests {
     use crate::message::{
         Message, MessageDetails, Messages, QueryMessage, QueryResponse, QueryType, Value,
     };
-    use crate::protocols::RawFrame;
+    use crate::protocols::Frame;
     use crate::transforms::null::Null;
     use crate::transforms::{Transform, Transforms, Wrapper};
     use std::collections::HashMap;
@@ -278,7 +278,7 @@ mod scatter_transform_tests {
         let response = vec![Message::new(
             MessageDetails::Response(QueryResponse::just_result(Value::Strings("OK".to_string()))),
             true,
-            RawFrame::None,
+            Frame::None,
         )];
 
         let wrapper = Wrapper::new(vec![Message::new(
@@ -292,7 +292,7 @@ mod scatter_transform_tests {
                 ast: None,
             }),
             true,
-            RawFrame::None,
+            Frame::None,
         )]);
 
         let ok_repeat =

--- a/shotover-proxy/src/transforms/filter.rs
+++ b/shotover-proxy/src/transforms/filter.rs
@@ -53,7 +53,7 @@ impl Transform for QueryTypeFilter {
 #[cfg(test)]
 mod test {
     use crate::message::{Message, QueryMessage, QueryType};
-    use crate::protocols::RawFrame;
+    use crate::protocols::Frame;
     use crate::protocols::RedisFrame;
     use crate::transforms::filter::QueryTypeFilter;
     use crate::transforms::loopback::Loopback;
@@ -86,7 +86,7 @@ mod test {
                         ast: None,
                     },
                     true,
-                    RawFrame::Redis(RedisFrame::BulkString("FOO".into())),
+                    Frame::Redis(RedisFrame::BulkString("FOO".into())),
                 )
             })
             .collect();
@@ -100,13 +100,13 @@ mod test {
             if i % 2 == 0 {
                 assert_eq!(
                     message.original,
-                    RawFrame::Redis(RedisFrame::Error(
+                    Frame::Redis(RedisFrame::Error(
                         "ERR Message was filtered out by shotover".into()
                     )),
                 )
             } else {
                 // Turned into RawFrame::None by the loopback transform
-                assert_eq!(message.original, RawFrame::None)
+                assert_eq!(message.original, Frame::None)
             }
         }
     }

--- a/shotover-proxy/src/transforms/kafka_sink.rs
+++ b/shotover-proxy/src/transforms/kafka_sink.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 
 use crate::error::ChainResponse;
 use crate::message::{Message, MessageDetails, QueryResponse};
-use crate::protocols::RawFrame;
+use crate::protocols::Frame;
 use crate::transforms::{Transform, Transforms, Wrapper};
 
 #[derive(Clone)]
@@ -95,7 +95,7 @@ impl Transform for KafkaSink {
             responses.push(Message::new_response(
                 QueryResponse::empty(),
                 true,
-                RawFrame::None,
+                Frame::None,
             ))
         }
         Ok(responses)

--- a/shotover-proxy/src/transforms/loopback.rs
+++ b/shotover-proxy/src/transforms/loopback.rs
@@ -1,6 +1,6 @@
 use crate::error::ChainResponse;
 use crate::message::{Message, MessageDetails, QueryResponse};
-use crate::protocols::RawFrame;
+use crate::protocols::Frame;
 use crate::transforms::{Transform, Wrapper};
 use async_trait::async_trait;
 
@@ -18,7 +18,7 @@ impl Transform for Loopback {
                     Some(Message::new_response(
                         QueryResponse::empty_with_matching(qm),
                         true,
-                        RawFrame::None,
+                        Frame::None,
                     ))
                 } else {
                     None

--- a/shotover-proxy/src/transforms/null.rs
+++ b/shotover-proxy/src/transforms/null.rs
@@ -1,6 +1,6 @@
 use crate::error::ChainResponse;
 use crate::message::{Message, MessageDetails, QueryResponse};
-use crate::protocols::RawFrame;
+use crate::protocols::Frame;
 use crate::transforms::{Transform, Wrapper};
 use async_trait::async_trait;
 
@@ -17,7 +17,7 @@ impl Transform for Null {
         Ok(vec![Message::new(
             MessageDetails::Response(QueryResponse::empty()),
             true,
-            RawFrame::None,
+            Frame::None,
         )])
     }
 }

--- a/shotover-proxy/src/transforms/protect/mod.rs
+++ b/shotover-proxy/src/transforms/protect/mod.rs
@@ -261,7 +261,7 @@ mod protect_transform_tests {
         IntSize, Message, MessageDetails, QueryMessage, QueryResponse, QueryType, Value,
     };
     use crate::protocols::cassandra_codec::CassandraCodec;
-    use crate::protocols::RawFrame;
+    use crate::protocols::Frame;
     use crate::transforms::chain::TransformChain;
     use crate::transforms::debug::returner::{DebugReturner, Response};
     use crate::transforms::loopback::Loopback;
@@ -316,7 +316,7 @@ mod protect_transform_tests {
             projection: Some(projection),
             query_type: QueryType::Write,
             ast: None,
-        }), true, RawFrame::None)));
+        }), true, Frame::None)));
 
         let transforms: Vec<Transforms> = vec![Transforms::Loopback(Loopback::default())];
 
@@ -388,7 +388,7 @@ mod protect_transform_tests {
                             DebugReturner::new(Response::Message(vec![Message::new(
                                 MessageDetails::Response(returner_message.clone()),
                                 true,
-                                RawFrame::None,
+                                Frame::None,
                             )])),
                         )];
 
@@ -398,7 +398,7 @@ mod protect_transform_tests {
                         let mut new_wrapper = Wrapper::new(vec![Message::new(
                             MessageDetails::Query(qm),
                             true,
-                            RawFrame::None,
+                            Frame::None,
                         )]);
 
                         new_wrapper.reset(ret_chain.get_inner_chain_refs());
@@ -481,7 +481,7 @@ mod protect_transform_tests {
             projection: Some(projection),
             query_type: QueryType::Write,
             ast: None,
-        }), true, RawFrame::None)));
+        }), true, Frame::None)));
 
         let transforms: Vec<Transforms> = vec![Transforms::Loopback(Loopback::default())];
 
@@ -554,7 +554,7 @@ mod protect_transform_tests {
                         DebugReturner::new(Response::Message(vec![Message::new(
                             MessageDetails::Response(returner_message.clone()),
                             true,
-                            RawFrame::None,
+                            Frame::None,
                         )])),
                     )];
 
@@ -564,7 +564,7 @@ mod protect_transform_tests {
                     let mut new_wrapper = Wrapper::new(vec![Message::new(
                         MessageDetails::Query(qm.clone()),
                         true,
-                        RawFrame::None,
+                        Frame::None,
                     )]);
 
                     new_wrapper.reset(ret_chain.get_inner_chain_refs());

--- a/shotover-proxy/src/transforms/redis/sink_single.rs
+++ b/shotover-proxy/src/transforms/redis/sink_single.rs
@@ -13,7 +13,7 @@ use tokio_util::codec::Framed;
 
 use crate::error::ChainResponse;
 use crate::protocols::redis_codec::{DecodeType, RedisCodec};
-use crate::protocols::RawFrame;
+use crate::protocols::Frame;
 use crate::tls::{AsyncStream, TlsConfig, TlsConnector};
 use crate::transforms::{Transform, Transforms, Wrapper};
 
@@ -105,7 +105,7 @@ impl Transform for RedisSinkSingle {
             Some(a) => {
                 if let Ok(ref messages) = a {
                     for message in messages {
-                        if let RawFrame::Redis(RedisFrame::Error(_)) = message.original {
+                        if let Frame::Redis(RedisFrame::Error(_)) = message.original {
                             self.failed_requests.increment(1);
                         }
                     }

--- a/shotover-proxy/src/transforms/tee.rs
+++ b/shotover-proxy/src/transforms/tee.rs
@@ -1,7 +1,7 @@
 use crate::config::topology::TopicHolder;
 use crate::error::ChainResponse;
 use crate::message::{Message, QueryResponse, Value};
-use crate::protocols::RawFrame;
+use crate::protocols::Frame;
 use crate::transforms::chain::BufferedChain;
 use crate::transforms::{
     build_chain_from_config, Transform, Transforms, TransformsConfig, Wrapper,
@@ -160,7 +160,7 @@ impl Transform for Tee {
                                     .to_string(),
                             ))),
                             true,
-                            RawFrame::None,
+                            Frame::None,
                         );
                     }
                 }

--- a/shotover-proxy/src/transforms/util/unordered_cluster_connection_pool.rs
+++ b/shotover-proxy/src/transforms/util/unordered_cluster_connection_pool.rs
@@ -1,4 +1,4 @@
-use crate::protocols::RawFrame;
+use crate::protocols::Frame;
 use crate::server::CodecReadHalf;
 use crate::server::CodecWriteHalf;
 use crate::transforms::util::{Request, Response};
@@ -129,7 +129,7 @@ async fn rx_process<C: CodecReadHalf>(
                 match maybe_req {
                     Ok(req) => {
                         for m in req {
-                            if let RawFrame::Cassandra(frame) = &m.original {
+                            if let Frame::Cassandra(frame) = &m.original {
                                 match return_channel_map.remove(&frame.stream_id) {
                                     None => {
                                         return_message_map.insert(frame.stream_id, m);


### PR DESCRIPTION
Frame and RawFrame are semantically a bit different but they end up getting used in pretty much the same places so may as well arrive at Frame by converting RawFrame into it.