### PR TITLE
Remove actions-rs/toolchain

### DIFF
--- a/.github/workflows/bench_run.yml
+++ b/.github/workflows/bench_run.yml
@@ -19,14 +19,6 @@ jobs:
     name: Benchmarks
     steps:
     - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-          # `toolchain: stable` results in the latest stable toolchain being installed.
-          # However as soon as we use cargo the real version specified in rust-toolchain.toml replaces the stable toolchain.
-          #
-          # When something like https://github.com/actions-rs/toolchain/pull/184 lands we can delete this line and get a nice speedup
-          profile: minimal
-          toolchain: stable
     - uses: Swatinem/rust-cache@v1
       with:
         # Unique key is used to avoid collisions with the Testing workflow

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,14 +33,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
     - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-          # `toolchain: stable` results in the latest stable toolchain being installed.
-          # However as soon as we use cargo the real version specified in rust-toolchain.toml replaces the stable toolchain.
-          #
-          # When something like https://github.com/actions-rs/toolchain/pull/184 lands we can delete this line and get a nice speedup
-          profile: minimal
-          toolchain: stable
     - uses: Swatinem/rust-cache@v1
       with:
         # rust-cache already handles all the sane defaults for caching rust builds.


### PR DESCRIPTION
I saw a suspicious log in the `actions-rs/toolchain@v1` section of our CI.
After investigating I realized that github actions installs rustup by default so theres really no need to be mucking around with `actions-rs/toolchain` in the first place.

The default rustup installation provided by github actions has no toolchains installed which is perfect for us as we want the correct toolchain to be pulled in as specified by the rust-toolchain.toml.

I thought this would give us a ci runtime improvement but the 11s time to run this step seems to have just been completely moved to the next step as thats when the rust toolchain actually gets pulled in now.