### PR TITLE
Implement Protect integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
       # * clippy --all-targets causes clippy to run against tests and examples which it doesnt do by default.
       run: cargo hack --feature-powerset clippy --all-targets --locked ${{ matrix.cargo_profile }} -- -D warnings
     - name: Ensure that tests pass
-      run: cargo test ${{ matrix.cargo_profile }} -- --include-ignored --show-output
+      run: cargo test ${{ matrix.cargo_profile }} --all-features -- --include-ignored --show-output
       # can not run tests if cpp driver not installed
       if: ${{ matrix.runner == 'ubuntu-18.04' }}
     - name: License Check

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -8,6 +8,10 @@ license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+# Include WIP alpha transforms in the public API
+alpha-transforms = []
+
 [dependencies]
 tokio = { version = "1.14.0", features = ["full", "macros"] }
 tokio-util = { version = "0.6.1", features = ["full"] }

--- a/shotover-proxy/examples/cassandra-protect-aws/docker-compose.yml
+++ b/shotover-proxy/examples/cassandra-protect-aws/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.3"
+services:
+  cassandra-one:
+    image: library/cassandra:3.11.10
+    ports:
+      - "9043:9042"
+    environment:
+      MAX_HEAP_SIZE: "400M"
+      MIN_HEAP_SIZE: "400M"
+      HEAP_NEWSIZE: "48M"
+      CASSANDRA_ENABLE_SCRIPTED_USER_DEFINED_FUNCTIONS: "true"
+      CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS: "true"
+    volumes:
+      - ./docker-entrypoint.sh:/usr/local/bin/docker-entrypoint.sh

--- a/shotover-proxy/examples/cassandra-protect-aws/docker-entrypoint.sh
+++ b/shotover-proxy/examples/cassandra-protect-aws/docker-entrypoint.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+set -e
+
+###  https://github.com/docker-library/cassandra/blob/master/3.11/docker-entrypoint.sh
+###  This file has been copied from the above link and modified to include enable_user_defined_functions and enable_scripted_user_defined_functions to the for yaml in \ loop
+###  so extra cassandra config options can be modified from the docker-compose.yml
+
+# first arg is `-f` or `--some-option`
+# or there are no args
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+	set -- cassandra -f "$@"
+fi
+
+# allow the container to be started with `--user`
+if [ "$1" = 'cassandra' -a "$(id -u)" = '0' ]; then
+	find "$CASSANDRA_CONF" /var/lib/cassandra /var/log/cassandra \
+		\! -user cassandra -exec chown cassandra '{}' +
+	exec gosu cassandra "$BASH_SOURCE" "$@"
+fi
+
+_ip_address() {
+	# scrape the first non-localhost IP address of the container
+	# in Swarm Mode, we often get two IPs -- the container IP, and the (shared) VIP, and the container IP should always be first
+	ip address | awk '
+		$1 != "inet" { next } # only lines with ip addresses
+		$NF == "lo" { next } # skip loopback devices
+		$2 ~ /^127[.]/ { next } # skip loopback addresses
+		$2 ~ /^169[.]254[.]/ { next } # skip link-local addresses
+		{
+			gsub(/\/.+$/, "", $2)
+			print $2
+			exit
+		}
+	'
+}
+
+# "sed -i", but without "mv" (which doesn't work on a bind-mounted file, for example)
+_sed-in-place() {
+	local filename="$1"; shift
+	local tempFile
+	tempFile="$(mktemp)"
+	sed "$@" "$filename" > "$tempFile"
+	cat "$tempFile" > "$filename"
+	rm "$tempFile"
+}
+
+if [ "$1" = 'cassandra' ]; then
+	: ${CASSANDRA_RPC_ADDRESS='0.0.0.0'}
+
+	: ${CASSANDRA_LISTEN_ADDRESS='auto'}
+	if [ "$CASSANDRA_LISTEN_ADDRESS" = 'auto' ]; then
+		CASSANDRA_LISTEN_ADDRESS="$(_ip_address)"
+	fi
+
+	: ${CASSANDRA_BROADCAST_ADDRESS="$CASSANDRA_LISTEN_ADDRESS"}
+
+	if [ "$CASSANDRA_BROADCAST_ADDRESS" = 'auto' ]; then
+		CASSANDRA_BROADCAST_ADDRESS="$(_ip_address)"
+	fi
+	: ${CASSANDRA_BROADCAST_RPC_ADDRESS:=$CASSANDRA_BROADCAST_ADDRESS}
+
+	if [ -n "${CASSANDRA_NAME:+1}" ]; then
+		: ${CASSANDRA_SEEDS:="cassandra"}
+	fi
+	: ${CASSANDRA_SEEDS:="$CASSANDRA_BROADCAST_ADDRESS"}
+
+	_sed-in-place "$CASSANDRA_CONF/cassandra.yaml" \
+		-r 's/(- seeds:).*/\1 "'"$CASSANDRA_SEEDS"'"/'
+
+	for yaml in \
+		broadcast_address \
+		broadcast_rpc_address \
+		cluster_name \
+		endpoint_snitch \
+		listen_address \
+		num_tokens \
+		rpc_address \
+		start_rpc \
+		enable_user_defined_functions \
+		enable_scripted_user_defined_functions \
+	; do
+		var="CASSANDRA_${yaml^^}"
+		val="${!var}"
+		if [ "$val" ]; then
+			_sed-in-place "$CASSANDRA_CONF/cassandra.yaml" \
+				-r 's/^(# )?('"$yaml"':).*/\2 '"$val"'/'
+		fi
+	done
+
+	for rackdc in dc rack; do
+		var="CASSANDRA_${rackdc^^}"
+		val="${!var}"
+		if [ "$val" ]; then
+			_sed-in-place "$CASSANDRA_CONF/cassandra-rackdc.properties" \
+				-r 's/^('"$rackdc"'=).*/\1 '"$val"'/'
+		fi
+	done
+fi
+
+exec "$@"

