### PR TITLE
Fix RedisSinkCluster returning an array of responses instead of a single response

### DIFF
--- a/shotover-proxy/src/transforms/redis/sink_cluster.rs
+++ b/shotover-proxy/src/transforms/redis/sink_cluster.rs
@@ -130,6 +130,7 @@ impl RedisSinkCluster {
         };
 
         Ok(match channels.len() {
+            // Return an error as we cant send anything if there are no channels.
             0 => {
                 let (one_tx, one_rx) = immediate_responder();
                 match self.connection_error {
@@ -140,11 +141,15 @@ impl RedisSinkCluster {
                 };
                 Box::pin(one_rx)
             }
+            // Send to the single channel and return its response.
             1 => {
                 let channel = channels.get(0).unwrap();
                 let one_rx = self.choose_and_send(channel, message).await?;
                 Box::pin(one_rx.map_err(|_| anyhow!("no response from single channel")))
             }
+            // Send to all senders.
+            // If any of the responses were a failure then return that failure.
+            // Otherwise return the first successful result
             _ => {
                 let responses = FuturesUnordered::new();
 
@@ -152,36 +157,36 @@ impl RedisSinkCluster {
                     responses.push(self.choose_and_send(&channel, message.clone()).await?);
                 }
 
-                // Reassemble upstream responses in any order into an array, as the downstream response.
-                // TODO: Improve error messages within the reassembled response. E.g. which channel failed.
-
                 Box::pin(async move {
-                    let mut response = responses
-                        .fold(vec![], |mut acc, response| async move {
-                            match response {
-                                Ok(Response {
-                                    response: Ok(mut messages),
-                                    ..
-                                }) => acc.push(messages.pop().map_or(
-                                    RedisFrame::Null,
-                                    |mut message| match message.frame().unwrap() {
-                                        Frame::Redis(frame) => frame.take(),
-                                        _ => unreachable!(),
-                                    },
-                                )),
-                                Ok(Response {
-                                    response: Err(e), ..
-                                }) => acc.push(RedisFrame::Error(e.to_string().into())),
-                                Err(e) => acc.push(RedisFrame::Error(e.to_string().into())),
+                    let response = responses
+                        .fold(None, |acc, response| async move {
+                            if let Some(RedisFrame::Error(_)) = acc {
+                                acc
+                            } else {
+                                match response {
+                                    Ok(Response {
+                                        response: Ok(mut messages),
+                                        ..
+                                    }) => Some(messages.pop().map_or(
+                                        RedisFrame::Null,
+                                        |mut message| match message.frame().unwrap() {
+                                            Frame::Redis(frame) => frame.take(),
+                                            _ => unreachable!("This is a direct response from a redis sink so it must be a redis message"),
+                                        },
+                                    )),
+                                    Ok(Response {
+                                        response: Err(e), ..
+                                    }) => Some(RedisFrame::Error(e.to_string().into())),
+                                    Err(e) => Some(RedisFrame::Error(e.to_string().into())),
+                                }
                             }
-                            acc
                         })
                         .await;
 
                     Ok(Response {
                         original: message,
                         response: ChainResponse::Ok(vec![Message::from_frame(Frame::Redis(
-                            response.remove(0),
+                            response.unwrap(),
                         ))]),
                     })
                 })

--- a/shotover-proxy/src/transforms/redis/sink_cluster.rs
+++ b/shotover-proxy/src/transforms/redis/sink_cluster.rs
@@ -156,7 +156,7 @@ impl RedisSinkCluster {
                 // TODO: Improve error messages within the reassembled response. E.g. which channel failed.
 
                 Box::pin(async move {
-                    let response = responses
+                    let mut response = responses
                         .fold(vec![], |mut acc, response| async move {
                             match response {
                                 Ok(Response {
@@ -181,7 +181,7 @@ impl RedisSinkCluster {
                     Ok(Response {
                         original: message,
                         response: ChainResponse::Ok(vec![Message::from_frame(Frame::Redis(
-                            RedisFrame::Array(response),
+                            response.remove(0),
                         ))]),
                     })
                 })

--- a/shotover-proxy/tests/redis_int_tests/assert.rs
+++ b/shotover-proxy/tests/redis_int_tests/assert.rs
@@ -9,10 +9,7 @@ pub async fn assert_nil(cmd: &mut Cmd, connection: &mut Connection) {
 }
 
 pub async fn assert_ok(cmd: &mut Cmd, connection: &mut Connection) {
-    // TODO: enable this assert once its fixed in the codebase
-    //assert_eq!(cmd.query_async(connection).await, Ok("OK".to_string()));
-
-    cmd.query_async::<_, ()>(connection).await.unwrap();
+    assert_eq!(cmd.query_async(connection).await, Ok("OK".to_string()));
 }
 
 pub async fn assert_int(cmd: &mut Cmd, connection: &mut Connection, value: i64) {

--- a/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
+++ b/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
@@ -4,7 +4,7 @@ use rand::{thread_rng, Rng};
 use rand_distr::Alphanumeric;
 use redis::aio::Connection;
 use redis::cluster::ClusterConnection;
-use redis::{AsyncCommands, Cmd, Commands, ErrorKind, RedisError, Value};
+use redis::{AsyncCommands, Commands, ErrorKind, RedisError, Value};
 use serial_test::serial;
 use shotover_proxy::tls::TlsConfig;
 use std::collections::{HashMap, HashSet};
@@ -21,24 +21,6 @@ const STRESS_TEST_MULTIPLIER: usize = 1;
 
 #[cfg(not(debug_assertions))]
 const STRESS_TEST_MULTIPLIER: usize = 100;
-
-async fn assert_nil(cmd: &mut Cmd, connection: &mut Connection) {
-    assert_eq!(
-        cmd.query_async::<_, Option<String>>(connection).await,
-        Ok(None)
-    );
-}
-async fn assert_ok(cmd: &mut Cmd, connection: &mut Connection) {
-    assert_eq!(cmd.query_async(connection).await, Ok("OK".to_string()));
-}
-
-async fn assert_int(cmd: &mut Cmd, connection: &mut Connection, value: i64) {
-    assert_eq!(cmd.query_async(connection).await, Ok(value));
-}
-
-async fn assert_bytes(cmd: &mut Cmd, connection: &mut Connection, value: &[u8]) {
-    assert_eq!(cmd.query_async(connection).await, Ok(value.to_vec()));
-}
 
 async fn test_args(connection: &mut Connection) {
     assert_ok(redis::cmd("SET").arg("key1").arg(b"foo"), connection).await;


### PR DESCRIPTION
This adds an integration test case `test_client_name` that reproduces the issue explained in #605
This PR also adds asserts on the return value of every write only command.
Doing so discovered that this bug also affects the FLUSHDB command.
In fact it should affect every command listed in here https://github.com/shotover/shotover-proxy/blob/1a0f731ea01423d919f588b8c5bc7d5aefa1f575/shotover-proxy/src/transforms/redis/sink_cluster.rs#L552+#L555

Im not sure if these assert_int/assert_ok helpers are the best approach, maybe I should have used the connection.get/set helpers combined with assert_eq instead.
But oh well we can always swap to that later.

The PR includes a fix that fixes the issue but I have set the PR as draft because I still want to investigate if there is a more appropriate fix.