### PR TITLE
Rewrite TimestampTagger and ConsistentScatter to use message.original

### DIFF
--- a/shotover-proxy/src/codec/cassandra.rs
+++ b/shotover-proxy/src/codec/cassandra.rs
@@ -568,6 +568,7 @@ impl Decoder for CassandraCodec {
                         warnings: vec![],
                     }),
                     return_to_sender: true,
+                    meta_timestamp: None,
                 };
                 Ok(Some(vec![message]))
             }

--- a/shotover-proxy/src/message/mod.rs
+++ b/shotover-proxy/src/message/mod.rs
@@ -137,21 +137,18 @@ impl Message {
                 Frame::Redis(RedisFrame::Error(Str::from_inner(error.into()).unwrap()))
             }
             Frame::Cassandra(frame) => {
-                let body = ErrorBody {
+                let body = CassandraOperation::Error(ErrorBody {
                     error_code: 0,
                     message: error,
                     additional_info: AdditionalErrorInfo::Server,
-                };
+                });
 
                 Frame::Cassandra(CassandraFrame {
                     version: frame.version,
                     stream_id: frame.stream_id,
-                    direction: Direction::Response,
-                    opcode: Opcode::Error,
                     tracing_id: None,
-                    flags: Flags::default(),
                     warnings: frame.warnings.clone(),
-                    body: body.serialize_to_vec(),
+                    operation: body,
                 })
             }
             Frame::None => Frame::None,

--- a/shotover-proxy/src/message/mod.rs
+++ b/shotover-proxy/src/message/mod.rs
@@ -35,6 +35,10 @@ pub struct Message {
     pub original: Frame,
     /// identifies a message that is to be returned to the sender.  Message is stored in the `original` frame.
     pub return_to_sender: bool,
+
+    // TODO: Not a fan of this field and we could get rid of it by making TimestampTagger an implicit part of ConsistentScatter
+    // This metadata field is only used for communication between transforms and should not be touched by sinks or sources
+    pub meta_timestamp: Option<i64>,
 }
 
 #[derive(PartialEq, Debug, Clone)]
@@ -51,6 +55,7 @@ impl Message {
             modified,
             original,
             return_to_sender: false,
+            meta_timestamp: None,
         }
     }
 
@@ -84,6 +89,7 @@ impl Message {
             modified,
             original: Frame::None,
             return_to_sender: false,
+            meta_timestamp: None,
         }
     }
 
@@ -110,6 +116,7 @@ impl Message {
                 Frame::None => Frame::None,
             },
             return_to_sender: false,
+            meta_timestamp: None,
         }
     }
 

--- a/shotover-proxy/src/server.rs
+++ b/shotover-proxy/src/server.rs
@@ -47,6 +47,7 @@ fn perform_custom_handling(messages: Messages, tx_out: &UnboundedSender<Messages
                     modified: true,
                     return_to_sender: true,
                     original: Frame::None,
+                    meta_timestamp: None,
                 }
             } else {
                 m

--- a/shotover-proxy/src/transforms/cassandra/sink_single.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_single.rs
@@ -4,7 +4,7 @@ use crate::concurrency::FuturesOrdered;
 use crate::error::ChainResponse;
 use crate::frame::CassandraFrame;
 use crate::frame::Frame;
-use crate::message::{Message, Messages};
+use crate::message::Messages;
 use crate::transforms::util::Response;
 use crate::transforms::{Transform, Transforms, Wrapper};
 use anyhow::Result;
@@ -119,12 +119,11 @@ impl CassandraSinkSingle {
                                         responses.append(&mut resp);
                                     }
                                     Response {
-                                        original,
+                                        mut original,
                                         response: Err(err),
                                     } => {
-                                        let mut message = Message::from_frame(original.original);
-                                        message.set_error(err.to_string());
-                                        responses.push(message);
+                                        original.set_error(err.to_string());
+                                        responses.push(original);
                                     }
                                 };
                             }

