### PR TITLE
Add cqlparser crate implemented by nom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,6 +447,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cqlparser"
+version = "0.1.0"
+dependencies = [
+ "criterion",
+ "nom 7.1.0",
+]
+
+[[package]]
 name = "crc16"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "shotover-proxy",
     "test-helpers",
+    "cqlparser"
 ]
 
 # https://deterministic.space/high-performance-rust.html

--- a/cqlparser/Cargo.toml
+++ b/cqlparser/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "cqlparser"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+nom = "7.1.0"
+
+[dev-dependencies]
+criterion = { git = "https://github.com/shotover/criterion.rs", branch = "version-0.4", version = "0.3" }
+
+[[bench]]
+name = "benches"
+harness = false

--- a/cqlparser/benches/benches.rs
+++ b/cqlparser/benches/benches.rs
@@ -1,0 +1,35 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use cqlparser::parse;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("select");
+
+    group.bench_function("simple", |b| {
+        b.iter(|| parse(black_box("SELECT * FROM FOO")))
+    });
+
+    let mut lots_of_field = "SELECT field as alias".to_string();
+    for _ in 0..100 {
+        lots_of_field.push_str(", field as alias")
+    }
+    lots_of_field.push_str(" FROM table");
+    group.bench_function("lots_of_field", |b| {
+        b.iter(|| parse(black_box(&lots_of_field)))
+    });
+
+    let mut lots_of_where = "SELECT field FROM table WHERE foo = 'some string'".to_string();
+    for _ in 0..100 {
+        lots_of_where.push_str(" AND foo = 'some string'")
+    }
+    group.bench_function("lots_of_where", |b| {
+        b.iter(|| parse(black_box(&lots_of_where)))
+    });
+
+    group.bench_function("christmas_tree", |b| {
+        b.iter(|| parse(black_box("SELECT distinct json field1, field2 as foo FROM table order by order_column WHERE foo = 1 DESC limit 9999 allow filtering")))
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/cqlparser/src/ast.rs
+++ b/cqlparser/src/ast.rs
@@ -1,0 +1,107 @@
+#[derive(Debug, Clone, PartialEq)]
+pub enum Statement {
+    Select(Select),
+    Insert(Insert),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Insert {}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Select {
+    pub distinct: bool,
+    pub json: bool,
+    pub select: Vec<SelectElement>,
+    pub from: Vec<String>,
+    /// Every element is AND'd together
+    pub where_: Vec<RelationElement>,
+    pub order_by: Option<OrderBy>,
+    pub limit: Option<u64>,
+    pub allow_filtering: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SelectElement {
+    pub expr: Expr,
+    pub as_alias: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum RelationElement {
+    Comparison(RelationComparison),
+    In(RelationIn),
+    Contains(RelationContains),
+    ContainsKey(RelationContainsKey),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RelationComparison {
+    pub lhs: Expr,
+    pub operator: ComparisonOperator,
+    pub rhs: Expr,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RelationIn {
+    pub lhs: String,
+    pub rhs: Vec<Expr>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RelationContains {
+    pub lhs: String,
+    pub rhs: Constant,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RelationContainsKey {
+    pub lhs: String,
+    pub rhs: Constant,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ComparisonOperator {
+    Equals,
+    LessThan,
+    LessThanOrEqualTo,
+    GreaterThan,
+    GreaterThanOrEqualTo,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct OrderBy {
+    pub name: String,
+    pub ordering: Ordering,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Ordering {
+    Asc,
+    Desc,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Expr {
+    Name(String),
+    Constant(Constant),
+    FunctionCall(FunctionCall),
+    Wildcard,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Constant {
+    UUID,
+    String(String),
+    Decimal(i64),
+    Float(f64), // TODO: we should store raw instead of ieee
+    Hex(i64),
+    Bool(bool),
+    CodeBlock(String),
+    Null,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct FunctionCall {
+    pub function: String,
+    pub args: Vec<Expr>,
+}

--- a/cqlparser/src/lib.rs
+++ b/cqlparser/src/lib.rs
@@ -1,0 +1,23 @@
+pub mod ast;
+pub(crate) mod parser;
+
+use std::str;
+
+use nom::branch::alt;
+use nom::combinator::map;
+use nom::IResult;
+
+use crate::ast::*;
+use crate::parser::insert::insert;
+use crate::parser::select::select;
+
+pub fn parse(value: &str) -> Vec<Statement> {
+    vec![sql_query(value.as_bytes()).unwrap().1]
+}
+
+pub fn sql_query(i: &[u8]) -> IResult<&[u8], Statement> {
+    alt((
+        map(select, Statement::Select),
+        map(insert, Statement::Insert),
+    ))(i)
+}

--- a/cqlparser/src/lib.rs
+++ b/cqlparser/src/lib.rs
@@ -4,18 +4,35 @@ pub(crate) mod parser;
 use std::str;
 
 use nom::branch::alt;
+use nom::bytes::complete::tag;
+use nom::character::complete::multispace0;
 use nom::combinator::map;
+use nom::multi::many0;
+use nom::sequence::{delimited, terminated};
 use nom::IResult;
 
 use crate::ast::*;
 use crate::parser::insert::insert;
 use crate::parser::select::select;
 
-pub fn parse(value: &str) -> Vec<Statement> {
-    vec![sql_query(value.as_bytes()).unwrap().1]
+pub fn parse(value: &str) -> Result<Vec<Statement>, String> {
+    // TODO: parse multiple statements
+    match statements(value.as_bytes()) {
+        Ok(([], o)) => Ok(o),
+        Ok((a @ [..], _)) => Err(format!("Unexpected end of query: {:?}", str::from_utf8(a))),
+        Err(e) => Err(format!("nom error: {:?}", e)),
+    }
 }
 
-pub fn sql_query(i: &[u8]) -> IResult<&[u8], Statement> {
+fn statements(i: &[u8]) -> IResult<&[u8], Vec<Statement>> {
+    many0(terminated(statement, semicolon))(i)
+}
+
+fn semicolon(i: &[u8]) -> IResult<&[u8], &[u8]> {
+    delimited(multispace0, tag(";"), multispace0)(i)
+}
+
+fn statement(i: &[u8]) -> IResult<&[u8], Statement> {
     alt((
         map(select, Statement::Select),
         map(insert, Statement::Insert),

--- a/cqlparser/src/parser/insert.rs
+++ b/cqlparser/src/parser/insert.rs
@@ -1,0 +1,10 @@
+use nom::bytes::complete::tag_no_case;
+use nom::sequence::tuple;
+use nom::IResult;
+
+use crate::ast::*;
+
+pub fn insert(i: &[u8]) -> IResult<&[u8], Insert> {
+    let (remaining_input, _) = tuple((tag_no_case("insert"),))(i)?;
+    Ok((remaining_input, Insert {}))
+}

--- a/cqlparser/src/parser/mod.rs
+++ b/cqlparser/src/parser/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod insert;
+pub(crate) mod select;

--- a/cqlparser/src/parser/select.rs
+++ b/cqlparser/src/parser/select.rs
@@ -1,0 +1,228 @@
+use std::str;
+use std::str::FromStr;
+
+use nom::branch::alt;
+use nom::bytes::complete::{is_not, tag, tag_no_case, take_while1};
+use nom::character::complete::{digit1, multispace0, multispace1};
+use nom::character::is_alphanumeric;
+use nom::combinator::{map, opt};
+use nom::multi::{fold_many0, many0};
+use nom::sequence::{delimited, pair, preceded, terminated, tuple};
+use nom::IResult;
+
+use crate::ast::*;
+
+pub fn select(i: &[u8]) -> IResult<&[u8], Select> {
+    let (
+        remaining_input,
+        (_, _, distinct, json, select, from, where_, order_by, limit, allow_filtering),
+    ) = tuple((
+        tag_no_case("select"),
+        multispace1,
+        distinct,
+        json,
+        fields,
+        from,
+        where_,
+        opt(order_by),
+        limit,
+        allow_filtering,
+    ))(i)?;
+    Ok((
+        remaining_input,
+        Select {
+            distinct,
+            json,
+            select,
+            from,
+            where_,
+            order_by,
+            limit,
+            allow_filtering,
+        },
+    ))
+}
+
+pub fn json(i: &[u8]) -> IResult<&[u8], bool> {
+    map(opt(terminated(tag_no_case("json"), multispace1)), |v| {
+        v.is_some()
+    })(i)
+}
+
+pub fn distinct(i: &[u8]) -> IResult<&[u8], bool> {
+    map(opt(terminated(tag_no_case("distinct"), multispace1)), |v| {
+        v.is_some()
+    })(i)
+}
+
+pub fn where_(i: &[u8]) -> IResult<&[u8], Vec<RelationElement>> {
+    map(
+        opt(preceded(
+            tuple((multispace1, tag_no_case("where"), multispace1)),
+            where_elements,
+        )),
+        |x| x.unwrap_or_default(),
+    )(i)
+}
+
+pub fn where_elements(i: &[u8]) -> IResult<&[u8], Vec<RelationElement>> {
+    many0(terminated(
+        where_element,
+        opt(tuple((multispace1, tag_no_case("AND"), multispace1))), // TODO: this seems wrong
+    ))(i)
+}
+
+pub fn where_element(i: &[u8]) -> IResult<&[u8], RelationElement> {
+    let (remaining_input, (lhs, _, operator, _, rhs)) =
+        tuple((expr, multispace1, operator, multispace1, expr))(i)?;
+
+    Ok((
+        remaining_input,
+        RelationElement::Comparison(RelationComparison { lhs, operator, rhs }),
+    ))
+}
+
+pub fn order_by(i: &[u8]) -> IResult<&[u8], OrderBy> {
+    let (remaining_input, (_, _, _, _, _, name, ordering)) = tuple((
+        multispace1,
+        tag_no_case("order"),
+        multispace1,
+        tag_no_case("by"),
+        multispace1,
+        identifier,
+        opt(preceded(multispace1, ordering)),
+    ))(i)?;
+
+    let name = String::from_utf8(name.to_vec()).unwrap();
+    let ordering = ordering.unwrap_or(Ordering::Asc);
+    Ok((remaining_input, OrderBy { name, ordering }))
+}
+
+pub fn operator(i: &[u8]) -> IResult<&[u8], ComparisonOperator> {
+    alt((
+        map(tag("="), |_| ComparisonOperator::Equals),
+        map(tag(">="), |_| ComparisonOperator::GreaterThanOrEqualTo),
+        map(tag(">"), |_| ComparisonOperator::GreaterThan),
+        map(tag("<="), |_| ComparisonOperator::LessThanOrEqualTo),
+        map(tag("<"), |_| ComparisonOperator::LessThan),
+    ))(i)
+}
+
+pub fn ordering(i: &[u8]) -> IResult<&[u8], Ordering> {
+    alt((
+        map(tag_no_case("asc"), |_| Ordering::Asc),
+        map(tag_no_case("desc"), |_| Ordering::Desc),
+    ))(i)
+}
+
+pub fn limit(i: &[u8]) -> IResult<&[u8], Option<u64>> {
+    opt(preceded(
+        tuple((multispace1, tag_no_case("limit"), multispace1)),
+        unsigned_number,
+    ))(i)
+}
+
+pub fn unsigned_number(i: &[u8]) -> IResult<&[u8], u64> {
+    map(digit1, |d| {
+        FromStr::from_str(str::from_utf8(d).unwrap()).unwrap()
+    })(i)
+}
+
+pub fn allow_filtering(i: &[u8]) -> IResult<&[u8], bool> {
+    opt(preceded(multispace1, tag_no_case("allow filtering")))(i).map(|(r, v)| (r, v.is_some()))
+}
+
+pub fn fields(i: &[u8]) -> IResult<&[u8], Vec<SelectElement>> {
+    many0(terminated(field, opt(ws_sep_comma)))(i) // TODO: this seems wrong
+}
+
+pub fn field(i: &[u8]) -> IResult<&[u8], SelectElement> {
+    let (remaining, (expr, as_alias)) = pair(
+        expr,
+        opt(preceded(
+            tuple((multispace1, tag_no_case("AS"), multispace1)),
+            identifier,
+        )),
+    )(i)?;
+
+    let as_alias = as_alias.map(|x| String::from_utf8(x.to_vec()).unwrap());
+    Ok((remaining, SelectElement { expr, as_alias }))
+}
+
+pub fn from(i: &[u8]) -> IResult<&[u8], Vec<String>> {
+    preceded(
+        tuple((multispace1, tag_no_case("from"), multispace1)),
+        map(identifier, |name| {
+            vec![String::from_utf8(name.to_vec()).unwrap()]
+        }),
+    )(i)
+}
+
+pub fn expr(i: &[u8]) -> IResult<&[u8], Expr> {
+    alt((
+        map(tag("*"), |_| Expr::Wildcard),
+        map(constant, Expr::Constant),
+        map(identifier, |name| {
+            Expr::Name(String::from_utf8(name.to_vec()).unwrap())
+        }),
+    ))(i)
+}
+
+pub fn constant(i: &[u8]) -> IResult<&[u8], Constant> {
+    alt((
+        map(integer_constant, Constant::Decimal),
+        map(string_constant, Constant::String),
+        map(bool_constant, Constant::Bool),
+    ))(i)
+}
+
+pub fn integer_constant(i: &[u8]) -> IResult<&[u8], i64> {
+    map(pair(opt(tag("-")), digit1), |(negative, bytes)| {
+        let mut intval = i64::from_str(str::from_utf8(bytes).unwrap()).unwrap();
+        if (negative).is_some() {
+            intval *= -1;
+        }
+        intval
+    })(i)
+}
+
+pub fn string_constant(i: &[u8]) -> IResult<&[u8], String> {
+    map(raw_string_quoted, |bytes| String::from_utf8(bytes).unwrap())(i)
+}
+
+fn raw_string_quoted(i: &[u8]) -> IResult<&[u8], Vec<u8>> {
+    delimited(
+        tag("'"),
+        fold_many0(
+            alt((
+                is_not("'"), //
+                map(tag("''"), |_| &b"'"[..]),
+            )),
+            Vec::new,
+            |mut acc: Vec<u8>, bytes: &[u8]| {
+                acc.extend(bytes);
+                acc
+            },
+        ),
+        tag("'"),
+    )(i)
+}
+
+pub fn bool_constant(i: &[u8]) -> IResult<&[u8], bool> {
+    alt((
+        map(tag_no_case("true"), |_| true),
+        map(tag_no_case("false"), |_| false),
+    ))(i)
+}
+
+pub(crate) fn ws_sep_comma(i: &[u8]) -> IResult<&[u8], &[u8]> {
+    delimited(multispace0, tag(","), multispace0)(i)
+}
+
+pub fn identifier(i: &[u8]) -> IResult<&[u8], &[u8]> {
+    take_while1(is_identifier)(i)
+}
+
+pub fn is_identifier(chr: u8) -> bool {
+    is_alphanumeric(chr) || chr == b'_'
+}

--- a/cqlparser/tests/combined/mod.rs
+++ b/cqlparser/tests/combined/mod.rs
@@ -1,0 +1,12 @@
+use crate::assert_fails_to_parse;
+
+#[test]
+fn test_invalid_after_complete_query() {
+    assert_fails_to_parse(
+        &[
+            "select field from table; BLAH",
+            "SELECT    field    FROM    table; BLAH",
+        ],
+        "Unexpected end of query: Ok(\"BLAH\")",
+    );
+}

--- a/cqlparser/tests/insert/mod.rs
+++ b/cqlparser/tests/insert/mod.rs
@@ -1,0 +1,8 @@
+use cqlparser::ast::*;
+
+use crate::assert_parses;
+
+#[test]
+fn test_insert() {
+    assert_parses(&["insert;"], vec![Statement::Insert(Insert {})]);
+}

--- a/cqlparser/tests/select/mod.rs
+++ b/cqlparser/tests/select/mod.rs
@@ -1,23 +1,13 @@
 use cqlparser::ast::*;
-use cqlparser::parse;
 
-fn assert_parses(input: &[&str], ast: Vec<Statement>) {
-    for input in input {
-        assert_eq!(parse(input), ast);
-    }
-}
-
-#[test]
-fn test_insert() {
-    assert_parses(&["insert"], vec![Statement::Insert(Insert {})]);
-}
+use crate::assert_parses;
 
 #[test]
 fn test_select_one_field() {
     assert_parses(
         &[
-            "select field from table",
-            "SELECT    field    FROM    table",
+            "select field from table;",
+            "SELECT    field    FROM    table   ;",
         ],
         vec![Statement::Select(Select {
             distinct: false,
@@ -39,8 +29,8 @@ fn test_select_one_field() {
 fn test_select_one_field_as() {
     assert_parses(
         &[
-            "select field as alias from table",
-            "SELECT    field    AS    alias   FROM    table",
+            "select field as alias from table;",
+            "SELECT    field    AS    alias   FROM    table   ;",
         ],
         vec![Statement::Select(Select {
             distinct: false,
@@ -62,8 +52,8 @@ fn test_select_one_field_as() {
 fn test_select_many_fields_as() {
     assert_parses(
         &[
-            "select field1 as foo, field2, field3 as bar from table",
-            "select field1    as    foo    ,   field2    ,   field3   as   bar from table",
+            "select field1 as foo, field2, field3 as bar from table;",
+            "select field1    as    foo    ,   field2    ,   field3   as   bar from table    ;",
         ],
         vec![Statement::Select(Select {
             distinct: false,
@@ -95,8 +85,8 @@ fn test_select_many_fields_as() {
 fn test_select_distinct() {
     assert_parses(
         &[
-            "SELECT distinct field FROM table",
-            "SELECT    DISTINCT    field FROM table",
+            "SELECT distinct field FROM table;",
+            "SELECT    DISTINCT    field FROM table    ;",
         ],
         vec![Statement::Select(Select {
             distinct: true,
@@ -118,8 +108,8 @@ fn test_select_distinct() {
 fn test_select_json() {
     assert_parses(
         &[
-            "SELECT json field FROM table",
-            "SELECT    JSON    field FROM table",
+            "SELECT json field FROM table;",
+            "SELECT    JSON    field FROM table      ;",
         ],
         vec![Statement::Select(Select {
             distinct: false,
@@ -141,10 +131,10 @@ fn test_select_json() {
 fn test_select_order_by_asc() {
     assert_parses(
         &[
-            "SELECT field FROM table order by pk_field",
-            "SELECT field FROM table ORDER BY     pk_field",
-            "SELECT field FROM table order   BY    pk_field asc",
-            "SELECT field FROM table ORDER     BY     pk_field    ASC",
+            "SELECT field FROM table order by pk_field;",
+            "SELECT field FROM table ORDER BY     pk_field;",
+            "SELECT field FROM table order   BY    pk_field asc;",
+            "SELECT field FROM table ORDER     BY     pk_field    ASC;",
         ],
         vec![Statement::Select(Select {
             distinct: false,
@@ -169,8 +159,8 @@ fn test_select_order_by_asc() {
 fn test_select_where_field_greater_than_int() {
     assert_parses(
         &[
-            "select field from table where foo > 1",
-            "select field from table where     foo     >     1",
+            "select field from table where foo > 1;",
+            "select field from table where     foo     >     1;",
         ],
         vec![Statement::Select(Select {
             distinct: false,
@@ -196,8 +186,8 @@ fn test_select_where_field_greater_than_int() {
 fn test_select_where_field_and() {
     assert_parses(
         &[
-            "select field from table where foo < 1 and bar <= 1111",
-            "select field from table where     foo    <   1    AND    bar   <=    1111",
+            "select field from table where foo < 1 and bar <= 1111;",
+            "select field from table where     foo    <   1    AND    bar   <=    1111;",
         ],
         vec![Statement::Select(Select {
             distinct: false,
@@ -230,8 +220,8 @@ fn test_select_where_field_and() {
 fn test_select_where_field_greater_than_or_equal_negative_int() {
     assert_parses(
         &[
-            "select field from table where foo >= -13",
-            "select field from table where     foo     >=     -13",
+            "select field from table where foo >= -13;",
+            "select field from table where     foo     >=     -13;",
         ],
         vec![Statement::Select(Select {
             distinct: false,
@@ -257,8 +247,8 @@ fn test_select_where_field_greater_than_or_equal_negative_int() {
 fn test_select_where_field_equals_bool() {
     assert_parses(
         &[
-            "select field from table where foo = true",
-            "select field from table where     foo     =     true",
+            "select field from table where foo = true;",
+            "select field from table where     foo     =     true;",
         ],
         vec![Statement::Select(Select {
             distinct: false,
@@ -284,8 +274,8 @@ fn test_select_where_field_equals_bool() {
 fn test_select_where_field_equals_string() {
     assert_parses(
         &[
-            "select field from table where foo = 'bar'",
-            "select field from table where     foo     =     'bar'",
+            "select field from table where foo = 'bar';",
+            "select field from table where     foo     =     'bar';",
         ],
         vec![Statement::Select(Select {
             distinct: false,
@@ -311,8 +301,8 @@ fn test_select_where_field_equals_string() {
 fn test_select_where_field_equals_string_escape_quote() {
     assert_parses(
         &[
-            "select field from table where foo = 'lucas'' cool string '''''",
-            "select field from table where     foo     =     'lucas'' cool string '''''",
+            "select field from table where foo = 'lucas'' cool string ''''';",
+            "select field from table where     foo     =     'lucas'' cool string ''''';",
         ],
         vec![Statement::Select(Select {
             distinct: false,
@@ -338,8 +328,8 @@ fn test_select_where_field_equals_string_escape_quote() {
 fn test_select_order_by_desc() {
     assert_parses(
         &[
-            "SELECT field FROM table order by foo desc",
-            "SELECT field FROM table ORDER     BY     foo    DESC",
+            "SELECT field FROM table order by foo desc;",
+            "SELECT field FROM table ORDER     BY     foo    DESC;",
         ],
         vec![Statement::Select(Select {
             distinct: false,
@@ -364,8 +354,8 @@ fn test_select_order_by_desc() {
 fn test_select_limit_42() {
     assert_parses(
         &[
-            "SELECT field FROM table limit 42",
-            "SELECT field FROM table    LIMIT    42",
+            "SELECT field FROM table limit 42;",
+            "SELECT field FROM table    LIMIT    42;",
         ],
         vec![Statement::Select(Select {
             distinct: false,
@@ -387,8 +377,8 @@ fn test_select_limit_42() {
 fn test_select_limit_0() {
     assert_parses(
         &[
-            "SELECT field FROM table limit 0",
-            "SELECT field FROM table    LIMIT    0",
+            "SELECT field FROM table limit 0;",
+            "SELECT field FROM table    LIMIT    0;",
         ],
         vec![Statement::Select(Select {
             distinct: false,
@@ -410,8 +400,8 @@ fn test_select_limit_0() {
 fn test_select_allow_filtering() {
     assert_parses(
         &[
-            "SELECT field FROM table allow filtering",
-            "SELECT field FROM table    ALLOW FILTERING",
+            "SELECT field FROM table allow filtering;",
+            "SELECT field FROM table    ALLOW FILTERING;",
         ],
         vec![Statement::Select(Select {
             distinct: false,
@@ -433,9 +423,9 @@ fn test_select_allow_filtering() {
 fn test_select_two_fields() {
     assert_parses(
         &[
-            "SELECT field1,field2 FROM table",
-            "SELECT field1, field2 FROM table",
-            "SELECT   field1  ,   field2    FROM    table",
+            "SELECT field1,field2 FROM table;",
+            "SELECT field1, field2 FROM table;",
+            "SELECT   field1  ,   field2    FROM    table;",
         ],
         vec![Statement::Select(Select {
             distinct: false,
@@ -463,8 +453,8 @@ fn test_select_two_fields() {
 fn test_select_all() {
     assert_parses(
         &[
-            "SELECT * FROM foo",
-            "SELECT        *        FROM        foo",
+            "SELECT * FROM foo;",
+            "SELECT        *        FROM        foo;",
         ],
         vec![Statement::Select(Select {
             distinct: false,
@@ -485,7 +475,7 @@ fn test_select_all() {
 #[test]
 fn test_select_christmas_tree() {
     assert_parses(
-        &["SELECT distinct json field1, field2 as foo FROM table WHERE foo = 1 order by order_column DESC limit 9999 allow filtering"],
+        &["SELECT distinct json field1, field2 as foo FROM table WHERE foo = 1 order by order_column DESC limit 9999 allow filtering;"],
         vec![Statement::Select(Select {
             distinct: true,
             json: true,

--- a/cqlparser/tests/test.rs
+++ b/cqlparser/tests/test.rs
@@ -1,0 +1,516 @@
+use cqlparser::ast::*;
+use cqlparser::parse;
+
+fn assert_parses(input: &[&str], ast: Vec<Statement>) {
+    for input in input {
+        assert_eq!(parse(input), ast);
+    }
+}
+
+#[test]
+fn test_insert() {
+    assert_parses(&["insert"], vec![Statement::Insert(Insert {})]);
+}
+
+#[test]
+fn test_select_one_field() {
+    assert_parses(
+        &[
+            "select field from table",
+            "SELECT    field    FROM    table",
+        ],
+        vec![Statement::Select(Select {
+            distinct: false,
+            json: false,
+            select: vec![SelectElement {
+                expr: Expr::Name("field".to_string()),
+                as_alias: None,
+            }],
+            from: vec!["table".to_string()],
+            where_: vec![],
+            order_by: None,
+            limit: None,
+            allow_filtering: false,
+        })],
+    );
+}
+
+#[test]
+fn test_select_one_field_as() {
+    assert_parses(
+        &[
+            "select field as alias from table",
+            "SELECT    field    AS    alias   FROM    table",
+        ],
+        vec![Statement::Select(Select {
+            distinct: false,
+            json: false,
+            select: vec![SelectElement {
+                expr: Expr::Name("field".to_string()),
+                as_alias: Some("alias".into()),
+            }],
+            from: vec!["table".to_string()],
+            where_: vec![],
+            order_by: None,
+            limit: None,
+            allow_filtering: false,
+        })],
+    );
+}
+
+#[test]
+fn test_select_many_fields_as() {
+    assert_parses(
+        &[
+            "select field1 as foo, field2, field3 as bar from table",
+            "select field1    as    foo    ,   field2    ,   field3   as   bar from table",
+        ],
+        vec![Statement::Select(Select {
+            distinct: false,
+            json: false,
+            select: vec![
+                SelectElement {
+                    expr: Expr::Name("field1".to_string()),
+                    as_alias: Some("foo".into()),
+                },
+                SelectElement {
+                    expr: Expr::Name("field2".to_string()),
+                    as_alias: None,
+                },
+                SelectElement {
+                    expr: Expr::Name("field3".to_string()),
+                    as_alias: Some("bar".into()),
+                },
+            ],
+            from: vec!["table".to_string()],
+            where_: vec![],
+            order_by: None,
+            limit: None,
+            allow_filtering: false,
+        })],
+    );
+}
+
+#[test]
+fn test_select_distinct() {
+    assert_parses(
+        &[
+            "SELECT distinct field FROM table",
+            "SELECT    DISTINCT    field FROM table",
+        ],
+        vec![Statement::Select(Select {
+            distinct: true,
+            json: false,
+            select: vec![SelectElement {
+                expr: Expr::Name("field".to_string()),
+                as_alias: None,
+            }],
+            from: vec!["table".to_string()],
+            where_: vec![],
+            order_by: None,
+            limit: None,
+            allow_filtering: false,
+        })],
+    );
+}
+
+#[test]
+fn test_select_json() {
+    assert_parses(
+        &[
+            "SELECT json field FROM table",
+            "SELECT    JSON    field FROM table",
+        ],
+        vec![Statement::Select(Select {
+            distinct: false,
+            json: true,
+            select: vec![SelectElement {
+                expr: Expr::Name("field".to_string()),
+                as_alias: None,
+            }],
+            from: vec!["table".to_string()],
+            where_: vec![],
+            order_by: None,
+            limit: None,
+            allow_filtering: false,
+        })],
+    );
+}
+
+#[test]
+fn test_select_order_by_asc() {
+    assert_parses(
+        &[
+            "SELECT field FROM table order by pk_field",
+            "SELECT field FROM table ORDER BY     pk_field",
+            "SELECT field FROM table order   BY    pk_field asc",
+            "SELECT field FROM table ORDER     BY     pk_field    ASC",
+        ],
+        vec![Statement::Select(Select {
+            distinct: false,
+            json: false,
+            select: vec![SelectElement {
+                expr: Expr::Name("field".to_string()),
+                as_alias: None,
+            }],
+            from: vec!["table".to_string()],
+            where_: vec![],
+            order_by: Some(OrderBy {
+                name: "pk_field".to_string(),
+                ordering: Ordering::Asc,
+            }),
+            limit: None,
+            allow_filtering: false,
+        })],
+    );
+}
+
+#[test]
+fn test_select_where_field_greater_than_int() {
+    assert_parses(
+        &[
+            "select field from table where foo > 1",
+            "select field from table where     foo     >     1",
+        ],
+        vec![Statement::Select(Select {
+            distinct: false,
+            json: false,
+            select: vec![SelectElement {
+                expr: Expr::Name("field".to_string()),
+                as_alias: None,
+            }],
+            from: vec!["table".to_string()],
+            where_: vec![RelationElement::Comparison(RelationComparison {
+                lhs: Expr::Name("foo".to_string()),
+                operator: ComparisonOperator::GreaterThan,
+                rhs: Expr::Constant(Constant::Decimal(1)),
+            })],
+            order_by: None,
+            limit: None,
+            allow_filtering: false,
+        })],
+    );
+}
+
+#[test]
+fn test_select_where_field_and() {
+    assert_parses(
+        &[
+            "select field from table where foo < 1 and bar <= 1111",
+            "select field from table where     foo    <   1    AND    bar   <=    1111",
+        ],
+        vec![Statement::Select(Select {
+            distinct: false,
+            json: false,
+            select: vec![SelectElement {
+                expr: Expr::Name("field".to_string()),
+                as_alias: None,
+            }],
+            from: vec!["table".to_string()],
+            where_: vec![
+                RelationElement::Comparison(RelationComparison {
+                    lhs: Expr::Name("foo".to_string()),
+                    operator: ComparisonOperator::LessThan,
+                    rhs: Expr::Constant(Constant::Decimal(1)),
+                }),
+                RelationElement::Comparison(RelationComparison {
+                    lhs: Expr::Name("bar".to_string()),
+                    operator: ComparisonOperator::LessThanOrEqualTo,
+                    rhs: Expr::Constant(Constant::Decimal(1111)),
+                }),
+            ],
+            order_by: None,
+            limit: None,
+            allow_filtering: false,
+        })],
+    );
+}
+
+#[test]
+fn test_select_where_field_greater_than_or_equal_negative_int() {
+    assert_parses(
+        &[
+            "select field from table where foo >= -13",
+            "select field from table where     foo     >=     -13",
+        ],
+        vec![Statement::Select(Select {
+            distinct: false,
+            json: false,
+            select: vec![SelectElement {
+                expr: Expr::Name("field".to_string()),
+                as_alias: None,
+            }],
+            from: vec!["table".to_string()],
+            where_: vec![RelationElement::Comparison(RelationComparison {
+                lhs: Expr::Name("foo".to_string()),
+                operator: ComparisonOperator::GreaterThanOrEqualTo,
+                rhs: Expr::Constant(Constant::Decimal(-13)),
+            })],
+            order_by: None,
+            limit: None,
+            allow_filtering: false,
+        })],
+    );
+}
+
+#[test]
+fn test_select_where_field_equals_bool() {
+    assert_parses(
+        &[
+            "select field from table where foo = true",
+            "select field from table where     foo     =     true",
+        ],
+        vec![Statement::Select(Select {
+            distinct: false,
+            json: false,
+            select: vec![SelectElement {
+                expr: Expr::Name("field".to_string()),
+                as_alias: None,
+            }],
+            from: vec!["table".to_string()],
+            where_: vec![RelationElement::Comparison(RelationComparison {
+                lhs: Expr::Name("foo".to_string()),
+                operator: ComparisonOperator::Equals,
+                rhs: Expr::Constant(Constant::Bool(true)),
+            })],
+            order_by: None,
+            limit: None,
+            allow_filtering: false,
+        })],
+    );
+}
+
+#[test]
+fn test_select_where_field_equals_string() {
+    assert_parses(
+        &[
+            "select field from table where foo = 'bar'",
+            "select field from table where     foo     =     'bar'",
+        ],
+        vec![Statement::Select(Select {
+            distinct: false,
+            json: false,
+            select: vec![SelectElement {
+                expr: Expr::Name("field".to_string()),
+                as_alias: None,
+            }],
+            from: vec!["table".to_string()],
+            where_: vec![RelationElement::Comparison(RelationComparison {
+                lhs: Expr::Name("foo".to_string()),
+                operator: ComparisonOperator::Equals,
+                rhs: Expr::Constant(Constant::String("bar".into())),
+            })],
+            order_by: None,
+            limit: None,
+            allow_filtering: false,
+        })],
+    );
+}
+
+#[test]
+fn test_select_where_field_equals_string_escape_quote() {
+    assert_parses(
+        &[
+            "select field from table where foo = 'lucas'' cool string '''''",
+            "select field from table where     foo     =     'lucas'' cool string '''''",
+        ],
+        vec![Statement::Select(Select {
+            distinct: false,
+            json: false,
+            select: vec![SelectElement {
+                expr: Expr::Name("field".to_string()),
+                as_alias: None,
+            }],
+            from: vec!["table".to_string()],
+            where_: vec![RelationElement::Comparison(RelationComparison {
+                lhs: Expr::Name("foo".to_string()),
+                operator: ComparisonOperator::Equals,
+                rhs: Expr::Constant(Constant::String("lucas' cool string ''".into())),
+            })],
+            order_by: None,
+            limit: None,
+            allow_filtering: false,
+        })],
+    );
+}
+
+#[test]
+fn test_select_order_by_desc() {
+    assert_parses(
+        &[
+            "SELECT field FROM table order by foo desc",
+            "SELECT field FROM table ORDER     BY     foo    DESC",
+        ],
+        vec![Statement::Select(Select {
+            distinct: false,
+            json: false,
+            select: vec![SelectElement {
+                expr: Expr::Name("field".to_string()),
+                as_alias: None,
+            }],
+            from: vec!["table".to_string()],
+            where_: vec![],
+            order_by: Some(OrderBy {
+                name: "foo".to_string(),
+                ordering: Ordering::Desc,
+            }),
+            limit: None,
+            allow_filtering: false,
+        })],
+    );
+}
+
+#[test]
+fn test_select_limit_42() {
+    assert_parses(
+        &[
+            "SELECT field FROM table limit 42",
+            "SELECT field FROM table    LIMIT    42",
+        ],
+        vec![Statement::Select(Select {
+            distinct: false,
+            json: false,
+            select: vec![SelectElement {
+                expr: Expr::Name("field".to_string()),
+                as_alias: None,
+            }],
+            from: vec!["table".to_string()],
+            where_: vec![],
+            order_by: None,
+            limit: Some(42),
+            allow_filtering: false,
+        })],
+    );
+}
+
+#[test]
+fn test_select_limit_0() {
+    assert_parses(
+        &[
+            "SELECT field FROM table limit 0",
+            "SELECT field FROM table    LIMIT    0",
+        ],
+        vec![Statement::Select(Select {
+            distinct: false,
+            json: false,
+            select: vec![SelectElement {
+                expr: Expr::Name("field".to_string()),
+                as_alias: None,
+            }],
+            from: vec!["table".to_string()],
+            where_: vec![],
+            order_by: None,
+            limit: Some(0),
+            allow_filtering: false,
+        })],
+    );
+}
+
+#[test]
+fn test_select_allow_filtering() {
+    assert_parses(
+        &[
+            "SELECT field FROM table allow filtering",
+            "SELECT field FROM table    ALLOW FILTERING",
+        ],
+        vec![Statement::Select(Select {
+            distinct: false,
+            json: false,
+            select: vec![SelectElement {
+                expr: Expr::Name("field".to_string()),
+                as_alias: None,
+            }],
+            from: vec!["table".to_string()],
+            where_: vec![],
+            order_by: None,
+            limit: None,
+            allow_filtering: true,
+        })],
+    );
+}
+
+#[test]
+fn test_select_two_fields() {
+    assert_parses(
+        &[
+            "SELECT field1,field2 FROM table",
+            "SELECT field1, field2 FROM table",
+            "SELECT   field1  ,   field2    FROM    table",
+        ],
+        vec![Statement::Select(Select {
+            distinct: false,
+            json: false,
+            select: vec![
+                SelectElement {
+                    expr: Expr::Name("field1".to_string()),
+                    as_alias: None,
+                },
+                SelectElement {
+                    expr: Expr::Name("field2".to_string()),
+                    as_alias: None,
+                },
+            ],
+            from: vec!["table".to_string()],
+            where_: vec![],
+            order_by: None,
+            limit: None,
+            allow_filtering: false,
+        })],
+    );
+}
+
+#[test]
+fn test_select_all() {
+    assert_parses(
+        &[
+            "SELECT * FROM foo",
+            "SELECT        *        FROM        foo",
+        ],
+        vec![Statement::Select(Select {
+            distinct: false,
+            json: false,
+            select: vec![SelectElement {
+                expr: Expr::Wildcard,
+                as_alias: None,
+            }],
+            from: vec!["foo".to_string()],
+            where_: vec![],
+            order_by: None,
+            limit: None,
+            allow_filtering: false,
+        })],
+    );
+}
+
+#[test]
+fn test_select_christmas_tree() {
+    assert_parses(
+        &["SELECT distinct json field1, field2 as foo FROM table WHERE foo = 1 order by order_column DESC limit 9999 allow filtering"],
+        vec![Statement::Select(Select {
+            distinct: true,
+            json: true,
+            select: vec![
+                SelectElement {
+                    expr: Expr::Name("field1".to_string()),
+                    as_alias: None,
+                },
+                SelectElement {
+                    expr: Expr::Name("field2".to_string()),
+                    as_alias: Some("foo".into()),
+                },
+            ],
+            from: vec!["table".to_string()],
+            where_: vec![RelationElement::Comparison(RelationComparison {
+                lhs: Expr::Name("foo".to_string()),
+                operator: ComparisonOperator::Equals,
+                rhs: Expr::Constant(Constant::Decimal(1)),
+            })],
+            order_by: Some(OrderBy {
+                name: "order_column".to_string(),
+                ordering: Ordering::Desc,
+            }),
+            limit: Some(9999),
+            allow_filtering: true,
+        })],
+    );
+}

--- a/cqlparser/tests/tests.rs
+++ b/cqlparser/tests/tests.rs
@@ -1,0 +1,18 @@
+use cqlparser::ast::*;
+use cqlparser::parse;
+
+fn assert_parses(input: &[&str], ast: Vec<Statement>) {
+    for input in input {
+        assert_eq!(parse(input).unwrap(), ast);
+    }
+}
+
+fn assert_fails_to_parse(input: &[&str], error: &'static str) {
+    for input in input {
+        assert_eq!(parse(input), Err(error.to_string()));
+    }
+}
+
+mod combined;
+mod insert;
+mod select;


### PR DESCRIPTION
So far only implements select and even then still doesnt have full coverage of select.
However it does implement enough demonstrate the feasibility of writing a parser like this.

## Some background on parsers
This PR uses [nom](https://github.com/Geal/nom) which is a parser combinator library for rust.
That means it provides a whole bunch of composable functions to easily construct your own parser.
nom is designed around binary protocols but also happens to work well enough for simple programming languages. (I'm considering CQL a simple programming language)
Parser combinators are known to fall short when building a full general purpose programming language because you want more precise control over parsing mostly for error generating reasonable error messages.
However for our use case I think parser combinators should be more than enough.

## Error reporting
I am proposing that when given a bad query we just fail parsing with a generic error message.
I do like me some useful errors but in this case for simpler implementation and better performance I think it makes sense for shotover to just say "query {} failed to parse" and leave it at that.
We can of course reevaluate this in the future.
Especially once we have something in place, it will be easier to evaluate the affect on performance of improving the diagnostics.
If we want to go all out in terms of error reporting we can use something like https://github.com/zesterer/chumsky instead of nom

## Bytes
I attempted to rewrite the parser in its current state to store Strings as Bytes however this unexpectedly reduced performance by 4x. There might be a way to get parsing with Bytes working performantly but for now I would focus on just using allocating types and then we can investigate a rewrite later if it turns up in benchmarks.

## Just a draft
This PR is not to say that this is the way we should do things, its just a draft and one that I only spent a few days on. So im happy for this to go in a completely different direction if we find a better direction.

If we decide this is a good direction and we want to start collaborating on this code then we can land as is and start iterating on it.