--- a/shotover-proxy/examples/cassandra-protect-aws/topology.yaml
+++ b/shotover-proxy/examples/cassandra-protect-aws/topology.yaml
@@ -1,0 +1,34 @@
+---
+sources:
+  cassandra_prod:
+    Cassandra:
+      query_processing: true
+      listen_addr: "127.0.0.1:9042"
+      cassandra_ks:
+        system.local:
+          - key
+        test.simple:
+          - pk
+        test.clustering:
+          - pk
+          - clustering
+chain_config:
+  main_chain:
+    - Protect:
+        key_manager:
+          AWSKms:
+            endpoint: "http://localhost:5000"
+            region: "us-east-1"
+            cmk_id: "alias/aws/secretsmanager"
+            number_of_bytes: 32
+        keyspace_table_columns:
+          test_protect_keyspace:
+            test_table:
+              - col1
+    - CassandraSinkSingle:
+        result_processing: true
+        remote_address: "127.0.0.1:9043"
+named_topics:
+  testtopic: 5
+source_to_chain_mapping:
+  cassandra_prod: main_chain

--- a/shotover-proxy/examples/cassandra-protect-local/docker-compose.yml
+++ b/shotover-proxy/examples/cassandra-protect-local/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.3"
+services:
+  cassandra-one:
+    image: library/cassandra:3.11.10
+    ports:
+      - "9043:9042"
+    environment:
+      MAX_HEAP_SIZE: "400M"
+      MIN_HEAP_SIZE: "400M"
+      HEAP_NEWSIZE: "48M"
+      CASSANDRA_ENABLE_SCRIPTED_USER_DEFINED_FUNCTIONS: "true"
+      CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS: "true"
+    volumes:
+      - ./docker-entrypoint.sh:/usr/local/bin/docker-entrypoint.sh

