### PR TITLE
Add check for untracked/uncommitted files in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,12 @@ jobs:
       run: cargo test ${{ matrix.cargo_profile }} --all-features -- --include-ignored --show-output
       # can not run tests if cpp driver not installed
       if: ${{ matrix.runner == 'ubuntu-18.04' }}
+    - name: Ensure that tests did not create or modify any files that arent .gitignore'd
+      run: |
+        if [ -n "$(git status --porcelain)" ]; then
+          git status
+          exit 1
+        fi
     - name: License Check
       run: |
         cargo install --locked cargo-deny

--- a/shotover-proxy/build/install_ubuntu_packages.sh
+++ b/shotover-proxy/build/install_ubuntu_packages.sh
@@ -9,6 +9,8 @@ sudo apt-get install -y libpcap-dev wget
 
 if [ ${DISTRIB_RELEASE} == "18.04" ]
 then
+  mkdir pkgs
+  pushd pkgs
   wget https://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.16.0/cassandra-cpp-driver_2.16.0-1_amd64.deb &
   wget https://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.16.0/cassandra-cpp-driver-dev_2.16.0-1_amd64.deb &
   wget https://downloads.datastax.com/cpp-driver/ubuntu/18.04/dependencies/libuv/v1.35.0/libuv1_1.35.0-1_amd64.deb &
@@ -18,5 +20,8 @@ then
   sudo apt -y install ./cassandra-cpp-driver_2.16.0-1_amd64.deb \
     ./cassandra-cpp-driver-dev_2.16.0-1_amd64.deb \
     ./libuv1_1.35.0-1_amd64.deb ./libuv1-dev_1.35.0-1_amd64.deb
+
+  popd
+  rm -r pkgs
 fi
 


### PR DESCRIPTION
This will prevent incidents like https://github.com/shotover/shotover-proxy/pull/571 from occurring again.
Will also ensure tests aren't leaving weird files around.