### PR TITLE
OwnedUnorderedConnectionPool fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,12 +276,11 @@ checksum = "3a4f925191b4367301851c6d99b09890311d74b0d43f274c0b34c86d308a3663"
 
 [[package]]
 name = "cassandra-cpp"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427614898c95ddd1f8ca0613a44f44709a1737078238b7653d28329b32c3324f"
+checksum = "7022ac19888599289d095fe485fc0845e7bb373c917b1be80069d567c14bc712"
 dependencies = [
  "cassandra-cpp-sys",
- "decimal",
  "error-chain",
  "parking_lot",
  "slog",
@@ -310,7 +309,7 @@ dependencies = [
  "num",
  "snap",
  "thiserror",
- "time 0.3.6",
+ "time 0.3.7",
  "uuid",
 ]
 
@@ -362,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.10"
+version = "3.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a30c3bf9ff12dfe5dae53f0a96e0febcd18420d1c0e7fad77796d9d5c4b5375"
+checksum = "08799f92c961c7a1cf0cc398a9073da99e21ce388b46372c37f3191f2f3eed3e"
 dependencies = [
  "atty",
  "bitflags",
@@ -379,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.6"
+version = "3.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517358c28fcef6607bf6f76108e02afad7e82297d132a6b846dcc1fc3efcd153"
+checksum = "0fd2078197a22f338bd4fbf7d6387eb6f0d6a3c69e6cbc09f5c93e97321fd92a"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -603,20 +602,6 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "decimal"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a8ab77e91baeb15034c3be91e87bff4665c9036216148e4996d9a9f5792114d"
-dependencies = [
- "bitflags",
- "cc",
- "libc",
- "ord_subset",
- "rustc-serialize",
- "serde",
 ]
 
 [[package]]
@@ -932,9 +917,9 @@ checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "h2"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9de88456263e249e241fcd211d3954e2c9b0ef7ccfc235a444eb367cae3689"
+checksum = "d9f1f717ddc7b2ba36df7e871fd88db79326551d3d6f1fc406fbfd28b582ff8e"
 dependencies = [
  "bytes",
  "fnv",
@@ -954,15 +939,6 @@ name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
-
-[[package]]
-name = "halfbrown"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed39577259d319b81a15176a32673271be2786cb463889703c58c90fe83c825"
-dependencies = [
- "hashbrown",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1192,9 +1168,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
+checksum = "b0005d08a8f7b65fb8073cb697aa0b12b631ed251ce73d862ce50eeb52ce3b50"
 
 [[package]]
 name = "libloading"
@@ -1420,6 +1396,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.8.3"
+source = "git+https://github.com/conorbros/multimap?branch=remove-methods#57c077606de48a68c3ab0003b607f4df8898a43f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1627,9 +1611,9 @@ dependencies = [
 
 [[package]]
 name = "num_threads"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a1eb3a36534514077c1e079ada2fb170ef30c47d203aa6916138cf882ecd52"
+checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
 dependencies = [
  "libc",
 ]
@@ -1703,12 +1687,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "ord_subset"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ce14664caf5b27f5656ff727defd68ae1eb75ef3c4d95259361df1eb376bef"
 
 [[package]]
 name = "ordered-float"
@@ -2283,12 +2261,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2374,9 +2346,9 @@ checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"
-version = "1.0.135"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cf9235533494ea2ddcdb794665461814781c53f19d87b76e571a1c35acbad2b"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
@@ -2393,9 +2365,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.135"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dcde03d87d4c973c04be249e7d8f0b35db1c848c487bd43032808e59dd8328d"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2517,19 +2489,19 @@ dependencies = [
  "cached",
  "cassandra-cpp",
  "cassandra-protocol",
- "clap 3.0.10",
+ "clap 3.0.13",
  "crc16",
  "criterion",
  "csv",
  "derivative",
  "futures",
  "futures-core",
- "halfbrown",
  "hex-literal",
  "hyper",
  "itertools",
  "metrics",
  "metrics-exporter-prometheus",
+ "multimap",
  "nix",
  "num",
  "num_cpus",
@@ -2779,9 +2751,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
 ]
@@ -2807,9 +2779,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d54b9298e05179c335de2b9645d061255bcd5155f843b3e328d2cfe0a5b413"
+checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
 dependencies = [
  "itoa 1.0.1",
  "libc",
@@ -2985,7 +2957,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94571df2eae3ed4353815ea5a90974a594a1792d8782ff2cbcc9392d1101f366"
 dependencies = [
  "crossbeam-channel",
- "time 0.3.6",
+ "time 0.3.7",
  "tracing-subscriber",
 ]
 
@@ -3023,9 +2995,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77be66445c4eeebb934a7340f227bfe7b338173d3f8c00a60a5a58005c9faecf"
+checksum = "5312f325fe3588e277415f5a6cca1f4ccad0f248c4cd5a4bd33032d7286abc22"
 dependencies = [
  "ansi_term",
  "lazy_static",

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -28,6 +28,7 @@ pin-project-lite = "0.2"
 tokio-openssl = "0.6.2"
 openssl = { version = "0.10.36", features = ["vendored"] }
 async-recursion = "1.0"
+multimap = { git = "https://github.com/conorbros/multimap", branch = "remove-methods" }
 
 # Error handling
 thiserror = "1.0"
@@ -51,7 +52,6 @@ tracing-subscriber = { version = "0.3.1", features = ["env-filter"] }
 tracing-log = { version = "0.1.1", features = ["env_logger"] }
 tracing-appender = "0.2.0"
 hyper = { version = "0.14.14", features = ["server"] }
-halfbrown = "0.1.11"
 
 # Transform dependencies
 redis-protocol = { version = "4.0.1", features = ["decode-mut"] }

--- a/shotover-proxy/src/transforms/cassandra/sink_single.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_single.rs
@@ -3,12 +3,12 @@ use crate::error::ChainResponse;
 use crate::message;
 use crate::message::{Message, Messages, QueryResponse};
 use crate::protocols::cassandra_codec::CassandraCodec;
+use crate::protocols::CassandraFrame;
 use crate::protocols::Frame;
 use crate::transforms::util::unordered_cluster_connection_pool::OwnedUnorderedConnectionPool;
 use crate::transforms::util::Request;
 use crate::transforms::{Transform, Transforms, Wrapper};
 
-use crate::protocols::CassandraFrame;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use metrics::{register_counter, Counter};
@@ -87,6 +87,7 @@ impl CassandraSinkSingle {
                         .connections
                         .get_mut(0)
                         .expect("No connections found");
+
                     let expected_size = messages.len();
                     let results: Result<FuturesOrdered<Receiver<(Message, ChainResponse)>>> =
                         messages

--- a/shotover-proxy/src/transforms/util/cluster_connection_pool.rs
+++ b/shotover-proxy/src/transforms/util/cluster_connection_pool.rs
@@ -1,12 +1,17 @@
-use std::collections::HashMap;
-use std::fmt;
-use std::sync::Arc;
-use std::time::Duration;
+use crate::server::Codec;
+use crate::server::CodecReadHalf;
+use crate::server::CodecWriteHalf;
+use crate::tls::{TlsConfig, TlsConnector};
+use crate::transforms::util::{ConnectionError, Request};
 
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use derivative::Derivative;
 use futures::StreamExt;
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::Arc;
+use std::time::Duration;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::TcpStream;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
@@ -15,12 +20,6 @@ use tokio::time::timeout;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_util::codec::{FramedRead, FramedWrite};
 use tracing::{debug, trace, warn, Instrument};
-
-use crate::server::Codec;
-use crate::server::CodecReadHalf;
-use crate::server::CodecWriteHalf;
-use crate::tls::{TlsConfig, TlsConnector};
-use crate::transforms::util::{ConnectionError, Request};
 
 pub type Connection = UnboundedSender<Request>;
 pub type Lane = HashMap<String, Vec<Connection>>;

--- a/shotover-proxy/src/transforms/util/unordered_cluster_connection_pool.rs
+++ b/shotover-proxy/src/transforms/util/unordered_cluster_connection_pool.rs
@@ -121,11 +121,11 @@ async fn rx_process<C: CodecReadHalf>(
     loop {
         tokio::select! {
             Some(maybe_req) = in_r.next() => {
+                if return_message_map.len() > 1 || return_channel_map.len() > 1 {
+                    info!("message map {:?}", return_message_map);
+                    info!("channel map {:?}", return_channel_map);
+                }
 
-                        if return_message_map.len() > 1 || return_channel_map.len() > 1 {
-                info!("message map {:?}", return_message_map);
-                info!("channel map {:?}", return_channel_map);
-            }
                 match maybe_req {
                     Ok(req) => {
                         for m in req {
@@ -143,18 +143,16 @@ async fn rx_process<C: CodecReadHalf>(
                     }
                     Err(e) => {
                         info!("Couldn't decode message from upstream host {:?}", e);
-                        return Err(anyhow!(
-                                "Couldn't decode message from upstream host {:?}",
-                                e
-                            ));
+                        return Err(anyhow!("Couldn't decode message from upstream host {:?}", e));
                     }
                 }
             },
             Some(original_request) = return_rx.recv() => {
-            if return_message_map.len() > 1 || return_channel_map.len() > 1 {
-                info!("message map {:?}", return_message_map);
-                info!("channel map {:?}", return_channel_map);
-            }
+                if return_message_map.len() > 1 || return_channel_map.len() > 1 {
+                    info!("message map {:?}", return_message_map);
+                    info!("channel map {:?}", return_channel_map);
+                }
+
                 if let Request { messages: orig , return_chan: Some(chan), message_id: Some(id) } = original_request {
                     match return_message_map.remove(&id) {
                         None => {

--- a/shotover-proxy/src/transforms/util/unordered_cluster_connection_pool.rs
+++ b/shotover-proxy/src/transforms/util/unordered_cluster_connection_pool.rs
@@ -122,11 +122,6 @@ async fn rx_process<C: CodecReadHalf>(
     loop {
         tokio::select! {
             Some(maybe_req) = in_r.next() => {
-                if return_message_map.len() > 1 || return_channel_map.len() > 1 {
-                    info!("message map {:?}", return_message_map);
-                    info!("channel map {:?}", return_channel_map);
-                }
-
                 match maybe_req {
                     Ok(req) => {
                         for m in req {
@@ -149,11 +144,6 @@ async fn rx_process<C: CodecReadHalf>(
                 }
             },
             Some(original_request) = return_rx.recv() => {
-                if return_message_map.len() > 1 || return_channel_map.len() > 1 {
-                    info!("message map {:?}", return_message_map);
-                    info!("channel map {:?}", return_channel_map);
-                }
-
                 if let Request { messages: orig , return_chan: Some(chan), message_id: Some(id) } = original_request {
                     match return_message_map.remove_first(&id) {
                         None => {


### PR DESCRIPTION
While it's perfectly valid for a `stream_id` to be the same as another `stream_id`, it is very unlikely that a client will be sending multiple messages with the same `stream_id` asynchronously. If they are, it would indicate that they don't care about the order that the messages are coming back in. What's more likely is that they will only reuse a `stream_id` if sending messages synchronously so we wouldn't have any messages with the same `stream_id` waiting for responses in Shotover at the same time. 

More info on the use of `stream_id` in the Cassandra protocol is [here](https://github.com/apache/cassandra/blob/ff4d63d392c89e27ca6e02e38457a5199a24f6a9/doc/native_protocol_v4.spec#L160).

The current implementation of `OwnedUnorderedConnectionPool` will lose messages if they have the same `stream_id` so I have switched over to using a multi-map. If the same `stream_id` is used, the order doesn't matter, we just need to make sure we don't lose any messages. 

TODO:
- https://github.com/havarnov/multimap/pull/33 wait for this to be upstreamed. This PR is pointing at my personal fork for the moment.