--- a/shotover-proxy/src/transforms/cassandra/sink_single.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_single.rs
@@ -4,11 +4,9 @@ use crate::concurrency::FuturesOrdered;
 use crate::error::ChainResponse;
 use crate::frame::CassandraFrame;
 use crate::frame::Frame;
-use crate::message;
-use crate::message::{Message, Messages, QueryResponse};
+use crate::message::{Message, Messages};
 use crate::transforms::util::Response;
 use crate::transforms::{Transform, Transforms, Wrapper};
-
 use anyhow::Result;
 use async_trait::async_trait;
 use metrics::{register_counter, Counter};
@@ -124,13 +122,9 @@ impl CassandraSinkSingle {
                                         original,
                                         response: Err(err),
                                     } => {
-                                        responses.push(Message::new_response(
-                                            QueryResponse::empty_with_error(Some(
-                                                message::MessageValue::Strings(format!("{err}")),
-                                            )),
-                                            true,
-                                            original.original,
-                                        ));
+                                        let mut message = Message::from_frame(original.original);
+                                        message.set_error(err.to_string());
+                                        responses.push(message);
                                     }
                                 };
                             }

--- a/shotover-proxy/src/transforms/distributed/consistent_scatter.rs
+++ b/shotover-proxy/src/transforms/distributed/consistent_scatter.rs
@@ -49,7 +49,7 @@ impl ConsistentScatterConfig {
     }
 }
 
