### PR TITLE
Don't re-register counter on cassandra sink clone

### DIFF
--- a/shotover-proxy/src/transforms/cassandra/sink_single.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_single.rs
@@ -48,11 +48,13 @@ pub struct CassandraSinkSingle {
 
 impl Clone for CassandraSinkSingle {
     fn clone(&self) -> Self {
-        CassandraSinkSingle::new(
-            self.address.clone(),
-            self.chain_name.clone(),
-            self.tls.clone(),
-        )
+        CassandraSinkSingle {
+            address: self.address.clone(),
+            outbound: None,
+            chain_name: self.chain_name.clone(),
+            tls: self.tls.clone(),
+            failed_requests: self.failed_requests.clone(),
+        }
     }
 }
 


### PR DESCRIPTION
A simple metrics improvement. The previous implementation was re-registering the metric on each new connection instead of just cloning the existing handle. 

## Bench results

### This PR
![image](https://user-images.githubusercontent.com/39339036/162880533-9143fdd8-c7d1-4278-bc69-01605cea7f93.png)

### Main
![image](https://user-images.githubusercontent.com/39339036/162880568-d735f96d-70f2-4de6-8246-291c42dfa0bc.png)
