### PR TITLE
Fix redis benchmark initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,7 +464,7 @@ dependencies = [
 [[package]]
 name = "criterion"
 version = "0.3.5"
-source = "git+https://github.com/bheisler/criterion.rs?branch=version-0.4#412591edec4a0e8e05093c7f9ca0ba9611e5c17f"
+source = "git+https://github.com/shotover/criterion.rs?branch=version-0.4#b15f7c500b1b722e9e4dfb07957a6564eda10655"
 dependencies = [
  "anes",
  "atty",
@@ -491,7 +491,7 @@ dependencies = [
 [[package]]
 name = "criterion-plot"
 version = "0.4.4"
-source = "git+https://github.com/bheisler/criterion.rs?branch=version-0.4#412591edec4a0e8e05093c7f9ca0ba9611e5c17f"
+source = "git+https://github.com/shotover/criterion.rs?branch=version-0.4#b15f7c500b1b722e9e4dfb07957a6564eda10655"
 dependencies = [
  "cast",
  "itertools",

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -68,7 +68,7 @@ csv = "1.1.6"
 strum_macros = "0.23"
 
 [dev-dependencies]
-criterion = { git = "https://github.com/bheisler/criterion.rs", branch = "version-0.4", version = "0.3", features = ["async_tokio", "html_reports"] }
+criterion = { git = "https://github.com/shotover/criterion.rs", branch = "version-0.4", version = "0.3", features = ["async_tokio", "html_reports"] }
 redis = { version = "0.21.0", features = ["tokio-comp", "cluster"] }
 pcap = "0.9.0"
 pktparse = {version = "0.7.0", features = ["serde"]}

--- a/shotover-proxy/benches/redis_benches.rs
+++ b/shotover-proxy/benches/redis_benches.rs
@@ -8,104 +8,102 @@ use helpers::ShotoverManager;
 fn redis(c: &mut Criterion) {
     let mut group = c.benchmark_group("redis");
     group.throughput(criterion::Throughput::Elements(1));
-    group.noise_threshold(2.0);
+    group.noise_threshold(0.2);
 
-    {
-        let mut state = None;
-        group.bench_function("active", move |b| {
-            b.iter(|| {
-                let state = state.get_or_insert_with(|| {
-                    let compose = DockerCompose::new("examples/redis-multi/docker-compose.yml")
-                        .wait_for_n("Ready to accept connections", 3);
-                    let shotover_manager =
-                        ShotoverManager::from_topology_file("examples/redis-multi/topology.yaml");
-                    BenchResources::new(shotover_manager, compose)
-                });
-                redis::cmd("SET")
-                    .arg("foo")
-                    .arg(42)
-                    .execute(&mut state.connection);
-            })
-        });
-    }
-
-    {
-        let mut state = None;
-        group.bench_function("cluster", move |b| {
-            b.iter(|| {
-                let state = state.get_or_insert_with(|| {
-                    let compose = DockerCompose::new("examples/redis-cluster/docker-compose.yml")
-                        .wait_for_n("Cluster state changed", 6);
-                    let shotover_manager =
-                        ShotoverManager::from_topology_file("examples/redis-cluster/topology.yaml");
-                    BenchResources::new(shotover_manager, compose)
-                });
-                redis::cmd("SET")
-                    .arg("foo")
-                    .arg(42)
-                    .execute(&mut state.connection);
-            })
-        });
-    }
-
-    {
-        let mut state = None;
-        group.bench_function("passthrough", move |b| {
-            let state = state.get_or_insert_with(|| {
-                let compose = DockerCompose::new("examples/redis-passthrough/docker-compose.yml")
-                    .wait_for("Ready to accept connections");
-                let shotover_manager =
-                    ShotoverManager::from_topology_file("examples/redis-passthrough/topology.yaml");
-                BenchResources::new(shotover_manager, compose)
-            });
+    group.bench_with_input(
+        "active",
+        || {
+            let compose = DockerCompose::new("examples/redis-multi/docker-compose.yml")
+                .wait_for_n("Ready to accept connections", 3);
+            let shotover_manager =
+                ShotoverManager::from_topology_file("examples/redis-multi/topology.yaml");
+            BenchResources::new(shotover_manager, compose)
+        },
+        move |b, state| {
             b.iter(|| {
                 redis::cmd("SET")
                     .arg("foo")
                     .arg(42)
                     .execute(&mut state.connection);
             })
-        });
-    }
+        },
+    );
 
-    {
-        let mut state = None;
-        group.bench_function("single_tls", move |b| {
+    group.bench_with_input(
+        "cluster",
+        || {
+            let compose = DockerCompose::new("examples/redis-cluster/docker-compose.yml")
+                .wait_for_n("Cluster state changed", 6);
+            let shotover_manager =
+                ShotoverManager::from_topology_file("examples/redis-cluster/topology.yaml");
+            BenchResources::new(shotover_manager, compose)
+        },
+        move |b, state| {
             b.iter(|| {
-                let state = state.get_or_insert_with(|| {
-                    let compose = DockerCompose::new("examples/redis-tls/docker-compose.yml")
-                        .wait_for("Ready to accept connections");
-                    let shotover_manager =
-                        ShotoverManager::from_topology_file("examples/redis-tls/topology.yaml");
-                    BenchResources::new(shotover_manager, compose)
-                });
                 redis::cmd("SET")
                     .arg("foo")
                     .arg(42)
                     .execute(&mut state.connection);
             })
-        });
-    }
+        },
+    );
 
-    {
-        let mut state = None;
-        group.bench_function("cluster_tls", move |b| {
+    group.bench_with_input(
+        "passthrough",
+        || {
+            let compose = DockerCompose::new("examples/redis-passthrough/docker-compose.yml")
+                .wait_for("Ready to accept connections");
+            let shotover_manager =
+                ShotoverManager::from_topology_file("examples/redis-passthrough/topology.yaml");
+            BenchResources::new(shotover_manager, compose)
+        },
+        move |b, state| {
             b.iter(|| {
-                let state = state.get_or_insert_with(|| {
-                    let compose =
-                        DockerCompose::new("examples/redis-cluster-tls/docker-compose.yml")
-                            .wait_for_n("Cluster state changed", 6);
-                    let shotover_manager = ShotoverManager::from_topology_file(
-                        "examples/redis-cluster-tls/topology.yaml",
-                    );
-                    BenchResources::new(shotover_manager, compose)
-                });
                 redis::cmd("SET")
                     .arg("foo")
                     .arg(42)
                     .execute(&mut state.connection);
             })
-        });
-    }
+        },
+    );
+
+    group.bench_with_input(
+        "single_tls",
+        || {
+            let compose = DockerCompose::new("examples/redis-tls/docker-compose.yml")
+                .wait_for("Ready to accept connections");
+            let shotover_manager =
+                ShotoverManager::from_topology_file("examples/redis-tls/topology.yaml");
+            BenchResources::new(shotover_manager, compose)
+        },
+        move |b, state| {
+            b.iter(|| {
+                redis::cmd("SET")
+                    .arg("foo")
+                    .arg(42)
+                    .execute(&mut state.connection);
+            })
+        },
+    );
+
+    group.bench_with_input(
+        "cluster_tls",
+        || {
+            let compose = DockerCompose::new("examples/redis-cluster-tls/docker-compose.yml")
+                .wait_for_n("Cluster state changed", 6);
+            let shotover_manager =
+                ShotoverManager::from_topology_file("examples/redis-cluster-tls/topology.yaml");
+            BenchResources::new(shotover_manager, compose)
+        },
+        move |b, state| {
+            b.iter(|| {
+                redis::cmd("SET")
+                    .arg("foo")
+                    .arg(42)
+                    .execute(&mut state.connection);
+            })
+        },
+    );
 }
 
 criterion_group!(benches, redis);


### PR DESCRIPTION
Uses a fork of criterion that allows us to provide an Fn that will generate our state only when the bench is actually run.
This gives us the best of both worlds: improve noise in the redis integration benches while allowing us to continue running benches individually.

In order to land this PR in a reasonable amount of time I suggest that we create a shotover/criterion repo to host this fork until it reaches upstream.

I have created a PR to review the temporary fork https://github.com/shotover/criterion.rs/pull/1 