### PR TITLE
Remove SourcesFromConfig trait

### DIFF
--- a/shotover-proxy/src/sources/cassandra_source.rs
+++ b/shotover-proxy/src/sources/cassandra_source.rs
@@ -1,19 +1,16 @@
-use std::sync::Arc;
-
+use crate::codec::cassandra::CassandraCodec;
+use crate::config::topology::TopicHolder;
+use crate::server::TcpCodecListener;
+use crate::sources::Sources;
+use crate::tls::{TlsAcceptor, TlsConfig};
+use crate::transforms::chain::TransformChain;
 use anyhow::Result;
-use async_trait::async_trait;
 use serde::Deserialize;
+use std::sync::Arc;
 use tokio::runtime::Handle;
 use tokio::sync::{watch, Semaphore};
 use tokio::task::JoinHandle;
 use tracing::{error, info};
-
-use crate::codec::cassandra::CassandraCodec;
-use crate::config::topology::TopicHolder;
-use crate::server::TcpCodecListener;
-use crate::sources::{Sources, SourcesFromConfig};
-use crate::tls::{TlsAcceptor, TlsConfig};
-use crate::transforms::chain::TransformChain;
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct CassandraConfig {
@@ -23,9 +20,8 @@ pub struct CassandraConfig {
     pub tls: Option<TlsConfig>,
 }
 
-#[async_trait]
-impl SourcesFromConfig for CassandraConfig {
-    async fn get_source(
+impl CassandraConfig {
+    pub async fn get_source(
         &self,
         chain: &TransformChain,
         _topics: &mut TopicHolder,

--- a/shotover-proxy/src/sources/mod.rs
+++ b/shotover-proxy/src/sources/mod.rs
@@ -3,35 +3,14 @@ use crate::sources::cassandra_source::{CassandraConfig, CassandraSource};
 use crate::sources::mpsc_source::{AsyncMpsc, AsyncMpscConfig};
 use crate::sources::redis_source::{RedisConfig, RedisSource};
 use crate::transforms::chain::TransformChain;
-use async_trait::async_trait;
+use anyhow::Result;
 use serde::Deserialize;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 
-use anyhow::Result;
-
 pub mod cassandra_source;
 pub mod mpsc_source;
 pub mod redis_source;
-
-/*
-   notify_shutdown: broadcast::Sender<()>,
-
-   /// Used as part of the graceful shutdown process to wait for client
-   /// connections to complete processing.
-   ///
-   /// Tokio channels are closed once all `Sender` handles go out of scope.
-   /// When a channel is closed, the receiver receives `None`. This is
-   /// leveraged to detect all connection handlers completing. When a
-   /// connection handler is initialized, it is assigned a clone of
-   /// `shutdown_complete_tx`. When the listener shuts down, it drops the
-   /// sender held by this `shutdown_complete_tx` field. Once all handler tasks
-   /// complete, all clones of the `Sender` are also dropped. This results in
-   /// `shutdown_complete_rx.recv()` completing with `None`. At this point, it
-   /// is safe to exit the server process.
-   shutdown_complete_rx: mpsc::Receiver<()>,
-   shutdown_complete_tx: mpsc::Sender<()>,
-*/
 
 #[derive(Debug)]
 pub enum Sources {
@@ -70,14 +49,4 @@ impl SourcesConfig {
             SourcesConfig::Redis(r) => r.get_source(chain, topics, trigger_shutdown_rx).await,
         }
     }
-}
-
-#[async_trait]
-pub trait SourcesFromConfig: Send {
-    async fn get_source(
-        &self,
-        chain: &TransformChain,
-        topics: &mut TopicHolder,
-        trigger_shutdown_rx: watch::Receiver<bool>,
-    ) -> Result<Vec<Sources>>;
 }

--- a/shotover-proxy/src/sources/mpsc_source.rs
+++ b/shotover-proxy/src/sources/mpsc_source.rs
@@ -1,15 +1,13 @@
-use crate::transforms::chain::TransformChain;
-use tokio::sync::mpsc::Receiver;
-
 use crate::config::topology::{ChannelMessage, TopicHolder};
 use crate::server::Shutdown;
-use crate::sources::{Sources, SourcesFromConfig};
+use crate::sources::Sources;
+use crate::transforms::chain::TransformChain;
 use crate::transforms::Wrapper;
 use anyhow::{anyhow, Result};
-use async_trait::async_trait;
 use serde::Deserialize;
 use std::time::Instant;
 use tokio::runtime::Handle;
+use tokio::sync::mpsc::Receiver;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
@@ -27,9 +25,8 @@ pub struct AsyncMpscConfig {
     pub coalesce_behavior: Option<CoalesceBehavior>,
 }
 
-#[async_trait]
-impl SourcesFromConfig for AsyncMpscConfig {
-    async fn get_source(
+impl AsyncMpscConfig {
+    pub async fn get_source(
         &self,
         chain: &TransformChain,
         topics: &mut TopicHolder,

--- a/shotover-proxy/src/sources/redis_source.rs
+++ b/shotover-proxy/src/sources/redis_source.rs
@@ -1,11 +1,10 @@
 use crate::codec::redis::RedisCodec;
 use crate::config::topology::TopicHolder;
 use crate::server::TcpCodecListener;
-use crate::sources::{Sources, SourcesFromConfig};
+use crate::sources::Sources;
 use crate::tls::{TlsAcceptor, TlsConfig};
 use crate::transforms::chain::TransformChain;
 use anyhow::Result;
-use async_trait::async_trait;
 use serde::Deserialize;
 use std::sync::Arc;
 use tokio::runtime::Handle;
@@ -21,9 +20,8 @@ pub struct RedisConfig {
     pub tls: Option<TlsConfig>,
 }
 
-#[async_trait]
-impl SourcesFromConfig for RedisConfig {
-    async fn get_source(
+impl RedisConfig {
+    pub async fn get_source(
         &self,
         chain: &TransformChain,
         _topics: &mut TopicHolder,


### PR DESCRIPTION
Remove an unneeded trait, similar to the other one for Transforms we removed a couple months ago.