### PR TITLE
Initial protect test cleanup

### DIFF
--- a/shotover-proxy/src/transforms/protect/mod.rs
+++ b/shotover-proxy/src/transforms/protect/mod.rs
@@ -246,10 +246,6 @@ impl Transform for Protect {
 #[cfg(test)]
 mod protect_transform_tests {
     use std::collections::HashMap;
-    use std::env;
-    use std::error::Error;
-
-    use anyhow::{anyhow, Result};
 
     use crate::protocols::CassandraFrame;
     use cassandra_protocol::consistency::Consistency;
@@ -270,7 +266,7 @@ mod protect_transform_tests {
     use crate::transforms::{Transform, Transforms, Wrapper};
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_protect_transform() -> Result<(), Box<dyn Error>> {
+    async fn test_protect_transform() {
         let projection: Vec<String> = vec!["pk", "cluster", "col1", "col2", "col3"]
             .iter()
             .map(|&x| String::from(x))
@@ -336,7 +332,7 @@ mod protect_transform_tests {
 
         wrapper.reset(chain.get_inner_chain_refs());
 
-        if let Transforms::Protect(mut protect) = protect_t.get_source().await? {
+        if let Transforms::Protect(mut protect) = protect_t.get_source().await.unwrap() {
             let result = protect.transform(wrapper).await;
             if let Ok(mut m) = result {
                 if let MessageDetails::Query(QueryMessage {
@@ -352,7 +348,7 @@ mod protect_transform_tests {
                     assert!(!encrypted_payload.contains(
                         format!(
                             "plaintext {:?}",
-                            bincode::serialize(&secret_data.clone().into_bytes())?
+                            bincode::serialize(&secret_data.clone().into_bytes()).unwrap()
                         )
                         .as_str()
                     ));
@@ -419,7 +415,7 @@ mod protect_transform_tests {
                         {
                             if let MessageValue::Strings(s) = r.get(0).unwrap().get(0).unwrap() {
                                 assert_eq!(s, &secret_data);
-                                return Ok(());
+                                return;
                             }
                         }
                     }
@@ -429,34 +425,44 @@ mod protect_transform_tests {
         panic!()
     }
 
-    /// Creates a new AWS key and returns the key ARN
-    async fn create_aws_key() -> Result<String> {
+    async fn create_aws_key_and_alias() {
         let client = reqwest::Client::new();
 
         let res = client.post("http://localhost:5000")
-            .body( r#"{ "Description":"Testing Key",
-                               "KeyUsage":"ENCRYPT_DECRYPT",
-                               "CustomerMasterKeySpec":"SYMMETRIC_DEFAULT"}"#)
-            .header( "Accept-Encoding", "identity" )
-            .header( "Accept", "text/plain")
-            .header( "X-Amz-Target","TrentService.CreateKey")
-            .header( "Content-Type","application/x-amz-json-1.1")
-            .header( "X-Amz-Date","20220126T133630Z")
-            .header( "X-Amz-Security-Token","testing")
-            .header( "Authorization","AWS4-HMAC-SHA256 Credential=testing/20220126/us-east-1/kms/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-security-token;x-amz-target, Signature=7983d06364243f7d9a2a3353d65c724e79bffd7381a10753725a04727a9d8c07")
-            .send().await?;
+            .body(r#"{ "Description":"Testing Key",
+                       "KeyUsage":"ENCRYPT_DECRYPT",
+                       "CustomerMasterKeySpec":"SYMMETRIC_DEFAULT"}"#)
+            .header("Accept-Encoding", "identity")
+            .header("Accept", "text/plain")
+            .header("X-Amz-Target","TrentService.CreateKey")
+            .header("Content-Type","application/x-amz-json-1.1")
+            .header("X-Amz-Date","20220126T133630Z")
+            .header("X-Amz-Security-Token","testing")
+            .header("Authorization","AWS4-HMAC-SHA256 Credential=testing/20220126/us-east-1/kms/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-security-token;x-amz-target, Signature=7983d06364243f7d9a2a3353d65c724e79bffd7381a10753725a04727a9d8c07")
+            .send().await.unwrap();
 
-        let result = res.text().await?;
-        let parsed: serde_json::Value = serde_json::from_str(result.as_str())?;
-        Ok(parsed["KeyMetadata"]["Arn"].as_str().unwrap().to_string())
+        let result = res.text().await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(result.as_str()).unwrap();
+        let key = parsed["KeyMetadata"]["KeyId"].as_str().unwrap().to_string();
+
+        client.post("http://localhost:5000")
+            .body(format!("{{ \"AliasName\":\"alias/KeyAlias\", \"TargetKeyId\":\"{}\"}}", key))
+            .header("Accept-Encoding", "identity" )
+            .header("Accept", "text/plain")
+            .header("X-Amz-Target","TrentService.CreateAlias")
+            .header("Content-Type","application/x-amz-json-1.1")
+            .header("X-Amz-Date","20220126T133630Z")
+            .header("X-Amz-Security-Token","testing")
+            .header("Authorization","AWS4-HMAC-SHA256 Credential=testing/20220126/us-east-1/kms/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-security-token;x-amz-target, Signature=7983d06364243f7d9a2a3353d65c724e79bffd7381a10753725a04727a9d8c07")
+            .send().await.unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_protect_kms_transform() -> Result<()> {
+    async fn test_protect_kms_transform() {
         let _compose = DockerCompose::new("tests/transforms/docker-compose-moto.yml")
             .wait_for(r#"Press CTRL\+C to quit"#);
 
-        let key_id = create_aws_key().await.unwrap();
+        create_aws_key_and_alias().await;
 
         let projection: Vec<String> = vec!["pk", "cluster", "col1", "col2", "col3"]
             .iter()
@@ -468,13 +474,10 @@ mod protect_transform_tests {
         protection_table_map.insert("old".to_string(), vec!["col1".to_string()]);
         protection_map.insert("keyspace".to_string(), protection_table_map);
 
-        env::set_var("AWS_ACCESS_KEY_ID", "dummy-access-key");
-        env::set_var("AWS_SECRET_ACCESS_KEY", "dummy-access-key-secret");
-
         let aws_config = KeyManagerConfig::AWSKms {
             endpoint: Some("http://localhost:5000".to_string()),
             region: "us-east-1".to_string(),
-            cmk_id: key_id,
+            cmk_id: "alias/KeyAlias".to_string(),
             encryption_context: None,
             key_spec: None,
             number_of_bytes: Some(32), // 256-bit (it's specified in bytes)
@@ -533,9 +536,9 @@ mod protect_transform_tests {
 
         wrapper.reset(chain.get_inner_chain_refs());
 
-        let t = protect_t.get_source().await?;
+        let t = protect_t.get_source().await.unwrap();
         if let Transforms::Protect(mut protect) = t {
-            let mut m = protect.transform(wrapper).await?;
+            let mut m = protect.transform(wrapper).await.unwrap();
             let mut details = m.pop().unwrap().details;
 
             if let MessageDetails::Query(QueryMessage {
@@ -554,7 +557,7 @@ mod protect_transform_tests {
                 assert!(!encrypted_payload.contains(
                     format!(
                         "plaintext {:?}",
-                        bincode::serialize(&secret_data.clone().into_bytes())?
+                        bincode::serialize(&secret_data.clone().into_bytes()).unwrap()
                     )
                     .as_str()
                 ));
@@ -621,9 +624,8 @@ mod protect_transform_tests {
                     {
                         return if let MessageValue::Strings(s) = r.get(0).unwrap().get(0).unwrap() {
                             assert_eq!(s.clone(), secret_data);
-                            Ok(())
                         } else {
-                            Err(anyhow!("Couldn't get string"))
+                            panic!("Couldn't get string");
                         };
                     }
                 }


### PR DESCRIPTION
* Panics instead of returning Err to better report failures
* ~~create_aws_key is now create_aws_key_and_alias~~ I realized there are some default keys provided by moto that we can make use of rather than creating our own: https://github.com/spulec/moto/blob/0a1bb6bae165b38cdec5e299a7f859f2cb27de93/moto/kms/utils.py#L41
    + By using a stable alias of a key we will be able to write integration tests for Protect that specify the stable key alias in their topology.yaml