### PR TITLE
Reenable parallelization of packet parsing in packet tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2517,7 +2517,6 @@ dependencies = [
  "nix",
  "nonzero_ext",
  "num",
- "num_cpus",
  "openssl",
  "ordered-float",
  "pcap",
@@ -2526,6 +2525,7 @@ dependencies = [
  "pretty-hex",
  "rand",
  "rand_distr",
+ "rayon",
  "redis",
  "redis-protocol",
  "reqwest",
@@ -2540,7 +2540,6 @@ dependencies = [
  "strum_macros",
  "test-helpers",
  "thiserror",
- "threadpool",
  "tls-parser",
  "tokio",
  "tokio-io-timeout",
@@ -2777,15 +2776,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
 ]
 
 [[package]]

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -75,14 +75,13 @@ csv = "1.1.6"
 strum_macros = "0.24"
 
 [dev-dependencies]
+rayon = "1.5.1"
 criterion = { git = "https://github.com/shotover/criterion.rs", branch = "version-0.4", version = "0.3", features = ["async_tokio", "html_reports"] }
 redis = { version = "0.21.0", features = ["tokio-comp", "cluster"] }
 pcap = "0.9.0"
 pktparse = { version = "0.7.0", features = ["serde"] }
 tls-parser = "0.11.0"
-threadpool = "1.0"
 tokio-io-timeout = "1.1.1"
-num_cpus = "1.0"
 serial_test = "0.6.0"
 cassandra-cpp = "1.1.0"
 test-helpers = { path = "../test-helpers" }


### PR DESCRIPTION
Ended up down this rabbit hole because I went to remove the num_cpus dep as its now built into rust 1.59, however discovered that we didnt need it at all in the first place.

* Removes commented out code + dependencies used by commented out code
* Reduces test runtime by 10s by parallelizing the workload, theres still 10s of runtime left that could be optimized but I dont have high confidence in the approach of this test in the first place so i'll leave as is.
* Simplifies implementation, rayon is much simpler to use than raw Threadpools