### PR TITLE
Replace instances of Message::new with Message::from_frame

### DIFF
--- a/shotover-proxy/src/codec/cassandra.rs
+++ b/shotover-proxy/src/codec/cassandra.rs
@@ -797,20 +797,16 @@ mod cassandra_protocol_tests {
     fn test_codec_startup() {
         let mut codec = new_codec();
         let bytes = hex!("0400000001000000160001000b43514c5f56455253494f4e0005332e302e30");
-        let messages = vec![Message::new(
-            MessageDetails::Unknown,
-            false,
-            Frame::Cassandra(CassandraFrame {
-                version: Version::V4,
-                direction: Direction::Request,
-                flags: Flags::empty(),
-                opcode: Opcode::Startup,
-                stream_id: 0,
-                body: hex!("0001000b43514c5f56455253494f4e0005332e302e30").to_vec(),
-                tracing_id: None,
-                warnings: vec![],
-            }),
-        )];
+        let messages = vec![Message::from_frame(Frame::Cassandra(CassandraFrame {
+            version: Version::V4,
+            direction: Direction::Request,
+            flags: Flags::empty(),
+            opcode: Opcode::Startup,
+            stream_id: 0,
+            body: hex!("0001000b43514c5f56455253494f4e0005332e302e30").to_vec(),
+            tracing_id: None,
+            warnings: vec![],
+        }))];
         test_frame_codec_roundtrip(&mut codec, &bytes, messages);
     }
 
@@ -818,20 +814,16 @@ mod cassandra_protocol_tests {
     fn test_codec_options() {
         let mut codec = new_codec();
         let bytes = hex!("040000000500000000");
-        let messages = vec![Message::new(
-            MessageDetails::Unknown,
-            false,
-            Frame::Cassandra(CassandraFrame {
-                version: Version::V4,
-                direction: Direction::Request,
-                flags: Flags::empty(),
-                opcode: Opcode::Options,
-                stream_id: 0,
-                body: vec![],
-                tracing_id: None,
-                warnings: vec![],
-            }),
-        )];
+        let messages = vec![Message::from_frame(Frame::Cassandra(CassandraFrame {
+            version: Version::V4,
+            direction: Direction::Request,
+            flags: Flags::empty(),
+            opcode: Opcode::Options,
+            stream_id: 0,
+            body: vec![],
+            tracing_id: None,
+            warnings: vec![],
+        }))];
         test_frame_codec_roundtrip(&mut codec, &bytes, messages);
     }
 
@@ -839,20 +831,16 @@ mod cassandra_protocol_tests {
     fn test_codec_ready() {
         let mut codec = new_codec();
         let bytes = hex!("840000000200000000");
-        let messages = vec![Message::new(
-            MessageDetails::Unknown,
-            false,
-            Frame::Cassandra(CassandraFrame {
-                version: Version::V4,
-                direction: Direction::Response,
-                flags: Flags::empty(),
-                opcode: Opcode::Ready,
-                stream_id: 0,
-                body: vec![],
-                tracing_id: None,
-                warnings: vec![],
-            }),
-        )];
+        let messages = vec![Message::from_frame(Frame::Cassandra(CassandraFrame {
+            version: Version::V4,
+            direction: Direction::Response,
+            flags: Flags::empty(),
+            opcode: Opcode::Ready,
+            stream_id: 0,
+            body: vec![],
+            tracing_id: None,
+            warnings: vec![],
+        }))];
         test_frame_codec_roundtrip(&mut codec, &bytes, messages);
     }
 
@@ -863,24 +851,20 @@ mod cassandra_protocol_tests {
             "040000010b000000310003000f544f504f4c4f47595f4348414e4745
             000d5354415455535f4348414e4745000d534348454d415f4348414e4745"
         );
-        let messages = vec![Message::new(
-            MessageDetails::Unknown,
-            false,
-            Frame::Cassandra(CassandraFrame {
-                version: Version::V4,
-                direction: Direction::Request,
-                flags: Flags::empty(),
-                opcode: Opcode::Register,
-                stream_id: 1,
-                body: hex!(
-                    "0003000f544f504f4c4f47595f4348414e4745
-                    000d5354415455535f4348414e4745000d534348454d415f4348414e4745"
-                )
-                .to_vec(),
-                tracing_id: None,
-                warnings: vec![],
-            }),
-        )];
+        let messages = vec![Message::from_frame(Frame::Cassandra(CassandraFrame {
+            version: Version::V4,
+            direction: Direction::Request,
+            flags: Flags::empty(),
+            opcode: Opcode::Register,
+            stream_id: 1,
+            body: hex!(
+                "0003000f544f504f4c4f47595f4348414e4745
+                000d5354415455535f4348414e4745000d534348454d415f4348414e4745"
+            )
+            .to_vec(),
+            tracing_id: None,
+            warnings: vec![],
+        }))];
         test_frame_codec_roundtrip(&mut codec, &bytes, messages);
     }
 

--- a/shotover-proxy/src/transforms/debug/returner.rs
+++ b/shotover-proxy/src/transforms/debug/returner.rs
@@ -1,5 +1,5 @@
 use crate::frame::{Frame, RedisFrame};
-use crate::message::{Message, MessageDetails, Messages};
+use crate::message::{Message, Messages};
 use crate::transforms::{ChainResponse, Transform, Transforms, Wrapper};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -47,11 +47,9 @@ impl Transform for DebugReturner {
                 .messages
                 .iter()
                 .map(|_| {
-                    Message::new(
-                        MessageDetails::Unknown,
-                        false,
-                        Frame::Redis(RedisFrame::BulkString(string.to_string().into())),
-                    )
+                    Message::from_frame(Frame::Redis(RedisFrame::BulkString(
+                        string.to_string().into(),
+                    )))
                 })
                 .collect()),
             Response::Fail => Err(anyhow!("Intentional Fail")),

--- a/shotover-proxy/src/transforms/redis/sink_cluster.rs
+++ b/shotover-proxy/src/transforms/redis/sink_cluster.rs
@@ -734,7 +734,7 @@ fn send_frame_request(
     let (return_chan_tx, return_chan_rx) = oneshot::channel();
 
     sender.send(Request {
-        message: Message::new(MessageDetails::Unknown, false, Frame::Redis(frame)),
+        message: Message::from_frame(Frame::Redis(frame)),
         return_chan: Some(return_chan_tx),
     })?;
 


### PR DESCRIPTION
All of these changes result in identical functionality as Message::from_frame is currently just:
```rust
    pub fn from_frame(raw_frame: Frame) -> Self {
        Self::new(MessageDetails::Unknown, false, raw_frame)
    }
```