### PR TITLE
Add DebugForceParse transform

### DIFF
--- a/shotover-proxy/benches/cassandra_benches.rs
+++ b/shotover-proxy/benches/cassandra_benches.rs
@@ -87,7 +87,53 @@ fn cassandra(c: &mut Criterion) {
         });
         for query in &queries {
             group.bench_with_input(
-                format!("passthrough_{}", query.name),
+                format!("passthrough_no_parse_{}", query.name),
+                &resources,
+                |b, resources| {
+                    b.iter(|| {
+                        let mut resources = resources.borrow_mut();
+                        let connection = &mut resources.as_mut().unwrap().connection;
+                        connection.execute(&query.statement).wait().unwrap();
+                    })
+                },
+            );
+        }
+    }
+
+    #[cfg(feature = "alpha-transforms")]
+    {
+        let resources = new_lazy_shared(|| {
+            BenchResources::new(
+                "tests/test-configs/cassandra-passthrough-parse-request/topology.yaml",
+                "example-configs/cassandra-passthrough/docker-compose.yml",
+            )
+        });
+        for query in &queries {
+            group.bench_with_input(
+                format!("passthrough_parse_request_{}", query.name),
+                &resources,
+                |b, resources| {
+                    b.iter(|| {
+                        let mut resources = resources.borrow_mut();
+                        let connection = &mut resources.as_mut().unwrap().connection;
+                        connection.execute(&query.statement).wait().unwrap();
+                    })
+                },
+            );
+        }
+    }
+
+    #[cfg(feature = "alpha-transforms")]
+    {
+        let resources = new_lazy_shared(|| {
+            BenchResources::new(
+                "tests/test-configs/cassandra-passthrough-parse-response/topology.yaml",
+                "example-configs/cassandra-passthrough/docker-compose.yml",
+            )
+        });
+        for query in &queries {
+            group.bench_with_input(
+                format!("passthrough_parse_response_{}", query.name),
                 &resources,
                 |b, resources| {
                     b.iter(|| {

--- a/shotover-proxy/src/transforms/debug/force_parse.rs
+++ b/shotover-proxy/src/transforms/debug/force_parse.rs
@@ -1,0 +1,55 @@
+/// This transform will by default parse requests and responses that pass through it.
+/// request and response parsing can be individually disabled if desired.
+///
+/// The use of this transform is to allow benchmarking the performance impact of parsing messages
+/// without worrying about the performance impact of other transform logic.
+/// It could also be used to ensure that messages round trip correctly when parsed.
+use crate::error::ChainResponse;
+use crate::transforms::{Transform, Transforms, Wrapper};
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct DebugForceParseConfig {
+    parse_requests: Option<bool>,
+    parse_responses: Option<bool>,
+}
+
+impl DebugForceParseConfig {
+    pub async fn get_transform(&self) -> Result<Transforms> {
+        Ok(Transforms::DebugForceParse(DebugForceParse {
+            parse_requests: self.parse_requests.unwrap_or(true),
+            parse_responses: self.parse_responses.unwrap_or(true),
+        }))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DebugForceParse {
+    parse_requests: bool,
+    parse_responses: bool,
+}
+
+#[async_trait]
+impl Transform for DebugForceParse {
+    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> ChainResponse {
+        if self.parse_requests {
+            for message in &mut message_wrapper.messages {
+                message.frame();
+            }
+        }
+
+        let mut response = message_wrapper.call_next_transform().await;
+
+        if self.parse_responses {
+            if let Ok(response) = response.as_mut() {
+                for message in response {
+                    message.frame();
+                }
+            }
+        }
+
+        response
+    }
+}

--- a/shotover-proxy/src/transforms/debug/mod.rs
+++ b/shotover-proxy/src/transforms/debug/mod.rs
@@ -1,3 +1,4 @@
+pub mod force_parse;
 pub mod printer;
 pub mod random_delay;
 pub mod returner;

--- a/shotover-proxy/tests/test-configs/cassandra-passthrough-parse-request/topology.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra-passthrough-parse-request/topology.yaml
@@ -1,0 +1,16 @@
+---
+sources:
+  cassandra_prod:
+    Cassandra:
+      listen_addr: "127.0.0.1:9042"
+chain_config:
+  main_chain:
+    - DebugForceParse:
+        parse_requests: true
+        parse_responses: false
+    - CassandraSinkSingle:
+        remote_address: "127.0.0.1:9043"
+named_topics:
+  testtopic: 5
+source_to_chain_mapping:
+  cassandra_prod: main_chain

--- a/shotover-proxy/tests/test-configs/cassandra-passthrough-parse-response/topology.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra-passthrough-parse-response/topology.yaml
@@ -1,0 +1,16 @@
+---
+sources:
+  cassandra_prod:
+    Cassandra:
+      listen_addr: "127.0.0.1:9042"
+chain_config:
+  main_chain:
+    - DebugForceParse:
+        parse_requests: false
+        parse_responses: true
+    - CassandraSinkSingle:
+        remote_address: "127.0.0.1:9043"
+named_topics:
+  testtopic: 5
+source_to_chain_mapping:
+  cassandra_prod: main_chain


### PR DESCRIPTION
This will be useful for evaluating the performance of the cassandra parser.

To get realistic evaluation of the performance impact we would want to run cassandra-passthrough-parse-request/topology.yaml etc on the cassandra_bench example.
The benches here could be useful but at the very least they ensure that these yaml's dont bitrot and that DebugForceParse the transform doesnt explode.