### PR TITLE
Replace message.message_details with message.frame()

### DIFF
--- a/docs/src/source-types.md
+++ b/docs/src/source-types.md
@@ -13,11 +13,6 @@ Cassandra:
   # The address to listen from.
   listen_addr: "127.0.0.1:6379"
 
-  cassandra_ks:
-    foo: "bar"
-
-  query_processing: false
-
   # The number of concurrent connections the source will accept.
   connection_limit: 1000
 

--- a/docs/src/transforms.md
+++ b/docs/src/transforms.md
@@ -53,9 +53,6 @@ This transform will take a query, serialise it into a CQL4 compatible format and
 - CassandraSinkSingle:
     # The IP address and port of the upstream cassandra node/service.
     remote_address: "127.0.0.1:9042"
-    # When true creates an AST for the query.
-    # When false the AST is not created, this saves CPU for straight passthrough cases (no processing on the query).
-    result_processing: true
 ```
 
 Note: this will just pass the query to the remote node. No cluster discovery or routing occurs with this transform.

--- a/docs/src/user-guide/configuration.md
+++ b/docs/src/user-guide/configuration.md
@@ -61,14 +61,6 @@ sources:
     # This will generally include a listen address and port
     Cassandra:
       listen_addr: "127.0.0.1:9042"
-      cassandra_ks:
-        system.local:
-          - key
-        test.simple:
-          - pk
-        test.clustering:
-          - pk
-          - clustering
   
   # The spcial mpsc_chan source, it will receive messages from a named topic
   mpsc_chan:

--- a/shotover-proxy/examples/cassandra-passthrough-tls/topology.yaml
+++ b/shotover-proxy/examples/cassandra-passthrough-tls/topology.yaml
@@ -2,25 +2,14 @@
 sources:
   cassandra_prod:
     Cassandra:
-      query_processing: true
       listen_addr: "127.0.0.1:9043"
       tls:
         certificate_authority_path: "examples/cassandra-passthrough-tls/certs/localhost_CA.crt"
         certificate_path: "examples/cassandra-passthrough-tls/certs/localhost.crt"
         private_key_path: "examples/cassandra-passthrough-tls/certs/localhost.key"
-
-      cassandra_ks:
-        system.local:
-          - key
-        test.simple:
-          - pk
-        test.clustering:
-          - pk
-          - clustering
 chain_config:
   main_chain:
     - CassandraSinkSingle:
-        result_processing: true
         remote_address: "127.0.0.1:9042"
         tls:
           certificate_authority_path: "examples/cassandra-passthrough-tls/certs/localhost_CA.crt"

--- a/shotover-proxy/examples/cassandra-passthrough/topology.yaml
+++ b/shotover-proxy/examples/cassandra-passthrough/topology.yaml
@@ -2,20 +2,10 @@
 sources:
   cassandra_prod:
     Cassandra:
-      query_processing: true
       listen_addr: "127.0.0.1:9042"
-      cassandra_ks:
-        system.local:
-          - key
-        test.simple:
-          - pk
-        test.clustering:
-          - pk
-          - clustering
 chain_config:
   main_chain:
     - CassandraSinkSingle:
-        result_processing: true
         remote_address: "127.0.0.1:9043"
 named_topics:
   testtopic: 5

--- a/shotover-proxy/examples/cassandra-protect-aws/topology.yaml
+++ b/shotover-proxy/examples/cassandra-protect-aws/topology.yaml
@@ -4,14 +4,6 @@ sources:
     Cassandra:
       query_processing: true
       listen_addr: "127.0.0.1:9042"
-      cassandra_ks:
-        system.local:
-          - key
-        test.simple:
-          - pk
-        test.clustering:
-          - pk
-          - clustering
 chain_config:
   main_chain:
     - Protect:

--- a/shotover-proxy/examples/cassandra-protect-aws/topology.yaml
+++ b/shotover-proxy/examples/cassandra-protect-aws/topology.yaml
@@ -2,7 +2,6 @@
 sources:
   cassandra_prod:
     Cassandra:
-      query_processing: true
       listen_addr: "127.0.0.1:9042"
 chain_config:
   main_chain:
@@ -18,7 +17,6 @@ chain_config:
             test_table:
               - col1
     - CassandraSinkSingle:
-        result_processing: true
         remote_address: "127.0.0.1:9043"
 named_topics:
   testtopic: 5

--- a/shotover-proxy/examples/cassandra-protect-local/topology.yaml
+++ b/shotover-proxy/examples/cassandra-protect-local/topology.yaml
@@ -4,14 +4,6 @@ sources:
     Cassandra:
       query_processing: true
       listen_addr: "127.0.0.1:9042"
-      cassandra_ks:
-        system.local:
-          - key
-        test.simple:
-          - pk
-        test.clustering:
-          - pk
-          - clustering
 chain_config:
   main_chain:
     - Protect:

--- a/shotover-proxy/examples/cassandra-protect-local/topology.yaml
+++ b/shotover-proxy/examples/cassandra-protect-local/topology.yaml
@@ -2,7 +2,6 @@
 sources:
   cassandra_prod:
     Cassandra:
-      query_processing: true
       listen_addr: "127.0.0.1:9042"
 chain_config:
   main_chain:
@@ -48,7 +47,6 @@ chain_config:
             test_table:
               - col1
     - CassandraSinkSingle:
-        result_processing: true
         remote_address: "127.0.0.1:9043"
 named_topics:
   testtopic: 5

--- a/shotover-proxy/examples/cassandra-redis-cache/topology.yaml
+++ b/shotover-proxy/examples/cassandra-redis-cache/topology.yaml
@@ -2,13 +2,7 @@
 sources:
   cassandra_prod:
     Cassandra:
-      query_processing: true
       listen_addr: "127.0.0.1:9042"
-      cassandra_ks:
-        test_cache_keyspace_batch_insert.test_table:
-          - id
-        test_cache_keyspace_simple.test_table:
-          - id
 chain_config:
   main_chain:
     - RedisCache:
@@ -24,7 +18,6 @@ chain_config:
               remote_address: "127.0.0.1:6379"
     - CassandraSinkSingle:
         remote_address: "127.0.0.1:9043"
-        result_processing: false
 named_topics:
   testtopic: 5
 source_to_chain_mapping:

--- a/shotover-proxy/examples/cassandra-rewrite-peers/topology.yaml
+++ b/shotover-proxy/examples/cassandra-rewrite-peers/topology.yaml
@@ -2,22 +2,12 @@
 sources:
   cassandra_prod:
     Cassandra:
-      query_processing: false
       listen_addr: "0.0.0.0:9043"
-      cassandra_ks:
-        system.local:
-          - key
-        test.simple:
-          - pk
-        test.clustering:
-          - pk
-          - clustering
 chain_config:
   main_chain:
     - CassandraPeersRewrite:
         port: 9043
     - CassandraSinkSingle:
-        result_processing: false
         remote_address: "127.0.0.1:9042"
 named_topics:
   testtopic: 5

--- a/shotover-proxy/examples/null-cassandra/topology.yaml
+++ b/shotover-proxy/examples/null-cassandra/topology.yaml
@@ -3,14 +3,6 @@ sources:
   cassandra_prod:
     Cassandra:
       listen_addr: "127.0.0.1:9042"
-      cassandra_ks:
-        system.local:
-          - key
-        test.simple:
-          - pk
-        test.clustering:
-          - pk
-          - clustering
 chain_config:
   main_chain:
     - Null

--- a/shotover-proxy/src/codec/cassandra.rs
+++ b/shotover-proxy/src/codec/cassandra.rs
@@ -95,7 +95,7 @@ impl Decoder for CassandraCodec {
                     version: Version::V4,
                     stream_id: 0,
                     operation: CassandraOperation::Error(ErrorBody {
-                        error_code: 0xA,
+                        error_code: 0xA, // https://github.com/apache/cassandra/blob/adf2f4c83a2766ef8ebd20b35b49df50957bdf5e/doc/native_protocol_v4.spec#L1053
                         message: "Invalid or unsupported protocol version".into(),
                         additional_info: AdditionalErrorInfo::Server,
                     }),
@@ -120,7 +120,7 @@ impl Encoder<Messages> for CassandraCodec {
     ) -> std::result::Result<(), Self::Error> {
         for m in item {
             // TODO: always check if cassandra message
-            match m.into_encodable() {
+            match m.into_encodable(MessageType::Cassandra)? {
                 Encodable::Bytes(bytes) => dst.extend_from_slice(&bytes),
                 Encodable::Frame(frame) => self.encode_raw(frame.into_cassandra().unwrap(), dst),
             }

--- a/shotover-proxy/src/codec/cassandra.rs
+++ b/shotover-proxy/src/codec/cassandra.rs
@@ -1,46 +1,17 @@
-use std::borrow::{Borrow, BorrowMut};
-use std::collections::HashMap;
-use std::ops::DerefMut;
-
-use crate::frame::CassandraFrame;
-use anyhow::{anyhow, Result};
-
+use crate::frame::cassandra::CassandraOperation;
+use crate::frame::{CassandraFrame, Frame, MessageType};
+use crate::message::{Encodable, Message, Messages};
+use anyhow::anyhow;
 use bytes::{BufMut, BytesMut};
 use cassandra_protocol::compression::Compression;
-use cassandra_protocol::consistency::Consistency;
 use cassandra_protocol::frame::frame_error::{AdditionalErrorInfo, ErrorBody};
-
-use cassandra_protocol::frame::frame_result::{
-    ColSpec, ColType, ColTypeOption, RowsMetadata, RowsMetadataFlags, TableSpec,
-};
 use cassandra_protocol::frame::{Frame as RawCassandraFrame, ParseFrameError, Version};
-use cassandra_protocol::query::QueryValues;
-use cassandra_protocol::types::value::Value as CValue;
-
-use itertools::Itertools;
-use sqlparser::ast::Expr::{BinaryOp, Identifier};
-use sqlparser::ast::Statement::{Delete, Insert, Update};
-use sqlparser::ast::{
-    BinaryOperator, Expr, ObjectName, Select, SelectItem, SetExpr, Statement, TableFactor,
-    Value as SQLValue,
-};
-use sqlparser::dialect::GenericDialect;
-use sqlparser::parser::Parser;
 use tokio_util::codec::{Decoder, Encoder};
-use tracing::{debug, error, info, warn};
-
-use crate::frame::cassandra::{CassandraOperation, CassandraResult, CQL};
-use crate::frame::Frame;
-use crate::message::{
-    ASTHolder, Message, MessageDetails, MessageValue, Messages, QueryMessage, QueryResponse,
-    QueryType,
-};
+use tracing::{debug, info};
 
 #[derive(Debug, Clone)]
 pub struct CassandraCodec {
     compressor: Compression,
-    pk_col_map: HashMap<String, Vec<String>>,
-    bypass: bool,
     /// if force_close is Some then the connection will be closed the next time the
     /// system attempts to read data from it.  This is used in protocol errors where we
     /// need to return a message to the client so we can not immediately close the connection
@@ -50,463 +21,22 @@ pub struct CassandraCodec {
     force_close: Option<String>,
 }
 
-pub(crate) struct ParsedCassandraQueryString {
-    namespace: Option<Vec<String>>,
-    pub(crate) colmap: Option<HashMap<String, MessageValue>>,
-    projection: Option<Vec<String>>,
-    primary_key: HashMap<String, MessageValue>,
-    pub(crate) ast: Option<Statement>,
+impl Default for CassandraCodec {
+    fn default() -> Self {
+        CassandraCodec::new()
+    }
 }
 
 impl CassandraCodec {
-    pub fn new(pk_col_map: HashMap<String, Vec<String>>, bypass: bool) -> CassandraCodec {
+    pub fn new() -> CassandraCodec {
         CassandraCodec {
             compressor: Compression::None,
-            pk_col_map,
-            bypass,
             force_close: None,
         }
     }
-
-    pub fn build_cassandra_query_frame(
-        mut query: QueryMessage,
-        consistency: Consistency,
-    ) -> CassandraFrame {
-        CassandraCodec::rebuild_ast_in_message(&mut query);
-        CassandraCodec::rebuild_query_string_from_ast(&mut query);
-        let QueryMessage { query_values, .. } = query;
-
-        let params = cassandra_protocol::query::QueryParams {
-            consistency,
-            with_names: false,
-            values: Some(QueryValues::SimpleValues(
-                query_values
-                    .unwrap()
-                    .values()
-                    .map(|x| CValue::new(x.clone()))
-                    .collect(),
-            )),
-            page_size: None,
-            paging_state: None,
-            serial_consistency: None,
-            timestamp: None,
-        };
-
-        CassandraFrame {
-            version: Version::V4,
-            operation: CassandraOperation::Query {
-                query: CQL::Parsed(
-                    query
-                        .ast
-                        .map(|ast| match ast {
-                            ASTHolder::SQL(ast) => vec![*ast],
-                            _ => unreachable!("Must be cassandra message"),
-                        })
-                        .unwrap_or_default(),
-                ),
-                params,
-            },
-            stream_id: 0,
-            tracing_id: None,
-            warnings: Vec::new(),
-        }
-    }
-
-    pub fn build_cassandra_response_frame(
-        resp: QueryResponse,
-        query_frame: CassandraFrame,
-    ) -> CassandraFrame {
-        if let Some(MessageValue::Rows(rows)) = resp.result {
-            if let Some(ref query) = resp.matching_query {
-                if let Some(ref proj) = query.projection {
-                    let col_spec = proj
-                        .iter()
-                        .map(|x| {
-                            ColSpec {
-                                table_spec: Some(TableSpec {
-                                    ks_name: query.namespace.get(0).unwrap().clone(),
-                                    table_name: query.namespace.get(1).unwrap().clone(),
-                                }),
-                                name: x.clone(),
-                                col_type: ColTypeOption {
-                                    id: ColType::Ascii, // TODO: get types working
-                                    value: None,
-                                },
-                            }
-                        })
-                        .collect();
-
-                    let count = rows.get(0).unwrap().len() as i32;
-                    let metadata = RowsMetadata {
-                        flags: RowsMetadataFlags::empty(),
-                        columns_count: count,
-                        paging_state: None,
-                        global_table_spec: None,
-                        col_specs: col_spec,
-                    };
-
-                    return CassandraFrame {
-                        version: Version::V4,
-                        operation: CassandraOperation::Result(CassandraResult::Rows {
-                            metadata,
-                            value: MessageValue::Rows(rows),
-                        }),
-                        stream_id: query_frame.stream_id,
-                        tracing_id: query_frame.tracing_id,
-                        warnings: Vec::new(),
-                    };
-                }
-            }
-        }
-        unreachable!()
-    }
 }
 
 impl CassandraCodec {
-    fn value_to_bind(_v: &MessageValue) -> SQLValue {
-        //TODO fix bind handling
-        SQLValue::SingleQuotedString("XYz-1-zYX".to_string())
-    }
-
-    fn expr_to_string(v: &SQLValue) -> String {
-        match v {
-            SQLValue::Number(v, false) => v.to_string(),
-            SQLValue::SingleQuotedString(v)
-            | SQLValue::NationalStringLiteral(v)
-            | SQLValue::HexStringLiteral(v) => v.to_string(),
-            SQLValue::Boolean(v) => v.to_string(),
-            _ => "NULL".to_string(),
-        }
-    }
-
-    fn rebuild_binops_tree(
-        node: &mut Expr,
-        map: &mut HashMap<String, MessageValue>,
-        use_bind: bool,
-    ) {
-        if let BinaryOp { left, op, right } = node {
-            match op {
-                BinaryOperator::And => {
-                    CassandraCodec::rebuild_binops_tree(left, map, use_bind);
-                    CassandraCodec::rebuild_binops_tree(right, map, use_bind);
-                }
-                BinaryOperator::Eq => {
-                    if let Identifier(i) = left.borrow_mut() {
-                        if let Expr::Value(v) = right.borrow_mut() {
-                            if let Some((_, new_v)) = map.get_key_value(&i.to_string()) {
-                                *v = if use_bind {
-                                    CassandraCodec::value_to_bind(new_v)
-                                } else {
-                                    new_v.into()
-                                };
-                            }
-                        }
-                    }
-                }
-                _ => {}
-            }
-        }
-    }
-
-    fn binary_ops_to_hashmap(node: &Expr, map: &mut HashMap<String, MessageValue>) {
-        if let BinaryOp { left, op, right } = node {
-            match op {
-                BinaryOperator::And => {
-                    CassandraCodec::binary_ops_to_hashmap(left, map);
-                    CassandraCodec::binary_ops_to_hashmap(right, map);
-                }
-                BinaryOperator::Eq => {
-                    if let Identifier(i) = left.borrow() {
-                        if let Expr::Value(v) = right.borrow() {
-                            map.insert(i.to_string(), v.into());
-                        }
-                    }
-                }
-                _ => {}
-            }
-        }
-    }
-
-    fn get_column_values(expr: &SetExpr) -> Vec<String> {
-        let mut cumulator: Vec<String> = Vec::new();
-        if let SetExpr::Values(v) = expr {
-            for value in &v.0 {
-                for ex in value {
-                    if let Expr::Value(v) = ex {
-                        cumulator.push(CassandraCodec::expr_to_string(v));
-                    }
-                }
-            }
-        }
-        cumulator
-    }
-
-    pub fn rebuild_query_string_from_ast(message: &mut QueryMessage) {
-        if let QueryMessage {
-            query_string,
-            ast: Some(ASTHolder::SQL(ast)),
-            ..
-        } = message
-        {
-            *query_string = format!("{ast}");
-        }
-    }
-
-    pub fn rebuild_ast_in_message(message: &mut QueryMessage) {
-        if let QueryMessage {
-            namespace,
-            query_values: Some(query_values),
-            projection: Some(qm_projection),
-            ast: Some(ASTHolder::SQL(ast)),
-            ..
-        } = message
-        {
-            match &mut **ast {
-                Statement::Query(query) => {
-                    if let SetExpr::Select(select) = &mut query.body {
-                        let Select {
-                            projection,
-                            from,
-                            selection,
-                            ..
-                        } = select.deref_mut();
-
-                        // Rebuild projection
-                        *projection = qm_projection
-                            .iter()
-                            .map(|x| {
-                                SelectItem::UnnamedExpr(Expr::Value(SQLValue::SingleQuotedString(
-                                    x.clone(),
-                                )))
-                            })
-                            .collect();
-
-                        // Rebuild namespace
-                        if let Some(table_ref) = from.get_mut(0) {
-                            if let TableFactor::Table { name, .. } = &mut table_ref.relation {
-                                *name = ObjectName(
-                                    namespace
-                                        .iter()
-                                        .cloned()
-                                        .map(sqlparser::ast::Ident::new)
-                                        .collect(),
-                                );
-                            }
-                        }
-
-                        //Rebuild selection
-                        // TODO allow user control of bind
-                        if let Some(selection) = selection {
-                            CassandraCodec::rebuild_binops_tree(selection, query_values, true);
-                        }
-                    }
-                }
-                Statement::Insert { .. } => {}
-                Statement::Update { .. } => {}
-                Statement::Delete { .. } => {}
-                _ => {}
-            }
-        }
-    }
-
-    pub(crate) fn parse_query_string(
-        query_string: &str,
-        pk_col_map: &HashMap<String, Vec<String>>,
-    ) -> ParsedCassandraQueryString {
-        let dialect = GenericDialect {}; //TODO write CQL dialect
-        let mut namespace: Vec<String> = Vec::new();
-        let mut colmap: HashMap<String, MessageValue> = HashMap::new();
-        let mut projection: Vec<String> = Vec::new();
-        let mut primary_key: HashMap<String, MessageValue> = HashMap::new();
-        let mut ast: Option<Statement> = None;
-        let parsed_sql = Parser::parse_sql(&dialect, query_string);
-
-        //TODO handle pks
-        match parsed_sql {
-            Ok(ast_list) => {
-                //TODO: We absolutely don't handle multiple statements despite this loop indicating otherwise
-                // for statement in ast_list.iter() {
-                if let Some(statement) = ast_list.get(0) {
-                    ast = Some(statement.clone());
-                    match statement {
-                        Statement::Query(q) => {
-                            if let SetExpr::Select(s) = &q.body {
-                                projection = s.projection.iter().map(|s| s.to_string()).collect();
-                                if let TableFactor::Table { name, .. } =
-                                    &s.from.get(0).unwrap().relation
-                                {
-                                    namespace = name.0.iter().map(|a| a.value.clone()).collect();
-                                }
-                                if let Some(sel) = &s.selection {
-                                    CassandraCodec::binary_ops_to_hashmap(sel, &mut colmap);
-                                }
-                                if let Some(pk_col_names) = pk_col_map.get(&namespace.join(".")) {
-                                    for pk_component in pk_col_names {
-                                        if let Some(value) = colmap.get(pk_component) {
-                                            primary_key.insert(pk_component.clone(), value.clone());
-                                        } else {
-                                            primary_key
-                                                .insert(pk_component.clone(), MessageValue::NULL);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        Insert {
-                            table_name,
-                            columns,
-                            source,
-                            ..
-                        } => {
-                            namespace = table_name.0.iter().map(|a| a.value.clone()).collect();
-                            let values = CassandraCodec::get_column_values(&source.body);
-                            for (i, c) in columns.iter().enumerate() {
-                                projection.push(c.value.clone());
-                                if let Some(v) = values.get(i) {
-                                    colmap.insert(c.to_string(), MessageValue::Strings(v.clone()));
-                                }
-                            }
-
-                            if let Some(pk_col_names) = pk_col_map.get(&namespace.join(".")) {
-                                for pk_component in pk_col_names {
-                                    if let Some(value) = colmap.get(pk_component) {
-                                        primary_key.insert(pk_component.clone(), value.clone());
-                                    } else {
-                                        primary_key
-                                            .insert(pk_component.clone(), MessageValue::NULL);
-                                    }
-                                }
-                            }
-                        }
-                        Update {
-                            table,
-                            assignments,
-                            selection,
-                        } => {
-                            match &table.relation {
-                            TableFactor::Table { name, .. } => {
-                                namespace = name.0.iter().map(|a| a.value.clone()).collect();
-                            }
-                            _ => error!(
-                                "The cassandra query language does not support `update`s with table of {:?}",
-                                table
-                            ),
-                        };
-                            for assignment in assignments {
-                                if let Expr::Value(v) = assignment.clone().value {
-                                    let converted_value = (&v).into();
-                                    colmap.insert(
-                                        assignment.id.iter().map(|x| &x.value).join("."),
-                                        converted_value,
-                                    );
-                                }
-                            }
-                            if let Some(s) = selection {
-                                CassandraCodec::binary_ops_to_hashmap(s, &mut primary_key);
-                            }
-                        }
-                        Delete {
-                            table_name,
-                            selection,
-                        } => {
-                            namespace = table_name.0.iter().map(|a| a.value.clone()).collect();
-                            if let Some(s) = selection {
-                                CassandraCodec::binary_ops_to_hashmap(s, &mut primary_key);
-                            }
-                        }
-                        _ => {}
-                    }
-                }
-            }
-            Err(err) => {
-                // TODO: We should handle this error better but for now we can at least log it
-                error!(
-                    "Failed to parse cql for message details: {:?}\nError: {:?}",
-                    query_string, err
-                )
-            }
-        }
-
-        ParsedCassandraQueryString {
-            namespace: Some(namespace),
-            colmap: Some(colmap),
-            projection: Some(projection),
-            primary_key,
-            ast,
-        }
-    }
-
-    fn build_response_message(message: &mut Message, matching_query: Option<QueryMessage>) {
-        let mut result: Option<MessageValue> = None;
-        let mut error: Option<MessageValue> = None;
-        if let Frame::Cassandra(cassandra) = &message.original {
-            match &cassandra.operation {
-                CassandraOperation::Error(e) => {
-                    error = Some(MessageValue::Strings(e.message.clone()))
-                }
-                CassandraOperation::Result(CassandraResult::Rows { value, metadata: _ }) => {
-                    result = Some(value.clone())
-                }
-                _ => {}
-            }
-        }
-
-        message.details = MessageDetails::Response(QueryResponse {
-            matching_query,
-            result,
-            error,
-            response_meta: None,
-        })
-    }
-
-    pub fn process_cassandra_frame(&self, message: &mut Message) {
-        if self.bypass {
-            return;
-        }
-
-        if let Frame::Cassandra(cassandra) = &mut message.original {
-            match &mut cassandra.operation {
-                CassandraOperation::Query { query, .. } => {
-                    let query_string = query.to_query_string();
-                    let parsed_query =
-                        CassandraCodec::parse_query_string(&query_string, &self.pk_col_map);
-                    if parsed_query.ast.is_none() {
-                        // TODO: Currently this will probably catch schema changes that don't match
-                        // what the SQL parser expects
-                        return;
-                    }
-                    message.details = MessageDetails::Query(QueryMessage {
-                        query_string,
-                        namespace: parsed_query.namespace.unwrap(),
-                        primary_key: parsed_query.primary_key,
-                        query_values: parsed_query.colmap,
-                        projection: parsed_query.projection,
-                        query_type: match &parsed_query.ast.as_ref() {
-                            Some(Statement::Query(_x)) => QueryType::Read,
-                            Some(Statement::Insert { .. }) => QueryType::Write,
-                            Some(Statement::Update { .. }) => QueryType::Write,
-                            Some(Statement::Delete { .. }) => QueryType::Write,
-                            _ => QueryType::Read,
-                        },
-                        ast: parsed_query.ast.map(|x| ASTHolder::SQL(Box::new(x))),
-                    });
-                }
-                CassandraOperation::Result(_) => {
-                    CassandraCodec::build_response_message(message, None)
-                }
-                CassandraOperation::Error(body) => {
-                    message.details = MessageDetails::Response(QueryResponse {
-                        result: None,
-                        matching_query: None,
-                        response_meta: None,
-                        error: Some(MessageValue::Strings(body.message.clone())),
-                    });
-                }
-                _ => {}
-            }
-        }
-    }
-
     fn encode_raw(&mut self, item: CassandraFrame, dst: &mut BytesMut) {
         let buffer = item.encode().encode_with(self.compressor).unwrap();
         tracing::debug!(
@@ -534,6 +64,7 @@ impl Decoder for CassandraCodec {
             return Err(anyhow!(result));
         }
 
+        // TODO: We could implement our own version and length check here directly on the bytes to avoid the duplicate frame parse
         match RawCassandraFrame::from_buffer(src, self.compressor) {
             Ok(parsed_frame) => {
                 // Clear the read bytes from the FramedReader
@@ -543,11 +74,10 @@ impl Decoder for CassandraCodec {
                     pretty_hex::pretty_hex(&bytes)
                 );
 
-                let mut message = Message::from_frame(Frame::Cassandra(
-                    CassandraFrame::from_bytes(bytes.freeze()).unwrap(),
-                ));
-                self.process_cassandra_frame(&mut message);
-                Ok(Some(vec![message]))
+                Ok(Some(vec![Message::from_bytes(
+                    bytes.freeze(),
+                    MessageType::Cassandra,
+                )]))
             }
             Err(ParseFrameError::NotEnoughBytes) => Ok(None),
             Err(ParseFrameError::UnsupportedVersion(version)) => {
@@ -561,57 +91,22 @@ impl Decoder for CassandraCodec {
                     version
                 ));
 
-                let message = Message {
-                    details: MessageDetails::Unknown,
-                    modified: false,
-                    original: Frame::Cassandra(CassandraFrame {
-                        version: Version::V4,
-                        stream_id: 0,
-                        operation: CassandraOperation::Error(ErrorBody {
-                            error_code: 0xA,
-                            message: "Invalid or unsupported protocol version".into(),
-                            additional_info: AdditionalErrorInfo::Server,
-                        }),
-                        tracing_id: None,
-                        warnings: vec![],
+                let mut message = Message::from_frame(Frame::Cassandra(CassandraFrame {
+                    version: Version::V4,
+                    stream_id: 0,
+                    operation: CassandraOperation::Error(ErrorBody {
+                        error_code: 0xA,
+                        message: "Invalid or unsupported protocol version".into(),
+                        additional_info: AdditionalErrorInfo::Server,
                     }),
-                    return_to_sender: true,
-                    meta_timestamp: None,
-                };
+                    tracing_id: None,
+                    warnings: vec![],
+                }));
+                message.return_to_sender = true;
                 Ok(Some(vec![message]))
             }
             err => Err(anyhow!("Failed to parse frame {:?}", err)),
         }
-    }
-}
-
-fn get_cassandra_frame(rf: Frame) -> Result<CassandraFrame> {
-    if let Frame::Cassandra(frame) = rf {
-        Ok(frame)
-    } else {
-        warn!("Unsupported Frame detected - Dropping Frame {:?}", rf);
-        Err(anyhow!("Unsupported frame found, not sending"))
-    }
-}
-
-impl CassandraCodec {
-    fn encode_message(&mut self, item: Message) -> Result<CassandraFrame> {
-        let frame = if !item.modified {
-            get_cassandra_frame(item.original)?
-        } else {
-            match item.details {
-                MessageDetails::Query(qm) => {
-                    CassandraCodec::build_cassandra_query_frame(qm, Consistency::LocalQuorum)
-                }
-                MessageDetails::Response(qr) => CassandraCodec::build_cassandra_response_frame(
-                    qr,
-                    get_cassandra_frame(item.original)?,
-                ),
-                MessageDetails::Unknown => get_cassandra_frame(item.original)?,
-            }
-        };
-        debug!("Encoded message as {:?}", &frame);
-        Ok(frame)
     }
 }
 
@@ -624,16 +119,11 @@ impl Encoder<Messages> for CassandraCodec {
         dst: &mut BytesMut,
     ) -> std::result::Result<(), Self::Error> {
         for m in item {
-            debug!("Encoding {:?}", &m);
-            match self.encode_message(m) {
-                Ok(frame) => {
-                    self.encode_raw(frame, dst);
-                    debug!("Encoded frame as {:?}", dst);
-                }
-                Err(e) => {
-                    warn!("Couldn't encode frame {:?}", e);
-                }
-            };
+            // TODO: always check if cassandra message
+            match m.into_encodable() {
+                Encodable::Bytes(bytes) => dst.extend_from_slice(&bytes),
+                Encodable::Frame(frame) => self.encode_raw(frame.into_cassandra().unwrap(), dst),
+            }
         }
         Ok(())
     }
@@ -642,12 +132,9 @@ impl Encoder<Messages> for CassandraCodec {
 #[cfg(test)]
 mod cassandra_protocol_tests {
     use crate::codec::cassandra::CassandraCodec;
-    use crate::frame::cassandra::{CassandraOperation, CassandraResult, CQL};
-    use crate::frame::CassandraFrame;
+    use crate::frame::cassandra::{CassandraFrame, CassandraOperation, CassandraResult, CQL};
     use crate::frame::Frame;
-    use crate::message::{
-        ASTHolder, Message, MessageDetails, MessageValue, QueryMessage, QueryResponse, QueryType,
-    };
+    use crate::message::{Message, MessageValue};
     use bytes::BytesMut;
     use cassandra_protocol::frame::frame_result::{
         ColSpec, ColType, ColTypeOption, ColTypeOptionValue, RowsMetadata, RowsMetadataFlags,
@@ -662,7 +149,6 @@ mod cassandra_protocol_tests {
         BinaryOperator, Expr, Ident, ObjectName, Query, Select, SelectItem, SetExpr, Statement,
         TableFactor, TableWithJoins, Value as SQLValue, Values,
     };
-    use std::collections::HashMap;
     use tokio_util::codec::{Decoder, Encoder};
 
     fn test_frame_codec_roundtrip(
@@ -675,17 +161,34 @@ mod cassandra_protocol_tests {
             .decode(&mut BytesMut::from(raw_frame))
             .unwrap()
             .unwrap();
-        assert_eq!(decoded_messages, expected_messages);
 
-        // test encode round trip
-        let mut dest = BytesMut::new();
-        codec.encode(decoded_messages, &mut dest).unwrap();
-        assert_eq!(raw_frame, &dest);
+        // test messages parse correctly
+        let mut parsed_messages = decoded_messages.clone();
+        for message in &mut parsed_messages {
+            // This has the side effect of modifying the inner message to be parsed
+            message.frame().unwrap();
+            message.invalidate_cache();
+        }
+        assert_eq!(parsed_messages, expected_messages);
+
+        // test encode round trip - parsed messages
+        {
+            let mut dest = BytesMut::new();
+            codec.encode(parsed_messages, &mut dest).unwrap();
+            assert_eq!(raw_frame, &dest.to_vec());
+        }
+
+        // test encode round trip - raw messages
+        {
+            let mut dest = BytesMut::new();
+            codec.encode(decoded_messages, &mut dest).unwrap();
+            assert_eq!(raw_frame, &dest.to_vec());
+        }
     }
 
     #[test]
     fn test_codec_startup() {
-        let mut codec = CassandraCodec::new(HashMap::new(), false);
+        let mut codec = CassandraCodec::new();
         let bytes = hex!("0400000001000000160001000b43514c5f56455253494f4e0005332e302e30");
         let messages = vec![Message::from_frame(Frame::Cassandra(CassandraFrame {
             version: Version::V4,
@@ -701,7 +204,7 @@ mod cassandra_protocol_tests {
 
     #[test]
     fn test_codec_options() {
-        let mut codec = CassandraCodec::new(HashMap::new(), false);
+        let mut codec = CassandraCodec::new();
         let bytes = hex!("040000000500000000");
         let messages = vec![Message::from_frame(Frame::Cassandra(CassandraFrame {
             version: Version::V4,
@@ -715,7 +218,7 @@ mod cassandra_protocol_tests {
 
     #[test]
     fn test_codec_ready() {
-        let mut codec = CassandraCodec::new(HashMap::new(), false);
+        let mut codec = CassandraCodec::new();
         let bytes = hex!("840000000200000000");
         let messages = vec![Message::from_frame(Frame::Cassandra(CassandraFrame {
             version: Version::V4,
@@ -729,7 +232,7 @@ mod cassandra_protocol_tests {
 
     #[test]
     fn test_codec_register() {
-        let mut codec = CassandraCodec::new(HashMap::new(), false);
+        let mut codec = CassandraCodec::new();
         let bytes = hex!(
             "040000010b000000310003000f544f504f4c4f47595f4348414e4745
             000d5354415455535f4348414e4745000d534348454d415f4348414e4745"
@@ -750,268 +253,191 @@ mod cassandra_protocol_tests {
 
     #[test]
     fn test_codec_result() {
-        let mut codec = CassandraCodec::new(HashMap::new(), false);
+        let mut codec = CassandraCodec::new();
         let bytes = hex!(
             "040000020800000099000000020000000100000009000673797374656
             d000570656572730004706565720010000b646174615f63656e746572000d0007686f73745f6964000c000c70726566
             65727265645f6970001000047261636b000d000f72656c656173655f76657273696f6e000d000b7270635f616464726
             573730010000e736368656d615f76657273696f6e000c0006746f6b656e730022000d00000000"
         );
-        let messages = vec![Message::new(
-            MessageDetails::Response(QueryResponse {
-                matching_query: None,
-                result: Some(MessageValue::Rows(vec![])),
-                error: None,
-                response_meta: None,
+        let messages = vec![Message::from_frame(Frame::Cassandra(CassandraFrame {
+            version: Version::V4,
+            operation: CassandraOperation::Result(CassandraResult::Rows {
+                value: MessageValue::Rows(vec![]),
+                metadata: RowsMetadata {
+                    flags: RowsMetadataFlags::GLOBAL_TABLE_SPACE,
+                    columns_count: 9,
+                    paging_state: None,
+                    global_table_spec: Some(TableSpec {
+                        ks_name: "system".into(),
+                        table_name: "peers".into(),
+                    }),
+                    col_specs: vec![
+                        ColSpec {
+                            table_spec: None,
+                            name: "peer".into(),
+                            col_type: ColTypeOption {
+                                id: ColType::Inet,
+                                value: None,
+                            },
+                        },
+                        ColSpec {
+                            table_spec: None,
+                            name: "data_center".into(),
+                            col_type: ColTypeOption {
+                                id: ColType::Varchar,
+                                value: None,
+                            },
+                        },
+                        ColSpec {
+                            table_spec: None,
+                            name: "host_id".into(),
+                            col_type: ColTypeOption {
+                                id: ColType::Uuid,
+                                value: None,
+                            },
+                        },
+                        ColSpec {
+                            table_spec: None,
+                            name: "preferred_ip".into(),
+                            col_type: ColTypeOption {
+                                id: ColType::Inet,
+                                value: None,
+                            },
+                        },
+                        ColSpec {
+                            table_spec: None,
+                            name: "rack".into(),
+                            col_type: ColTypeOption {
+                                id: ColType::Varchar,
+                                value: None,
+                            },
+                        },
+                        ColSpec {
+                            table_spec: None,
+                            name: "release_version".into(),
+                            col_type: ColTypeOption {
+                                id: ColType::Varchar,
+                                value: None,
+                            },
+                        },
+                        ColSpec {
+                            table_spec: None,
+                            name: "rpc_address".into(),
+                            col_type: ColTypeOption {
+                                id: ColType::Inet,
+                                value: None,
+                            },
+                        },
+                        ColSpec {
+                            table_spec: None,
+                            name: "schema_version".into(),
+                            col_type: ColTypeOption {
+                                id: ColType::Uuid,
+                                value: None,
+                            },
+                        },
+                        ColSpec {
+                            table_spec: None,
+                            name: "tokens".into(),
+                            col_type: ColTypeOption {
+                                id: ColType::Set,
+                                value: Some(ColTypeOptionValue::CSet(Box::new(ColTypeOption {
+                                    id: ColType::Varchar,
+                                    value: None,
+                                }))),
+                            },
+                        },
+                    ],
+                },
             }),
-            false,
-            Frame::Cassandra(CassandraFrame {
-                version: Version::V4,
-                operation: CassandraOperation::Result(CassandraResult::Rows {
-                    value: MessageValue::Rows(vec![]),
-                    metadata: RowsMetadata {
-                        flags: RowsMetadataFlags::GLOBAL_TABLE_SPACE,
-                        columns_count: 9,
-                        paging_state: None,
-                        global_table_spec: Some(TableSpec {
-                            ks_name: "system".into(),
-                            table_name: "peers".into(),
-                        }),
-                        col_specs: vec![
-                            ColSpec {
-                                table_spec: None,
-                                name: "peer".into(),
-                                col_type: ColTypeOption {
-                                    id: ColType::Inet,
-                                    value: None,
-                                },
-                            },
-                            ColSpec {
-                                table_spec: None,
-                                name: "data_center".into(),
-                                col_type: ColTypeOption {
-                                    id: ColType::Varchar,
-                                    value: None,
-                                },
-                            },
-                            ColSpec {
-                                table_spec: None,
-                                name: "host_id".into(),
-                                col_type: ColTypeOption {
-                                    id: ColType::Uuid,
-                                    value: None,
-                                },
-                            },
-                            ColSpec {
-                                table_spec: None,
-                                name: "preferred_ip".into(),
-                                col_type: ColTypeOption {
-                                    id: ColType::Inet,
-                                    value: None,
-                                },
-                            },
-                            ColSpec {
-                                table_spec: None,
-                                name: "rack".into(),
-                                col_type: ColTypeOption {
-                                    id: ColType::Varchar,
-                                    value: None,
-                                },
-                            },
-                            ColSpec {
-                                table_spec: None,
-                                name: "release_version".into(),
-                                col_type: ColTypeOption {
-                                    id: ColType::Varchar,
-                                    value: None,
-                                },
-                            },
-                            ColSpec {
-                                table_spec: None,
-                                name: "rpc_address".into(),
-                                col_type: ColTypeOption {
-                                    id: ColType::Inet,
-                                    value: None,
-                                },
-                            },
-                            ColSpec {
-                                table_spec: None,
-                                name: "schema_version".into(),
-                                col_type: ColTypeOption {
-                                    id: ColType::Uuid,
-                                    value: None,
-                                },
-                            },
-                            ColSpec {
-                                table_spec: None,
-                                name: "tokens".into(),
-                                col_type: ColTypeOption {
-                                    id: ColType::Set,
-                                    value: Some(ColTypeOptionValue::CSet(Box::new(
-                                        ColTypeOption {
-                                            id: ColType::Varchar,
-                                            value: None,
-                                        },
-                                    ))),
-                                },
-                            },
-                        ],
-                    },
-                }),
-                stream_id: 2,
-                tracing_id: None,
-                warnings: vec![],
-            }),
-        )];
+            stream_id: 2,
+            tracing_id: None,
+            warnings: vec![],
+        }))];
         test_frame_codec_roundtrip(&mut codec, &bytes, messages);
     }
 
     #[test]
     fn test_codec_query_select() {
-        let mut codec = CassandraCodec::new(HashMap::new(), false);
+        let mut codec = CassandraCodec::new();
         let bytes = hex!(
             "0400000307000000350000002e53454c454354202a2046524f4d20737973
             74656d2e6c6f63616c205748455245206b6579203d20276c6f63616c27000100"
         );
-        let messages = vec![Message::new(
-            MessageDetails::Query(QueryMessage {
-                query_string: "SELECT * FROM system.local WHERE key = 'local'".into(),
-                namespace: vec!["system".into(), "local".into()],
-                primary_key: HashMap::new(),
-                query_values: Some(HashMap::from([(
-                    "key".into(),
-                    MessageValue::Strings("local".into()),
-                )])),
-                projection: Some(vec!["*".into()]),
-                query_type: QueryType::Read,
-                ast: Some(ASTHolder::SQL(Box::new(Statement::Query(Box::new(
-                    Query {
-                        with: None,
-                        body: SetExpr::Select(Box::new(Select {
-                            distinct: false,
-                            top: None,
-                            projection: vec![SelectItem::Wildcard],
-                            from: vec![TableWithJoins {
-                                relation: TableFactor::Table {
-                                    name: ObjectName(vec![
-                                        Ident {
-                                            value: "system".into(),
-                                            quote_style: None,
-                                        },
-                                        Ident {
-                                            value: "local".into(),
-                                            quote_style: None,
-                                        },
-                                    ]),
-                                    alias: None,
-                                    args: vec![],
-                                    with_hints: vec![],
-                                },
-                                joins: vec![],
-                            }],
-                            lateral_views: vec![],
-                            selection: Some(BinaryOp {
-                                left: Box::new(Expr::Identifier(Ident {
-                                    value: "key".into(),
-                                    quote_style: None,
-                                })),
-                                op: BinaryOperator::Eq,
-                                right: Box::new(Expr::Value(SQLValue::SingleQuotedString(
-                                    "local".into(),
-                                ))),
-                            }),
-                            group_by: vec![],
-                            cluster_by: vec![],
-                            distribute_by: vec![],
-                            sort_by: vec![],
-                            having: None,
-                        })),
-                        order_by: vec![],
-                        limit: None,
-                        offset: None,
-                        fetch: None,
-                    },
-                ))))),
-            }),
-            false,
-            Frame::Cassandra(CassandraFrame {
-                version: Version::V4,
-                stream_id: 3,
-                tracing_id: None,
-                warnings: vec![],
-                operation: CassandraOperation::Query {
-                    query: CQL::Parsed(vec![Statement::Query(Box::new(Query {
-                        with: None,
-                        body: SetExpr::Select(Box::new(Select {
-                            distinct: false,
-                            top: None,
-                            projection: vec![SelectItem::Wildcard],
-                            from: vec![TableWithJoins {
-                                relation: TableFactor::Table {
-                                    name: ObjectName(vec![
-                                        Ident {
-                                            value: "system".into(),
-                                            quote_style: None,
-                                        },
-                                        Ident {
-                                            value: "local".into(),
-                                            quote_style: None,
-                                        },
-                                    ]),
-                                    alias: None,
-                                    args: vec![],
-                                    with_hints: vec![],
-                                },
-                                joins: vec![],
-                            }],
-                            lateral_views: vec![],
-                            selection: Some(BinaryOp {
-                                left: Box::new(Expr::Identifier(Ident {
-                                    value: "key".into(),
-                                    quote_style: None,
-                                })),
-                                op: BinaryOperator::Eq,
-                                right: Box::new(Expr::Value(SQLValue::SingleQuotedString(
-                                    "local".into(),
-                                ))),
-                            }),
-                            group_by: vec![],
-                            cluster_by: vec![],
-                            distribute_by: vec![],
-                            sort_by: vec![],
-                            having: None,
-                        })),
-                        order_by: vec![],
-                        limit: None,
-                        offset: None,
-                        fetch: None,
-                    }))]),
-                    params: QueryParams::default(),
-                },
-            }),
-        )];
+        let messages = vec![Message::from_frame(Frame::Cassandra(CassandraFrame {
+            version: Version::V4,
+            stream_id: 3,
+            tracing_id: None,
+            warnings: vec![],
+            operation: CassandraOperation::Query {
+                query: CQL::Parsed(vec![Statement::Query(Box::new(Query {
+                    with: None,
+                    body: SetExpr::Select(Box::new(Select {
+                        distinct: false,
+                        top: None,
+                        projection: vec![SelectItem::Wildcard],
+                        from: vec![TableWithJoins {
+                            relation: TableFactor::Table {
+                                name: ObjectName(vec![
+                                    Ident {
+                                        value: "system".into(),
+                                        quote_style: None,
+                                    },
+                                    Ident {
+                                        value: "local".into(),
+                                        quote_style: None,
+                                    },
+                                ]),
+                                alias: None,
+                                args: vec![],
+                                with_hints: vec![],
+                            },
+                            joins: vec![],
+                        }],
+                        lateral_views: vec![],
+                        selection: Some(BinaryOp {
+                            left: Box::new(Expr::Identifier(Ident {
+                                value: "key".into(),
+                                quote_style: None,
+                            })),
+                            op: BinaryOperator::Eq,
+                            right: Box::new(Expr::Value(SQLValue::SingleQuotedString(
+                                "local".into(),
+                            ))),
+                        }),
+                        group_by: vec![],
+                        cluster_by: vec![],
+                        distribute_by: vec![],
+                        sort_by: vec![],
+                        having: None,
+                    })),
+                    order_by: vec![],
+                    limit: None,
+                    offset: None,
+                    fetch: None,
+                }))]),
+                params: QueryParams::default(),
+            },
+        }))];
         test_frame_codec_roundtrip(&mut codec, &bytes, messages);
     }
 
     #[test]
     fn test_codec_query_insert() {
-        let mut codec = CassandraCodec::new(HashMap::new(), false);
+        let mut codec = CassandraCodec::new();
         let bytes = hex!(
             "0400000307000000330000002c494e5345525420494e544f207379737465
             6d2e666f6f2028626172292056414c554553202827626172322729000100"
         );
-        let messages = vec![Message::new(
-            MessageDetails::Query(QueryMessage {
-                query_string: "INSERT INTO system.foo (bar) VALUES ('bar2')".into(),
-                namespace: vec!["system".into(), "foo".into()],
-                primary_key: HashMap::new(),
-                query_values: Some(HashMap::from([(
-                    "bar".into(),
-                    MessageValue::Strings("bar2".into()),
-                )])),
-                projection: Some(vec!["bar".into()]),
-                query_type: QueryType::Write,
-                ast: Some(ASTHolder::SQL(Box::new(Statement::Insert {
+
+        let messages = vec![Message::from_frame(Frame::Cassandra(CassandraFrame {
+            version: Version::V4,
+            stream_id: 3,
+            tracing_id: None,
+            warnings: vec![],
+            operation: CassandraOperation::Query {
+                query: CQL::Parsed(vec![Statement::Insert {
                     or: None,
                     table_name: ObjectName(vec![
                         Ident {
@@ -1042,132 +468,10 @@ mod cassandra_protocol_tests {
                     after_columns: (vec![]),
                     table: false,
                     on: None,
-                }))),
-            }),
-            false,
-            Frame::Cassandra(CassandraFrame {
-                version: Version::V4,
-                stream_id: 3,
-                tracing_id: None,
-                warnings: vec![],
-                operation: CassandraOperation::Query {
-                    query: CQL::Parsed(vec![Statement::Insert {
-                        or: None,
-                        table_name: ObjectName(vec![
-                            Ident {
-                                value: "system".into(),
-                                quote_style: None,
-                            },
-                            Ident {
-                                value: "foo".into(),
-                                quote_style: None,
-                            },
-                        ]),
-                        columns: (vec![Ident {
-                            value: "bar".into(),
-                            quote_style: None,
-                        }]),
-                        overwrite: false,
-                        source: Box::new(Query {
-                            with: None,
-                            body: (SetExpr::Values(Values(vec![vec![
-                                sqlparser::ast::Expr::Value(SingleQuotedString("bar2".to_string())),
-                            ]]))),
-                            order_by: vec![],
-                            limit: None,
-                            offset: None,
-                            fetch: None,
-                        }),
-                        partitioned: None,
-                        after_columns: (vec![]),
-                        table: false,
-                        on: None,
-                    }]),
-                    params: QueryParams::default(),
-                },
-            }),
-        )];
+                }]),
+                params: QueryParams::default(),
+            },
+        }))];
         test_frame_codec_roundtrip(&mut codec, &bytes, messages);
-    }
-
-    #[test]
-    fn test_parse_insert_string() {
-        let query_str = "INSERT into tbl(col1,col2,col3) values('one', 2, 3);";
-        let hash_map: HashMap<String, Vec<String>> = HashMap::new();
-        let query = CassandraCodec::parse_query_string(query_str, &hash_map);
-        let colmap = query.colmap.unwrap();
-        let namespace = query.namespace.unwrap();
-        let projection = query.projection.unwrap();
-        assert_eq!(colmap.len(), 3);
-        assert_eq!(
-            colmap.get("col1").unwrap(),
-            &MessageValue::Strings("one".to_string())
-        );
-        assert_eq!(
-            colmap.get("col2").unwrap(),
-            &MessageValue::Strings("2".to_string())
-        );
-        assert_eq!(
-            colmap.get("col3").unwrap(),
-            &MessageValue::Strings("3".to_string())
-        );
-        assert_eq!(namespace.len(), 1);
-        assert_eq!(namespace[0], "tbl");
-        assert_eq!(projection.len(), 3);
-        assert_eq!(projection[0], "col1");
-        assert_eq!(projection[1], "col2");
-        assert_eq!(projection[2], "col3");
-    }
-
-    #[test]
-    fn test_parse_update_string() {
-        let query_str = "UPDATE keyspace.tbl Set col1='one', col2='2'  Where col3=3";
-        let hash_map: HashMap<String, Vec<String>> = HashMap::new();
-        let query = CassandraCodec::parse_query_string(query_str, &hash_map);
-        let colmap = query.colmap.unwrap();
-        let namespace = query.namespace.unwrap();
-        let projection = query.projection.unwrap();
-        assert_eq!(colmap.len(), 2);
-        assert_eq!(
-            colmap.get("col1").unwrap(),
-            &MessageValue::Strings("one".to_string())
-        );
-        assert_eq!(
-            colmap.get("col2").unwrap(),
-            &MessageValue::Strings("2".to_string())
-        );
-        assert_eq!(namespace.len(), 2);
-        assert_eq!(namespace[0], "keyspace");
-        assert_eq!(namespace[1], "tbl");
-        assert_eq!(projection.len(), 0);
-    }
-
-    #[test]
-    fn test_parse_delete_column_string() {
-        let query_str = "DELETE col1 from keyspace.tbl WHERE col3=3";
-        let hash_map: HashMap<String, Vec<String>> = HashMap::new();
-        let query = CassandraCodec::parse_query_string(query_str, &hash_map);
-        assert_eq!(query.ast, None);
-    }
-
-    #[test]
-    fn test_parse_delete_string() {
-        let query_str = "DELETE from keyspace.tbl Where col3=3";
-        let hash_map: HashMap<String, Vec<String>> = HashMap::new();
-        let query = CassandraCodec::parse_query_string(query_str, &hash_map);
-        let colmap = query.colmap.unwrap();
-        let namespace = query.namespace.unwrap();
-        let projection = query.projection.unwrap();
-        let primary_key = query.primary_key;
-        assert_eq!(primary_key.len(), 1);
-        assert_eq!(
-            primary_key.get("col3").unwrap(),
-            &MessageValue::Strings("3".to_string())
-        );
-        assert_eq!(colmap.len(), 0);
-        assert_eq!(namespace.len(), 2);
-        assert_eq!(namespace[0], "keyspace");
-        assert_eq!(namespace[1], "tbl");
-        assert_eq!(projection.len(), 0);
     }
 }

--- a/shotover-proxy/src/codec/redis.rs
+++ b/shotover-proxy/src/codec/redis.rs
@@ -1,30 +1,14 @@
 use crate::frame::Frame;
 use crate::frame::RedisFrame;
-use crate::message::{
-    ASTHolder, IntSize, Message, MessageDetails, MessageValue, Messages, QueryMessage,
-    QueryResponse, QueryType,
-};
+use crate::message::{Encodable, Message, Messages, QueryType};
 use anyhow::{anyhow, Result};
-use bytes::{Buf, Bytes, BytesMut};
-use itertools::Itertools;
+use bytes::{Buf, BytesMut};
 use redis_protocol::resp2::prelude::decode_mut;
 use redis_protocol::resp2::prelude::encode_bytes;
-use std::collections::{BTreeMap, HashMap};
 use tokio_util::codec::{Decoder, Encoder};
-use tracing::{debug, trace, warn};
-
-/// Redis doesn't have an explicit "Response" type as part of the protocol.
-/// So it is up to the code to know whether it is processing queries or responses.
-#[derive(Debug, Clone)]
-pub enum DecodeType {
-    Query,
-    Response,
-}
 
 #[derive(Debug, Clone)]
 pub struct RedisCodec {
-    decode_type: DecodeType,
-    enable_metadata: bool,
     messages: Messages,
 }
 
@@ -45,506 +29,15 @@ pub fn redis_query_type(frame: &RedisFrame) -> QueryType {
     QueryType::Write
 }
 
-fn get_keys(
-    fields: &mut HashMap<String, MessageValue>,
-    keys: &mut HashMap<String, MessageValue>,
-    frames: Vec<RedisFrame>,
-) -> Result<()> {
-    let mut keys_storage = vec![];
-    for frame in frames {
-        if let RedisFrame::BulkString(v) = frame {
-            fields.insert(String::from_utf8(v.to_vec())?, MessageValue::None);
-            keys_storage.push(RedisFrame::BulkString(v).into());
-        }
-    }
-    keys.insert("key".to_string(), MessageValue::List(keys_storage));
-    Ok(())
-}
-
-fn get_key_multi_values(
-    fields: &mut HashMap<String, MessageValue>,
-    keys: &mut HashMap<String, MessageValue>,
-    mut frames: Vec<RedisFrame>,
-) -> Result<()> {
-    if let Some(RedisFrame::BulkString(v)) = frames.pop() {
-        fields.insert(
-            String::from_utf8(v.to_vec())?,
-            MessageValue::List(frames.into_iter().map(|x| x.into()).collect()),
-        );
-        keys.insert(
-            "key".to_string(),
-            MessageValue::List(vec![RedisFrame::BulkString(v).into()]),
-        );
-    }
-    Ok(())
-}
-
-fn get_key_map(
-    fields: &mut HashMap<String, MessageValue>,
-    keys: &mut HashMap<String, MessageValue>,
-    mut frames: Vec<RedisFrame>,
-) -> Result<()> {
-    if let Some(RedisFrame::BulkString(v)) = frames.pop() {
-        let mut values = BTreeMap::new();
-        while !frames.is_empty() {
-            if let Some(RedisFrame::BulkString(field)) = frames.pop() {
-                if let Some(frame) = frames.pop() {
-                    values.insert(String::from_utf8(field.to_vec())?, frame.into());
-                }
-            }
-        }
-        fields.insert(
-            String::from_utf8(v.to_vec())?,
-            MessageValue::Document(values),
-        );
-        keys.insert(
-            "key".to_string(),
-            MessageValue::List(vec![RedisFrame::BulkString(v).into()]),
-        );
-    }
-    Ok(())
-}
-
-fn get_key_values(
-    fields: &mut HashMap<String, MessageValue>,
-    keys: &mut HashMap<String, MessageValue>,
-    mut frames: Vec<RedisFrame>,
-) -> Result<()> {
-    let mut keys_storage: Vec<MessageValue> = vec![];
-    while !frames.is_empty() {
-        if let Some(RedisFrame::BulkString(k)) = frames.pop() {
-            if let Some(frame) = frames.pop() {
-                fields.insert(String::from_utf8(k.to_vec())?, frame.into());
-            }
-            keys_storage.push(RedisFrame::BulkString(k).into());
-        }
-    }
-    keys.insert("key".to_string(), MessageValue::List(keys_storage));
-    Ok(())
-}
-
-fn handle_redis_array_query(commands_vec: Vec<RedisFrame>) -> Result<QueryMessage> {
-    let mut primary_key = HashMap::new();
-    let mut query_values = HashMap::new();
-    let mut query_type = QueryType::Write;
-    let mut commands: Vec<RedisFrame> = commands_vec.iter().cloned().rev().collect_vec();
-
-    // This should be a command from the server
-    // Behaviour cribbed from:
-    // https://redis.io/commands and
-    // https://gist.github.com/LeCoupa/1596b8f359ad8812c7271b5322c30946
-    if let Some(RedisFrame::BulkString(command)) = commands.pop() {
-        match command.to_ascii_uppercase().as_slice() {
-            b"APPEND" => {
-                get_key_values(&mut query_values, &mut primary_key, commands)?;
-            } // append a value to a key
-            b"BITCOUNT" => {
-                query_type = QueryType::Read;
-                get_key_values(&mut query_values, &mut primary_key, commands)?;
-            } // count set bits in a string
-            b"SET" => {
-                get_key_values(&mut query_values, &mut primary_key, commands)?;
-            } // set value in key
-            b"SETNX" => {
-                get_key_values(&mut query_values, &mut primary_key, commands)?;
-            } // set if not exist value in key
-            b"SETRANGE" => {
-                get_key_values(&mut query_values, &mut primary_key, commands)?;
-            } // overwrite part of a string at key starting at the specified offset
-            b"STRLEN" => {
-                query_type = QueryType::Read;
-                get_keys(&mut query_values, &mut primary_key, commands)?;
-            } // get the length of the value stored in a key
-            b"MSET" => {
-                get_key_values(&mut query_values, &mut primary_key, commands)?;
-            } // set multiple keys to multiple query_values
-            b"MSETNX" => {
-                get_key_values(&mut query_values, &mut primary_key, commands)?;
-            } // set multiple keys to multiple query_values, only if none of the keys exist
-            b"GET" => {
-                query_type = QueryType::Read;
-                get_keys(&mut query_values, &mut primary_key, commands)?;
-            } // get value in key
-            b"GETRANGE" => {
-                query_type = QueryType::Read;
-                get_key_values(&mut query_values, &mut primary_key, commands)?;
-            } // get a substring value of a key and return its old value
-            b"MGET" => {
-                query_type = QueryType::Read;
-                get_keys(&mut query_values, &mut primary_key, commands)?;
-            } // get the values of all the given keys
-            b"INCR" => {
-                get_keys(&mut query_values, &mut primary_key, commands)?;
-            } // increment value in key
-            b"INCRBY" => {
-                get_key_values(&mut query_values, &mut primary_key, commands)?;
-            } // increment the integer value of a key by the given amount
-            b"INCRBYFLOAT" => {
-                get_key_values(&mut query_values, &mut primary_key, commands)?;
-            } // increment the float value of a key by the given amount
-            b"DECR" => {
-                get_keys(&mut query_values, &mut primary_key, commands)?;
-            } // decrement the integer value of key by one
-            b"DECRBY" => {
-                get_key_values(&mut query_values, &mut primary_key, commands)?;
-            } // decrement the integer value of a key by the given number
-            b"DEL" => {
-                get_keys(&mut query_values, &mut primary_key, commands)?;
-            } // delete key
-            b"EXPIRE" => {
-                get_key_values(&mut query_values, &mut primary_key, commands)?;
-            } // key will be deleted in 120 seconds
-            b"TTL" => {
-                get_keys(&mut query_values, &mut primary_key, commands)?;
-            } // returns the number of seconds until a key is deleted
-            b"RPUSH" => {
-                get_key_multi_values(&mut query_values, &mut primary_key, commands)?;
-            } // put the new value at the end of the list
-            b"RPUSHX" => {
-                get_key_values(&mut query_values, &mut primary_key, commands)?;
-            } // append a value to a list, only if the exists
-            b"LPUSH" => {
-                get_key_multi_values(&mut query_values, &mut primary_key, commands)?;
-            } // put the new value at the start of the list
-            b"LRANGE" => {
-                query_type = QueryType::Read;
-                get_key_multi_values(&mut query_values, &mut primary_key, commands)?;
-            } // give a subset of the list
-            b"LINDEX" => {
-                query_type = QueryType::Read;
-                get_key_multi_values(&mut query_values, &mut primary_key, commands)?;
-            } // get an element from a list by its index
-            b"LINSERT" => {
-                get_key_multi_values(&mut query_values, &mut primary_key, commands)?;
-            } // insert an element before or after another element in a list
-            b"LLEN" => {
-                query_type = QueryType::Read;
-                get_keys(&mut query_values, &mut primary_key, commands)?;
-            } // return the current length of the list
-            b"LPOP" => {
-                get_keys(&mut query_values, &mut primary_key, commands)?;
-            } // remove the first element from the list and returns it
-            b"LSET" => {
-                get_key_multi_values(&mut query_values, &mut primary_key, commands)?;
-            } // set the value of an element in a list by its index
-            b"LTRIM" => {
-                get_key_multi_values(&mut query_values, &mut primary_key, commands)?;
-            } // trim a list to the specified range
-            b"RPOP" => {
-                get_keys(&mut query_values, &mut primary_key, commands)?;
-            } // remove the last element from the list and returns it
-            b"SADD" => {
-                get_key_multi_values(&mut query_values, &mut primary_key, commands)?;
-            } // add the given value to the set
-            b"SCARD" => {
-                query_type = QueryType::Read;
-                get_keys(&mut query_values, &mut primary_key, commands)?;
-            } // get the number of members in a set
-            b"SREM" => {
-                get_key_multi_values(&mut query_values, &mut primary_key, commands)?;
-            } // remove the given value from the set
-            b"SISMEMBER" => {
-                query_type = QueryType::Read;
-                get_keys(&mut query_values, &mut primary_key, commands)?;
-            } // test if the given value is in the set.
-            b"SMEMBERS" => {
-                query_type = QueryType::Read;
-                get_keys(&mut query_values, &mut primary_key, commands)?;
-            } // return a list of all the members of this set
-            b"SUNION" => {
-                query_type = QueryType::Read;
-                get_keys(&mut query_values, &mut primary_key, commands)?;
-            } // combine two or more sets and returns the list of all elements
-            b"SINTER" => {
-                query_type = QueryType::Read;
-                get_keys(&mut query_values, &mut primary_key, commands)?;
-            } // intersect multiple sets
-            b"SMOVE" => {
-                query_type = QueryType::Write;
-                get_key_values(&mut query_values, &mut primary_key, commands)?;
-            } // move a member from one set to another
-            b"SPOP" => {
-                query_type = QueryType::Write;
-                get_key_values(&mut query_values, &mut primary_key, commands)?;
-            } // remove and return one or multiple random members from a set
-            b"ZADD" => {
-                get_key_multi_values(&mut query_values, &mut primary_key, commands)?;
-            } // add one or more members to a sorted set, or update its score if it already exists
-            b"ZCARD" => {
-                query_type = QueryType::Read;
-                get_keys(&mut query_values, &mut primary_key, commands)?;
-            } // get the number of members in a sorted set
-            b"ZCOUNT" => {
-                query_type = QueryType::Read;
-                get_key_multi_values(&mut query_values, &mut primary_key, commands)?;
-            } // count the members in a sorted set with scores within the given values
-            b"ZINCRBY" => {
-                get_key_multi_values(&mut query_values, &mut primary_key, commands)?;
-            } // increment the score of a member in a sorted set
-            b"ZRANGE" => {
-                query_type = QueryType::Read;
-                get_key_multi_values(&mut query_values, &mut primary_key, commands)?;
-            } // returns a subset of the sorted set
-            b"ZRANK" => {
-                query_type = QueryType::Read;
-                get_keys(&mut query_values, &mut primary_key, commands)?;
-            } // determine the index of a member in a sorted set
-            b"ZREM" => {
-                get_key_multi_values(&mut query_values, &mut primary_key, commands)?;
-            } // remove one or more members from a sorted set
-            b"ZREMRANGEBYRANK" => {
-                get_key_multi_values(&mut query_values, &mut primary_key, commands)?;
-            } // remove all members in a sorted set within the given indexes
-            b"ZREMRANGEBYSCORE" => {
-                get_key_multi_values(&mut query_values, &mut primary_key, commands)?;
-            } // remove all members in a sorted set, by index, with scores ordered from high to low
-            b"ZSCORE" => {
-                query_type = QueryType::Read;
-                get_keys(&mut query_values, &mut primary_key, commands)?;
-            } // get the score associated with the given mmeber in a sorted set
-            b"ZRANGEBYSCORE" => {
-                query_type = QueryType::Read;
-                get_key_multi_values(&mut query_values, &mut primary_key, commands)?;
-            } // return a range of members in a sorted set, by score
-            b"HGET" => {
-                query_type = QueryType::Read;
-                get_keys(&mut query_values, &mut primary_key, commands)?;
-            } // get the value of a hash field
-            b"HGETALL" => {
-                query_type = QueryType::Read;
-                get_keys(&mut query_values, &mut primary_key, commands)?;
-            } // get all the fields and values in a hash
-            b"HSET" => {
-                get_key_map(&mut query_values, &mut primary_key, commands)?;
-            } // set the string value of a hash field
-            b"HSETNX" => {
-                get_key_map(&mut query_values, &mut primary_key, commands)?;
-            } // set the string value of a hash field, only if the field does not exists
-            b"HMSET" => {
-                get_key_map(&mut query_values, &mut primary_key, commands)?;
-            } // set multiple fields at once
-            b"HINCRBY" => {
-                get_key_multi_values(&mut query_values, &mut primary_key, commands)?;
-            } // increment value in hash by X
-            b"HDEL" => {
-                get_key_multi_values(&mut query_values, &mut primary_key, commands)?;
-            } // delete one or more hash fields
-            b"HEXISTS" => {
-                query_type = QueryType::Read;
-                get_key_values(&mut query_values, &mut primary_key, commands)?;
-            } // determine if a hash field exists
-            b"HKEYS" => {
-                query_type = QueryType::Read;
-                get_keys(&mut query_values, &mut primary_key, commands)?;
-            } // get all the fields in a hash
-            b"HLEN" => {
-                query_type = QueryType::Read;
-                get_keys(&mut query_values, &mut primary_key, commands)?;
-            } // get all the fields in a hash
-            b"HSTRLEN" => {
-                query_type = QueryType::Read;
-                get_key_values(&mut query_values, &mut primary_key, commands)?;
-            } // get the length of the value of a hash field
-            b"HVALS" => {
-                query_type = QueryType::Read;
-                get_keys(&mut query_values, &mut primary_key, commands)?;
-            } // get all the values in a hash
-            b"PFADD" => {
-                get_key_multi_values(&mut query_values, &mut primary_key, commands)?;
-            } // add the specified elements to the specified HyperLogLog
-            b"PFCOUNT" => {
-                query_type = QueryType::Read;
-                get_keys(&mut query_values, &mut primary_key, commands)?;
-            } // return the approximated cardinality of the set(s) observed by the HyperLogLog at key's)
-            b"PFMERGE" => {
-                get_key_multi_values(&mut query_values, &mut primary_key, commands)?;
-            } // merge N HyperLogLogs into a single one
-            _ => {}
-        }
-
-        let query_string = commands_vec.iter().filter_map(|f| f.as_str()).join(" ");
-
-        let ast = ASTHolder::Commands(MessageValue::List(
-            commands_vec.into_iter().map(|f| f.into()).collect(),
-        ));
-
-        Ok(QueryMessage {
-            query_string,
-            namespace: vec![],
-            primary_key,
-            query_values: Some(query_values),
-            projection: None,
-            query_type,
-            ast: Some(ast),
-        })
-    } else {
-        Ok(QueryMessage::empty())
-    }
-}
-
-pub fn process_redis_frame_response(frame: &RedisFrame) -> Result<QueryResponse> {
-    match frame.clone() {
-        RedisFrame::SimpleString(string) => Ok(QueryResponse {
-            matching_query: None,
-            result: Some(MessageValue::Strings(
-                String::from_utf8_lossy(&string).to_string(),
-            )),
-            error: None,
-            response_meta: None,
-        }),
-        RedisFrame::BulkString(bulkstring) => Ok(QueryResponse {
-            matching_query: None,
-            result: Some(MessageValue::Bytes(bulkstring)),
-            error: None,
-            response_meta: None,
-        }),
-        RedisFrame::Array(frames) => Ok(QueryResponse {
-            matching_query: None,
-            result: Some(MessageValue::List(
-                frames.into_iter().map(|f| f.into()).collect(),
-            )),
-            error: None,
-            response_meta: None,
-        }),
-        RedisFrame::Integer(integer) => Ok(QueryResponse {
-            matching_query: None,
-            result: Some(MessageValue::Integer(integer, IntSize::I32)),
-            error: None,
-            response_meta: None,
-        }),
-        RedisFrame::Error(error) => Ok(QueryResponse {
-            matching_query: None,
-            result: None,
-            error: Some(MessageValue::Strings(error.to_string())),
-            response_meta: None,
-        }),
-        RedisFrame::Null => Ok(QueryResponse::empty()),
-    }
-}
-
-pub fn process_redis_frame_query(frame: &RedisFrame) -> Result<QueryMessage> {
-    match frame {
-        RedisFrame::SimpleString(string) => Ok(QueryMessage {
-            query_string: String::from_utf8_lossy(string.as_ref()).to_string(),
-            namespace: vec![],
-            primary_key: Default::default(),
-            query_values: None,
-            projection: None,
-            query_type: QueryType::ReadWrite,
-            ast: None,
-        }),
-        RedisFrame::BulkString(bulkstring) => Ok(QueryMessage {
-            query_string: String::from_utf8_lossy(bulkstring.as_ref()).to_string(),
-            namespace: vec![],
-            primary_key: Default::default(),
-            query_values: None,
-            projection: None,
-            query_type: QueryType::ReadWrite,
-            ast: None,
-        }),
-
-        RedisFrame::Array(frames) => handle_redis_array_query(frames.clone()),
-        RedisFrame::Integer(integer) => Ok(QueryMessage {
-            query_string: integer.to_string(),
-            namespace: vec![],
-            primary_key: Default::default(),
-            query_values: None,
-            projection: None,
-            query_type: QueryType::ReadWrite,
-            ast: None,
-        }),
-        RedisFrame::Error(error) => Ok(QueryMessage {
-            query_string: error.to_string(),
-            namespace: vec![],
-            primary_key: Default::default(),
-            query_values: None,
-            projection: None,
-            query_type: QueryType::ReadWrite,
-            ast: None,
-        }),
-        RedisFrame::Null => Ok(QueryMessage::empty()),
-    }
-}
-
-#[inline]
-fn get_redis_frame(rf: Frame) -> Result<RedisFrame> {
-    if let Frame::Redis(frame) = rf {
-        Ok(frame)
-    } else {
-        warn!("Unsupported Frame detected - Dropping Frame {:?}", rf);
-        Err(anyhow!("Unsupported frame found, not sending"))
+impl Default for RedisCodec {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
 impl RedisCodec {
-    fn encode_message(&mut self, item: Message) -> Result<RedisFrame> {
-        let frame = if !item.modified {
-            get_redis_frame(item.original)?
-        } else {
-            match item.details {
-                MessageDetails::Query(qm) => RedisCodec::build_redis_query_frame(qm),
-                MessageDetails::Response(qr) => RedisCodec::build_redis_response_frame(qr),
-                MessageDetails::Unknown => get_redis_frame(item.original)?,
-            }
-        };
-        Ok(frame)
-    }
-
-    pub fn new(decode_type: DecodeType) -> RedisCodec {
-        RedisCodec {
-            decode_type,
-            enable_metadata: false,
-            messages: vec![],
-        }
-    }
-
-    pub fn frame_to_message(&self, frame: RedisFrame) -> Result<Message> {
-        trace!("processing bulk response {:?}", frame);
-        if self.enable_metadata {
-            Ok(Message::new(
-                match self.decode_type {
-                    DecodeType::Response => {
-                        MessageDetails::Response(process_redis_frame_response(&frame)?)
-                    }
-                    DecodeType::Query => MessageDetails::Query(process_redis_frame_query(&frame)?),
-                },
-                false,
-                Frame::Redis(frame),
-            ))
-        } else {
-            Ok(Message::new(
-                MessageDetails::Unknown,
-                false,
-                Frame::Redis(frame),
-            ))
-        }
-    }
-
-    fn build_redis_response_frame(resp: QueryResponse) -> RedisFrame {
-        if let Some(result) = resp.result {
-            return result.into();
-        }
-        if let Some(MessageValue::Strings(s)) = resp.error {
-            return RedisFrame::Error(s.into());
-        }
-
-        debug!("{:?}", resp);
-        RedisFrame::SimpleString(Bytes::from_static(b"OK"))
-    }
-
-    fn build_redis_query_frame(query: QueryMessage) -> RedisFrame {
-        match query.ast {
-            Some(ASTHolder::Commands(MessageValue::List(ast))) => {
-                RedisFrame::Array(ast.into_iter().map(|v| v.into()).collect())
-            }
-            _ => RedisFrame::SimpleString(query.query_string.into()),
-        }
-    }
-
-    fn encode_raw(&mut self, item: RedisFrame, dst: &mut BytesMut) -> Result<()> {
-        encode_bytes(dst, &item)
-            .map(|_| ())
-            .map_err(|e| anyhow!("Redis encoding error: {} - {:#?}", e, item))
+    pub fn new() -> RedisCodec {
+        RedisCodec { messages: vec![] }
     }
 }
 
@@ -555,8 +48,9 @@ impl Decoder for RedisCodec {
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>> {
         loop {
             match decode_mut(src).map_err(|e| anyhow!("Error decoding redis frame {}", e))? {
-                Some((frame, _size, _bytes)) => {
-                    self.messages.push(self.frame_to_message(frame)?);
+                Some((frame, _size, bytes)) => {
+                    self.messages
+                        .push(Message::from_bytes_and_frame(bytes, Frame::Redis(frame)));
                 }
                 None => {
                     if self.messages.is_empty() || src.remaining() != 0 {
@@ -574,16 +68,24 @@ impl Encoder<Messages> for RedisCodec {
     type Error = anyhow::Error;
 
     fn encode(&mut self, item: Messages, dst: &mut BytesMut) -> Result<()> {
-        item.into_iter().try_for_each(|m| {
-            let frame = self.encode_message(m)?;
-            self.encode_raw(frame, dst)
+        item.into_iter().try_for_each(|m| match m.into_encodable() {
+            Encodable::Bytes(bytes) => {
+                dst.extend_from_slice(&bytes);
+                Ok(())
+            }
+            Encodable::Frame(frame) => {
+                let item = frame.into_redis().unwrap();
+                encode_bytes(dst, &item)
+                    .map(|_| ())
+                    .map_err(|e| anyhow!("Redis encoding error: {} - {:#?}", e, item))
+            }
         })
     }
 }
 
 #[cfg(test)]
 mod redis_tests {
-    use crate::codec::redis::{DecodeType, RedisCodec};
+    use crate::codec::redis::RedisCodec;
     use bytes::BytesMut;
     use hex_literal::hex;
     use tokio_util::codec::{Decoder, Encoder};
@@ -623,55 +125,55 @@ mod redis_tests {
 
     #[test]
     fn test_ok_codec() {
-        let mut codec = RedisCodec::new(DecodeType::Response);
+        let mut codec = RedisCodec::new();
         test_frame(&mut codec, &OK_MESSAGE);
     }
 
     #[test]
     fn test_set_codec() {
-        let mut codec = RedisCodec::new(DecodeType::Query);
+        let mut codec = RedisCodec::new();
         test_frame(&mut codec, &SET_MESSAGE);
     }
 
     #[test]
     fn test_get_codec() {
-        let mut codec = RedisCodec::new(DecodeType::Query);
+        let mut codec = RedisCodec::new();
         test_frame(&mut codec, &GET_MESSAGE);
     }
 
     #[test]
     fn test_inc_codec() {
-        let mut codec = RedisCodec::new(DecodeType::Query);
+        let mut codec = RedisCodec::new();
         test_frame(&mut codec, &INC_MESSAGE);
     }
 
     #[test]
     fn test_lpush_codec() {
-        let mut codec = RedisCodec::new(DecodeType::Query);
+        let mut codec = RedisCodec::new();
         test_frame(&mut codec, &LPUSH_MESSAGE);
     }
 
     #[test]
     fn test_rpush_codec() {
-        let mut codec = RedisCodec::new(DecodeType::Query);
+        let mut codec = RedisCodec::new();
         test_frame(&mut codec, &RPUSH_MESSAGE);
     }
 
     #[test]
     fn test_lpop_codec() {
-        let mut codec = RedisCodec::new(DecodeType::Query);
+        let mut codec = RedisCodec::new();
         test_frame(&mut codec, &LPOP_MESSAGE);
     }
 
     #[test]
     fn test_sadd_codec() {
-        let mut codec = RedisCodec::new(DecodeType::Query);
+        let mut codec = RedisCodec::new();
         test_frame(&mut codec, &SADD_MESSAGE);
     }
 
     #[test]
     fn test_hset_codec() {
-        let mut codec = RedisCodec::new(DecodeType::Query);
+        let mut codec = RedisCodec::new();
         test_frame(&mut codec, &HSET_MESSAGE);
     }
 }

--- a/shotover-proxy/src/frame/cassandra.rs
+++ b/shotover-proxy/src/frame/cassandra.rs
@@ -145,6 +145,7 @@ impl CassandraFrame {
                 Some(Statement::Insert { .. }) => QueryType::Write,
                 Some(Statement::Update { .. }) => QueryType::Write,
                 Some(Statement::Delete { .. }) => QueryType::Write,
+                // TODO: handle prepared, execute and schema change query types
                 _ => QueryType::Read,
             },
             _ => QueryType::Read,

--- a/shotover-proxy/src/frame/mod.rs
+++ b/shotover-proxy/src/frame/mod.rs
@@ -6,10 +6,11 @@ pub use redis_protocol::resp2::types::Frame as RedisFrame;
 use anyhow::{anyhow, Result};
 use bytes::Bytes;
 
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Debug, Clone, Copy)]
 pub enum MessageType {
     Redis,
     Cassandra,
+    None,
 }
 
 #[derive(PartialEq, Debug, Clone)]
@@ -26,14 +27,23 @@ impl Frame {
             MessageType::Redis => redis_protocol::resp2::decode::decode(&bytes)
                 .map(|x| Frame::Redis(x.unwrap().0))
                 .map_err(|e| anyhow!("{e:?}")),
+            MessageType::None => Ok(Frame::None),
         }
     }
 
-    fn name(&self) -> &'static str {
+    pub fn name(&self) -> &'static str {
         match self {
             Frame::Redis(_) => "Redis",
             Frame::Cassandra(_) => "Cassandra",
             Frame::None => "None",
+        }
+    }
+
+    pub fn get_type(&self) -> MessageType {
+        match self {
+            Frame::Cassandra(_) => MessageType::Cassandra,
+            Frame::Redis(_) => MessageType::Redis,
+            Frame::None => MessageType::None,
         }
     }
 

--- a/shotover-proxy/src/lib.rs
+++ b/shotover-proxy/src/lib.rs
@@ -10,7 +10,6 @@
 //!
 //! ## Messages
 //! * [`message::Message`], the main struct that carries database queries/frames around in Shotover.
-//! * [`message::MessageDetails`], an enriched struct that contains computed, easy to work with information about the message.
 //!
 //! ## Transform
 //! * [`transforms::Wrapper`], used to wrap messages as they traverse the [`transforms::Transform`] chain.

--- a/shotover-proxy/src/message/mod.rs
+++ b/shotover-proxy/src/message/mod.rs
@@ -1,10 +1,7 @@
-use crate::frame::cassandra::CassandraOperation;
-use crate::frame::CassandraFrame;
-use crate::frame::Frame;
-use crate::frame::RedisFrame;
+use anyhow::Result;
 use bigdecimal::BigDecimal;
 use byteorder::{BigEndian, WriteBytesExt};
-use bytes::Bytes;
+use bytes::{Buf, Bytes};
 use bytes_utils::Str;
 use cassandra_protocol::{
     frame::{
@@ -20,21 +17,19 @@ use itertools::Itertools;
 use num::BigInt;
 use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
-use sqlparser::ast::Statement;
 use sqlparser::ast::Value as SQLValue;
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 use std::net::IpAddr;
 use uuid::Uuid;
+
+use crate::frame::cassandra::CassandraOperation;
+use crate::frame::{CassandraFrame, Frame, MessageType, RedisFrame};
 
 pub type Messages = Vec<Message>;
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct Message {
-    pub details: MessageDetails,
-    pub modified: bool,
-    /// The frame in the format defined by the protocol.
-    pub original: Frame,
-    /// identifies a message that is to be returned to the sender.  Message is stored in the `original` frame.
+    inner: Option<MessageInner>,
     pub return_to_sender: bool,
 
     // TODO: Not a fan of this field and we could get rid of it by making TimestampTagger an implicit part of ConsistentScatter
@@ -42,60 +37,63 @@ pub struct Message {
     pub meta_timestamp: Option<i64>,
 }
 
-#[derive(PartialEq, Debug, Clone)]
-pub enum MessageDetails {
-    Query(QueryMessage),
-    Response(QueryResponse),
-    Unknown,
-}
-
 impl Message {
-    pub fn new(details: MessageDetails, modified: bool, original: Frame) -> Self {
+    pub fn from_bytes(bytes: Bytes, message_type: MessageType) -> Self {
         Message {
-            details,
-            modified,
-            original,
+            inner: Some(MessageInner::RawBytes {
+                bytes,
+                message_type,
+            }),
             return_to_sender: false,
             meta_timestamp: None,
         }
     }
 
-    pub fn generate_message_details_response(&mut self) {
-        if let MessageDetails::Unknown = self.details {
-            self.details = self.original.build_message_response().unwrap()
-        }
-    }
-
-    pub fn generate_message_details_query(&mut self) {
-        if let MessageDetails::Unknown = self.details {
-            self.details = self.original.build_message_query().unwrap() // TODO: this will panic on non utf8 data
-        }
-    }
-
-    pub fn new_query(qm: QueryMessage, modified: bool, original: Frame) -> Self {
-        Self::new(MessageDetails::Query(qm), modified, original)
-    }
-
-    pub fn new_response(qr: QueryResponse, modified: bool, original: Frame) -> Self {
-        Self::new(MessageDetails::Response(qr), modified, original)
-    }
-
-    pub fn from_frame(raw_frame: Frame) -> Self {
-        Self::new(MessageDetails::Unknown, false, raw_frame)
-    }
-
-    pub fn new_no_original(details: MessageDetails, modified: bool) -> Self {
+    pub fn from_bytes_and_frame(bytes: Bytes, frame: Frame) -> Self {
         Message {
-            details,
-            modified,
-            original: Frame::None,
+            inner: Some(MessageInner::Parsed { bytes, frame }),
             return_to_sender: false,
             meta_timestamp: None,
         }
     }
 
-    pub fn namespace(&self) -> Option<Vec<String>> {
-        match &self.original {
+    pub fn from_frame(frame: Frame) -> Self {
+        Message {
+            inner: Some(MessageInner::Modified { frame }),
+            return_to_sender: false,
+            meta_timestamp: None,
+        }
+    }
+
+    /// Returns None when fails to parse the message.
+    /// Internally logs the failure to parse.
+    pub fn frame(&mut self) -> Option<&mut Frame> {
+        let (inner, result) = self.inner.take().unwrap().ensure_parsed();
+        self.inner = Some(inner);
+        if let Err(err) = result {
+            // TODO: If we could include a stacktrace in this error it would be really helpful
+            tracing::error!("Failed to parse frame {err}");
+            return None;
+        }
+
+        match self.inner.as_mut().unwrap() {
+            MessageInner::RawBytes { .. } => unreachable!(),
+            MessageInner::Parsed { frame, .. } => Some(frame),
+            MessageInner::Modified { frame } => Some(frame),
+        }
+    }
+
+    pub fn into_encodable(self) -> Encodable {
+        match self.inner.unwrap() {
+            MessageInner::RawBytes { bytes, .. } => Encodable::Bytes(bytes),
+            MessageInner::Parsed { bytes, .. } => Encodable::Bytes(bytes),
+            MessageInner::Modified { frame } => Encodable::Frame(frame),
+        }
+    }
+
+    /// Returns None when fails to parse the message
+    pub fn namespace(&mut self) -> Option<Vec<String>> {
+        match self.frame()? {
             Frame::Cassandra(cassandra) => Some(cassandra.namespace()),
             Frame::Redis(_) => unimplemented!(),
             Frame::None => Some(vec![]),
@@ -103,242 +101,149 @@ impl Message {
     }
 
     pub fn invalidate_cache(&mut self) {
-        // TODO: invalidate cache when we have a cache to invalidate
+        // TODO: clear message details cache fields if we ever add any
+
+        self.inner = self.inner.take().map(|x| x.invalidate_cache());
     }
 
-    #[must_use]
-    pub fn to_filtered_reply(&self) -> Self {
-        Message {
-            details: MessageDetails::Unknown,
-            modified: true,
-            original: match &self.original {
-                Frame::Redis(_) => Frame::Redis(RedisFrame::Error(
-                    "ERR Message was filtered out by shotover".into(),
-                )),
-                Frame::Cassandra(frame) => Frame::Cassandra(CassandraFrame {
-                    version: frame.version,
-                    stream_id: frame.stream_id,
-                    operation: CassandraOperation::Error(ErrorBody {
-                        error_code: 0,
-                        message: "Message was filtered out by shotover".into(),
-                        additional_info: AdditionalErrorInfo::Server,
-                    }),
-                    tracing_id: None,
-                    warnings: vec![],
+    // TODO: this could be optimized to avoid parsing the cassandra sql
+    pub fn to_filtered_reply(&mut self) -> Message {
+        // TODO: set_filtered_reply
+        Message::from_frame(match self.frame().unwrap() {
+            Frame::Redis(_) => Frame::Redis(RedisFrame::Error(
+                "ERR Message was filtered out by shotover".into(),
+            )),
+            Frame::Cassandra(frame) => Frame::Cassandra(CassandraFrame {
+                version: frame.version,
+                stream_id: frame.stream_id,
+                operation: CassandraOperation::Error(ErrorBody {
+                    error_code: 0,
+                    message: "Message was filtered out by shotover".into(),
+                    additional_info: AdditionalErrorInfo::Server,
                 }),
-                Frame::None => Frame::None,
-            },
-            return_to_sender: false,
-            meta_timestamp: None,
-        }
+                tracing_id: None,
+                warnings: vec![],
+            }),
+            Frame::None => Frame::None,
+        })
     }
 
-    /// Gets the `QueryType` for a message.
-    /// First checks the `details` of the message and then falls back to the `original` message.
-    pub fn get_query_type(&self) -> QueryType {
-        if let MessageDetails::Query(query) = &self.details {
-            query.query_type.clone()
-        } else {
-            self.original.get_query_type()
+    pub fn get_query_type(&mut self) -> QueryType {
+        match self.frame() {
+            Some(Frame::Cassandra(cassandra)) => cassandra.get_query_type(),
+            Some(Frame::Redis(redis)) => crate::codec::redis::redis_query_type(redis), // free-standing function as we cant define methods on RedisFrame
+            Some(Frame::None) => QueryType::ReadWrite,
+            None => QueryType::ReadWrite,
         }
     }
 
     pub fn set_error(&mut self, error: String) {
-        *self = Message::from_frame(match &self.original {
+        *self = Message::from_frame(match self.frame().unwrap() {
             Frame::Redis(_) => {
                 Frame::Redis(RedisFrame::Error(Str::from_inner(error.into()).unwrap()))
             }
-            Frame::Cassandra(frame) => {
-                let body = CassandraOperation::Error(ErrorBody {
+            Frame::Cassandra(frame) => Frame::Cassandra(CassandraFrame {
+                version: frame.version,
+                stream_id: frame.stream_id,
+                operation: CassandraOperation::Error(ErrorBody {
                     error_code: 0,
                     message: error,
                     additional_info: AdditionalErrorInfo::Server,
-                });
-
-                Frame::Cassandra(CassandraFrame {
-                    version: frame.version,
-                    stream_id: frame.stream_id,
-                    tracing_id: None,
-                    warnings: frame.warnings.clone(),
-                    operation: body,
-                })
-            }
+                }),
+                tracing_id: None,
+                warnings: vec![],
+            }),
             Frame::None => Frame::None,
         })
     }
-}
 
-#[derive(PartialEq, Debug, Clone)]
-pub struct RawMessage {
-    pub original: Frame,
-}
-
-// Transforms should not try to directly serialize the AST - it's purely an in-memory representation
-// query_string is also mainly there from a debugging / logging perspective as its a utf8
-// encoded represntation of the query.
-// Statement can be "serialized"/rendered through it's display methods
-// Commands can be serialized by getting the underlying Value
-
-#[derive(PartialEq, Debug, Clone)]
-pub enum ASTHolder {
-    // Statement is boxed because Statement takes up a lot more stack space than Value.
-    SQL(Box<Statement>),
-    Commands(MessageValue), // A flexible representation of a structured query that will naturally convert into the required type via into/from traits
-}
-
-impl ASTHolder {
-    pub fn get_command(&self) -> String {
-        match self {
-            ASTHolder::SQL(statement) => match **statement {
-                Statement::Query(_) => "SELECT",
-                Statement::Insert { .. } => "INSERT",
-                Statement::Update { .. } => "UPDATE",
-                Statement::Delete { .. } => "DELETE",
-                Statement::CreateView { .. } => "CREATE VIEW",
-                Statement::CreateTable { .. } => "CREATE TABLE",
-                Statement::AlterTable { .. } => "ALTER TABLE",
-                Statement::Drop { .. } => "DROP",
-                _ => "UNKNOWN",
-            }
-            .to_string(),
-            ASTHolder::Commands(commands) => {
-                if let MessageValue::List(coms) = commands {
-                    if let Some(MessageValue::Bytes(b)) = coms.get(0) {
-                        String::from_utf8(b.to_vec())
-                            .unwrap_or_else(|_| "couldn't decode".to_string())
-                    } else {
-                        "UNKNOWN".to_string()
-                    }
+    // Retrieves the stream_id without parsing the rest of the frame.
+    // Used for ordering out of order messages without parsing their contents.
+    // TODO: We will have a better idea of how to make this generic once we have multiple out of order protocols
+    //       For now its just written to match cassandra's stream_id field
+    pub fn stream_id(&self) -> Option<i16> {
+        match &self.inner {
+            Some(MessageInner::RawBytes {
+                bytes,
+                message_type: MessageType::Cassandra,
+            }) => {
+                const HEADER_LEN: usize = 9;
+                if bytes.len() >= HEADER_LEN {
+                    Some((&bytes[2..4]).get_i16())
                 } else {
-                    "UNKNOWN".to_string()
+                    None
                 }
             }
+            Some(MessageInner::RawBytes {
+                message_type: MessageType::Redis,
+                ..
+            }) => None,
+            Some(MessageInner::Parsed { frame, .. } | MessageInner::Modified { frame }) => {
+                match frame {
+                    Frame::Cassandra(cassandra) => Some(cassandra.stream_id),
+                    Frame::Redis(_) => None,
+                    Frame::None => None,
+                }
+            }
+            None => None,
         }
     }
 }
 
+// TODO: When im finished, evaluate if MessageInner as an enum brings value over just a struct of Options
+
+/// There are 3 levels of processing the message can be in.
+/// RawBytes -> Parsed -> Modified
+/// Where possible transforms should avoid moving to further stages to improve performance but this is an implementation detail hidden from them
 #[derive(PartialEq, Debug, Clone)]
-pub struct QueryMessage {
-    pub query_string: String,
-    pub namespace: Vec<String>,
-    pub primary_key: HashMap<String, MessageValue>,
-    pub query_values: Option<HashMap<String, MessageValue>>,
-    pub projection: Option<Vec<String>>,
-    pub query_type: QueryType,
-    pub ast: Option<ASTHolder>,
+enum MessageInner {
+    RawBytes {
+        bytes: Bytes,
+        message_type: MessageType,
+    },
+    Parsed {
+        bytes: Bytes,
+        frame: Frame,
+    },
+    Modified {
+        frame: Frame,
+    },
 }
 
-impl QueryMessage {
-    pub fn empty() -> Self {
-        QueryMessage {
-            query_string: "".to_string(),
-            namespace: vec![],
-            primary_key: Default::default(),
-            query_values: None,
-            projection: None,
-            query_type: QueryType::Read,
-            ast: None,
+impl MessageInner {
+    fn ensure_parsed(self) -> (Self, Result<()>) {
+        match self {
+            MessageInner::RawBytes {
+                bytes,
+                message_type,
+            } => match Frame::from_bytes(bytes.clone(), message_type.clone()) {
+                Ok(frame) => (MessageInner::Parsed { bytes, frame }, Ok(())),
+                Err(err) => (
+                    MessageInner::RawBytes {
+                        bytes,
+                        message_type,
+                    },
+                    Err(err),
+                ),
+            },
+            MessageInner::Parsed { .. } => (self, Ok(())),
+            MessageInner::Modified { .. } => (self, Ok(())),
         }
     }
 
-    pub fn get_namespace(&self) -> Vec<String> {
-        self.namespace.clone()
-    }
-
-    pub fn set_namespace_elem(&mut self, index: usize, elem: String) -> String {
-        let old = self.namespace.remove(index);
-        self.namespace.insert(index, elem);
-        old
-    }
-
-    pub fn get_primary_key(&self) -> Option<String> {
-        let f: Vec<String> = self
-            .primary_key
-            .iter()
-            .map(|(_, v)| serde_json::to_string(&v).unwrap())
-            .collect();
-        Some(f.join("."))
-    }
-
-    pub fn get_namespaced_primary_key(&self) -> Option<String> {
-        self.get_primary_key().map(|pk| {
-            let mut buffer = String::new();
-            let f = self.namespace.join(".");
-            buffer.push_str(f.as_str());
-            buffer.push('.');
-            buffer.push_str(serde_json::to_string(&pk).unwrap().as_str());
-            buffer
-        })
+    fn invalidate_cache(self) -> Self {
+        match self {
+            MessageInner::RawBytes { .. } => self,
+            MessageInner::Parsed { frame, .. } => MessageInner::Modified { frame },
+            MessageInner::Modified { .. } => self,
+        }
     }
 }
 
-#[derive(PartialEq, Debug, Clone)]
-pub struct QueryResponse {
-    pub matching_query: Option<QueryMessage>,
-    pub result: Option<MessageValue>,
-    pub error: Option<MessageValue>,
-    pub response_meta: Option<MessageValue>,
-}
-
-//TODO this could use a Builder
-impl QueryResponse {
-    pub fn empty() -> Self {
-        QueryResponse {
-            matching_query: None,
-            result: None,
-            error: None,
-            response_meta: None,
-        }
-    }
-
-    pub fn just_result(result: MessageValue) -> Self {
-        QueryResponse {
-            matching_query: None,
-            result: Some(result),
-            error: None,
-            response_meta: None,
-        }
-    }
-
-    pub fn result_with_matching(matching: Option<QueryMessage>, result: MessageValue) -> Self {
-        QueryResponse {
-            matching_query: matching,
-            result: Some(result),
-            error: None,
-            response_meta: None,
-        }
-    }
-
-    pub fn result_error_with_matching(
-        matching: Option<QueryMessage>,
-        result: Option<MessageValue>,
-        error: Option<MessageValue>,
-    ) -> Self {
-        QueryResponse {
-            matching_query: matching,
-            result,
-            error,
-            response_meta: None,
-        }
-    }
-
-    pub fn error_with_matching(matching: Option<QueryMessage>, error: MessageValue) -> Self {
-        QueryResponse {
-            matching_query: matching,
-            result: None,
-            error: Some(error),
-            response_meta: None,
-        }
-    }
-
-    pub fn empty_with_matching(original: QueryMessage) -> Self {
-        QueryResponse {
-            matching_query: Some(original),
-            result: None,
-            error: None,
-            response_meta: None,
-        }
-    }
+#[derive(Debug)]
+pub enum Encodable {
+    Bytes(Bytes),
+    Frame(Frame),
 }
 
 #[derive(PartialEq, Debug, Clone, Deserialize)]

--- a/shotover-proxy/src/sources/cassandra_source.rs
+++ b/shotover-proxy/src/sources/cassandra_source.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -19,8 +18,6 @@ use crate::transforms::chain::TransformChain;
 #[derive(Deserialize, Debug, Clone)]
 pub struct CassandraConfig {
     pub listen_addr: String,
-    pub cassandra_ks: HashMap<String, Vec<String>>,
-    pub query_processing: Option<bool>,
     pub connection_limit: Option<usize>,
     pub hard_connection_limit: Option<bool>,
     pub tls: Option<TlsConfig>,
@@ -38,9 +35,7 @@ impl SourcesFromConfig for CassandraConfig {
             CassandraSource::new(
                 chain,
                 self.listen_addr.clone(),
-                self.cassandra_ks.clone(),
                 trigger_shutdown_rx,
-                self.query_processing.unwrap_or(false),
                 self.connection_limit,
                 self.hard_connection_limit,
                 self.tls.clone(),
@@ -62,9 +57,7 @@ impl CassandraSource {
     pub async fn new(
         chain: &TransformChain,
         listen_addr: String,
-        cassandra_ks: HashMap<String, Vec<String>>,
         mut trigger_shutdown_rx: watch::Receiver<bool>,
-        query_processing: bool,
         connection_limit: Option<usize>,
         hard_connection_limit: Option<bool>,
         tls: Option<TlsConfig>,
@@ -78,7 +71,7 @@ impl CassandraSource {
             name.to_string(),
             listen_addr.clone(),
             hard_connection_limit.unwrap_or(false),
-            CassandraCodec::new(cassandra_ks, !query_processing),
+            CassandraCodec::new(),
             Arc::new(Semaphore::new(connection_limit.unwrap_or(512))),
             trigger_shutdown_rx.clone(),
             tls.map(TlsAcceptor::new).transpose()?,

--- a/shotover-proxy/src/sources/redis_source.rs
+++ b/shotover-proxy/src/sources/redis_source.rs
@@ -1,4 +1,4 @@
-use crate::codec::redis::{DecodeType, RedisCodec};
+use crate::codec::redis::RedisCodec;
 use crate::config::topology::TopicHolder;
 use crate::server::TcpCodecListener;
 use crate::sources::{Sources, SourcesFromConfig};
@@ -67,7 +67,7 @@ impl RedisSource {
             name.to_string(),
             listen_addr.clone(),
             hard_connection_limit.unwrap_or(false),
-            RedisCodec::new(DecodeType::Query),
+            RedisCodec::new(),
             Arc::new(Semaphore::new(connection_limit.unwrap_or(512))),
             trigger_shutdown_rx.clone(),
             tls.map(TlsAcceptor::new).transpose()?,

--- a/shotover-proxy/src/transforms/cassandra/peers_rewrite.rs
+++ b/shotover-proxy/src/transforms/cassandra/peers_rewrite.rs
@@ -29,14 +29,13 @@ pub struct CassandraPeersRewrite {
 
 #[async_trait]
 impl Transform for CassandraPeersRewrite {
-    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> ChainResponse {
+    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> ChainResponse {
         // Find the indices of queries to system.peers & system.peers_v2
         let system_peers = message_wrapper
             .messages
-            .iter()
+            .iter_mut()
             .enumerate()
-            .filter(|(_, m)| is_system_peers(*m))
-            .map(|(i, _)| i)
+            .filter_map(|(i, m)| if is_system_peers(m) { Some(i) } else { None })
             .collect::<Vec<_>>();
 
         let mut response = message_wrapper.call_next_transform().await?;
@@ -49,8 +48,8 @@ impl Transform for CassandraPeersRewrite {
     }
 }
 
-fn is_system_peers(message: &Message) -> bool {
-    if let Frame::Cassandra(_) = message.original {
+fn is_system_peers(message: &mut Message) -> bool {
+    if let Some(Frame::Cassandra(_)) = message.frame() {
         if let Some(namespace) = message.namespace() {
             if namespace.len() > 1 {
                 return namespace[0] == "system" && namespace[1] == "peers_v2";
@@ -64,7 +63,7 @@ fn is_system_peers(message: &Message) -> bool {
 /// Rewrite the `native_port` field in the results from a query to `system.peers_v2` table
 /// Only Cassandra queries to the `system.peers` table found via the `is_system_peers` function should be passed to this
 fn rewrite_port(message: &mut Message, new_port: u32) {
-    if let Frame::Cassandra(frame) = &mut message.original {
+    if let Some(Frame::Cassandra(frame)) = &mut message.frame() {
         if let CassandraOperation::Result(CassandraResult::Rows { value, metadata }) =
             &mut frame.operation
         {
@@ -78,6 +77,7 @@ fn rewrite_port(message: &mut Message, new_port: u32) {
                     for row in rows.iter_mut() {
                         row[i] = MessageValue::Integer(new_port as i64, IntSize::I32);
                     }
+                    message.invalidate_cache();
                 }
             }
         } else {
@@ -86,8 +86,6 @@ fn rewrite_port(message: &mut Message, new_port: u32) {
                 frame
             );
         }
-    } else {
-        panic!("Expected Frame::Cassandra, got {:?}", message.original);
     }
 }
 
@@ -165,15 +163,15 @@ mod test {
 
     #[test]
     fn test_is_system_peers_v2() {
-        assert!(is_system_peers(&create_query_message(
+        assert!(is_system_peers(&mut create_query_message(
             "SELECT * FROM system.peers_v2;".into()
         )));
 
-        assert!(!is_system_peers(&create_query_message(
+        assert!(!is_system_peers(&mut create_query_message(
             "SELECT * FROM not_system.peers_v2;".into()
         )));
 
-        assert!(!is_system_peers(&create_query_message("".into())));
+        assert!(!is_system_peers(&mut create_query_message("".into())));
     }
 
     #[test]

--- a/shotover-proxy/src/transforms/cassandra/peers_rewrite.rs
+++ b/shotover-proxy/src/transforms/cassandra/peers_rewrite.rs
@@ -63,7 +63,7 @@ fn is_system_peers(message: &mut Message) -> bool {
 /// Rewrite the `native_port` field in the results from a query to `system.peers_v2` table
 /// Only Cassandra queries to the `system.peers` table found via the `is_system_peers` function should be passed to this
 fn rewrite_port(message: &mut Message, new_port: u32) {
-    if let Some(Frame::Cassandra(frame)) = &mut message.frame() {
+    if let Some(Frame::Cassandra(frame)) = message.frame() {
         if let CassandraOperation::Result(CassandraResult::Rows { value, metadata }) =
             &mut frame.operation
         {

--- a/shotover-proxy/src/transforms/cassandra/sink_single.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_single.rs
@@ -2,8 +2,8 @@ use super::connection::CassandraConnection;
 use crate::codec::cassandra::CassandraCodec;
 use crate::concurrency::FuturesOrdered;
 use crate::error::ChainResponse;
-use crate::frame::CassandraFrame;
-use crate::frame::Frame;
+use crate::frame::cassandra::CassandraOperation;
+use crate::frame::{CassandraFrame, Frame};
 use crate::message::Messages;
 use crate::tls::TlsConfig;
 use crate::tls::TlsConnector;
@@ -13,7 +13,6 @@ use anyhow::Result;
 use async_trait::async_trait;
 use metrics::{register_counter, Counter};
 use serde::Deserialize;
-use std::collections::HashMap;
 use std::time::Duration;
 use tokio::sync::oneshot;
 use tokio::sync::oneshot::Receiver;
@@ -25,7 +24,6 @@ use tracing::{info, trace};
 pub struct CassandraSinkSingleConfig {
     #[serde(rename = "remote_address")]
     pub address: String,
-    pub result_processing: bool,
     pub tls: Option<TlsConfig>,
 }
 
@@ -34,7 +32,6 @@ impl CassandraSinkSingleConfig {
         let tls = self.tls.clone().map(TlsConnector::new).transpose()?;
         Ok(Transforms::CassandraSinkSingle(CassandraSinkSingle::new(
             self.address.clone(),
-            self.result_processing,
             chain_name,
             tls,
         )))
@@ -44,8 +41,6 @@ impl CassandraSinkSingleConfig {
 pub struct CassandraSinkSingle {
     address: String,
     outbound: Option<CassandraConnection>,
-    cassandra_ks: HashMap<String, Vec<String>>,
-    bypass: bool,
     chain_name: String,
     failed_requests: Counter,
     tls: Option<TlsConnector>,
@@ -55,7 +50,6 @@ impl Clone for CassandraSinkSingle {
     fn clone(&self) -> Self {
         CassandraSinkSingle::new(
             self.address.clone(),
-            self.bypass,
             self.chain_name.clone(),
             self.tls.clone(),
         )
@@ -65,7 +59,6 @@ impl Clone for CassandraSinkSingle {
 impl CassandraSinkSingle {
     pub fn new(
         address: String,
-        bypass: bool,
         chain_name: String,
         tls: Option<TlsConnector>,
     ) -> CassandraSinkSingle {
@@ -74,8 +67,6 @@ impl CassandraSinkSingle {
         CassandraSinkSingle {
             address,
             outbound: None,
-            cassandra_ks: HashMap::new(),
-            bypass,
             chain_name,
             failed_requests,
             tls,
@@ -89,14 +80,15 @@ impl CassandraSinkSingle {
             match self.outbound {
                 None => {
                     trace!("creating outbound connection {:?}", self.address);
+                    self.outbound = Some(
+                        CassandraConnection::new(
+                            self.address.clone(),
+                            CassandraCodec::new(),
+                            self.tls.clone(),
+                        )
+                        .await?,
+                    );
                     // we should either connect and set the value of outbound, or return an error... so we shouldn't loop more than 2 times
-                    let conn_pool = CassandraConnection::new(
-                        self.address.clone(),
-                        CassandraCodec::new(self.cassandra_ks.clone(), self.bypass),
-                        self.tls.clone(),
-                    )
-                    .await?;
-                    self.outbound = Some(conn_pool);
                 }
                 Some(ref mut outbound_framed_codec) => {
                     trace!("sending frame upstream");
@@ -106,7 +98,6 @@ impl CassandraSinkSingle {
                         .into_iter()
                         .map(|m| {
                             let (return_chan_tx, return_chan_rx) = oneshot::channel();
-
                             outbound_framed_codec.send(m, return_chan_tx)?;
 
                             Ok(return_chan_rx)
@@ -124,12 +115,11 @@ impl CassandraSinkSingle {
                                         response: Ok(mut resp),
                                         ..
                                     } => {
-                                        for message in &resp {
-                                            use crate::frame::cassandra::CassandraOperation;
-                                            if let Frame::Cassandra(CassandraFrame {
+                                        for message in &mut resp {
+                                            if let Some(Frame::Cassandra(CassandraFrame {
                                                 operation: CassandraOperation::Error(_),
                                                 ..
-                                            }) = &message.original
+                                            })) = message.frame()
                                             {
                                                 self.failed_requests.increment(1);
                                             }
@@ -140,6 +130,7 @@ impl CassandraSinkSingle {
                                         mut original,
                                         response: Err(err),
                                     } => {
+                                        // TODO: This is wrong: need to have a response for each incoming message
                                         original.set_error(err.to_string());
                                         responses.push(original);
                                     }

--- a/shotover-proxy/src/transforms/distributed/consistent_scatter.rs
+++ b/shotover-proxy/src/transforms/distributed/consistent_scatter.rs
@@ -1,6 +1,5 @@
 use crate::config::topology::TopicHolder;
 use crate::error::ChainResponse;
-
 use crate::message::{Message, QueryType};
 use crate::transforms::chain::BufferedChain;
 use crate::transforms::{

--- a/shotover-proxy/src/transforms/distributed/consistent_scatter.rs
+++ b/shotover-proxy/src/transforms/distributed/consistent_scatter.rs
@@ -1,5 +1,6 @@
 use crate::config::topology::TopicHolder;
 use crate::error::ChainResponse;
+
 use crate::message::{Message, QueryType};
 use crate::transforms::chain::BufferedChain;
 use crate::transforms::{
@@ -110,7 +111,6 @@ impl Transform for ConsistentScatter {
             .messages
             .iter_mut()
             .map(|m| {
-                m.generate_message_details_query();
                 if m.get_query_type() == QueryType::Read {
                     self.read_consistency
                 } else {
@@ -212,15 +212,15 @@ mod scatter_transform_tests {
     use std::collections::HashMap;
 
     fn check_ok_responses(mut messages: Messages) {
-        let message = messages.pop().unwrap();
+        let mut message = messages.pop().unwrap();
         let expected = Frame::Redis(RedisFrame::BulkString("OK".into()));
-        assert_eq!(message.original, expected);
+        assert_eq!(message.frame().unwrap(), &expected);
     }
 
     fn check_err_responses(mut messages: Messages, expected_err: &str) {
-        let message = messages.pop().unwrap();
+        let mut message = messages.pop().unwrap();
         let expected = Frame::Redis(RedisFrame::Error(expected_err.into()));
-        assert_eq!(message.original, expected);
+        assert_eq!(message.frame().unwrap(), &expected);
     }
 
     async fn build_chains(route_map: HashMap<String, TransformChain>) -> Vec<BufferedChain> {

--- a/shotover-proxy/src/transforms/null.rs
+++ b/shotover-proxy/src/transforms/null.rs
@@ -1,6 +1,6 @@
 use crate::error::ChainResponse;
 use crate::frame::Frame;
-use crate::message::{Message, MessageDetails, QueryResponse};
+use crate::message::Message;
 use crate::transforms::{Transform, Wrapper};
 use async_trait::async_trait;
 
@@ -14,10 +14,6 @@ impl Transform for Null {
     }
 
     async fn transform<'a>(&'a mut self, _message_wrapper: Wrapper<'a>) -> ChainResponse {
-        Ok(vec![Message::new(
-            MessageDetails::Response(QueryResponse::empty()),
-            true,
-            Frame::None,
-        )])
+        Ok(vec![Message::from_frame(Frame::None)])
     }
 }

--- a/shotover-proxy/src/transforms/null.rs
+++ b/shotover-proxy/src/transforms/null.rs
@@ -1,6 +1,4 @@
 use crate::error::ChainResponse;
-use crate::frame::Frame;
-use crate::message::Message;
 use crate::transforms::{Transform, Wrapper};
 use async_trait::async_trait;
 
@@ -13,7 +11,10 @@ impl Transform for Null {
         true
     }
 
-    async fn transform<'a>(&'a mut self, _message_wrapper: Wrapper<'a>) -> ChainResponse {
-        Ok(vec![Message::from_frame(Frame::None)])
+    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> ChainResponse {
+        for message in &mut message_wrapper.messages {
+            message.set_error("Handled by shotover null transform".to_string());
+        }
+        Ok(message_wrapper.messages)
     }
 }

--- a/shotover-proxy/src/transforms/protect/mod.rs
+++ b/shotover-proxy/src/transforms/protect/mod.rs
@@ -207,12 +207,13 @@ impl Transform for Protect {
     async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> ChainResponse {
         // encrypt the values included in any INSERT or UPDATE queries
         for message in message_wrapper.messages.iter_mut() {
+            let mut invalidate_cache = false;
             if let Some(namespace) = message.namespace() {
                 if namespace.len() == 2 {
-                    if let Frame::Cassandra(CassandraFrame {
+                    if let Some(Frame::Cassandra(CassandraFrame {
                         operation: CassandraOperation::Query { query, .. },
                         ..
-                    }) = &mut message.original
+                    })) = &mut message.frame()
                     {
                         if let Some((_, tables)) =
                             self.keyspace_table_columns.get_key_value(&namespace[0])
@@ -227,6 +228,7 @@ impl Transform for Protect {
                                             .protect(&self.key_source, &self.key_id)
                                             .await?;
                                         **value = SQLValue::from(&MessageValue::from(protected));
+                                        invalidate_cache = true;
                                     }
                                 }
                             }
@@ -234,26 +236,30 @@ impl Transform for Protect {
                     }
                 }
             }
+            if invalidate_cache {
+                message.invalidate_cache();
+            }
         }
 
         let mut original_messages = message_wrapper.messages.clone();
         let mut result = message_wrapper.call_next_transform().await?;
 
         for (response, request) in result.iter_mut().zip(original_messages.iter_mut()) {
-            if let Frame::Cassandra(CassandraFrame {
+            let mut invalidate_cache = false;
+            if let Some(Frame::Cassandra(CassandraFrame {
                 operation:
                     CassandraOperation::Result(CassandraResult::Rows {
                         value: MessageValue::Rows(rows),
                         ..
                     }),
                 ..
-            }) = &mut response.original
+            })) = response.frame()
             {
                 if let Some(namespace) = request.namespace() {
-                    if let Frame::Cassandra(CassandraFrame {
+                    if let Some(Frame::Cassandra(CassandraFrame {
                         operation: CassandraOperation::Query { query, .. },
                         ..
-                    }) = &mut request.original
+                    })) = &mut request.frame()
                     {
                         let projection: Vec<String> = get_values_from_insert_or_update_mut(query)
                             .into_keys()
@@ -282,6 +288,7 @@ impl Transform for Protect {
                                                         .unprotect(&self.key_source, &self.key_id)
                                                         .await?;
                                                     *v = new_value;
+                                                    invalidate_cache = true;
                                                 } else {
                                                     warn!("Tried decrypting non-blob column")
                                                 }
@@ -293,6 +300,9 @@ impl Transform for Protect {
                         }
                     }
                 }
+            }
+            if invalidate_cache {
+                response.invalidate_cache();
             }
         }
 

--- a/shotover-proxy/src/transforms/protect/mod.rs
+++ b/shotover-proxy/src/transforms/protect/mod.rs
@@ -213,7 +213,7 @@ impl Transform for Protect {
                     if let Some(Frame::Cassandra(CassandraFrame {
                         operation: CassandraOperation::Query { query, .. },
                         ..
-                    })) = &mut message.frame()
+                    })) = message.frame()
                     {
                         if let Some((_, tables)) =
                             self.keyspace_table_columns.get_key_value(&namespace[0])
@@ -259,7 +259,7 @@ impl Transform for Protect {
                     if let Some(Frame::Cassandra(CassandraFrame {
                         operation: CassandraOperation::Query { query, .. },
                         ..
-                    })) = &mut request.frame()
+                    })) = request.frame()
                     {
                         let projection: Vec<String> = get_values_from_insert_or_update_mut(query)
                             .into_keys()

--- a/shotover-proxy/src/transforms/redis/cache.rs
+++ b/shotover-proxy/src/transforms/redis/cache.rs
@@ -456,7 +456,7 @@ impl Transform for SimpleRedisCache {
             if let Some(Frame::Cassandra(CassandraFrame {
                 operation: CassandraOperation::Query { .. },
                 ..
-            })) = &m.frame()
+            })) = m.frame()
             {
                 if m.get_query_type() == QueryType::Write {
                     updates = true;

--- a/shotover-proxy/src/transforms/redis/cache.rs
+++ b/shotover-proxy/src/transforms/redis/cache.rs
@@ -1,7 +1,6 @@
 use crate::config::topology::TopicHolder;
 use crate::error::ChainResponse;
-use crate::frame::cassandra::{CassandraOperation, CassandraResult, CQL};
-use crate::frame::{CassandraFrame, Frame, RedisFrame};
+use crate::frame::{CassandraFrame, CassandraOperation, CassandraResult, Frame, RedisFrame, CQL};
 use crate::message::{Message, MessageValue, Messages, QueryType};
 use crate::transforms::chain::TransformChain;
 use crate::transforms::{
@@ -57,17 +56,17 @@ impl SimpleRedisCache {
     async fn get_or_update_from_cache(&mut self, mut messages: Messages) -> ChainResponse {
         let mut stream_ids = Vec::with_capacity(messages.len());
         for message in &mut messages {
-            if let Frame::Cassandra(frame) = &message.original {
+            if let Some(Frame::Cassandra(frame)) = message.frame() {
                 stream_ids.push(frame.stream_id);
             } else {
                 bail!("Failed to parse cassandra message");
             }
             if let Some(table_name) = message.namespace().map(|x| x.join(".")) {
-                *message = match &message.original {
-                    Frame::Cassandra(CassandraFrame {
+                *message = match message.frame() {
+                    Some(Frame::Cassandra(CassandraFrame {
                         operation: CassandraOperation::Query { query, .. },
                         ..
-                    }) => {
+                    })) => {
                         let table_cache_schema = self
                             .caching_schema
                             .get(&table_name)
@@ -454,10 +453,10 @@ impl Transform for SimpleRedisCache {
         let mut updates = false;
 
         for m in &mut message_wrapper.messages {
-            if let Frame::Cassandra(CassandraFrame {
+            if let Some(Frame::Cassandra(CassandraFrame {
                 operation: CassandraOperation::Query { .. },
                 ..
-            }) = &m.original
+            })) = &m.frame()
             {
                 if m.get_query_type() == QueryType::Write {
                     updates = true;

--- a/shotover-proxy/src/transforms/redis/sink_cluster.rs
+++ b/shotover-proxy/src/transforms/redis/sink_cluster.rs
@@ -1,23 +1,3 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
-
-use anyhow::{anyhow, bail, ensure, Context, Result};
-use async_trait::async_trait;
-use bytes::Bytes;
-use bytes_utils::string::Str;
-use derivative::Derivative;
-use futures::stream::FuturesUnordered;
-use futures::{Future, StreamExt, TryFutureExt};
-use metrics::{counter, register_counter};
-use rand::prelude::SmallRng;
-use rand::SeedableRng;
-use redis_protocol::types::Redirection;
-use serde::Deserialize;
-use tokio::sync::mpsc::UnboundedSender;
-use tokio::sync::oneshot;
-use tokio::time::timeout;
-use tokio::time::Duration;
-use tracing::{debug, error, info, trace, warn};
-
 use crate::codec::redis::RedisCodec;
 use crate::concurrency::FuturesOrdered;
 use crate::error::ChainResponse;
@@ -31,6 +11,24 @@ use crate::transforms::util::{Request, Response};
 use crate::transforms::ResponseFuture;
 use crate::transforms::CONTEXT_CHAIN_NAME;
 use crate::transforms::{Transform, Transforms, Wrapper};
+use anyhow::{anyhow, bail, ensure, Context, Result};
+use async_trait::async_trait;
+use bytes::Bytes;
+use bytes_utils::string::Str;
+use derivative::Derivative;
+use futures::stream::FuturesUnordered;
+use futures::{Future, StreamExt, TryFutureExt};
+use metrics::{counter, register_counter};
+use rand::prelude::SmallRng;
+use rand::SeedableRng;
+use redis_protocol::types::Redirection;
+use serde::Deserialize;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::oneshot;
+use tokio::time::timeout;
+use tokio::time::Duration;
+use tracing::{debug, error, info, trace, warn};
 
 const SLOT_SIZE: usize = 16384;
 

--- a/shotover-proxy/src/transforms/redis/sink_single.rs
+++ b/shotover-proxy/src/transforms/redis/sink_single.rs
@@ -1,6 +1,5 @@
 use std::fmt::Debug;
 
-use crate::frame::RedisFrame;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use futures::{FutureExt, SinkExt};
@@ -11,9 +10,10 @@ use tokio::net::TcpStream;
 use tokio_stream::StreamExt;
 use tokio_util::codec::Framed;
 
-use crate::codec::redis::{DecodeType, RedisCodec};
+use crate::codec::redis::RedisCodec;
 use crate::error::ChainResponse;
 use crate::frame::Frame;
+use crate::frame::RedisFrame;
 use crate::tls::{AsyncStream, TlsConfig, TlsConnector};
 use crate::transforms::{Transform, Transforms, Wrapper};
 
@@ -88,10 +88,7 @@ impl Transform for RedisSinkSingle {
             } else {
                 Box::pin(tcp_stream) as Pin<Box<dyn AsyncStream + Send + Sync>>
             };
-            self.outbound = Some(Framed::new(
-                generic_stream,
-                RedisCodec::new(DecodeType::Response),
-            ));
+            self.outbound = Some(Framed::new(generic_stream, RedisCodec::new()));
         }
 
         // self.outbound is gauranteed to be Some by the previous block
@@ -102,10 +99,10 @@ impl Transform for RedisSinkSingle {
             .ok();
 
         match outbound_framed_codec.next().fuse().await {
-            Some(a) => {
-                if let Ok(ref messages) = a {
+            Some(mut a) => {
+                if let Ok(messages) = &mut a {
                     for message in messages {
-                        if let Frame::Redis(RedisFrame::Error(_)) = message.original {
+                        if let Some(Frame::Redis(RedisFrame::Error(_))) = message.frame() {
                             self.failed_requests.increment(1);
                         }
                     }

--- a/shotover-proxy/src/transforms/redis/sink_single.rs
+++ b/shotover-proxy/src/transforms/redis/sink_single.rs
@@ -1,21 +1,19 @@
-use std::fmt::Debug;
-
-use anyhow::{anyhow, Result};
-use async_trait::async_trait;
-use futures::{FutureExt, SinkExt};
-use metrics::{register_counter, Counter};
-use serde::Deserialize;
-use std::pin::Pin;
-use tokio::net::TcpStream;
-use tokio_stream::StreamExt;
-use tokio_util::codec::Framed;
-
 use crate::codec::redis::RedisCodec;
 use crate::error::ChainResponse;
 use crate::frame::Frame;
 use crate::frame::RedisFrame;
 use crate::tls::{AsyncStream, TlsConfig, TlsConnector};
 use crate::transforms::{Transform, Transforms, Wrapper};
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use futures::{FutureExt, SinkExt};
+use metrics::{register_counter, Counter};
+use serde::Deserialize;
+use std::fmt::Debug;
+use std::pin::Pin;
+use tokio::net::TcpStream;
+use tokio_stream::StreamExt;
+use tokio_util::codec::Framed;
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct RedisSinkSingleConfig {

--- a/shotover-proxy/src/transforms/util/cluster_connection_pool.rs
+++ b/shotover-proxy/src/transforms/util/cluster_connection_pool.rs
@@ -310,7 +310,7 @@ mod test {
     use tokio::time::timeout;
 
     use super::spawn_read_write_tasks;
-    use crate::codec::redis::{DecodeType, RedisCodec};
+    use crate::codec::redis::RedisCodec;
 
     #[tokio::test]
     async fn test_remote_shutdown() {
@@ -335,7 +335,7 @@ mod test {
 
         let stream = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
         let (rx, tx) = stream.into_split();
-        let codec = RedisCodec::new(DecodeType::Response);
+        let codec = RedisCodec::new();
         let sender = spawn_read_write_tasks(&codec, rx, tx);
 
         assert!(remote.await.unwrap());
@@ -375,7 +375,7 @@ mod test {
 
         let stream = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
         let (rx, tx) = stream.into_split();
-        let codec = RedisCodec::new(DecodeType::Response);
+        let codec = RedisCodec::new();
 
         // Drop sender immediately.
         std::mem::drop(spawn_read_write_tasks(&codec, rx, tx));

--- a/shotover-proxy/tests/codec/cassandra.rs
+++ b/shotover-proxy/tests/codec/cassandra.rs
@@ -1,23 +1,17 @@
 use bytes::Bytes;
 use futures::SinkExt;
 use shotover_proxy::codec::cassandra::CassandraCodec;
-use std::collections::HashMap;
+
 use tokio::io::BufWriter;
 use tokio_stream::StreamExt;
 use tokio_util::codec::{FramedRead, FramedWrite};
 use tokio_util::io::StreamReader;
 
 async fn check_vec_of_bytes(packet_stream: Vec<Bytes>) {
-    let mut pk_map = HashMap::new();
     let mut comparator_iter = packet_stream.clone().into_iter();
-    pk_map.insert("test.simple".to_string(), vec!["pk".to_string()]);
-    pk_map.insert(
-        "test.clustering".to_string(),
-        vec!["pk".to_string(), "clustering".to_string()],
-    );
 
-    let codec = CassandraCodec::new(pk_map.clone(), true);
-    let write_codec = CassandraCodec::new(pk_map.clone(), true);
+    let codec = CassandraCodec::new();
+    let write_codec = CassandraCodec::new();
     let stream = tokio_stream::iter(
         packet_stream
             .into_iter()

--- a/shotover-proxy/tests/runner/observability_int_tests.rs
+++ b/shotover-proxy/tests/runner/observability_int_tests.rs
@@ -79,20 +79,20 @@ async fn test_metrics() {
         .arg(42)
         .query_async::<_, ()>(&mut connection)
         .await
-        .unwrap();
+        .unwrap_err();
 
     redis::cmd("SET")
         .arg("the_key")
         .arg(43)
         .query_async::<_, ()>(&mut connection)
         .await
-        .unwrap();
+        .unwrap_err();
 
     redis::cmd("GET")
         .arg("the_key")
         .query_async::<_, ()>(&mut connection)
         .await
-        .unwrap();
+        .unwrap_err();
 
     body = http_request_metrics().await;
 

--- a/shotover-proxy/tests/test-topologies/cassandra-peers-rewrite/topology.yaml
+++ b/shotover-proxy/tests/test-topologies/cassandra-peers-rewrite/topology.yaml
@@ -2,24 +2,20 @@
 sources:
   cassandra_prod_1:
     Cassandra:
-      query_processing: false
       listen_addr: "127.0.0.1:9043"
 
   cassandra_prod_2:
     Cassandra:
-      query_processing: false
       listen_addr: "127.0.0.1:9044"
 
 chain_config:
   main_chain:
     - CassandraSinkSingle:
-        result_processing: false
         remote_address: "172.16.1.2:9042"
   peers_rewrite_port:
     - CassandraPeersRewrite:
         port: 9044
     - CassandraSinkSingle:
-        result_processing: false
         remote_address: "172.16.1.2:9042"
 
 named_topics:

--- a/shotover-proxy/tests/test-topologies/cassandra-peers-rewrite/topology.yaml
+++ b/shotover-proxy/tests/test-topologies/cassandra-peers-rewrite/topology.yaml
@@ -4,27 +4,11 @@ sources:
     Cassandra:
       query_processing: false
       listen_addr: "127.0.0.1:9043"
-      cassandra_ks:
-        system.local:
-          - key
-        test.simple:
-          - pk
-        test.clustering:
-          - pk
-          - clustering
 
   cassandra_prod_2:
     Cassandra:
       query_processing: false
       listen_addr: "127.0.0.1:9044"
-      cassandra_ks:
-        system.local:
-          - key
-        test.simple:
-          - pk
-        test.clustering:
-          - pk
-          - clustering
 
 chain_config:
   main_chain:


### PR DESCRIPTION
I think it would be easiest to just land the rest of the changes at this point but im more than happy to pull anything out that you think should go in separately.

## message/mod.rs
The most important changes are in message/mod.rs
There we implement the new MessageInner abstraction which manages the message internal state in an efficient way.
Initially all incoming messages are `MessageInner::RawBytes`.
A RawBytes is very cheap to create and to send as its just the raw bytes of the message.

Then when a transform needs to access message data it calls `message.frame()` which internally converts the message into a `MessageInner::Parsed` which contains the parsed message and the raw bytes of the message.
This is expensive to create but is still cheap to send.

Then if a transform needs to modify a message it modifies the `&mut Frame` returned by `message.frame()` and then calls `message.invalidate_cache()` which converts the message into a `MessageInner::Modified` deleting the internally stored raw bytes of the message.
Doing this is cheap but results in a message that is expensive to send as the message bytes must be rebuilt from the frame at send time.

## Transforms
Some minor adjustments to use the new Message API.
There should not be any logic changes here.

## Codecs

The codec changes are mostly just deleting the old message details -> message and message -> message details logic.
That has been superceded by calling Frame::from_bytes() to create a frame that just holds bytes at receive time.
Then at send time the codec calls message.into_encodable() which returns either a Bytes which can be directly sent or a Frame which the codec converts to bytes before sending.

## Config

Cassandra source and sink configs are drastically simplified.
We no longer need to toggle on/off message details generation/processing (query_processing)
We also no longer need to configure which fields should be included in the message details. (cassandra_ks)