### PR TITLE
Split protocols module into frame + codec modules

### DIFF
--- a/shotover-proxy/benches/chain_benches.rs
+++ b/shotover-proxy/benches/chain_benches.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use bytes::Bytes;
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 
+use shotover_proxy::frame::Frame;
 use shotover_proxy::message::{Message, QueryMessage, QueryType};
-use shotover_proxy::protocols::Frame;
 use shotover_proxy::transforms::chain::TransformChain;
 use shotover_proxy::transforms::debug::returner::{DebugReturner, Response};
 use shotover_proxy::transforms::null::Null;
@@ -51,7 +51,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     }
 
     {
-        use shotover_proxy::protocols::RedisFrame;
+        use shotover_proxy::frame::RedisFrame;
         let chain = TransformChain::new(
             vec![
                 Transforms::RedisTimestampTagger(RedisTimestampTagger::new()),
@@ -82,7 +82,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     }
 
     {
-        use shotover_proxy::protocols::RedisFrame;
+        use shotover_proxy::frame::RedisFrame;
         let chain = TransformChain::new(
             vec![
                 Transforms::RedisClusterPortsRewrite(RedisClusterPortsRewrite::new(2004)),

--- a/shotover-proxy/src/codec/cassandra.rs
+++ b/shotover-proxy/src/codec/cassandra.rs
@@ -2,7 +2,7 @@ use std::borrow::{Borrow, BorrowMut};
 use std::collections::HashMap;
 use std::ops::DerefMut;
 
-use crate::protocols::CassandraFrame;
+use crate::frame::CassandraFrame;
 use anyhow::{anyhow, Result};
 use byteorder::{BigEndian, WriteBytesExt};
 use bytes::{BufMut, BytesMut};
@@ -31,11 +31,11 @@ use sqlparser::parser::Parser;
 use tokio_util::codec::{Decoder, Encoder};
 use tracing::{debug, error, info, warn};
 
+use crate::frame::Frame;
 use crate::message::{
     ASTHolder, IntSize, Message, MessageDetails, MessageValue, Messages, QueryMessage,
     QueryResponse, QueryType,
 };
-use crate::protocols::Frame;
 
 #[derive(Debug, Clone)]
 pub struct CassandraCodec {
@@ -747,12 +747,12 @@ impl Encoder<Messages> for CassandraCodec {
 
 #[cfg(test)]
 mod cassandra_protocol_tests {
+    use crate::codec::cassandra::CassandraCodec;
+    use crate::frame::CassandraFrame;
+    use crate::frame::Frame;
     use crate::message::{
         ASTHolder, Message, MessageDetails, MessageValue, QueryMessage, QueryResponse, QueryType,
     };
-    use crate::protocols::cassandra_codec::CassandraCodec;
-    use crate::protocols::CassandraFrame;
-    use crate::protocols::Frame;
     use bytes::BytesMut;
     use cassandra_protocol::frame::{Direction, Flags, Opcode, Version};
     use hex_literal::hex;

--- a/shotover-proxy/src/codec/mod.rs
+++ b/shotover-proxy/src/codec/mod.rs
@@ -1,0 +1,2 @@
+pub mod cassandra;
+pub mod redis;

--- a/shotover-proxy/src/codec/redis.rs
+++ b/shotover-proxy/src/codec/redis.rs
@@ -1,9 +1,9 @@
+use crate::frame::Frame;
+use crate::frame::RedisFrame;
 use crate::message::{
     ASTHolder, IntSize, Message, MessageDetails, MessageValue, Messages, QueryMessage,
     QueryResponse, QueryType,
 };
-use crate::protocols::Frame;
-use crate::protocols::RedisFrame;
 use anyhow::{anyhow, Result};
 use bytes::{Buf, Bytes, BytesMut};
 use itertools::Itertools;
@@ -583,7 +583,7 @@ impl Encoder<Messages> for RedisCodec {
 
 #[cfg(test)]
 mod redis_tests {
-    use crate::protocols::redis_codec::{DecodeType, RedisCodec};
+    use crate::codec::redis::{DecodeType, RedisCodec};
     use bytes::BytesMut;
     use hex_literal::hex;
     use tokio_util::codec::{Decoder, Encoder};

--- a/shotover-proxy/src/frame/mod.rs
+++ b/shotover-proxy/src/frame/mod.rs
@@ -1,6 +1,3 @@
-pub mod cassandra_codec;
-pub mod redis_codec;
-
 pub use cassandra_protocol::frame::Frame as CassandraFrame;
 pub use redis_protocol::resp2::types::Frame as RedisFrame;
 
@@ -19,9 +16,8 @@ impl Frame {
     pub fn build_message_response(&self) -> Result<MessageDetails> {
         match self {
             Frame::Cassandra(_c) => Ok(MessageDetails::Unknown),
-            Frame::Redis(frame) => {
-                redis_codec::process_redis_frame_response(frame).map(MessageDetails::Response)
-            }
+            Frame::Redis(frame) => crate::codec::redis::process_redis_frame_response(frame)
+                .map(MessageDetails::Response),
             Frame::None => Ok(MessageDetails::Unknown),
         }
     }
@@ -30,7 +26,7 @@ impl Frame {
         match self {
             Frame::Cassandra(_c) => Ok(MessageDetails::Unknown),
             Frame::Redis(frame) => {
-                redis_codec::process_redis_frame_query(frame).map(MessageDetails::Query)
+                crate::codec::redis::process_redis_frame_query(frame).map(MessageDetails::Query)
             }
             Frame::None => Ok(MessageDetails::Unknown),
         }
@@ -40,7 +36,7 @@ impl Frame {
     pub fn get_query_type(&self) -> QueryType {
         match self {
             Frame::Cassandra(_) => QueryType::ReadWrite,
-            Frame::Redis(frame) => redis_codec::redis_query_type(frame),
+            Frame::Redis(frame) => crate::codec::redis::redis_query_type(frame),
             Frame::None => QueryType::ReadWrite,
         }
     }

--- a/shotover-proxy/src/lib.rs
+++ b/shotover-proxy/src/lib.rs
@@ -19,11 +19,12 @@
 //! * [`transforms::TransformsConfig`], the enum to register with (add a variant) for configuring your own transform.
 
 mod admin;
+pub mod codec;
 mod concurrency;
 pub mod config;
 pub mod error;
+pub mod frame;
 pub mod message;
-pub mod protocols;
 pub mod runner;
 mod server;
 pub mod sources;

--- a/shotover-proxy/src/message/mod.rs
+++ b/shotover-proxy/src/message/mod.rs
@@ -1,6 +1,6 @@
-use crate::protocols::CassandraFrame;
-use crate::protocols::Frame;
-use crate::protocols::RedisFrame;
+use crate::frame::CassandraFrame;
+use crate::frame::Frame;
+use crate::frame::RedisFrame;
 use bigdecimal::BigDecimal;
 use bytes::Bytes;
 use cassandra_protocol::{

--- a/shotover-proxy/src/server.rs
+++ b/shotover-proxy/src/server.rs
@@ -1,5 +1,5 @@
+use crate::frame::Frame;
 use crate::message::{Message, MessageDetails, Messages};
-use crate::protocols::Frame;
 use crate::tls::TlsAcceptor;
 use crate::transforms::chain::TransformChain;
 use crate::transforms::Wrapper;

--- a/shotover-proxy/src/sources/cassandra_source.rs
+++ b/shotover-proxy/src/sources/cassandra_source.rs
@@ -9,8 +9,8 @@ use tokio::sync::{watch, Semaphore};
 use tokio::task::JoinHandle;
 use tracing::{error, info};
 
+use crate::codec::cassandra::CassandraCodec;
 use crate::config::topology::TopicHolder;
-use crate::protocols::cassandra_codec::CassandraCodec;
 use crate::server::TcpCodecListener;
 use crate::sources::{Sources, SourcesFromConfig};
 use crate::transforms::chain::TransformChain;

--- a/shotover-proxy/src/sources/redis_source.rs
+++ b/shotover-proxy/src/sources/redis_source.rs
@@ -1,5 +1,5 @@
+use crate::codec::redis::{DecodeType, RedisCodec};
 use crate::config::topology::TopicHolder;
-use crate::protocols::redis_codec::{DecodeType, RedisCodec};
 use crate::server::TcpCodecListener;
 use crate::sources::{Sources, SourcesFromConfig};
 use crate::tls::{TlsAcceptor, TlsConfig};

--- a/shotover-proxy/src/transforms/cassandra/connection.rs
+++ b/shotover-proxy/src/transforms/cassandra/connection.rs
@@ -1,4 +1,4 @@
-use crate::protocols::Frame;
+use crate::frame::Frame;
 use crate::server::CodecReadHalf;
 use crate::server::CodecWriteHalf;
 use crate::transforms::util::Response;

--- a/shotover-proxy/src/transforms/cassandra/sink_single.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_single.rs
@@ -1,11 +1,11 @@
 use super::connection::CassandraConnection;
+use crate::codec::cassandra::CassandraCodec;
 use crate::concurrency::FuturesOrdered;
 use crate::error::ChainResponse;
+use crate::frame::CassandraFrame;
+use crate::frame::Frame;
 use crate::message;
 use crate::message::{Message, Messages, QueryResponse};
-use crate::protocols::cassandra_codec::CassandraCodec;
-use crate::protocols::CassandraFrame;
-use crate::protocols::Frame;
 use crate::transforms::util::Response;
 use crate::transforms::{Transform, Transforms, Wrapper};
 

--- a/shotover-proxy/src/transforms/coalesce.rs
+++ b/shotover-proxy/src/transforms/coalesce.rs
@@ -1,6 +1,6 @@
 use crate::error::ChainResponse;
+use crate::frame::Frame;
 use crate::message::{Message, MessageDetails, Messages, QueryResponse};
-use crate::protocols::Frame;
 use crate::transforms::{Transform, Transforms, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -84,8 +84,8 @@ impl Transform for Coalesce {
 
 #[cfg(test)]
 mod test {
+    use crate::frame::Frame;
     use crate::message::{Message, QueryMessage};
-    use crate::protocols::Frame;
     use crate::transforms::coalesce::Coalesce;
     use crate::transforms::loopback::Loopback;
     use crate::transforms::{Transform, Transforms, Wrapper};

--- a/shotover-proxy/src/transforms/debug/returner.rs
+++ b/shotover-proxy/src/transforms/debug/returner.rs
@@ -1,9 +1,6 @@
-use crate::error::ChainResponse;
+use crate::frame::{Frame, RedisFrame};
 use crate::message::{Message, MessageDetails, Messages};
-use crate::protocols::Frame;
-use crate::protocols::RedisFrame;
-use crate::transforms::Transforms;
-use crate::transforms::{Transform, Wrapper};
+use crate::transforms::{ChainResponse, Transform, Transforms, Wrapper};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use serde::Deserialize;

--- a/shotover-proxy/src/transforms/distributed/consistent_scatter.rs
+++ b/shotover-proxy/src/transforms/distributed/consistent_scatter.rs
@@ -9,8 +9,8 @@ use tracing::{debug, error, trace, warn};
 
 use crate::config::topology::TopicHolder;
 use crate::error::ChainResponse;
+use crate::frame::Frame;
 use crate::message::{Message, MessageDetails, MessageValue, QueryResponse, QueryType};
-use crate::protocols::Frame;
 use crate::transforms::chain::BufferedChain;
 use crate::transforms::{
     build_chain_from_config, Transform, Transforms, TransformsConfig, Wrapper,
@@ -235,10 +235,10 @@ mod scatter_transform_tests {
     use crate::transforms::debug::returner::{DebugReturner, Response};
     use crate::transforms::distributed::consistent_scatter::ConsistentScatter;
 
+    use crate::frame::Frame;
     use crate::message::{
         Message, MessageDetails, MessageValue, Messages, QueryMessage, QueryResponse, QueryType,
     };
-    use crate::protocols::Frame;
     use crate::transforms::null::Null;
     use crate::transforms::{Transform, Transforms, Wrapper};
     use std::collections::HashMap;

--- a/shotover-proxy/src/transforms/filter.rs
+++ b/shotover-proxy/src/transforms/filter.rs
@@ -52,9 +52,9 @@ impl Transform for QueryTypeFilter {
 
 #[cfg(test)]
 mod test {
+    use crate::frame::Frame;
+    use crate::frame::RedisFrame;
     use crate::message::{Message, QueryMessage, QueryType};
-    use crate::protocols::Frame;
-    use crate::protocols::RedisFrame;
     use crate::transforms::filter::QueryTypeFilter;
     use crate::transforms::loopback::Loopback;
     use crate::transforms::{Transform, Transforms, Wrapper};

--- a/shotover-proxy/src/transforms/kafka_sink.rs
+++ b/shotover-proxy/src/transforms/kafka_sink.rs
@@ -8,8 +8,8 @@ use rdkafka::util::Timeout;
 use serde::Deserialize;
 
 use crate::error::ChainResponse;
+use crate::frame::Frame;
 use crate::message::{Message, MessageDetails, QueryResponse};
-use crate::protocols::Frame;
 use crate::transforms::{Transform, Transforms, Wrapper};
 
 #[derive(Clone)]

--- a/shotover-proxy/src/transforms/null.rs
+++ b/shotover-proxy/src/transforms/null.rs
@@ -1,6 +1,6 @@
 use crate::error::ChainResponse;
+use crate::frame::Frame;
 use crate::message::{Message, MessageDetails, QueryResponse};
-use crate::protocols::Frame;
 use crate::transforms::{Transform, Wrapper};
 use async_trait::async_trait;
 

--- a/shotover-proxy/src/transforms/protect/mod.rs
+++ b/shotover-proxy/src/transforms/protect/mod.rs
@@ -248,17 +248,17 @@ mod protect_transform_tests {
     use std::collections::HashMap;
     use std::env;
 
-    use crate::protocols::CassandraFrame;
+    use crate::frame::CassandraFrame;
     use cassandra_protocol::consistency::Consistency;
     use cassandra_protocol::frame::{Flags, Version};
     use sodiumoxide::crypto::secretbox;
     use test_helpers::docker_compose::DockerCompose;
 
+    use crate::codec::cassandra::CassandraCodec;
+    use crate::frame::Frame;
     use crate::message::{
         IntSize, Message, MessageDetails, MessageValue, QueryMessage, QueryResponse, QueryType,
     };
-    use crate::protocols::cassandra_codec::CassandraCodec;
-    use crate::protocols::Frame;
     use crate::transforms::chain::TransformChain;
     use crate::transforms::debug::returner::{DebugReturner, Response};
     use crate::transforms::loopback::Loopback;

--- a/shotover-proxy/src/transforms/redis/cache.rs
+++ b/shotover-proxy/src/transforms/redis/cache.rs
@@ -7,8 +7,8 @@ use tracing::info;
 
 use crate::config::topology::TopicHolder;
 use crate::error::ChainResponse;
+use crate::frame::{CassandraFrame, Frame};
 use crate::message::{ASTHolder, MessageDetails, MessageValue, Messages, QueryType};
-use crate::protocols::{CassandraFrame, Frame};
 use crate::transforms::chain::TransformChain;
 use crate::transforms::{
     build_chain_from_config, Transform, Transforms, TransformsConfig, Wrapper,
@@ -415,10 +415,10 @@ impl Transform for SimpleRedisCache {
 
 #[cfg(test)]
 mod test {
+    use crate::codec::cassandra::CassandraCodec;
+    use crate::codec::redis::{DecodeType, RedisCodec};
     use crate::message::{ASTHolder, MessageDetails};
     use crate::message::{IntSize as MessageIntSize, MessageValue};
-    use crate::protocols::cassandra_codec::CassandraCodec;
-    use crate::protocols::redis_codec::{DecodeType, RedisCodec};
     use crate::transforms::chain::TransformChain;
     use crate::transforms::debug::printer::DebugPrinter;
     use crate::transforms::null::Null;

--- a/shotover-proxy/src/transforms/redis/cluster_ports_rewrite.rs
+++ b/shotover-proxy/src/transforms/redis/cluster_ports_rewrite.rs
@@ -1,11 +1,11 @@
-use crate::protocols::RedisFrame;
+use crate::frame::RedisFrame;
 use anyhow::{anyhow, bail, Context, Result};
 use async_trait::async_trait;
 use bytes::{BufMut, Bytes, BytesMut};
 use serde::Deserialize;
 
 use crate::error::ChainResponse;
-use crate::protocols::Frame;
+use crate::frame::Frame;
 use crate::transforms::{Transform, Transforms, Wrapper};
 
 #[derive(Deserialize, Debug, Clone)]
@@ -224,7 +224,7 @@ fn is_cluster_slots(frame: &Frame) -> bool {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::protocols::redis_codec::{DecodeType, RedisCodec};
+    use crate::codec::redis::{DecodeType, RedisCodec};
     use crate::transforms::redis::sink_cluster::parse_slots;
     use tokio_util::codec::Decoder;
 

--- a/shotover-proxy/src/transforms/redis/sink_cluster.rs
+++ b/shotover-proxy/src/transforms/redis/sink_cluster.rs
@@ -18,11 +18,11 @@ use tokio::time::timeout;
 use tokio::time::Duration;
 use tracing::{debug, error, info, trace, warn};
 
+use crate::codec::redis::{DecodeType, RedisCodec};
 use crate::concurrency::FuturesOrdered;
 use crate::error::ChainResponse;
+use crate::frame::{Frame, RedisFrame};
 use crate::message::{Message, MessageDetails, QueryResponse};
-use crate::protocols::redis_codec::{DecodeType, RedisCodec};
-use crate::protocols::{Frame, RedisFrame};
 use crate::tls::TlsConfig;
 use crate::transforms::redis::RedisError;
 use crate::transforms::redis::TransformError;

--- a/shotover-proxy/src/transforms/redis/sink_single.rs
+++ b/shotover-proxy/src/transforms/redis/sink_single.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use crate::protocols::RedisFrame;
+use crate::frame::RedisFrame;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use futures::{FutureExt, SinkExt};
@@ -11,9 +11,9 @@ use tokio::net::TcpStream;
 use tokio_stream::StreamExt;
 use tokio_util::codec::Framed;
 
+use crate::codec::redis::{DecodeType, RedisCodec};
 use crate::error::ChainResponse;
-use crate::protocols::redis_codec::{DecodeType, RedisCodec};
-use crate::protocols::Frame;
+use crate::frame::Frame;
 use crate::tls::{AsyncStream, TlsConfig, TlsConnector};
 use crate::transforms::{Transform, Transforms, Wrapper};
 

--- a/shotover-proxy/src/transforms/tee.rs
+++ b/shotover-proxy/src/transforms/tee.rs
@@ -1,7 +1,7 @@
 use crate::config::topology::TopicHolder;
 use crate::error::ChainResponse;
+use crate::frame::Frame;
 use crate::message::{Message, MessageValue, QueryResponse};
-use crate::protocols::Frame;
 use crate::transforms::chain::BufferedChain;
 use crate::transforms::{
     build_chain_from_config, Transform, Transforms, TransformsConfig, Wrapper,

--- a/shotover-proxy/src/transforms/util/cluster_connection_pool.rs
+++ b/shotover-proxy/src/transforms/util/cluster_connection_pool.rs
@@ -307,7 +307,7 @@ mod test {
     use tokio::time::timeout;
 
     use super::spawn_read_write_tasks;
-    use crate::protocols::redis_codec::{DecodeType, RedisCodec};
+    use crate::codec::redis::{DecodeType, RedisCodec};
 
     #[tokio::test]
     async fn test_remote_shutdown() {

--- a/shotover-proxy/tests/codec/cassandra.rs
+++ b/shotover-proxy/tests/codec/cassandra.rs
@@ -1,6 +1,6 @@
 use bytes::Bytes;
 use futures::SinkExt;
-use shotover_proxy::protocols::cassandra_codec::CassandraCodec;
+use shotover_proxy::codec::cassandra::CassandraCodec;
 use std::collections::HashMap;
 use tokio::io::BufWriter;
 use tokio_stream::StreamExt;


### PR DESCRIPTION
Moves the following:
* protocols::Frame -> frame::Frame
* protocols::RedisFrame -> frame::RedisFrame
* protocols::CassandraFrame -> frame::CassandraFrame
* protocols::redis_codec -> codec::redis
* protocols::cassandra_codec -> codec::cassandra

This will allow us to make a frame::cassandra::CassandraFrame to hold the new CassandraFrame struct introduced by the message details rewrite.

I havent put too much thought into this but it seemed like an obvious improvement, let me know if you have any better ideas.