### PR TITLE
Fix RedisClusterPortsRewrite noauth handling

### DIFF
--- a/shotover-proxy/example-configs/redis-cluster-auth/topology.yaml
+++ b/shotover-proxy/example-configs/redis-cluster-auth/topology.yaml
@@ -5,6 +5,10 @@ sources:
       listen_addr: "127.0.0.1:6379"
 chain_config:
   redis_chain:
+    # This transform is only here to ensure that the transform correctly handles the case where
+    # redis returns an error due to being unauthenticated
+    - RedisClusterPortsRewrite:
+        new_port: 6379
     - RedisSinkCluster:
         first_contact_points:
           [

--- a/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
+++ b/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
@@ -642,6 +642,26 @@ async fn test_auth(connection: &mut Connection) {
         Some("NOAUTH")
     );
 
+    // Ensure RedisClusterPortsRewrite correctly handles NOAUTH errors
+    assert_eq!(
+        redis::cmd("CLUSTER")
+            .arg("SLOTS")
+            .query_async::<_, String>(connection)
+            .await
+            .unwrap_err()
+            .code(),
+        Some("NOAUTH")
+    );
+    assert_eq!(
+        redis::cmd("CLUSTER")
+            .arg("NODES")
+            .query_async::<_, String>(connection)
+            .await
+            .unwrap_err()
+            .code(),
+        Some("NOAUTH")
+    );
+
     // Authenticating with incorrect password should fail.
     assert_eq!(
         redis::cmd("AUTH")


### PR DESCRIPTION
closes https://github.com/shotover/shotover-proxy/issues/606

The issue was that we were failing as soon as we received an unexpected message in this transform.
To handle NOAUTH and likely other error cases too we should just ignore messages in an unexpected format.
