### PR TITLE
CassandraConnection cleanup

### DIFF
--- a/shotover-proxy/src/transforms/cassandra/connection.rs
+++ b/shotover-proxy/src/transforms/cassandra/connection.rs
@@ -16,6 +16,7 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_util::codec::{FramedRead, FramedWrite};
 use tracing::{info, Instrument};
 
+/// Represents a `Request` to a `CassandraConnection`
 #[derive(Debug)]
 struct Request {
     message: Message,
@@ -54,6 +55,7 @@ impl<C: Codec + 'static> CassandraConnection<C> {
         Ok(())
     }
 
+    /// Send a `Message` to this `CassandraConnection` and expect a response on `return_chan`
     pub fn send(&self, message: Message, return_chan: oneshot::Sender<Response>) -> Result<()> {
         let message_id = if let Frame::Cassandra(frame) = &message.original {
             frame.stream_id
@@ -64,6 +66,7 @@ impl<C: Codec + 'static> CassandraConnection<C> {
 
         let connection = self.connection.as_ref().expect("No connection found");
 
+        // Convert the message to `Request` and send upstream
         Ok(connection.send(Request {
             message,
             return_chan,

--- a/shotover-proxy/src/transforms/cassandra/connection.rs
+++ b/shotover-proxy/src/transforms/cassandra/connection.rs
@@ -60,7 +60,6 @@ impl<C: Codec + 'static> CassandraConnection<C> {
         let message_id = if let Frame::Cassandra(frame) = &message.original {
             frame.stream_id
         } else {
-            info!("no cassandra frame found");
             return Err(anyhow!("no cassandra frame found"));
         };
 

--- a/shotover-proxy/src/transforms/mod.rs
+++ b/shotover-proxy/src/transforms/mod.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 
 use crate::config::topology::TopicHolder;
 use crate::error::ChainResponse;
-use crate::message::{Message, Messages};
+use crate::message::Messages;
 use crate::transforms::cassandra::sink_single::{CassandraSinkSingle, CassandraSinkSingleConfig};
 use metrics::{counter, histogram};
 
@@ -518,5 +518,4 @@ pub trait Transform: Send {
     }
 }
 
-pub type ResponseFuture =
-    Pin<Box<dyn Future<Output = Result<(Message, Result<Messages>)>> + std::marker::Send>>;
+pub type ResponseFuture = Pin<Box<dyn Future<Output = Result<util::Response>> + std::marker::Send>>;

--- a/shotover-proxy/src/transforms/redis/sink_cluster.rs
+++ b/shotover-proxy/src/transforms/redis/sink_cluster.rs
@@ -20,7 +20,7 @@ use tracing::{debug, error, info, trace, warn};
 
 use crate::concurrency::FuturesOrdered;
 use crate::error::ChainResponse;
-use crate::message::{Message, MessageDetails, Messages, QueryResponse};
+use crate::message::{Message, MessageDetails, QueryResponse};
 use crate::protocols::redis_codec::{DecodeType, RedisCodec};
 use crate::protocols::{Frame, RedisFrame};
 use crate::tls::TlsConfig;
@@ -164,7 +164,10 @@ impl RedisSinkCluster {
                     let response = responses
                         .fold(vec![], |mut acc, response| async move {
                             match response {
-                                Ok((_, Ok(mut messages))) => {
+                                Ok(Response {
+                                    response: Ok(mut messages),
+                                    ..
+                                }) => {
                                     acc.push(messages.pop().map_or(RedisFrame::Null, |message| {
                                         match message.original {
                                             Frame::Redis(frame) => frame,
@@ -172,23 +175,23 @@ impl RedisSinkCluster {
                                         }
                                     }))
                                 }
-                                Ok((_, Err(e))) => {
-                                    acc.push(RedisFrame::Error(e.to_string().into()))
-                                }
+                                Ok(Response {
+                                    response: Err(e), ..
+                                }) => acc.push(RedisFrame::Error(e.to_string().into())),
                                 Err(e) => acc.push(RedisFrame::Error(e.to_string().into())),
                             }
                             acc
                         })
                         .await;
 
-                    Ok((
-                        message,
-                        ChainResponse::Ok(vec![Message::new(
+                    Ok(Response {
+                        original: message,
+                        response: ChainResponse::Ok(vec![Message::new(
                             MessageDetails::Unknown,
                             false,
                             Frame::Redis(RedisFrame::Array(response)),
                         )]),
-                    ))
+                    })
                 })
             }
         })
@@ -310,7 +313,7 @@ impl RedisSinkCluster {
         &mut self,
         host: &str,
         message: Message,
-    ) -> Result<oneshot::Receiver<(Message, ChainResponse)>> {
+    ) -> Result<oneshot::Receiver<Response>> {
         let (one_tx, one_rx) = oneshot::channel::<Response>();
 
         let channel = match self.channels.get_mut(host) {
@@ -376,9 +379,8 @@ impl RedisSinkCluster {
         };
 
         if let Err(e) = channel.send(Request {
-            messages: message,
+            message,
             return_chan: Some(one_tx),
-            message_id: None,
         }) {
             if let Some(error_return) = e.0.return_chan {
                 self.rebuild_connections = true;
@@ -728,26 +730,23 @@ fn send_simple_response(one_tx: oneshot::Sender<Response>, message: &str) -> Res
 fn send_frame_request(
     sender: &UnboundedSender<Request>,
     frame: RedisFrame,
-) -> Result<oneshot::Receiver<(Message, Result<Messages>)>> {
+) -> Result<oneshot::Receiver<Response>> {
     let (return_chan_tx, return_chan_rx) = oneshot::channel();
 
     sender.send(Request {
-        messages: Message::new(MessageDetails::Unknown, false, Frame::Redis(frame)),
+        message: Message::new(MessageDetails::Unknown, false, Frame::Redis(frame)),
         return_chan: Some(return_chan_tx),
-        message_id: None,
     })?;
 
     Ok(return_chan_rx)
 }
 
 #[inline(always)]
-async fn receive_frame_response(
-    receiver: oneshot::Receiver<(Message, Result<Messages>)>,
-) -> Result<RedisFrame> {
-    let (_, result) = receiver.await?;
+async fn receive_frame_response(receiver: oneshot::Receiver<Response>) -> Result<RedisFrame> {
+    let Response { response, .. } = receiver.await?;
 
     // Exactly one Redis response is guaranteed by the codec on success.
-    let message = result?.pop().unwrap().original;
+    let message = response?.pop().unwrap().original;
 
     match message {
         Frame::Redis(frame) => Ok(frame),
@@ -760,14 +759,14 @@ fn send_frame_response(
     one_tx: oneshot::Sender<Response>,
     frame: RedisFrame,
 ) -> Result<(), Response> {
-    one_tx.send((
-        Message::new_raw(Frame::None),
-        Ok(vec![Message::new(
+    one_tx.send(Response {
+        original: Message::new_raw(Frame::None),
+        response: Ok(vec![Message::new(
             MessageDetails::Response(QueryResponse::empty()),
             false,
             Frame::Redis(frame),
         )]),
-    ))
+    })
 }
 
 fn immediate_responder() -> (
@@ -811,10 +810,11 @@ impl Transform for RedisSinkCluster {
 
         while let Some(s) = responses.next().await {
             trace!("Got resp {:?}", s);
-            let (original, response) = s.or_else(|_| -> Result<(_, _)> {
-                Ok((
-                    Message::new_raw(Frame::None),
-                    Ok(vec![Message::new(
+
+            let Response { original, response } = s.or_else(|_| -> Result<Response> {
+                Ok(Response {
+                    original: Message::new_raw(Frame::None),
+                    response: Ok(vec![Message::new(
                         MessageDetails::Response(QueryResponse::empty()),
                         false,
                         Frame::Redis(RedisFrame::Error(
@@ -822,8 +822,9 @@ impl Transform for RedisSinkCluster {
                                 .unwrap(),
                         )),
                     )]),
-                ))
+                })
             })?;
+
             let mut response = response?;
             assert_eq!(response.len(), 1);
             let response_m = response.remove(0);

--- a/shotover-proxy/src/transforms/util/mod.rs
+++ b/shotover-proxy/src/transforms/util/mod.rs
@@ -7,14 +7,19 @@ use crate::message::Message;
 
 pub mod cluster_connection_pool;
 
+/// Represents a `Request` to a connection within Shotover
 #[derive(Debug)]
 pub struct Request {
-    pub messages: Message,
-    pub return_chan: Option<tokio::sync::oneshot::Sender<Response>>,
-    pub message_id: Option<i16>,
+    pub message: Message, // Message to send upstream to connection
+    pub return_chan: Option<tokio::sync::oneshot::Sender<Response>>, // Channel to return the response to
 }
 
-pub type Response = (Message, ChainResponse);
+/// Represents a `Response` to a `Request`
+#[derive(Debug)]
+pub struct Response {
+    pub original: Message,       // Original `Message` that this `Response` is to
+    pub response: ChainResponse, // Response to the original `Message`
+}
 
 #[derive(thiserror::Error, Debug)]
 pub enum ConnectionError<E: fmt::Debug + fmt::Display> {


### PR DESCRIPTION
### CassandraConnection changes
- Moved `Request` struct to be private to `CassandraConnection`. This means that the `Request` used for `ConnectionPool` doesn't need to have an `Option<i16>` field for the message id.
- added a `send` method. Transforms can just give the connection pool their message and return channel instead of having to interact with the implementation of `CassandraConnection`.

### Other changes
- Renamed `messages` in `Request` to `message` because it only holds one message.
- Changed `Response` from a tuple to a struct. This was used lots and it was confusing. Sometimes it was used without the `Response` type and instead another tuple was declared. 