### PR TITLE
Parse cassandra batch messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,7 @@ checksum = "eadde404d13254d8592f8aaa946a1fb7a2769c137df56ed29a3be5996973a156"
 [[package]]
 name = "cassandra-protocol"
 version = "1.1.0"
-source = "git+https://github.com/krojew/cdrs-tokio#59e271ef7f63f6b69bcc0011c3897dc1aaaa2a07"
+source = "git+https://github.com/krojew/cdrs-tokio#1946d5f7025f168aaea7b9ab27eda4708a0d8ba6"
 dependencies = [
  "arrayref",
  "bitflags",

--- a/shotover-proxy/src/frame/cassandra.rs
+++ b/shotover-proxy/src/frame/cassandra.rs
@@ -96,6 +96,7 @@ impl CassandraFrame {
     pub(crate) fn get_message_count(&self) -> Result<NonZeroU32> {
         Ok(match &self.operation {
             CassandraOperation::Batch(batch) => {
+                // it doesnt make sense to say a message is 0 messages, so when the batch has no queries we round up to 1
                 NonZeroU32::new(batch.queries.len() as u32).unwrap_or(nonzero!(1u32))
             }
             _ => nonzero!(1u32),
@@ -114,7 +115,7 @@ impl CassandraFrame {
                         params: body.query_params,
                     }
                 } else {
-                    unreachable!()
+                    unreachable!("We already know the operation is a query")
                 }
             }
             Opcode::Result => {
@@ -169,14 +170,14 @@ impl CassandraFrame {
                         ResResultBody::Void => CassandraOperation::Result(CassandraResult::Void),
                     }
                 } else {
-                    unreachable!()
+                    unreachable!("We already know the operation is a result")
                 }
             }
             Opcode::Error => {
                 if let ResponseBody::Error(body) = frame.response_body()? {
                     CassandraOperation::Error(body)
                 } else {
-                    unreachable!()
+                    unreachable!("We already know the operation is an error")
                 }
             }
             Opcode::Startup => CassandraOperation::Startup(frame.body),
@@ -212,7 +213,7 @@ impl CassandraFrame {
                         timestamp: body.timestamp,
                     })
                 } else {
-                    unreachable!()
+                    unreachable!("We already know the operation is a batch")
                 }
             }
             Opcode::AuthChallenge => CassandraOperation::AuthChallenge(frame.body),


### PR DESCRIPTION
Takes the same approach as CassandraOperation::Result, recreate a bunch of structures so that we can replace the string query with the query AST.
batch queries are now parsed by sql_parser (soon to be replaced with claudes parser)