--- a/shotover-proxy/examples/cassandra-protect-local/docker-entrypoint.sh
+++ b/shotover-proxy/examples/cassandra-protect-local/docker-entrypoint.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+set -e
+
+###  https://github.com/docker-library/cassandra/blob/master/3.11/docker-entrypoint.sh
+###  This file has been copied from the above link and modified to include enable_user_defined_functions and enable_scripted_user_defined_functions to the for yaml in \ loop
+###  so extra cassandra config options can be modified from the docker-compose.yml
+
+# first arg is `-f` or `--some-option`
+# or there are no args
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+	set -- cassandra -f "$@"
+fi
+
+# allow the container to be started with `--user`
+if [ "$1" = 'cassandra' -a "$(id -u)" = '0' ]; then
+	find "$CASSANDRA_CONF" /var/lib/cassandra /var/log/cassandra \
+		\! -user cassandra -exec chown cassandra '{}' +
+	exec gosu cassandra "$BASH_SOURCE" "$@"
+fi
+
+_ip_address() {
+	# scrape the first non-localhost IP address of the container
+	# in Swarm Mode, we often get two IPs -- the container IP, and the (shared) VIP, and the container IP should always be first
+	ip address | awk '
+		$1 != "inet" { next } # only lines with ip addresses
+		$NF == "lo" { next } # skip loopback devices
+		$2 ~ /^127[.]/ { next } # skip loopback addresses
+		$2 ~ /^169[.]254[.]/ { next } # skip link-local addresses
+		{
+			gsub(/\/.+$/, "", $2)
+			print $2
+			exit
+		}
+	'
+}
+
+# "sed -i", but without "mv" (which doesn't work on a bind-mounted file, for example)
+_sed-in-place() {
+	local filename="$1"; shift
+	local tempFile
+	tempFile="$(mktemp)"
+	sed "$@" "$filename" > "$tempFile"
+	cat "$tempFile" > "$filename"
+	rm "$tempFile"
+}
+
+if [ "$1" = 'cassandra' ]; then
+	: ${CASSANDRA_RPC_ADDRESS='0.0.0.0'}
+
+	: ${CASSANDRA_LISTEN_ADDRESS='auto'}
+	if [ "$CASSANDRA_LISTEN_ADDRESS" = 'auto' ]; then
+		CASSANDRA_LISTEN_ADDRESS="$(_ip_address)"
+	fi
+
+	: ${CASSANDRA_BROADCAST_ADDRESS="$CASSANDRA_LISTEN_ADDRESS"}
+
+	if [ "$CASSANDRA_BROADCAST_ADDRESS" = 'auto' ]; then
+		CASSANDRA_BROADCAST_ADDRESS="$(_ip_address)"
+	fi
+	: ${CASSANDRA_BROADCAST_RPC_ADDRESS:=$CASSANDRA_BROADCAST_ADDRESS}
+
+	if [ -n "${CASSANDRA_NAME:+1}" ]; then
+		: ${CASSANDRA_SEEDS:="cassandra"}
+	fi
+	: ${CASSANDRA_SEEDS:="$CASSANDRA_BROADCAST_ADDRESS"}
+
+	_sed-in-place "$CASSANDRA_CONF/cassandra.yaml" \
+		-r 's/(- seeds:).*/\1 "'"$CASSANDRA_SEEDS"'"/'
+
+	for yaml in \
+		broadcast_address \
+		broadcast_rpc_address \
+		cluster_name \
+		endpoint_snitch \
+		listen_address \
+		num_tokens \
+		rpc_address \
+		start_rpc \
+		enable_user_defined_functions \
+		enable_scripted_user_defined_functions \
+	; do
+		var="CASSANDRA_${yaml^^}"
+		val="${!var}"
+		if [ "$val" ]; then
+			_sed-in-place "$CASSANDRA_CONF/cassandra.yaml" \
+				-r 's/^(# )?('"$yaml"':).*/\2 '"$val"'/'
+		fi
+	done
+
+	for rackdc in dc rack; do
+		var="CASSANDRA_${rackdc^^}"
+		val="${!var}"
+		if [ "$val" ]; then
+			_sed-in-place "$CASSANDRA_CONF/cassandra-rackdc.properties" \
+				-r 's/^('"$rackdc"'=).*/\1 '"$val"'/'
+		fi
+	done
+fi
+
+exec "$@"

--- a/shotover-proxy/examples/cassandra-protect-local/topology.yaml
+++ b/shotover-proxy/examples/cassandra-protect-local/topology.yaml
@@ -18,38 +18,38 @@ chain_config:
         key_manager:
           Local:
             kek:
-              - 30
-              - 223
-              - 12
-              - 214
-              - 112
-              - 206
-              - 255
-              - 183
-              - 218
-              - 203
-              - 231
-              - 31
-              - 183
-              - 189
-              - 76
-              - 217
-              - 124
-              - 187
-              - 143
-              - 125
-              - 4
-              - 156
-              - 176
-              - 44
-              - 3
-              - 206
-              - 33
-              - 73
-              - 67
-              - 2
-              - 155
-              - 89
+              - 0x1e
+              - 0xdf
+              - 0x0c
+              - 0xd6
+              - 0x70
+              - 0xce
+              - 0xff
+              - 0xb7
+              - 0xda
+              - 0xcb
+              - 0xe7
+              - 0x1f
+              - 0xb7
+              - 0xbd
+              - 0x4c
+              - 0xd9
+              - 0x7c
+              - 0xbb
+              - 0x8f
+              - 0x7d
+              - 0x04
+              - 0x9c
+              - 0xb0
+              - 0x2c
+              - 0x03
+              - 0xce
+              - 0x21
+              - 0x49
+              - 0x43
+              - 0x02
+              - 0x9b
+              - 0x59
             kek_id: ""
         keyspace_table_columns:
           test_protect_keyspace:

