### PR TITLE
Fail to start shotover when configured port already taken

### DIFF
--- a/shotover-proxy/src/sources/cassandra_source.rs
+++ b/shotover-proxy/src/sources/cassandra_source.rs
@@ -71,7 +71,8 @@ impl CassandraSource {
             Arc::new(Semaphore::new(connection_limit.unwrap_or(512))),
             trigger_shutdown_rx.clone(),
             tls.map(TlsAcceptor::new).transpose()?,
-        );
+        )
+        .await?;
 
         let join_handle = Handle::current().spawn(async move {
             // Check we didn't receive a shutdown signal before the receiver was created

--- a/shotover-proxy/src/sources/redis_source.rs
+++ b/shotover-proxy/src/sources/redis_source.rs
@@ -69,7 +69,8 @@ impl RedisSource {
             Arc::new(Semaphore::new(connection_limit.unwrap_or(512))),
             trigger_shutdown_rx.clone(),
             tls.map(TlsAcceptor::new).transpose()?,
-        );
+        )
+        .await?;
 
         let join_handle = Handle::current().spawn(async move {
             // Check we didn't receive a shutdown signal before the receiver was created


### PR DESCRIPTION
Previously if you run two `cargo run` and then run another `cargo run` at the same time, you would get a success exit code and the error `failed to accept connection cause=Address already in use (os error 98) address=127.0.0.1:6379`

With this PR doing the same will give you a failure exit code and the error: `Address already in use (os error 98) address=127.0.0.1:6379`

The original implementation shutting down shotover only occurs when all sources have their port taken, what happens is shotover detects that there are no longer any sources running and performs its natural shutdown procedure.
With this change it will always fail to startup even if only one of many sources have their port taken.

I was motivated to make this change to make integration tests fail in a clearer way when there is a stray shotover process.
But I believe it will also help users to quickly catch mistakes such as running multiple shotover instances or running shotover on the same port as the currently running DB.