### PR TITLE
Add debug traces to hex dump cassandra messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,6 +1858,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
+name = "pretty-hex"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5c99d529f0d30937f6f4b8a86d988047327bb88d04d2c4afc356de74722131"
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2515,6 +2521,7 @@ dependencies = [
  "pcap",
  "pin-project-lite",
  "pktparse",
+ "pretty-hex",
  "rand",
  "rand_distr",
  "rdkafka",

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -13,6 +13,7 @@ license = "Apache-2.0"
 alpha-transforms = []
 
 [dependencies]
+pretty-hex = "0.2.1"
 tokio = { version = "1.14.0", features = ["full", "macros"] }
 tokio-util = { version = "0.7.0", features = ["full"] }
 tokio-stream = "0.1.2"

--- a/shotover-proxy/src/codec/cassandra.rs
+++ b/shotover-proxy/src/codec/cassandra.rs
@@ -509,6 +509,10 @@ impl CassandraCodec {
 
     fn encode_raw(&mut self, item: CassandraFrame, dst: &mut BytesMut) {
         let buffer = item.encode().encode_with(self.compressor).unwrap();
+        tracing::debug!(
+            "outgoing cassandra message:\n{}",
+            pretty_hex::pretty_hex(&buffer)
+        );
         if buffer.is_empty() {
             info!("trying to send 0 length frame");
         }
@@ -534,6 +538,10 @@ impl Decoder for CassandraCodec {
             Ok(parsed_frame) => {
                 // Clear the read bytes from the FramedReader
                 let bytes = src.split_to(parsed_frame.frame_len);
+                tracing::debug!(
+                    "incoming cassandra message:\n{}",
+                    pretty_hex::pretty_hex(&bytes)
+                );
 
                 let mut message = Message::from_frame(Frame::Cassandra(
                     CassandraFrame::from_bytes(bytes.freeze()).unwrap(),


### PR DESCRIPTION
This was extremely useful for recent debugging of cassandra messages and im sure we'll need it again.

There is too much noise at debug level tracing for this to be directly useful, the intended use case is to temporarily bump the tracing::debug up to a tracing::warn or something when you need to view this log.

This PR is a bare minimum approach, but i would love to hear ideas on how to better solve this problem.
We could do something like log this to tracing::info when a CLI arg is provided to give easier developer access and user access to these logs.
I dont want to make it tracing::info by default because its:
* too noisy
* a security concern to be logging the contents of all messages.

Example output:
```
2022-02-07T00:35:38.718884Z  WARN request{id=5 source="CassandraSource"}: shotover_proxy::codec::cassandra: incoming cassandra message:
Length: 83 (0x53) bytes
0000:   04 00 2a 80  07 00 00 00  4a 00 00 00  3b 53 45 4c   ..*.....J...;SEL
0010:   45 43 54 20  2a 20 46 52  4f 4d 20 74  65 73 74 5f   ECT * FROM test_
0020:   70 72 65 70  61 72 65 5f  73 74 61 74  65 6d 65 6e   prepare_statemen
0030:   74 73 2e 74  61 62 6c 65  5f 31 20 77  68 65 72 65   ts.table_1 where
0040:   20 69 64 20  3d 20 31 3b  00 0a 20 00  05 d7 62 c7    id = 1;.. ...b.
0050:   94 81 b1                                             ...
2022-02-07T00:35:38.719779Z  WARN request{id=5 source="CassandraSource"}: shotover_proxy::codec::cassandra: outgoing cassandra message:
Length: 83 (0x53) bytes
0000:   04 00 2a 80  07 00 00 00  4a 00 00 00  3b 53 45 4c   ..*.....J...;SEL
0010:   45 43 54 20  2a 20 46 52  4f 4d 20 74  65 73 74 5f   ECT * FROM test_
0020:   70 72 65 70  61 72 65 5f  73 74 61 74  65 6d 65 6e   prepare_statemen
0030:   74 73 2e 74  61 62 6c 65  5f 31 20 77  68 65 72 65   ts.table_1 where
0040:   20 69 64 20  3d 20 31 3b  00 0a 20 00  05 d7 62 c7    id = 1;.. ...b.
0050:   94 81 b1                                             ...
2022-02-07T00:35:38.720845Z  WARN request{id=5 source="CassandraSource"}: shotover_proxy::codec::cassandra: incoming cassandra message:
Length: 78 (0x4e) bytes
0000:   84 00 2a 80  08 00 00 00  45 00 00 00  02 00 00 00   ..*.....E.......
0010:   01 00 00 00  03 00 17 74  65 73 74 5f  70 72 65 70   .......test_prep
0020:   61 72 65 5f  73 74 61 74  65 6d 65 6e  74 73 00 07   are_statements..
0030:   74 61 62 6c  65 5f 31 00  02 69 64 00  09 00 04 6e   table_1..id....n
0040:   61 6d 65 00  0d 00 01 78  00 09 00 00  00 00         ame....x......
2022-02-07T00:35:38.721322Z  WARN request{id=5 source="CassandraSource"}: shotover_proxy::codec::cassandra: outgoing cassandra message:
Length: 78 (0x4e) bytes
0000:   84 00 2a 80  08 00 00 00  45 00 00 00  02 00 00 00   ..*.....E.......
0010:   01 00 00 00  03 00 17 74  65 73 74 5f  70 72 65 70   .......test_prep
0020:   61 72 65 5f  73 74 61 74  65 6d 65 6e  74 73 00 07   are_statements..
0030:   74 61 62 6c  65 5f 31 00  02 69 64 00  09 00 04 6e   table_1..id....n
0040:   61 6d 65 00  0d 00 01 78  00 09 00 00  00 00         ame....x......
```