### PR TITLE
Misc message details progress

### DIFF
--- a/shotover-proxy/benches/chain_benches.rs
+++ b/shotover-proxy/benches/chain_benches.rs
@@ -1,10 +1,7 @@
-use std::collections::HashMap;
-
 use bytes::Bytes;
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-
 use shotover_proxy::frame::Frame;
-use shotover_proxy::message::{Message, QueryMessage, QueryType};
+use shotover_proxy::message::{Message, QueryType};
 use shotover_proxy::transforms::chain::TransformChain;
 use shotover_proxy::transforms::debug::returner::{DebugReturner, Response};
 use shotover_proxy::transforms::filter::QueryTypeFilter;
@@ -22,19 +19,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let chain =
             TransformChain::new(vec![Transforms::Null(Null::default())], "bench".to_string());
         let wrapper = Wrapper::new_with_chain_name(
-            vec![Message::new_query(
-                QueryMessage {
-                    query_string: "".to_string(),
-                    namespace: vec![],
-                    primary_key: HashMap::new(),
-                    query_values: None,
-                    projection: None,
-                    query_type: QueryType::Write,
-                    ast: None,
-                },
-                true,
-                Frame::None,
-            )],
+            vec![Message::from_frame(Frame::None)],
             chain.name.clone(),
         );
 

--- a/shotover-proxy/src/transforms/null.rs
+++ b/shotover-proxy/src/transforms/null.rs
@@ -1,6 +1,6 @@
 use crate::error::ChainResponse;
 use crate::frame::Frame;
-use crate::message::Message;
+use crate::message::{Message, MessageDetails, QueryResponse};
 use crate::transforms::{Transform, Wrapper};
 use async_trait::async_trait;
 
@@ -14,6 +14,10 @@ impl Transform for Null {
     }
 
     async fn transform<'a>(&'a mut self, _message_wrapper: Wrapper<'a>) -> ChainResponse {
-        Ok(vec![Message::from_frame(Frame::None)])
+        Ok(vec![Message::new(
+            MessageDetails::Response(QueryResponse::empty()),
+            true,
+            Frame::None,
+        )])
     }
 }

--- a/shotover-proxy/src/transforms/null.rs
+++ b/shotover-proxy/src/transforms/null.rs
@@ -1,6 +1,6 @@
 use crate::error::ChainResponse;
 use crate::frame::Frame;
-use crate::message::{Message, MessageDetails, QueryResponse};
+use crate::message::Message;
 use crate::transforms::{Transform, Wrapper};
 use async_trait::async_trait;
 
@@ -14,10 +14,6 @@ impl Transform for Null {
     }
 
     async fn transform<'a>(&'a mut self, _message_wrapper: Wrapper<'a>) -> ChainResponse {
-        Ok(vec![Message::new(
-            MessageDetails::Response(QueryResponse::empty()),
-            true,
-            Frame::None,
-        )])
+        Ok(vec![Message::from_frame(Frame::None)])
     }
 }


### PR DESCRIPTION
chain_benches change is straightforward, just using simpler message construction because the custom field values arent actually needed.

server changes maintain identical functionality but is now simpler as we no longer construct an entire new message just to check that it has a return_to_sender flag later on.
Unfortunately we hit a clippy false positive here, so we need to add `#[allow(clippy::unnecessary_filter_map)]`.
Whats happening is we need to use filter_map instead of filter so that we have ownership of the message and can send it off but clippy doesnt realize we are actually using the value.