--- a/shotover-proxy/examples/cassandra-protect-local/topology.yaml
+++ b/shotover-proxy/examples/cassandra-protect-local/topology.yaml
@@ -1,0 +1,64 @@
+---
+sources:
+  cassandra_prod:
+    Cassandra:
+      query_processing: true
+      listen_addr: "127.0.0.1:9042"
+      cassandra_ks:
+        system.local:
+          - key
+        test.simple:
+          - pk
+        test.clustering:
+          - pk
+          - clustering
+chain_config:
+  main_chain:
+    - Protect:
+        key_manager:
+          Local:
+            kek:
+              - 30
+              - 223
+              - 12
+              - 214
+              - 112
+              - 206
+              - 255
+              - 183
+              - 218
+              - 203
+              - 231
+              - 31
+              - 183
+              - 189
+              - 76
+              - 217
+              - 124
+              - 187
+              - 143
+              - 125
+              - 4
+              - 156
+              - 176
+              - 44
+              - 3
+              - 206
+              - 33
+              - 73
+              - 67
+              - 2
+              - 155
+              - 89
+            kek_id: ""
+        keyspace_table_columns:
+          test_protect_keyspace:
+            test_table:
+              - col1
+    - CassandraSinkSingle:
+        result_processing: true
+        remote_address: "127.0.0.1:9043"
+named_topics:
+  testtopic: 5
+source_to_chain_mapping:
+  cassandra_prod: main_chain

--- a/shotover-proxy/src/transforms/mod.rs
+++ b/shotover-proxy/src/transforms/mod.rs
@@ -30,6 +30,8 @@ use crate::transforms::loopback::Loopback;
 use crate::transforms::null::Null;
 use crate::transforms::parallel_map::{ParallelMap, ParallelMapConfig};
 use crate::transforms::protect::Protect;
