### PR TITLE
Bump up Cassandra request throttling tests threshold

### DIFF
--- a/shotover-proxy/tests/cassandra_int_tests/basic_driver_tests.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/basic_driver_tests.rs
@@ -1493,7 +1493,7 @@ async fn test_cassandra_request_throttling() {
         });
 
         let len = results.len();
-        assert!(50 < len && len <= 55, "got {len}");
+        assert!(50 < len && len <= 60, "got {len}");
     }
 
     std::thread::sleep(std::time::Duration::from_secs(1)); // sleep to reset the window


### PR DESCRIPTION
Bumping up due to intermittent failures on the CI, as demonstrated on https://github.com/shotover/shotover-proxy/pull/577