### PR TITLE
Add empty cassandra_benches file

### DIFF
--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -94,3 +94,7 @@ harness = false
 [[bench]]
 name = "chain_benches"
 harness = false
+
+[[bench]]
+name = "cassandra_benches"
+harness = false

--- a/shotover-proxy/benches/cassandra_benches.rs
+++ b/shotover-proxy/benches/cassandra_benches.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello world");
+}

--- a/shotover-proxy/benches/redis_benches.rs
+++ b/shotover-proxy/benches/redis_benches.rs
@@ -8,7 +8,7 @@ use helpers::ShotoverManager;
 fn redis_multi(c: &mut Criterion) {
     let mut group = c.benchmark_group("redis");
     group.throughput(criterion::Throughput::Elements(1));
-    group.noise_threshold(2.0);
+    group.noise_threshold(0.2);
 
     {
         let mut state = {
@@ -33,7 +33,7 @@ fn redis_multi(c: &mut Criterion) {
 fn redis_cluster(c: &mut Criterion) {
     let mut group = c.benchmark_group("redis");
     group.throughput(criterion::Throughput::Elements(1));
-    group.noise_threshold(2.0);
+    group.noise_threshold(0.2);
 
     {
         let mut state = {
@@ -59,7 +59,7 @@ fn redis_passthrough(c: &mut Criterion) {
     {
         let mut group = c.benchmark_group("redis");
         group.throughput(criterion::Throughput::Elements(1));
-        group.noise_threshold(2.0);
+        group.noise_threshold(0.2);
 
         let mut state = {
             let compose = DockerCompose::new("examples/redis-passthrough/docker-compose.yml")
@@ -84,7 +84,7 @@ fn redis_tls(c: &mut Criterion) {
     {
         let mut group = c.benchmark_group("redis");
         group.throughput(criterion::Throughput::Elements(1));
-        group.noise_threshold(2.0);
+        group.noise_threshold(0.2);
 
         let mut state = {
             let compose = DockerCompose::new("examples/redis-tls/docker-compose.yml")
@@ -109,7 +109,7 @@ fn redis_cluster_tls(c: &mut Criterion) {
     {
         let mut group = c.benchmark_group("redis");
         group.throughput(criterion::Throughput::Elements(1));
-        group.noise_threshold(2.0);
+        group.noise_threshold(0.2);
 
         let mut state = {
             let compose = DockerCompose::new("examples/redis-cluster-tls/docker-compose.yml")

--- a/shotover-proxy/benches/redis_benches.rs
+++ b/shotover-proxy/benches/redis_benches.rs
@@ -5,10 +5,10 @@ use test_helpers::docker_compose::DockerCompose;
 mod helpers;
 use helpers::ShotoverManager;
 
-fn redis_multi(c: &mut Criterion) {
+fn redis(c: &mut Criterion) {
     let mut group = c.benchmark_group("redis");
     group.throughput(criterion::Throughput::Elements(1));
-    group.noise_threshold(0.2);
+    group.noise_threshold(2.0);
 
     {
         let mut state = {
@@ -28,12 +28,6 @@ fn redis_multi(c: &mut Criterion) {
             })
         });
     }
-}
-
-fn redis_cluster(c: &mut Criterion) {
-    let mut group = c.benchmark_group("redis");
-    group.throughput(criterion::Throughput::Elements(1));
-    group.noise_threshold(0.2);
 
     {
         let mut state = {
@@ -53,14 +47,8 @@ fn redis_cluster(c: &mut Criterion) {
             })
         });
     }
-}
 
-fn redis_passthrough(c: &mut Criterion) {
     {
-        let mut group = c.benchmark_group("redis");
-        group.throughput(criterion::Throughput::Elements(1));
-        group.noise_threshold(0.2);
-
         let mut state = {
             let compose = DockerCompose::new("examples/redis-passthrough/docker-compose.yml")
                 .wait_for("Ready to accept connections");
@@ -78,14 +66,8 @@ fn redis_passthrough(c: &mut Criterion) {
             })
         });
     }
-}
 
-fn redis_tls(c: &mut Criterion) {
     {
-        let mut group = c.benchmark_group("redis");
-        group.throughput(criterion::Throughput::Elements(1));
-        group.noise_threshold(0.2);
-
         let mut state = {
             let compose = DockerCompose::new("examples/redis-tls/docker-compose.yml")
                 .wait_for("Ready to accept connections");
@@ -103,14 +85,8 @@ fn redis_tls(c: &mut Criterion) {
             })
         });
     }
-}
 
-fn redis_cluster_tls(c: &mut Criterion) {
     {
-        let mut group = c.benchmark_group("redis");
-        group.throughput(criterion::Throughput::Elements(1));
-        group.noise_threshold(0.2);
-
         let mut state = {
             let compose = DockerCompose::new("examples/redis-cluster-tls/docker-compose.yml")
                 .wait_for_n("Cluster state changed", 6);
@@ -130,15 +106,8 @@ fn redis_cluster_tls(c: &mut Criterion) {
     }
 }
 
-criterion_group!(
-    redis,
-    redis_multi,
-    redis_cluster,
-    redis_passthrough,
-    redis_tls,
-    redis_cluster_tls
-);
-criterion_main!(redis);
+criterion_group!(benches, redis);
+criterion_main!(benches);
 
 struct BenchResources {
     _compose: DockerCompose,

--- a/shotover-proxy/benches/redis_benches.rs
+++ b/shotover-proxy/benches/redis_benches.rs
@@ -5,10 +5,10 @@ use test_helpers::docker_compose::DockerCompose;
 mod helpers;
 use helpers::ShotoverManager;
 
-fn redis(c: &mut Criterion) {
+fn redis_multi(c: &mut Criterion) {
     let mut group = c.benchmark_group("redis");
     group.throughput(criterion::Throughput::Elements(1));
-    group.noise_threshold(2.0);
+    group.noise_threshold(0.2);
 
     {
         let mut state = {
@@ -28,6 +28,12 @@ fn redis(c: &mut Criterion) {
             })
         });
     }
+}
+
+fn redis_cluster(c: &mut Criterion) {
+    let mut group = c.benchmark_group("redis");
+    group.throughput(criterion::Throughput::Elements(1));
+    group.noise_threshold(0.2);
 
     {
         let mut state = {
@@ -47,8 +53,14 @@ fn redis(c: &mut Criterion) {
             })
         });
     }
+}
 
+fn redis_passthrough(c: &mut Criterion) {
     {
+        let mut group = c.benchmark_group("redis");
+        group.throughput(criterion::Throughput::Elements(1));
+        group.noise_threshold(0.2);
+
         let mut state = {
             let compose = DockerCompose::new("examples/redis-passthrough/docker-compose.yml")
                 .wait_for("Ready to accept connections");
@@ -66,8 +78,14 @@ fn redis(c: &mut Criterion) {
             })
         });
     }
+}
 
+fn redis_tls(c: &mut Criterion) {
     {
+        let mut group = c.benchmark_group("redis");
+        group.throughput(criterion::Throughput::Elements(1));
+        group.noise_threshold(0.2);
+
         let mut state = {
             let compose = DockerCompose::new("examples/redis-tls/docker-compose.yml")
                 .wait_for("Ready to accept connections");
@@ -85,8 +103,14 @@ fn redis(c: &mut Criterion) {
             })
         });
     }
+}
 
+fn redis_cluster_tls(c: &mut Criterion) {
     {
+        let mut group = c.benchmark_group("redis");
+        group.throughput(criterion::Throughput::Elements(1));
+        group.noise_threshold(0.2);
+
         let mut state = {
             let compose = DockerCompose::new("examples/redis-cluster-tls/docker-compose.yml")
                 .wait_for_n("Cluster state changed", 6);
@@ -106,8 +130,15 @@ fn redis(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, redis);
-criterion_main!(benches);
+criterion_group!(
+    redis,
+    redis_multi,
+    redis_cluster,
+    redis_passthrough,
+    redis_tls,
+    redis_cluster_tls
+);
+criterion_main!(redis);
 
 struct BenchResources {
     _compose: DockerCompose,

--- a/shotover-proxy/benches/redis_benches.rs
+++ b/shotover-proxy/benches/redis_benches.rs
@@ -8,7 +8,7 @@ use helpers::ShotoverManager;
 fn redis_multi(c: &mut Criterion) {
     let mut group = c.benchmark_group("redis");
     group.throughput(criterion::Throughput::Elements(1));
-    group.noise_threshold(0.2);
+    group.noise_threshold(2.0);
 
     {
         let mut state = {
@@ -33,7 +33,7 @@ fn redis_multi(c: &mut Criterion) {
 fn redis_cluster(c: &mut Criterion) {
     let mut group = c.benchmark_group("redis");
     group.throughput(criterion::Throughput::Elements(1));
-    group.noise_threshold(0.2);
+    group.noise_threshold(2.0);
 
     {
         let mut state = {
@@ -59,7 +59,7 @@ fn redis_passthrough(c: &mut Criterion) {
     {
         let mut group = c.benchmark_group("redis");
         group.throughput(criterion::Throughput::Elements(1));
-        group.noise_threshold(0.2);
+        group.noise_threshold(2.0);
 
         let mut state = {
             let compose = DockerCompose::new("examples/redis-passthrough/docker-compose.yml")
@@ -84,7 +84,7 @@ fn redis_tls(c: &mut Criterion) {
     {
         let mut group = c.benchmark_group("redis");
         group.throughput(criterion::Throughput::Elements(1));
-        group.noise_threshold(0.2);
+        group.noise_threshold(2.0);
 
         let mut state = {
             let compose = DockerCompose::new("examples/redis-tls/docker-compose.yml")
@@ -109,7 +109,7 @@ fn redis_cluster_tls(c: &mut Criterion) {
     {
         let mut group = c.benchmark_group("redis");
         group.throughput(criterion::Throughput::Elements(1));
-        group.noise_threshold(0.2);
+        group.noise_threshold(2.0);
 
         let mut state = {
             let compose = DockerCompose::new("examples/redis-cluster-tls/docker-compose.yml")

--- a/shotover-proxy/benches/redis_benches.rs
+++ b/shotover-proxy/benches/redis_benches.rs
@@ -5,111 +5,140 @@ use test_helpers::docker_compose::DockerCompose;
 mod helpers;
 use helpers::ShotoverManager;
 
-fn redis(c: &mut Criterion) {
+fn redis_multi(c: &mut Criterion) {
     let mut group = c.benchmark_group("redis");
     group.throughput(criterion::Throughput::Elements(1));
     group.noise_threshold(2.0);
 
     {
-        let mut state = None;
+        let mut state = {
+            let compose = DockerCompose::new("examples/redis-multi/docker-compose.yml")
+                .wait_for_n("Ready to accept connections", 3);
+            let shotover_manager =
+                ShotoverManager::from_topology_file("examples/redis-multi/topology.yaml");
+            BenchResources::new(shotover_manager, compose)
+        };
+
         group.bench_function("active", move |b| {
             b.iter(|| {
-                let state = state.get_or_insert_with(|| {
-                    let compose = DockerCompose::new("examples/redis-multi/docker-compose.yml")
-                        .wait_for_n("Ready to accept connections", 3);
-                    let shotover_manager =
-                        ShotoverManager::from_topology_file("examples/redis-multi/topology.yaml");
-                    BenchResources::new(shotover_manager, compose)
-                });
                 redis::cmd("SET")
                     .arg("foo")
-                    .arg(42)
-                    .execute(&mut state.connection);
-            })
-        });
-    }
-
-    {
-        let mut state = None;
-        group.bench_function("cluster", move |b| {
-            b.iter(|| {
-                let state = state.get_or_insert_with(|| {
-                    let compose = DockerCompose::new("examples/redis-cluster/docker-compose.yml")
-                        .wait_for_n("Cluster state changed", 6);
-                    let shotover_manager =
-                        ShotoverManager::from_topology_file("examples/redis-cluster/topology.yaml");
-                    BenchResources::new(shotover_manager, compose)
-                });
-                redis::cmd("SET")
-                    .arg("foo")
-                    .arg(42)
-                    .execute(&mut state.connection);
-            })
-        });
-    }
-
-    {
-        let mut state = None;
-        group.bench_function("passthrough", move |b| {
-            let state = state.get_or_insert_with(|| {
-                let compose = DockerCompose::new("examples/redis-passthrough/docker-compose.yml")
-                    .wait_for("Ready to accept connections");
-                let shotover_manager =
-                    ShotoverManager::from_topology_file("examples/redis-passthrough/topology.yaml");
-                BenchResources::new(shotover_manager, compose)
-            });
-            b.iter(|| {
-                redis::cmd("SET")
-                    .arg("foo")
-                    .arg(42)
-                    .execute(&mut state.connection);
-            })
-        });
-    }
-
-    {
-        let mut state = None;
-        group.bench_function("single_tls", move |b| {
-            b.iter(|| {
-                let state = state.get_or_insert_with(|| {
-                    let compose = DockerCompose::new("examples/redis-tls/docker-compose.yml")
-                        .wait_for("Ready to accept connections");
-                    let shotover_manager =
-                        ShotoverManager::from_topology_file("examples/redis-tls/topology.yaml");
-                    BenchResources::new(shotover_manager, compose)
-                });
-                redis::cmd("SET")
-                    .arg("foo")
-                    .arg(42)
-                    .execute(&mut state.connection);
-            })
-        });
-    }
-
-    {
-        let mut state = None;
-        group.bench_function("cluster_tls", move |b| {
-            b.iter(|| {
-                let state = state.get_or_insert_with(|| {
-                    let compose =
-                        DockerCompose::new("examples/redis-cluster-tls/docker-compose.yml")
-                            .wait_for_n("Cluster state changed", 6);
-                    let shotover_manager = ShotoverManager::from_topology_file(
-                        "examples/redis-cluster-tls/topology.yaml",
-                    );
-                    BenchResources::new(shotover_manager, compose)
-                });
-                redis::cmd("SET")
-                    .arg("foo")
-                    .arg(42)
+                    .arg::<i32>(42)
                     .execute(&mut state.connection);
             })
         });
     }
 }
 
-criterion_group!(benches, redis);
-criterion_main!(benches);
+fn redis_cluster(c: &mut Criterion) {
+    let mut group = c.benchmark_group("redis");
+    group.throughput(criterion::Throughput::Elements(1));
+    group.noise_threshold(2.0);
+
+    {
+        let mut state = {
+            let compose = DockerCompose::new("examples/redis-cluster/docker-compose.yml")
+                .wait_for_n("Cluster state changed", 6);
+            let shotover_manager =
+                ShotoverManager::from_topology_file("examples/redis-cluster/topology.yaml");
+            BenchResources::new(shotover_manager, compose)
+        };
+
+        group.bench_function("cluster", move |b| {
+            b.iter(|| {
+                redis::cmd("SET")
+                    .arg("foo")
+                    .arg::<i32>(42)
+                    .execute(&mut state.connection);
+            })
+        });
+    }
+}
+
+fn redis_passthrough(c: &mut Criterion) {
+    {
+        let mut group = c.benchmark_group("redis");
+        group.throughput(criterion::Throughput::Elements(1));
+        group.noise_threshold(2.0);
+
+        let mut state = {
+            let compose = DockerCompose::new("examples/redis-passthrough/docker-compose.yml")
+                .wait_for("Ready to accept connections");
+            let shotover_manager =
+                ShotoverManager::from_topology_file("examples/redis-passthrough/topology.yaml");
+            BenchResources::new(shotover_manager, compose)
+        };
+
+        group.bench_function("passthrough", move |b| {
+            b.iter(|| {
+                redis::cmd("SET")
+                    .arg("foo")
+                    .arg::<i32>(42)
+                    .execute(&mut state.connection);
+            })
+        });
+    }
+}
+
+fn redis_tls(c: &mut Criterion) {
+    {
+        let mut group = c.benchmark_group("redis");
+        group.throughput(criterion::Throughput::Elements(1));
+        group.noise_threshold(2.0);
+
+        let mut state = {
+            let compose = DockerCompose::new("examples/redis-tls/docker-compose.yml")
+                .wait_for("Ready to accept connections");
+            let shotover_manager =
+                ShotoverManager::from_topology_file("examples/redis-tls/topology.yaml");
+            BenchResources::new(shotover_manager, compose)
+        };
+
+        group.bench_function("single_tls", move |b| {
+            b.iter(|| {
+                redis::cmd("SET")
+                    .arg("foo")
+                    .arg::<i32>(42)
+                    .execute(&mut state.connection);
+            })
+        });
+    }
+}
+
+fn redis_cluster_tls(c: &mut Criterion) {
+    {
+        let mut group = c.benchmark_group("redis");
+        group.throughput(criterion::Throughput::Elements(1));
+        group.noise_threshold(2.0);
+
+        let mut state = {
+            let compose = DockerCompose::new("examples/redis-cluster-tls/docker-compose.yml")
+                .wait_for_n("Cluster state changed", 6);
+            let shotover_manager =
+                ShotoverManager::from_topology_file("examples/redis-cluster-tls/topology.yaml");
+            BenchResources::new(shotover_manager, compose)
+        };
+
+        group.bench_function("cluster_tls", move |b| {
+            b.iter(|| {
+                redis::cmd("SET")
+                    .arg("foo")
+                    .arg::<i32>(42)
+                    .execute(&mut state.connection);
+            })
+        });
+    }
+}
+
+criterion_group!(
+    redis,
+    redis_multi,
+    redis_cluster,
+    redis_passthrough,
+    redis_tls,
+    redis_cluster_tls
+);
+criterion_main!(redis);
 
 struct BenchResources {
     _compose: DockerCompose,


### PR DESCRIPTION
<s>- Move the init code out of the actual bench-marking code</s>
<s>- Move each of the Redis benchmarks to functions so they can be run individually without having to run other benchmark's init code beforehand.</s>

- add cassandra_benches.rs file so CI on #512 works