### PR TITLE
Store Wrapper.transforms as an IterMut instead of a cloned Vec

### DIFF
--- a/shotover-proxy/src/transforms/chain.rs
+++ b/shotover-proxy/src/transforms/chain.rs
@@ -260,8 +260,7 @@ impl TransformChain {
         client_details: String,
     ) -> ChainResponse {
         let start = Instant::now();
-        let iter = self.chain.iter_mut().collect_vec();
-        wrapper.reset(iter);
+        wrapper.reset(&mut self.chain);
 
         let result = wrapper.call_next_transform().await;
         self.chain_total.increment(1);

--- a/shotover-proxy/src/transforms/coalesce.rs
+++ b/shotover-proxy/src/transforms/coalesce.rs
@@ -96,28 +96,28 @@ mod test {
             last_write: Instant::now(),
         };
 
-        let mut loopback = Transforms::Loopback(Loopback::default());
+        let mut chain = vec![Transforms::Loopback(Loopback::default())];
 
         let messages: Vec<_> = (0..25).map(|_| Message::from_frame(Frame::None)).collect();
 
         let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.transforms = vec![&mut loopback];
+        message_wrapper.reset(&mut chain);
         assert_eq!(coalesce.transform(message_wrapper).await?.len(), 0);
 
         let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.transforms = vec![&mut loopback];
+        message_wrapper.reset(&mut chain);
         assert_eq!(coalesce.transform(message_wrapper).await?.len(), 0);
 
         let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.transforms = vec![&mut loopback];
+        message_wrapper.reset(&mut chain);
         assert_eq!(coalesce.transform(message_wrapper).await?.len(), 0);
 
         let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.transforms = vec![&mut loopback];
+        message_wrapper.reset(&mut chain);
         assert_eq!(coalesce.transform(message_wrapper).await?.len(), 100);
 
         let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.transforms = vec![&mut loopback];
+        message_wrapper.reset(&mut chain);
         assert_eq!(coalesce.transform(message_wrapper).await?.len(), 0);
 
         Ok(())
@@ -132,28 +132,28 @@ mod test {
             last_write: Instant::now(),
         };
 
-        let mut loopback = Transforms::Loopback(Loopback::default());
+        let mut chain = vec![Transforms::Loopback(Loopback::default())];
 
         let messages: Vec<_> = (0..25).map(|_| Message::from_frame(Frame::None)).collect();
 
         let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.transforms = vec![&mut loopback];
+        message_wrapper.reset(&mut chain);
         assert_eq!(coalesce.transform(message_wrapper).await?.len(), 0);
 
         tokio::time::sleep(Duration::from_millis(10_u64)).await;
 
         let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.transforms = vec![&mut loopback];
+        message_wrapper.reset(&mut chain);
         assert_eq!(coalesce.transform(message_wrapper).await?.len(), 0);
 
         tokio::time::sleep(Duration::from_millis(100_u64)).await;
 
         let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.transforms = vec![&mut loopback];
+        message_wrapper.reset(&mut chain);
         assert_eq!(coalesce.transform(message_wrapper).await?.len(), 75);
 
         let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.transforms = vec![&mut loopback];
+        message_wrapper.reset(&mut chain);
         assert_eq!(coalesce.transform(message_wrapper).await?.len(), 0);
 
         Ok(())
@@ -168,44 +168,44 @@ mod test {
             last_write: Instant::now(),
         };
 
-        let mut loopback = Transforms::Loopback(Loopback::default());
+        let mut chain = vec![Transforms::Loopback(Loopback::default())];
 
         let messages: Vec<_> = (0..25).map(|_| Message::from_frame(Frame::None)).collect();
 
         let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.transforms = vec![&mut loopback];
+        message_wrapper.reset(&mut chain);
         assert_eq!(coalesce.transform(message_wrapper).await?.len(), 0);
 
         tokio::time::sleep(Duration::from_millis(10_u64)).await;
 
         let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.transforms = vec![&mut loopback];
+        message_wrapper.reset(&mut chain);
         assert_eq!(coalesce.transform(message_wrapper).await?.len(), 0);
 
         tokio::time::sleep(Duration::from_millis(100_u64)).await;
 
         let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.transforms = vec![&mut loopback];
+        message_wrapper.reset(&mut chain);
         assert_eq!(coalesce.transform(message_wrapper).await?.len(), 75);
 
         let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.transforms = vec![&mut loopback];
+        message_wrapper.reset(&mut chain);
         assert_eq!(coalesce.transform(message_wrapper).await?.len(), 0);
 
         let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.transforms = vec![&mut loopback];
+        message_wrapper.reset(&mut chain);
         assert_eq!(coalesce.transform(message_wrapper).await?.len(), 0);
 
         let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.transforms = vec![&mut loopback];
+        message_wrapper.reset(&mut chain);
         assert_eq!(coalesce.transform(message_wrapper).await?.len(), 0);
 
         let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.transforms = vec![&mut loopback];
+        message_wrapper.reset(&mut chain);
         assert_eq!(coalesce.transform(message_wrapper).await?.len(), 100);
 
         let mut message_wrapper = Wrapper::new(messages);
-        message_wrapper.transforms = vec![&mut loopback];
+        message_wrapper.reset(&mut chain);
         assert_eq!(coalesce.transform(message_wrapper).await?.len(), 0);
 
         Ok(())

--- a/shotover-proxy/src/transforms/filter.rs
+++ b/shotover-proxy/src/transforms/filter.rs
@@ -71,7 +71,7 @@ mod test {
             filter: QueryType::Read,
         };
 
-        let mut loopback = Transforms::Loopback(Loopback::default());
+        let mut chain = vec![Transforms::Loopback(Loopback::default())];
 
         let messages: Vec<_> = (0..26)
             .map(|i| {
@@ -91,7 +91,7 @@ mod test {
             .collect();
 
         let mut message_wrapper = Wrapper::new(messages);
-        message_wrapper.transforms = vec![&mut loopback];
+        message_wrapper.reset(&mut chain);
         let result = filter_transform.transform(message_wrapper).await.unwrap();
 
         assert_eq!(result.len(), 26);


### PR DESCRIPTION
I noticed this when investigating redis pubsub support.

This change is more semantically accurate and avoids an extra allocation per request.