### PR TITLE
rework redis cluster command mapping

### DIFF
--- a/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
+++ b/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
@@ -87,10 +87,77 @@ async fn test_keys(connection: &mut Connection) {
         .unwrap();
     let expected = HashSet::from(["foo".to_string(), "bar".to_string(), "baz".to_string()]);
     assert_eq!(keys, expected);
+
+    assert_eq!(redis::cmd("DBSIZE").query_async(connection).await, Ok(3u64));
 }
 
 async fn test_client_name(connection: &mut Connection) {
     assert_ok(redis::cmd("CLIENT").arg("SETNAME").arg("FOO"), connection).await;
+    assert_eq!(
+        redis::cmd("CLIENT")
+            .arg("GETNAME")
+            .query_async(connection)
+            .await,
+        Ok("FOO".to_string())
+    );
+}
+
+async fn test_save(connection: &mut Connection) {
+    let lastsave1: u64 = redis::cmd("LASTSAVE")
+        .query_async(connection)
+        .await
+        .unwrap();
+
+    assert_ok(&mut redis::cmd("SAVE"), connection).await;
+
+    let lastsave2: u64 = redis::cmd("LASTSAVE")
+        .query_async(connection)
+        .await
+        .unwrap();
+
+    assert!(lastsave1 > 0);
+    assert!(lastsave2 > 0);
+    assert!(lastsave2 > lastsave1);
+}
+
+async fn test_ping_echo(connection: &mut Connection) {
+    assert_eq!(
+        redis::cmd("PING").query_async(connection).await,
+        Ok("PONG".to_string())
+    );
+    assert_eq!(
+        redis::cmd("ECHO")
+            .arg("reply")
+            .query_async(connection)
+            .await,
+        Ok("reply".to_string())
+    );
+}
+
+async fn test_time(connection: &mut Connection) {
+    let (time_seconds, extra_ms): (u64, u64) =
+        redis::cmd("TIME").query_async(connection).await.unwrap();
+
+    assert!(time_seconds > 0);
+    assert!(extra_ms < 1_000_000);
+}
+
+async fn test_time_cluster(connection: &mut Connection) {
+    assert_eq!(
+        redis::cmd("TIME")
+            .query_async::<_, ()>(connection)
+            .await
+            .unwrap_err()
+            .detail()
+            .unwrap(),
+        "Shotover RedisSinkCluster does not not support this command used in this way".to_string(),
+    );
+}
+
+async fn test_client_name_cluster(connection: &mut Connection) {
+    assert_ok(redis::cmd("CLIENT").arg("SETNAME").arg("FOO"), connection).await;
+    // RedisSinkCluster does not support SETNAME/GETNAME so GETNAME always returns nil
+    assert_nil(redis::cmd("CLIENT").arg("GETNAME"), connection).await;
 }
 
 async fn test_hash_ops(connection: &mut Connection) {
@@ -1170,13 +1237,13 @@ async fn test_cluster_ports_rewrite() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
-async fn test_active_active_redis() {
+async fn test_redis_multi() {
     let _compose = DockerCompose::new("example-configs/redis-multi/docker-compose.yml");
     let shotover_manager =
         ShotoverManager::from_topology_file("example-configs/redis-multi/topology.yaml");
     let mut connection = shotover_manager.redis_connection_async(6379).await;
 
-    run_all_active_safe(&mut connection).await;
+    run_all_multi_safe(&mut connection).await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -1275,7 +1342,7 @@ async fn test_cluster_dr_redis() {
     run_all_cluster_safe(&mut connection).await;
 }
 
-async fn run_all_active_safe(connection: &mut Connection) {
+async fn run_all_multi_safe(connection: &mut Connection) {
     test_cluster_basics(connection).await;
     test_cluster_eval(connection).await;
     test_cluster_script(connection).await; //TODO: script does not seem to be loading in the server?
@@ -1309,6 +1376,9 @@ async fn run_all_active_safe(connection: &mut Connection) {
     test_tuple_decoding_regression(connection).await;
     test_bit_operations(connection).await;
     test_client_name(connection).await;
+    //test_save(connection).await; // Save is not supported here
+    test_ping_echo(connection).await;
+    test_time(connection).await;
 }
 
 async fn run_all_cluster_safe(connection: &mut Connection) {
@@ -1349,7 +1419,10 @@ async fn run_all_cluster_safe(connection: &mut Connection) {
     test_nice_list_api(connection).await;
     test_tuple_decoding_regression(connection).await;
     test_bit_operations(connection).await;
-    test_client_name(connection).await;
+    test_client_name_cluster(connection).await;
+    test_save(connection).await;
+    test_ping_echo(connection).await;
+    test_time_cluster(connection).await;
 }
 
 async fn run_all(connection: &mut Connection) {
@@ -1385,4 +1458,7 @@ async fn run_all(connection: &mut Connection) {
     test_tuple_decoding_regression(connection).await;
     test_bit_operations(connection).await;
     test_client_name(connection).await;
+    test_save(connection).await;
+    test_ping_echo(connection).await;
+    test_time(connection).await;
 }


### PR DESCRIPTION
closes https://github.com/shotover/shotover-proxy/issues/605

Justification for changes to command mappings:
* DBSIZE
  + Query every master and sum the result. Allows us to pretend to be a single redis instance.
* KEYS
  + Query every master and combine the results.
  + Running `KEYS *` in a large production environment could OoM shotover, but I assume in such an environment the instances would be configured to not allow running KEYS, so each redis instance would return an error and then we would return a single error to the client which would be fine.
* ACL
  + Not sure about this one but it seemed like the majority of the ACL commands should be run uniformly against every instance.
  + Possibly we will need to revisit this in the future.
* SAVE + BGSAVE + BGREWRITEAOF
  + If the user wants to force redis to save to disk it makes sense that they want this to happen to EVERY instance not just the masters
* LASTSAVE
  + The LASTSAVE command is needed to confirm that a previous BGSAVE command has succeed.
     - In order to maintain this use case we query every instance and return the oldest save time. This way the return value wont change until every instance has completed their BGSAVE.
* CLIENT GETNAME/SETNAME
  + We cant reasonably support these commands in shotover
     - Connections are pooled so we cant forward it to the redis instance
     - We cant just implement the functionality shotover side because the connection names are supposed to be viewable from CLIENT LIST
  + However we dont want to just fail them either as clients like jedis would break so:
     - We just pretend to accept CLIENT SETNAME returning an "OK" but without hitting any instances
     - We just pretend to handle CLIENT GETNAME always returning nil without hitting any instances
* CONFIG
   + I believe each instance will need unique configuration for some things so allowing a command to reconfigure every instance with the same config sounded wrong so I disabled it.
* SLOWLOG
   + Instance specific results that cant be combined so I set to Unsupported
* INFO
  + Each instance will return different information and no reasonable way to combine them so I just set Unsupported.
* TIME
  + I just set to Unsupported because of potential differences in time state and I didnt think the functionality was that important?
  + Maybe we should just pick a random instance though?
* ECHO + PING
  + Stateless commands that return a response, we just need a single instance to handle this for us so shotover can pretend to be a single instance. So we just pick a random instance.


It might be useful to refer to how redis-cluster-proxy handles these commands as well: https://github.com/RedisLabs/redis-cluster-proxy/blob/unstable/COMMANDS.md