### PR TITLE
Cleanup and improve assertions of ShotoverProcess

### DIFF
--- a/shotover-proxy/examples/cassandra_bench.rs
+++ b/shotover-proxy/examples/cassandra_bench.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use test_helpers::docker_compose::DockerCompose;
-use test_helpers::shotover_process::ShotoverProcess;
+use test_helpers::shotover_process::{AssertExitsWith, ShotoverProcess};
 
 /// e.g.
 /// cargo run --release --example cassandra_bench -- --config-dir example-configs/cassandra-passthrough -r 1000
@@ -33,7 +33,10 @@ fn main() {
         let _compose = DockerCompose::new(&format!("{}/docker-compose.yml", args.config_dir));
 
         // Uses ShotoverProcess instead of ShotoverManager for a more accurate benchmark
-        let _shotover_manager = ShotoverProcess::new(&format!("{}/topology.yaml", args.config_dir));
+        let _shotover_manager = ShotoverProcess::new(
+            &format!("{}/topology.yaml", args.config_dir),
+            AssertExitsWith::Success,
+        );
 
         println!("Benching Shotover ...");
         bench_read(&latte, "localhost:9043", "localhost:9042");

--- a/shotover-proxy/examples/cassandra_bench.rs
+++ b/shotover-proxy/examples/cassandra_bench.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use test_helpers::docker_compose::DockerCompose;
-use test_helpers::shotover_process::{AssertExitsWith, ShotoverProcess};
+use test_helpers::shotover_process::ShotoverProcess;
 
 /// e.g.
 /// cargo run --release --example cassandra_bench -- --config-dir example-configs/cassandra-passthrough -r 1000
@@ -33,15 +33,14 @@ fn main() {
         let _compose = DockerCompose::new(&format!("{}/docker-compose.yml", args.config_dir));
 
         // Uses ShotoverProcess instead of ShotoverManager for a more accurate benchmark
-        let _shotover_manager = ShotoverProcess::new(
-            &format!("{}/topology.yaml", args.config_dir),
-            AssertExitsWith::Success,
-        );
+        let shotover_manager = ShotoverProcess::new(&format!("{}/topology.yaml", args.config_dir));
 
         println!("Benching Shotover ...");
         bench_read(&latte, "localhost:9043", "localhost:9042");
         println!("Benching Direct Cassandra ...");
         bench_read(&latte, "localhost:9043", "localhost:9043");
+
+        shotover_manager.shutdown_and_assert_success();
     }
 
     println!("Direct Cassandra (A) vs Shotover (B)");

--- a/shotover-proxy/tests/runner/runner_int_tests.rs
+++ b/shotover-proxy/tests/runner/runner_int_tests.rs
@@ -2,7 +2,7 @@ use serial_test::serial;
 use std::any::Any;
 
 use crate::helpers::ShotoverManager;
-use test_helpers::shotover_process::{AssertExitsWith, ShotoverProcess};
+use test_helpers::shotover_process::ShotoverProcess;
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
@@ -39,10 +39,7 @@ fn test_early_shutdown_cassandra_source() {
 #[test]
 #[serial]
 fn test_shotover_responds_sigterm() {
-    let shotover_process = ShotoverProcess::new(
-        "example-configs/null-redis/topology.yaml",
-        AssertExitsWith::Success,
-    );
+    let shotover_process = ShotoverProcess::new("example-configs/null-redis/topology.yaml");
     shotover_process.signal(nix::sys::signal::Signal::SIGTERM);
 
     let wait_output = shotover_process.wait();
@@ -58,10 +55,7 @@ fn test_shotover_responds_sigterm() {
 #[test]
 #[serial]
 fn test_shotover_responds_sigint() {
-    let shotover_process = ShotoverProcess::new(
-        "example-configs/null-redis/topology.yaml",
-        AssertExitsWith::Success,
-    );
+    let shotover_process = ShotoverProcess::new("example-configs/null-redis/topology.yaml");
     shotover_process.signal(nix::sys::signal::Signal::SIGINT);
 
     let wait_output = shotover_process.wait();

--- a/shotover-proxy/tests/runner/runner_int_tests.rs
+++ b/shotover-proxy/tests/runner/runner_int_tests.rs
@@ -2,7 +2,7 @@ use serial_test::serial;
 use std::any::Any;
 
 use crate::helpers::ShotoverManager;
-use test_helpers::shotover_process::ShotoverProcess;
+use test_helpers::shotover_process::{AssertExitsWith, ShotoverProcess};
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
@@ -39,15 +39,18 @@ fn test_early_shutdown_cassandra_source() {
 #[test]
 #[serial]
 fn test_shotover_responds_sigterm() {
-    let shotover_process = ShotoverProcess::new("example-configs/null-redis/topology.yaml");
+    let shotover_process = ShotoverProcess::new(
+        "example-configs/null-redis/topology.yaml",
+        AssertExitsWith::Success,
+    );
     shotover_process.signal(nix::sys::signal::Signal::SIGTERM);
 
-    let (code, stdout, _) = shotover_process.wait();
-    assert_eq!(code, Some(0));
-    if !stdout.contains("received SIGTERM") {
+    let wait_output = shotover_process.wait();
+    assert_eq!(wait_output.exit_code, 0);
+    if !wait_output.stdout.contains("received SIGTERM") {
         panic!(
             "stdout does not contain 'received SIGTERM'. Instead was: {}",
-            stdout
+            wait_output.stdout
         );
     }
 }
@@ -55,15 +58,18 @@ fn test_shotover_responds_sigterm() {
 #[test]
 #[serial]
 fn test_shotover_responds_sigint() {
-    let shotover_process = ShotoverProcess::new("example-configs/null-redis/topology.yaml");
+    let shotover_process = ShotoverProcess::new(
+        "example-configs/null-redis/topology.yaml",
+        AssertExitsWith::Success,
+    );
     shotover_process.signal(nix::sys::signal::Signal::SIGINT);
 
-    let (code, stdout, _) = shotover_process.wait();
-    assert_eq!(code, Some(0));
-    if !stdout.contains("received SIGINT") {
+    let wait_output = shotover_process.wait();
+    assert_eq!(wait_output.exit_code, 0);
+    if !wait_output.stdout.contains("received SIGINT") {
         panic!(
             "stdout does not contain 'received SIGINT'. Instead was: {}",
-            stdout
+            wait_output.stdout
         );
     }
 }

--- a/test-helpers/src/shotover_process.rs
+++ b/test-helpers/src/shotover_process.rs
@@ -1,3 +1,4 @@
+use crate::docker_compose::run_command;
 use nix::sys::signal::Signal;
 use nix::unistd::Pid;
 use std::process::{Child, Command, Stdio};
@@ -5,23 +6,56 @@ use std::process::{Child, Command, Stdio};
 pub struct ShotoverProcess {
     /// Always Some while ShotoverProcess is owned
     pub child: Option<Child>,
+    assert_exit: AssertExitsWith,
 }
 
 impl Drop for ShotoverProcess {
     fn drop(&mut self) {
-        if let Some(child) = &self.child {
+        if let Some(child) = self.child.take() {
             if let Err(err) =
                 nix::sys::signal::kill(Pid::from_raw(child.id() as i32), Signal::SIGKILL)
             {
                 println!("Failed to shutdown ShotoverProcess {err}");
             }
+
+            if !std::thread::panicking() {
+                let output = child.wait_with_output().unwrap();
+
+                let stdout = String::from_utf8(output.stdout).unwrap();
+                let stderr = String::from_utf8(output.stderr).unwrap();
+                let exit_code = output.status.code().unwrap();
+                match self.assert_exit {
+                    AssertExitsWith::Success => {
+                        if exit_code != 0 {
+                            panic!(
+                            "Shotover exited with {} but expected 0 exit code (Success).\nstdout: {}\nstderr: {}",
+                            exit_code, stdout, stderr
+                        );
+                        }
+                    }
+                    AssertExitsWith::Failure => {
+                        if exit_code == 0 {
+                            panic!(
+                            "Shotover exited with {} but expected non 0 exit code (Failure).\nstdout: {}\nstderr: {}",
+                            exit_code, stdout, stderr
+                        );
+                        }
+                    }
+                };
+            }
         }
     }
 }
 
+pub enum AssertExitsWith {
+    Success,
+    #[allow(unused)]
+    Failure,
+}
+
 impl ShotoverProcess {
     #[allow(unused)]
-    pub fn new(topology_path: &str) -> ShotoverProcess {
+    pub fn new(topology_path: &str, assert_exit: AssertExitsWith) -> ShotoverProcess {
         // First ensure shotover is fully built so that the potentially lengthy build time is not included in the wait_for_socket_to_open timeout
         // PROFILE is set in build.rs from PROFILE listed in https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts
         let all_args = if env!("PROFILE") == "release" {
@@ -29,12 +63,7 @@ impl ShotoverProcess {
         } else {
             vec!["build", "--all-features"]
         };
-        assert!(Command::new(env!("CARGO"))
-            .args(&all_args)
-            .stdout(Stdio::piped())
-            .status()
-            .unwrap()
-            .success());
+        run_command(env!("CARGO"), &all_args).unwrap();
 
         // Now actually run shotover and keep hold of the child process
         let all_args = if env!("PROFILE") == "release" {
@@ -51,7 +80,6 @@ impl ShotoverProcess {
         };
         let child = Some(
             Command::new(env!("CARGO"))
-                .env("RUST_LOG", "debug,shotover_proxy=debug")
                 .args(&all_args)
                 .stdout(Stdio::piped())
                 .spawn()
@@ -60,7 +88,7 @@ impl ShotoverProcess {
 
         crate::wait_for_socket_to_open("127.0.0.1", 9001); // Wait for observability metrics port to open
 
-        ShotoverProcess { child }
+        ShotoverProcess { child, assert_exit }
     }
 
     #[allow(unused)]
@@ -74,12 +102,22 @@ impl ShotoverProcess {
     }
 
     #[allow(unused)]
-    pub fn wait(mut self) -> (Option<i32>, String, String) {
+    pub fn wait(mut self) -> WaitOutput {
         let output = self.child.take().unwrap().wait_with_output().unwrap();
 
         let stdout = String::from_utf8(output.stdout).unwrap();
         let stderr = String::from_utf8(output.stderr).unwrap();
 
-        (output.status.code(), stdout, stderr)
+        WaitOutput {
+            exit_code: output.status.code().unwrap(),
+            stdout,
+            stderr,
+        }
     }
+}
+
+pub struct WaitOutput {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i32,
 }


### PR DESCRIPTION
Changes:
* The initial cargo build was swapped to `run_command` as that will print output on failure.
* `.env("RUST_LOG", "debug,shotover_proxy=debug")` was removed as it did nothing (didnt bother investigating why) and it is incorrect (we should be logging at info level not debug level)
* `wait()` now returns WaitOutput so we dont have to guess what tuple value contains what.
* implemented AssertExitsWith which will trigger the requested assert when ShotoverProcess is dropped.