### PR TITLE
Read multiple Cassandra frames

### DIFF
--- a/shotover-proxy/src/codec/redis.rs
+++ b/shotover-proxy/src/codec/redis.rs
@@ -1,7 +1,7 @@
 use crate::frame::RedisFrame;
 use crate::frame::{Frame, MessageType};
 use crate::message::{Encodable, Message, Messages, QueryType};
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Error, Result};
 use bytes::{Buf, BytesMut};
 use redis_protocol::resp2::prelude::decode_mut;
 use redis_protocol::resp2::prelude::encode_bytes;
@@ -43,7 +43,7 @@ impl RedisCodec {
 
 impl Decoder for RedisCodec {
     type Item = Messages;
-    type Error = anyhow::Error;
+    type Error = Error;
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>> {
         loop {


### PR DESCRIPTION
The Cassandra protocol is designed to allow multiple inflight messages, Shotover currently doesn't take advantage of this: we read one frame off the socket, process it through the transform chain, send to the upstream and wait for the response. This change allows us to read multiple frames off the socket and process a batch instead.

Bench results with latte:

![image](https://user-images.githubusercontent.com/39339036/166851493-e017e6ca-fff7-49a7-96bd-791c98ca6ba5.png)
