### PR TITLE
Add noise threshold for chain_benches.rs

### DIFF
--- a/shotover-proxy/benches/chain_benches.rs
+++ b/shotover-proxy/benches/chain_benches.rs
@@ -15,6 +15,7 @@ use shotover_proxy::transforms::{Transforms, Wrapper};
 fn criterion_benchmark(c: &mut Criterion) {
     let rt = tokio::runtime::Runtime::new().unwrap();
     let mut group = c.benchmark_group("transform");
+    group.noise_threshold(0.2);
 
     {
         let chain =


### PR DESCRIPTION
Both my local machine and CI usually have a variance of 3% but I have also seen one instance of CI going up to 6%

This sets chain_bench.rs to a noise_threshold of 0.1 (10%) compared to the default of 0.01 (1%)
redis_benches.rs is absurdly noisy so that was already set to 2.0 (200%)


Correctly setting the noise_threshold will prevent the erroneous benchmark warning comments.

I'm not sure if benchmarks are supposed to be more consistent then this, if we are supposed to be able to meet that default 1% variance then I suspect its caused by us using async.
If we figure out a way to reduce the threshold in the future then that would be great, for now being able to detect regressions or improvements of >10% will give enough value.