-fn get_size(_message: &mut Message) -> usize {
+fn get_size(_message: &Message) -> usize {
     4 // TODO: Implement. Old impl was just removed because it was broken anyway
 }
 
@@ -62,10 +62,10 @@ fn resolve_fragments(fragments: &mut Vec<Message>) -> Option<Message> {
     // Return newest, otherwise biggest. Returns newest, even
     // if we have a bigger response.
     while !fragments.is_empty() {
-        if let Some(mut fragment) = fragments.pop() {
+        if let Some(fragment) = fragments.pop() {
             let candidate = fragment.meta_timestamp.unwrap_or(0);
             if candidate > 0 {
-                match &mut newest_fragment {
+                match &newest_fragment {
                     None => newest_fragment = Some(fragment),
                     Some(frag) => {
                         let current = frag.meta_timestamp.unwrap_or(0);
@@ -75,8 +75,8 @@ fn resolve_fragments(fragments: &mut Vec<Message>) -> Option<Message> {
                     }
                 }
             } else {
-                let candidate = get_size(&mut fragment);
-                match &mut newest_fragment {
+                let candidate = get_size(&fragment);
+                match &newest_fragment {
                     None => newest_fragment = Some(fragment),
                     Some(frag) => {
                         let current = get_size(frag);
@@ -110,6 +110,7 @@ impl Transform for ConsistentScatter {
             .messages
             .iter_mut()
             .map(|m| {
+                m.generate_message_details_query();
                 if m.get_query_type() == QueryType::Read {
                     self.read_consistency
                 } else {

--- a/shotover-proxy/src/transforms/distributed/consistent_scatter.rs
+++ b/shotover-proxy/src/transforms/distributed/consistent_scatter.rs
@@ -1,7 +1,7 @@
 use crate::config::topology::TopicHolder;
 use crate::error::ChainResponse;
+use crate::frame::{Frame, RedisFrame};
 use crate::message::{Message, QueryType};
-use crate::protocols::{Frame, RedisFrame};
 use crate::transforms::chain::BufferedChain;
 use crate::transforms::{
     build_chain_from_config, Transform, Transforms, TransformsConfig, Wrapper,
@@ -14,15 +14,6 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use tokio_stream::StreamExt;
 use tracing::{debug, error, trace, warn};
-
-use crate::config::topology::TopicHolder;
-use crate::error::ChainResponse;
-use crate::frame::Frame;
-use crate::message::{Message, MessageDetails, MessageValue, QueryResponse, QueryType};
-use crate::transforms::chain::BufferedChain;
-use crate::transforms::{
-    build_chain_from_config, Transform, Transforms, TransformsConfig, Wrapper,
-};
 
 #[derive(Clone)]
 pub struct ConsistentScatter {
@@ -212,20 +203,14 @@ impl Transform for ConsistentScatter {
 
 #[cfg(test)]
 mod scatter_transform_tests {
+    use crate::frame::{Frame, RedisFrame};
     use crate::message::{Message, Messages};
-    use crate::protocols::{Frame, RedisFrame};
     use crate::transforms::chain::{BufferedChain, TransformChain};
     use crate::transforms::debug::printer::DebugPrinter;
     use crate::transforms::debug::returner::{DebugReturner, Response};
     use crate::transforms::distributed::consistent_scatter::ConsistentScatter;
-
-    use crate::frame::Frame;
-    use crate::message::{
-        Message, MessageDetails, MessageValue, Messages, QueryMessage, QueryResponse, QueryType,
-    };
     use crate::transforms::null::Null;
     use crate::transforms::{Transform, Transforms, Wrapper};
-
     use bytes::Bytes;
     use std::collections::HashMap;
 

--- a/shotover-proxy/src/transforms/distributed/consistent_scatter.rs
+++ b/shotover-proxy/src/transforms/distributed/consistent_scatter.rs
@@ -1,6 +1,5 @@
 use crate::config::topology::TopicHolder;
 use crate::error::ChainResponse;
-use crate::frame::{Frame, RedisFrame};
 use crate::message::{Message, QueryType};
 use crate::transforms::chain::BufferedChain;
 use crate::transforms::{
@@ -8,7 +7,6 @@ use crate::transforms::{
 };
 use anyhow::Result;
 use async_trait::async_trait;
-use bytes_utils::Str;
 use futures::stream::FuturesUnordered;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -153,9 +151,7 @@ impl Transform for ConsistentScatter {
         Ok(if results.len() < max_required_successes as usize {
             let mut messages = message_wrapper.messages;
             for message in &mut messages {
-                message.original = Frame::Redis(RedisFrame::Error(
-                    Str::from_inner("Not enough responses".into()).unwrap(),
-                ));
+                message.set_error("Not enough responses".into());
             }
             messages
         } else {

--- a/shotover-proxy/src/transforms/redis/timestamp_tagging.rs
+++ b/shotover-proxy/src/transforms/redis/timestamp_tagging.rs
@@ -1,6 +1,6 @@
 use crate::error::ChainResponse;
+use crate::frame::{Frame, RedisFrame};
 use crate::message::Message;
-use crate::protocols::{Frame, RedisFrame};
 use crate::transforms::{Transform, Transforms, Wrapper};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;

--- a/shotover-proxy/src/transforms/redis/timestamp_tagging.rs
+++ b/shotover-proxy/src/transforms/redis/timestamp_tagging.rs
@@ -1,18 +1,15 @@
 use crate::error::ChainResponse;
-use crate::message::{
-    ASTHolder, IntSize, MessageDetails, MessageValue, QueryMessage, QueryResponse,
-};
+use crate::message::Message;
+use crate::protocols::{Frame, RedisFrame};
 use crate::transforms::{Transform, Transforms, Wrapper};
-use anyhow::{bail, Result};
+use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
 use itertools::Itertools;
 use serde::Deserialize;
-use std::collections::BTreeMap;
 use std::fmt::Write;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::{debug, trace};
-
 #[derive(Clone, Default)]
 pub struct RedisTimestampTagger {}
 
@@ -36,115 +33,128 @@ impl RedisTimestampTaggerConfig {
 // or noeviction and maxmemory is set.
 // Unfortunately REDIS only provides a 10 second resolution on this, so high
 // update keys where update freq < 20 seconds, will not be terribly consistent
-
-fn wrap_command(qm: &mut QueryMessage) -> Result<()> {
-    if let Some(MessageValue::List(keys)) = qm.primary_key.get_mut("key") {
-        if keys.is_empty() {
-            bail!("primary key `key` contained no keys");
+fn wrap_command(frame: &mut RedisFrame) -> Result<RedisFrame> {
+    if let RedisFrame::Array(com) = frame {
+        if let Some(RedisFrame::BulkString(first)) = com.first() {
+            if first.eq_ignore_ascii_case(b"EVAL")
+                || first.eq_ignore_ascii_case(b"EVALSHA")
+                || first.eq_ignore_ascii_case(b"SCRIPT")
+                || first.eq_ignore_ascii_case(b"FLUSHDB")
+            {
+                return Err(anyhow!("cannot wrap command {:?}", first));
+            }
         }
-        let first = keys.swap_remove(0);
-        if let Some(ASTHolder::Commands(MessageValue::List(com))) = &qm.ast {
-            let original_command = com
-                .iter()
-                .map(|v| {
-                    if let MessageValue::Bytes(b) = v {
-                        let mut literal = String::with_capacity(2 + b.len() * 4);
-                        literal.push('\'');
-                        for value in b {
-                            // Here we encode an arbitrary sequence of bytes into a lua string.
-                            // lua, unlike rust, is quite happy to store whatever in its strings as long as you give it the relevant escape sequence https://www.lua.org/pil/2.4.html
-                            //
-                            // We could just write every value as a \ddd escape sequence but its probably faster and definitely more readable to someone inspecting traffic to just use the actual value when we can
-                            if *value == b'\'' {
-                                // despite being printable we cant include this without escaping it
-                                literal.push_str("\\\'");
-                            } else if *value == b'\\' {
-                                // despite being printable we cant include this without escaping it
-                                literal.push_str("\\\\");
-                            } else if value.is_ascii_graphic() {
-                                literal.push(*value as char);
-                            } else {
-                                write!(literal, "\\{}", value).unwrap();
-                            }
+
+        let original_command = com
+            .iter()
+            .map(|v| {
+                if let RedisFrame::BulkString(b) = v {
+                    let mut literal = String::with_capacity(2 + b.len() * 4);
+                    literal.push('\'');
+                    for value in b {
+                        // Here we encode an arbitrary sequence of bytes into a lua string.
+                        // lua, unlike rust, is quite happy to store whatever in its strings as long as you give it the relevant escape sequence https://www.lua.org/pil/2.4.html
+                        //
+                        // We could just write every value as a \ddd escape sequence but its probably faster and definitely more readable to someone inspecting traffic to just use the actual value when we can
+                        if *value == b'\'' {
+                            // despite being printable we cant include this without escaping it
+                            literal.push_str("\\\'");
+                        } else if *value == b'\\' {
+                            // despite being printable we cant include this without escaping it
+                            literal.push_str("\\\\");
+                        } else if value.is_ascii_graphic() {
+                            literal.push(*value as char);
+                        } else {
+                            write!(literal, "\\{}", value).unwrap();
                         }
-                        literal.push('\'');
-                        literal
-                    } else {
-                        todo!("this might not be right... but we should only be dealing with bytes")
                     }
-                })
-                .join(",");
+                    literal.push('\'');
+                    literal
+                } else {
+                    todo!("this might not be right... but we should only be dealing with bytes")
+                }
+            })
+            .join(",");
 
-            let original_pcall = format!(r###"redis.call({original_command})"###);
-            let last_used_pcall = r###"redis.call('OBJECT', 'IDLETIME', KEYS[1])"###;
+        let original_pcall = format!(r###"redis.call({original_command})"###);
+        let last_used_pcall = r###"redis.call('OBJECT', 'IDLETIME', KEYS[1])"###;
 
-            let script = format!("return {{{original_pcall},{last_used_pcall}}}");
-            debug!("\n\nGenerated eval script for timestamp: {}\n\n", script);
-            let commands = vec![
-                MessageValue::Bytes(Bytes::from_static(b"EVAL")),
-                MessageValue::Bytes(Bytes::from(script)),
-                MessageValue::Bytes(Bytes::from_static(b"1")),
-                first,
-            ];
-            qm.ast = Some(ASTHolder::Commands(MessageValue::List(commands)));
-        } else {
-            bail!("Ast is not a command with a list");
-        }
+        let script = format!("return {{{original_pcall},{last_used_pcall}}}");
+        debug!("\n\nGenerated eval script for timestamp: {}\n\n", script);
+        let commands = vec![
+            RedisFrame::BulkString(Bytes::from_static(b"EVAL")),
+            RedisFrame::BulkString(Bytes::from(script)),
+            RedisFrame::BulkString(Bytes::from_static(b"1")),
+            // Key is always the 2nd element of a redis command
+            com.swap_remove(1),
+        ];
+        Ok(RedisFrame::Array(commands))
     } else {
-        bail!("Primary key `key` does not exist or is not a list");
+        Err(anyhow!("redis frame is not an array"))
     }
-
-    Ok(())
 }
 
-fn unwrap_response(qr: &mut QueryResponse) {
-    if let Some(MessageValue::List(mut values)) = qr.result.take() {
-        let all_lists = values.iter().all(|v| matches!(v, MessageValue::List(_)));
-        qr.result = if all_lists && values.len() > 1 {
-            // This means the result is likely from a transaction or something that returns
-            // lots of things
+fn unwrap_response(message: &mut Message) -> Result<()> {
+    struct ToWrite {
+        meta_timestamp: i64,
+        frame: RedisFrame,
+    }
 
-            let mut timestamps: Vec<MessageValue> = vec![];
-            let mut results: Vec<MessageValue> = vec![];
-            for v_u in values {
-                if let MessageValue::List(mut v) = v_u {
-                    if v.len() == 2 {
-                        let timestamp = v.pop().unwrap();
-                        let actual = v.pop().unwrap();
-                        timestamps.push(timestamp);
-                        results.push(actual);
+    if let Frame::Redis(ref mut redis_frame) = message.original {
+        let to_write = if let RedisFrame::Array(ref mut values) = redis_frame {
+            let all_arrays = values.iter().all(|v| matches!(v, RedisFrame::Array(_)));
+            if all_arrays && values.len() > 1 {
+                // This means the result is likely from a transaction or something that returns
+                // lots of things
+
+                let mut timestamps: Vec<RedisFrame> = vec![];
+                let mut results: Vec<RedisFrame> = vec![];
+                for v_u in values {
+                    if let RedisFrame::Array(v) = v_u {
+                        if v.len() == 2 {
+                            let timestamp = v.pop().unwrap();
+                            let actual = v.pop().unwrap();
+                            timestamps.push(timestamp);
+                            results.push(actual);
+                        }
                     }
                 }
-            }
 
-            qr.response_meta = Some(MessageValue::Document(BTreeMap::from([(
-                "timestamp".to_string(),
-                MessageValue::List(timestamps),
-            )])));
-            Some(MessageValue::List(results))
-        } else if values.len() == 2 {
-            qr.response_meta = values.pop().map(|v| {
-                let processed_value = match v {
-                    MessageValue::Integer(i, _) => {
-                        let start = SystemTime::now();
-                        let since_the_epoch = start
-                            .duration_since(UNIX_EPOCH)
-                            .expect("Time went backwards");
-                        let seconds = since_the_epoch.as_secs();
-                        if seconds.leading_ones() > 1 {
-                            panic!("Cannot convert u64 to i64 without overflow");
-                        }
-                        MessageValue::Integer(seconds as i64 - i, IntSize::I64)
-                    }
-                    v => v,
+                todo!("ConsistentScatter isnt built to handle multiple timestamps yet: {timestamps:?} {results:?}",)
+            } else if values.len() == 2 {
+                let timestamp = values.pop().unwrap();
+                let frame = values.pop().unwrap();
+
+                let timestamp = match timestamp {
+                    RedisFrame::Integer(i) => i,
+                    _ => 0,
                 };
-                MessageValue::Document(BTreeMap::from([("timestamp".to_string(), processed_value)]))
-            });
-            values.pop()
+
+                let since_the_epoch = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .expect("Time went backwards");
+                let seconds_since_the_epoch = since_the_epoch.as_secs();
+                if seconds_since_the_epoch.leading_ones() > 1 {
+                    panic!("Cannot convert u64 to i64 without overflow");
+                }
+                let meta_timestamp = seconds_since_the_epoch as i64 - timestamp;
+                Some(ToWrite {
+                    meta_timestamp,
+                    frame,
+                })
+            } else {
+                None
+            }
         } else {
-            Some(MessageValue::List(values))
+            None
         };
+
+        if let Some(write) = to_write {
+            *redis_frame = write.frame;
+            message.meta_timestamp = Some(write.meta_timestamp);
+        }
     }
+    Ok(())
 }
 
 #[async_trait]
@@ -156,19 +166,25 @@ impl Transform for RedisTimestampTagger {
         let mut exec_block = false;
 
         for message in message_wrapper.messages.iter_mut() {
-            message.generate_message_details_query();
-            if let MessageDetails::Query(ref mut qm) = message.details {
-                if let Some(a) = &qm.ast {
-                    if a.get_command() == *"EXEC" {
+            if let Frame::Redis(ref mut frame) = message.original {
+                if let RedisFrame::Array(array) = frame {
+                    if array
+                        .get(0)
+                        .map(|x| x == &RedisFrame::BulkString("EXEC".into()))
+                        .unwrap_or(false)
+                    {
                         exec_block = true;
                     }
                 }
-
-                if let Err(err) = wrap_command(qm) {
-                    trace!("Couldn't wrap command with timestamp tagger: {}", err);
-                    tagged_success = false;
+                match wrap_command(frame) {
+                    Ok(result) => {
+                        *frame = result;
+                    }
+                    Err(err) => {
+                        trace!("Couldn't wrap command with timestamp tagger: {}", err);
+                        tagged_success = false;
+                    }
                 }
-                message.modified = true;
             }
         }
 
@@ -177,11 +193,7 @@ impl Transform for RedisTimestampTagger {
         if let Ok(messages) = &mut response {
             if tagged_success || exec_block {
                 for message in messages.iter_mut() {
-                    message.generate_message_details_response();
-                    if let MessageDetails::Response(qr) = &mut message.details {
-                        unwrap_response(qr);
-                        message.modified = true;
-                    }
+                    unwrap_response(message)?;
                 }
             }
         }

--- a/shotover-proxy/src/transforms/tee.rs
+++ b/shotover-proxy/src/transforms/tee.rs
@@ -1,7 +1,5 @@
 use crate::config::topology::TopicHolder;
 use crate::error::ChainResponse;
-use crate::frame::Frame;
-use crate::message::{Message, MessageValue, QueryResponse};
 use crate::transforms::chain::BufferedChain;
 use crate::transforms::{
     build_chain_from_config, Transform, Transforms, TransformsConfig, Wrapper,
@@ -154,14 +152,8 @@ impl Transform for Tee {
 
                 if !chain_response.eq(&tee_response) {
                     for message in &mut chain_response {
-                        *message = Message::new_response(
-                            QueryResponse::empty_with_error(Some(MessageValue::Strings(
-                                "ERR The responses from the Tee subchain and down-chain did not match and behavior is set to fail on mismatch"
-                                    .to_string(),
-                            ))),
-                            true,
-                            Frame::None,
-                        );
+                        message.set_error(
+                                "ERR The responses from the Tee subchain and down-chain did not match and behavior is set to fail on mismatch".into())
                     }
                 }
                 Ok(chain_response)


### PR DESCRIPTION
Mostly changes pulled from #445, modified to compile on `main`. I also:

- Attempted to fix the `get_size` method. It checks the length of the Redis frame. Wanted to confirm that this is the right approach before I modify cdrs-tokio to add a similar method for checking the length of the Cassandra frame.
- Addressed the TODO on `tagged_success` and `exec_block`