### PR TITLE
Use anyhow .context() instead of manually constructing error messages

### DIFF
--- a/shotover-proxy/src/codec/redis.rs
+++ b/shotover-proxy/src/codec/redis.rs
@@ -47,7 +47,7 @@ impl Decoder for RedisCodec {
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>> {
         loop {
-            match decode_mut(src).map_err(|e| anyhow!("Error decoding redis frame {}", e))? {
+            match decode_mut(src).map_err(|e| anyhow!(e).context("Error decoding redis frame)"))? {
                 Some((frame, _size, bytes)) => {
                     self.messages
                         .push(Message::from_bytes_and_frame(bytes, Frame::Redis(frame)));

--- a/shotover-proxy/src/config/mod.rs
+++ b/shotover-proxy/src/config/mod.rs
@@ -11,8 +11,9 @@ pub struct Config {
 
 impl Config {
     pub fn from_file(filepath: String) -> Result<Config> {
-        let file = std::fs::File::open(&filepath)
-            .map_err(|err| anyhow!("Couldn't open the config file {}: {}", &filepath, err))?;
+        let file = std::fs::File::open(&filepath).map_err(|err| {
+            anyhow!(err).context(format!("Couldn't open the config file {}", &filepath))
+        })?;
         Ok(serde_yaml::from_reader(file)?)
     }
 }

--- a/shotover-proxy/src/config/topology.rs
+++ b/shotover-proxy/src/config/topology.rs
@@ -158,8 +158,9 @@ impl Topology {
     }
 
     pub fn from_file(filepath: String) -> Result<Topology> {
-        let file = std::fs::File::open(&filepath)
-            .map_err(|err| anyhow!("Couldn't open the topology file {}: {}", &filepath, err))?;
+        let file = std::fs::File::open(&filepath).map_err(|err| {
+            anyhow!(err).context(format!("Couldn't open the topology file {}", &filepath))
+        })?;
         let config: TopologyConfig = serde_yaml::from_reader(file)?;
 
         Ok(Topology::topology_from_config(config))

--- a/shotover-proxy/src/observability/mod.rs
+++ b/shotover-proxy/src/observability/mod.rs
@@ -110,7 +110,7 @@ where
 
         let address = self.address;
         Server::try_bind(&address)
-            .map_err(|e| anyhow!("Failed to bind to {}: {}", address, e))?
+            .map_err(|e| anyhow!(e).context(format!("Failed to bind to {}", address)))?
             .serve(make_svc)
             .await
             .map_err(|e| anyhow!(e))

--- a/shotover-proxy/src/tls.rs
+++ b/shotover-proxy/src/tls.rs
@@ -43,8 +43,7 @@ impl TlsAcceptor {
         Pin::new(&mut ssl_stream)
             .accept()
             .await
-            .map_err(|x| anyhow!("Failed to accept TLS connection: {}", x))?;
-
+            .map_err(|e| anyhow!(e).context("Failed to accept TLS connection"))?;
         Ok(ssl_stream)
     }
 }

--- a/shotover-proxy/src/transforms/redis/sink_cluster.rs
+++ b/shotover-proxy/src/transforms/redis/sink_cluster.rs
@@ -58,7 +58,7 @@ impl RedisSinkClusterConfig {
                 info!("upstream requires auth");
             }
             Err(e) => {
-                bail!("failed to connect to upstream: {}", e);
+                return Err(anyhow!(e).context("failed to connect to upstream"));
             }
         }
 
@@ -461,7 +461,7 @@ impl RedisSinkCluster {
                 self.send_error_response(one_tx, e.to_string().as_str())?;
             }
             Err(e) => {
-                bail!("authentication failed: {}", e);
+                return Err(anyhow!(e).context("authentication failed"));
             }
         }
 


### PR DESCRIPTION
closes https://github.com/shotover/shotover-proxy/issues/183

The reason I jumped on this was because I hit an issue in https://github.com/shotover/shotover-proxy/pull/624 due to the incomplete use of context.
What happened was a contextified anyhow was printed with `error!("{}")` instead of `error!("{:?}")`.
This results in a log that lacks the innermost error.

So the core fix here is the changes to server.rs
However I wanted to make the rest of shotover make use of `.context` while I was doing this to make our errors uniform.

That said, I'm not 100% sure that using context is actually the right call.
The `{}`/`{:?}` difference is definitely a footgun.
So maybe we would be better off just entirely removing the use of `.context` instead?

Here is what logged error created via `.context()` looks like:
```
2022-05-02T01:22:59.373422Z ERROR request{id=2 source="RedisSource"}: shotover_proxy::server: chain failed to send and/or receive messages

Caused by:
    0: failed to rewrite CLUSTER NODES port
    1: RedisClusterPortsRewrite intercepted an incorrect message
```