### PR TITLE
check in cargo lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2461,7 +2461,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "shotover-proxy"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-recursion",


### PR DESCRIPTION
This fixes an issue where the benchmarks workflow fails due to an out of sync Cargo.lock on the main branch.
We'll have to force merge as the problem is due to the state of the main branch.