+#[cfg(feature = "alpha-transforms")]
+use crate::transforms::protect::ProtectConfig;
 use crate::transforms::query_counter::{QueryCounter, QueryCounterConfig};
 use crate::transforms::redis::cache::{RedisConfig, SimpleRedisCache};
 use crate::transforms::redis::cluster_ports_rewrite::{
@@ -226,6 +228,8 @@ pub enum TransformsConfig {
     Null,
     #[cfg(test)]
     Loopback,
+    #[cfg(feature = "alpha-transforms")]
+    Protect(ProtectConfig),
     ParallelMap(ParallelMapConfig),
     //PoolConnections(ConnectionBalanceAndPoolConfig),
     Coalesce(CoalesceConfig),
@@ -257,6 +261,8 @@ impl TransformsConfig {
             TransformsConfig::Null => Ok(Transforms::Null(Null::default())),
             #[cfg(test)]
             TransformsConfig::Loopback => Ok(Transforms::Loopback(Loopback::default())),
+            #[cfg(feature = "alpha-transforms")]
+            TransformsConfig::Protect(p) => p.get_source().await,
             TransformsConfig::RedisSinkCluster(r) => r.get_source(chain_name).await,
             TransformsConfig::ParallelMap(s) => s.get_source(topics).await,
             //TransformsConfig::PoolConnections(s) => s.get_source(topics).await,

--- a/shotover-proxy/src/transforms/protect/mod.rs
+++ b/shotover-proxy/src/transforms/protect/mod.rs
@@ -246,7 +246,6 @@ impl Transform for Protect {
 #[cfg(test)]
 mod protect_transform_tests {
     use std::collections::HashMap;
-    use std::env;
 
     use crate::frame::CassandraFrame;
     use cassandra_protocol::consistency::Consistency;
@@ -428,8 +427,7 @@ mod protect_transform_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_protect_kms_transform() {
-        let _compose = DockerCompose::new("tests/transforms/docker-compose-moto.yml")
-            .wait_for(r#"Press CTRL\+C to quit"#);
+        let _compose = DockerCompose::new_moto();
 
         let projection: Vec<String> = vec!["pk", "cluster", "col1", "col2", "col3"]
             .iter()
@@ -440,11 +438,6 @@ mod protect_transform_tests {
         let mut protection_table_map: HashMap<String, Vec<String>> = HashMap::new();
         protection_table_map.insert("old".to_string(), vec!["col1".to_string()]);
         protection_map.insert("keyspace".to_string(), protection_table_map);
-
-        // Overwrite any existing AWS credential env vars belonging to the user with dummy values to be sure that
-        // we wont hit their real AWS account in the case of a bug in shotover or the test
-        env::set_var("AWS_ACCESS_KEY_ID", "dummy-access-key");
-        env::set_var("AWS_SECRET_ACCESS_KEY", "dummy-access-key-secret");
 
         let aws_config = KeyManagerConfig::AWSKms {
             endpoint: Some("http://localhost:5000".to_string()),

--- a/shotover-proxy/src/transforms/protect/mod.rs
+++ b/shotover-proxy/src/transforms/protect/mod.rs
@@ -37,7 +37,7 @@ pub struct KeyMaterial {
     pub plaintext: Key,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct ProtectConfig {
     pub keyspace_table_columns: HashMap<String, HashMap<String, Vec<String>>>,
     pub key_manager: KeyManagerConfig,

--- a/shotover-proxy/tests/cassandra_int_tests/basic_driver_tests.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/basic_driver_tests.rs
@@ -1343,6 +1343,12 @@ fn test_cassandra_protect_transform_local() {
     let shotover_connection = cassandra_connection("127.0.0.1", 9042);
     let direct_connection = cassandra_connection("127.0.0.1", 9043);
 
+    keyspace::test(&shotover_connection);
+    table::test(&shotover_connection);
+    udt::test(&shotover_connection);
+    native_types::test(&shotover_connection);
+    collections::test(&shotover_connection);
+    functions::test(&shotover_connection);
     protect::test(&shotover_connection, &direct_connection);
 }
 
@@ -1360,5 +1366,11 @@ fn test_cassandra_protect_transform_aws() {
     let shotover_connection = cassandra_connection("127.0.0.1", 9042);
     let direct_connection = cassandra_connection("127.0.0.1", 9043);
 
+    keyspace::test(&shotover_connection);
+    table::test(&shotover_connection);
+    udt::test(&shotover_connection);
+    native_types::test(&shotover_connection);
+    collections::test(&shotover_connection);
+    functions::test(&shotover_connection);
     protect::test(&shotover_connection, &direct_connection);
 }

--- a/shotover-proxy/tests/cassandra_int_tests/basic_driver_tests.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/basic_driver_tests.rs
@@ -1218,6 +1218,52 @@ mod cache {
     }
 }
 
+#[cfg(feature = "alpha-transforms")]
+mod protect {
+    use crate::cassandra_int_tests::{assert_query_result, run_query, ResultValue};
+    use cassandra_cpp::Session;
+
+    pub fn test(shotover_session: &Session, direct_session: &Session) {
+        run_query(shotover_session, "CREATE KEYSPACE test_protect_keyspace WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };");
+        run_query(
+            shotover_session,
+            "CREATE TABLE test_protect_keyspace.test_table (pk varchar PRIMARY KEY, cluster varchar, col1 varchar, col2 int, col3 boolean);",
+        );
+
+        run_query(
+            shotover_session,
+            "INSERT INTO test_protect_keyspace.test_table (pk, cluster, col1, col2, col3) VALUES ('pk1', 'cluster', 'I am gonna get encrypted!!', 42, true);"
+        );
+
+        assert_query_result(
+            shotover_session,
+            "SELECT pk, cluster, col1, col2, col3 FROM test_protect_keyspace.test_table",
+            &[&[
+                ResultValue::Varchar("pk1".into()),
+                ResultValue::Varchar("cluster".into()),
+                ResultValue::Varchar("I am gonna get encrypted!!".into()),
+                ResultValue::Int(42),
+                ResultValue::Boolean(true),
+            ]],
+        );
+
+        // TODO: This should not pass.
+        //       Protect manages to encrypt the value in message details
+        //       but the cassandra codec never writes that back into the outgoing message.
+        assert_query_result(
+            direct_session,
+            "SELECT pk, cluster, col1, col2, col3 FROM test_protect_keyspace.test_table",
+            &[&[
+                ResultValue::Varchar("pk1".into()),
+                ResultValue::Varchar("cluster".into()),
+                ResultValue::Varchar("I am gonna get encrypted!!".into()),
+                ResultValue::Int(42),
+                ResultValue::Boolean(true),
+            ]],
+        );
+    }
+}
+
 #[test]
 #[serial]
 fn test_cluster() {
@@ -1282,4 +1328,38 @@ fn test_cassandra_redis_cache() {
     functions::test(&connection);
     cache::test(&connection, &mut redis_connection);
     prepared_statements::test(&connection);
+}
+
+#[test]
+#[serial]
+#[cfg(feature = "alpha-transforms")]
+fn test_cassandra_protect_transform_local() {
+    let _compose = DockerCompose::new("examples/cassandra-protect-local/docker-compose.yml")
+        .wait_for_n_t("Startup complete", 1, 90);
+
+    let _shotover_manager =
+        ShotoverManager::from_topology_file("examples/cassandra-protect-local/topology.yaml");
+
+    let shotover_connection = cassandra_connection("127.0.0.1", 9042);
+    let direct_connection = cassandra_connection("127.0.0.1", 9043);
+
+    protect::test(&shotover_connection, &direct_connection);
+}
+
+#[test]
+#[serial]
+#[cfg(feature = "alpha-transforms")]
+fn test_cassandra_protect_transform_aws() {
+    let _compose = DockerCompose::new("examples/cassandra-protect-aws/docker-compose.yml")
+        .wait_for_n_t("Startup complete", 1, 90);
+    let _compose_aws = DockerCompose::new("tests/transforms/docker-compose-moto.yml")
+        .wait_for(r#"Press CTRL\+C to quit"#);
+
+    let _shotover_manager =
+        ShotoverManager::from_topology_file("examples/cassandra-protect-aws/topology.yaml");
+
+    let shotover_connection = cassandra_connection("127.0.0.1", 9042);
+    let direct_connection = cassandra_connection("127.0.0.1", 9043);
+
+    protect::test(&shotover_connection, &direct_connection);
 }

--- a/shotover-proxy/tests/cassandra_int_tests/basic_driver_tests.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/basic_driver_tests.rs
@@ -1352,8 +1352,7 @@ fn test_cassandra_protect_transform_local() {
 fn test_cassandra_protect_transform_aws() {
     let _compose = DockerCompose::new("examples/cassandra-protect-aws/docker-compose.yml")
         .wait_for_n_t("Startup complete", 1, 90);
-    let _compose_aws = DockerCompose::new("tests/transforms/docker-compose-moto.yml")
-        .wait_for(r#"Press CTRL\+C to quit"#);
+    let _compose_aws = DockerCompose::new_moto();
 
     let _shotover_manager =
         ShotoverManager::from_topology_file("examples/cassandra-protect-aws/topology.yaml");

--- a/test-helpers/src/docker_compose.rs
+++ b/test-helpers/src/docker_compose.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Result};
 use regex::Regex;
+use std::env;
 use std::io::ErrorKind;
 use std::process::Command;
 use std::thread;
@@ -70,6 +71,17 @@ impl DockerCompose {
         DockerCompose {
             file_path: file_path.to_string(),
         }
+    }
+
+    /// Creates a new DockerCompose running an instance of moto the AWS mocking server
+    pub fn new_moto() -> Self {
+        // Overwrite any existing AWS credential env vars belonging to the user with dummy values to be sure that
+        // we wont hit their real AWS account in the case of a bug in shotover or the test
+        env::set_var("AWS_ACCESS_KEY_ID", "dummy-access-key");
+        env::set_var("AWS_SECRET_ACCESS_KEY", "dummy-access-key-secret");
+
+        DockerCompose::new("tests/transforms/docker-compose-moto.yml")
+            .wait_for(r#"Press CTRL\+C to quit"#)
     }
 
     /// Waits for a string to appear in the docker-compose log output.


### PR DESCRIPTION
closes https://github.com/shotover/shotover-proxy/issues/462

The motivation here is these integration tests will serve as replacements for the Protect unittests as those unittests are filled with implementation details of the old implementation.

I put the new tests in with the cassandra int tests as that is the only protocol that attempts to support protect at the moment.
When new protocols support it they should get their own int tests for it.

I added a new `protect` feature to allow us to write integration tests for protect while not including it in the public shotover API.
`#[cfg(test)]` does not allow this as it is only enabled during unit tests not integration tests.

I manually verified that the integration test tests the encryption code path as far as the current Protect implementation will go, but hopefully the message details rewrite will remove a lot of broken stuff and allow this test to actually test that encryption/decryption occurs.