### PR TITLE
Improve CassandraPeersRewrite int tests

### DIFF
--- a/shotover-proxy/tests/cassandra_int_tests/basic_driver_tests.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/basic_driver_tests.rs
@@ -1,4 +1,4 @@
-use crate::helpers::cassandra::{assert_query_result, run_query, ResultValue};
+use crate::helpers::cassandra::{assert_query_result, execute_query, run_query, ResultValue};
 use crate::helpers::ShotoverManager;
 use cassandra_cpp::{stmt, Batch, BatchType, Error, ErrorKind, Session};
 use futures::future::{join_all, try_join_all};
@@ -1573,6 +1573,21 @@ fn test_cassandra_peers_rewrite() {
             "SELECT native_port FROM system.peers_v2;",
             &[&[ResultValue::Int(9044)]],
         );
+
+        assert_query_result(
+            &rewrite_port_connection,
+            "SELECT native_port as foo FROM system.peers_v2;",
+            &[&[ResultValue::Int(9042)]],
+        );
+
+        assert_query_result(
+            &rewrite_port_connection,
+            "SELECT native_port, native_port FROM system.peers_v2;",
+            &[&[ResultValue::Int(9044), ResultValue::Int(9042)]],
+        );
+
+        let result = execute_query(&rewrite_port_connection, "SELECT * FROM system.peers_v2;");
+        assert_eq!(result[0][5], ResultValue::Int(9044));
     }
 }
 

--- a/shotover-proxy/tests/cassandra_int_tests/basic_driver_tests.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/basic_driver_tests.rs
@@ -1586,6 +1586,12 @@ fn test_cassandra_peers_rewrite() {
             &[&[ResultValue::Int(9044), ResultValue::Int(9042)]],
         );
 
+        assert_query_result(
+            &rewrite_port_connection,
+            "SELECT native_port, native_port as some_port FROM system.peers_v2;",
+            &[&[ResultValue::Int(9044), ResultValue::Int(9042)]],
+        );
+
         let result = execute_query(&rewrite_port_connection, "SELECT * FROM system.peers_v2;");
         assert_eq!(result[0][5], ResultValue::Int(9044));
     }


### PR DESCRIPTION
These extra test cases demonstrate where we do and dont currently rewrite the port.
Landing this PR will assist in demonstrating the changes to CassandraPeersRewrite functionality that is intended by https://github.com/shotover/shotover-proxy/pull/598/files