### PR TITLE
use check_frame instead of from_buffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,7 @@ checksum = "8234d29d30873ab5a41e3557b8515d3ecbaefb1ea5be579425b3b0074b6d0e40"
 [[package]]
 name = "cassandra-protocol"
 version = "1.1.1"
-source = "git+https://github.com/krojew/cdrs-tokio#62ce78e5592fc8ea00a13fc4c30df5343693b7ce"
+source = "git+https://github.com/conorbros/cdrs-tokio?branch=check-frame-length#fa31f519dc029da476e77ccc578c90d65a805842"
 dependencies = [
  "arrayref",
  "bitflags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,7 @@ checksum = "8234d29d30873ab5a41e3557b8515d3ecbaefb1ea5be579425b3b0074b6d0e40"
 [[package]]
 name = "cassandra-protocol"
 version = "1.1.1"
-source = "git+https://github.com/conorbros/cdrs-tokio?branch=check-frame-length#fa31f519dc029da476e77ccc578c90d65a805842"
+source = "git+https://github.com/krojew/cdrs-tokio#bd881e491daf908a51fb6f51cc9de9989057eda1"
 dependencies = [
  "arrayref",
  "bitflags",

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -63,7 +63,7 @@ halfbrown = "0.1.11"
 
 # Transform dependencies
 redis-protocol = { version = "4.0.1", features = ["decode-mut"] }
-cassandra-protocol = { git = "https://github.com/krojew/cdrs-tokio" }
+cassandra-protocol = { git = "https://github.com/conorbros/cdrs-tokio", branch = "check-frame-length" }
 crc16 = "0.4.0"
 ordered-float = { version = "2.8.0", features = ["serde"] }
 

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -63,7 +63,7 @@ halfbrown = "0.1.11"
 
 # Transform dependencies
 redis-protocol = { version = "4.0.1", features = ["decode-mut"] }
-cassandra-protocol = { git = "https://github.com/conorbros/cdrs-tokio", branch = "check-frame-length" }
+cassandra-protocol = { git = "https://github.com/krojew/cdrs-tokio" }
 crc16 = "0.4.0"
 ordered-float = { version = "2.8.0", features = ["serde"] }
 

--- a/shotover-proxy/src/codec/cassandra.rs
+++ b/shotover-proxy/src/codec/cassandra.rs
@@ -65,8 +65,7 @@ impl Decoder for CassandraCodec {
         }
 
         loop {
-            // TODO: We could implement our own version and length check here directly on the bytes to avoid the duplicate frame parse
-            match RawCassandraFrame::check_frame(src) {
+            match RawCassandraFrame::check_frame_size(src) {
                 Ok(frame_len) => {
                     // Clear the read bytes from the FramedReader
                     let bytes = src.split_to(frame_len);

--- a/shotover-proxy/src/codec/cassandra.rs
+++ b/shotover-proxy/src/codec/cassandra.rs
@@ -5,7 +5,7 @@ use anyhow::{anyhow, Error, Result};
 use bytes::{Buf, BufMut, BytesMut};
 use cassandra_protocol::compression::Compression;
 use cassandra_protocol::frame::frame_error::{AdditionalErrorInfo, ErrorBody};
-use cassandra_protocol::frame::{Frame as RawCassandraFrame, ParseFrameError, Version};
+use cassandra_protocol::frame::{CheckFrameError, Frame as RawCassandraFrame, Version};
 use tokio_util::codec::{Decoder, Encoder};
 use tracing::{debug, info};
 
@@ -66,10 +66,10 @@ impl Decoder for CassandraCodec {
 
         loop {
             // TODO: We could implement our own version and length check here directly on the bytes to avoid the duplicate frame parse
-            match RawCassandraFrame::from_buffer(src, self.compressor) {
-                Ok(parsed_frame) => {
+            match RawCassandraFrame::check_frame(src) {
+                Ok(frame_len) => {
                     // Clear the read bytes from the FramedReader
-                    let bytes = src.split_to(parsed_frame.frame_len);
+                    let bytes = src.split_to(frame_len);
                     tracing::debug!(
                         "incoming cassandra message:\n{}",
                         pretty_hex::pretty_hex(&bytes)
@@ -78,14 +78,14 @@ impl Decoder for CassandraCodec {
                     self.messages
                         .push(Message::from_bytes(bytes.freeze(), MessageType::Cassandra));
                 }
-                Err(ParseFrameError::NotEnoughBytes) => {
+                Err(CheckFrameError::NotEnoughBytes) => {
                     if self.messages.is_empty() || src.remaining() != 0 {
                         return Ok(None);
                     } else {
                         return Ok(Some(std::mem::take(&mut self.messages)));
                     }
                 }
-                Err(ParseFrameError::UnsupportedVersion(version)) => {
+                Err(CheckFrameError::UnsupportedVersion(version)) => {
                     // if we got an error force the close on the next read.
                     // We can not immediately close as we are gong to queue a message
                     // back to the client and we have to allow time for the message


### PR DESCRIPTION
Use a new method that only checks the frame length and version of incoming Cassandra frames before fully parsing them. 

Latte benchmarks against main:
![image](https://user-images.githubusercontent.com/39339036/167083870-4e422833-02f0-40aa-b254-73645ec79567.png)

<s>Waiting on https://github.com/krojew/cdrs-tokio/pull/93 to be merged.</s>