### PR TITLE
CassandraOperation::queries returns batch queries

### DIFF
--- a/shotover-proxy/tests/cassandra_int_tests/protect.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/protect.rs
@@ -1,5 +1,5 @@
 use crate::helpers::cassandra::{assert_query_result, execute_query, run_query, ResultValue};
-use cassandra_cpp::Session;
+use cassandra_cpp::{stmt, Batch, BatchType, Session};
 
 pub fn test(shotover_session: &Session, direct_session: &Session) {
     run_query(shotover_session, "CREATE KEYSPACE test_protect_keyspace WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };");
@@ -9,21 +9,46 @@ pub fn test(shotover_session: &Session, direct_session: &Session) {
         );
 
     run_query(
-            shotover_session,
-            "INSERT INTO test_protect_keyspace.test_table (pk, cluster, col1, col2, col3) VALUES ('pk1', 'cluster', 'I am gonna get encrypted!!', 42, true);"
-        );
+        shotover_session,
+        "INSERT INTO test_protect_keyspace.test_table (pk, cluster, col1, col2, col3) VALUES ('pk1', 'cluster', 'I am gonna get encrypted!!', 42, true);"
+    );
+
+    let mut batch = Batch::new(BatchType::LOGGED);
+    batch.add_statement(&stmt!(
+        "INSERT INTO test_protect_keyspace.test_table (pk, cluster, col1, col2, col3) VALUES ('pk2', 'cluster', 'encrypted2', 422, true)"
+    )).unwrap();
+    batch.add_statement(&stmt!(
+        "INSERT INTO test_protect_keyspace.test_table (pk, cluster, col1, col2, col3) VALUES ('pk3', 'cluster', 'encrypted3', 423, false)"
+    )).unwrap();
+    shotover_session.execute_batch(&batch).wait().unwrap();
 
     // assert that data is decrypted by shotover
     assert_query_result(
         shotover_session,
         "SELECT pk, cluster, col1, col2, col3 FROM test_protect_keyspace.test_table",
-        &[&[
-            ResultValue::Varchar("pk1".into()),
-            ResultValue::Varchar("cluster".into()),
-            ResultValue::Varchar("I am gonna get encrypted!!".into()),
-            ResultValue::Int(42),
-            ResultValue::Boolean(true),
-        ]],
+        &[
+            &[
+                ResultValue::Varchar("pk1".into()),
+                ResultValue::Varchar("cluster".into()),
+                ResultValue::Varchar("I am gonna get encrypted!!".into()),
+                ResultValue::Int(42),
+                ResultValue::Boolean(true),
+            ],
+            &[
+                ResultValue::Varchar("pk2".into()),
+                ResultValue::Varchar("cluster".into()),
+                ResultValue::Varchar("encrypted2".into()),
+                ResultValue::Int(422),
+                ResultValue::Boolean(true),
+            ],
+            &[
+                ResultValue::Varchar("pk3".into()),
+                ResultValue::Varchar("cluster".into()),
+                ResultValue::Varchar("encrypted3".into()),
+                ResultValue::Int(423),
+                ResultValue::Boolean(false),
+            ],
+        ],
     );
 
     // assert that data is encrypted on cassandra side
@@ -31,15 +56,18 @@ pub fn test(shotover_session: &Session, direct_session: &Session) {
         direct_session,
         "SELECT pk, cluster, col1, col2, col3 FROM test_protect_keyspace.test_table",
     );
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].len(), 5);
-    assert_eq!(result[0][0], ResultValue::Varchar("pk1".into()));
-    assert_eq!(result[0][1], ResultValue::Varchar("cluster".into()));
-    if let ResultValue::Varchar(value) = &result[0][2] {
-        assert!(value.starts_with("{\"cipher"), "but was {:?}", value);
-    } else {
-        panic!("expected 3rd column to be ResultValue::Varchar in {result:?}");
+    assert_eq!(result.len(), 3);
+    for row in result {
+        assert_eq!(row.len(), 5);
+
+        // regular values are stored unencrypted
+        assert_eq!(row[1], ResultValue::Varchar("cluster".into()));
+
+        // protected values are stored encrypted
+        if let ResultValue::Varchar(value) = &row[2] {
+            assert!(value.starts_with("{\"cipher"), "but was {:?}", value);
+        } else {
+            panic!("expected 3rd column to be ResultValue::Varchar in {row:?}");
+        }
     }
-    assert_eq!(result[0][3], ResultValue::Int(42));
-    assert_eq!(result[0][4], ResultValue::Boolean(true));
 }


### PR DESCRIPTION
closes https://github.com/shotover/shotover-proxy/issues/563

This PR allows transforms like redis cache and protect transform to work on batch messages.
This however only works for batch messages sent over the BATCH protocol, batch messages sent over QUERY are still broken.

You can verify the integration test tests the new functionality by disabling the new `CassandraOperation::Batch(batch)` handling and observing the test fail.