### PR TITLE
Fix redis tls bench to actually use tls

### DIFF
--- a/shotover-proxy/example-configs/redis-tls/topology.yaml
+++ b/shotover-proxy/example-configs/redis-tls/topology.yaml
@@ -1,11 +1,8 @@
 ---
 sources:
-  redis_prod:
-    Redis:
-      listen_addr: "127.0.0.1:6379"
   redis_prod_tls:
     Redis:
-      listen_addr: "127.0.0.1:6380"
+      listen_addr: "127.0.0.1:6379"
       tls:
         certificate_authority_path: "example-configs/redis-tls/certs/ca.crt"
         certificate_path: "example-configs/redis-tls/certs/redis.crt"
@@ -19,5 +16,4 @@ chain_config:
           certificate_path: "example-configs/redis-tls/certs/redis.crt"
           private_key_path: "example-configs/redis-tls/certs/redis.key"
 source_to_chain_mapping:
-  redis_prod: redis_chain_tls
   redis_prod_tls: redis_chain_tls

--- a/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
+++ b/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
@@ -1286,7 +1286,7 @@ async fn test_source_tls_and_single_tls() {
     };
 
     let mut connection = shotover_manager
-        .redis_connection_async_tls(6380, tls_config)
+        .redis_connection_async_tls(6379, tls_config)
         .await;
 
     run_all(&mut connection).await;


### PR DESCRIPTION
* The non TLS source in redis-tls is removed, I have no idea what its purpose was.
* The TLS source is given the default port 6379
* The redis tls integration test is changed to use 6379
* The redis tls bench is left as 6379 so it now correctly uses TLS