### PR TITLE
Change timeout in TcpCodecListener

### DIFF
--- a/shotover-proxy/src/config/topology.rs
+++ b/shotover-proxy/src/config/topology.rs
@@ -218,6 +218,7 @@ mod topology_tests {
             connection_limit: None,
             hard_connection_limit: None,
             tls: None,
+            timeout: None,
         });
 
         let mut sources = HashMap::new();

--- a/shotover-proxy/src/server.rs
+++ b/shotover-proxy/src/server.rs
@@ -96,6 +96,8 @@ pub struct TcpCodecListener<C: Codec> {
     message_count: u64,
 
     available_connections_gauge: Gauge,
+
+    timeout: Option<u64>,
 }
 
 impl<C: Codec + 'static> TcpCodecListener<C> {
@@ -109,6 +111,7 @@ impl<C: Codec + 'static> TcpCodecListener<C> {
         limit_connections: Arc<Semaphore>,
         trigger_shutdown_rx: watch::Receiver<bool>,
         tls: Option<TlsAcceptor>,
+        timeout: Option<u64>,
     ) -> Result<Self> {
         let available_connections_gauge =
             register_gauge!("shotover_available_connections", "source" => source_name.clone());
@@ -128,6 +131,7 @@ impl<C: Codec + 'static> TcpCodecListener<C> {
             tls,
             message_count: 0,
             available_connections_gauge,
+            timeout,
         })
     }
 
@@ -222,6 +226,8 @@ impl<C: Codec + 'static> TcpCodecListener<C> {
                 shutdown: Shutdown::new(self.trigger_shutdown_rx.clone()),
 
                 tls: self.tls.clone(),
+
+                timeout: self.timeout,
             };
 
             self.message_count = self.message_count.wrapping_add(1);
@@ -345,6 +351,8 @@ pub struct Handler<C: Codec> {
     shutdown: Shutdown,
 
     tls: Option<TlsAcceptor>,
+
+    timeout: Option<u64>,
 }
 
 fn spawn_read_write_tasks<
@@ -437,13 +445,13 @@ impl<C: Codec + 'static> Handler<C> {
                             }
                         },
                         Err(_) => {
-                            if idle_time_seconds < 35 {
-                                trace!("Connection Idle for more than {} seconds {}",
-                                    idle_time_seconds, self.conn_details);
-                            } else {
-                                debug!("Dropping. Connection Idle for more than {} seconds {}",
-                                    idle_time_seconds, self.conn_details);
-                                return Ok(());
+                            if let Some(timeout) =  self.timeout {
+                                if idle_time_seconds < timeout {
+                                    trace!("Connection Idle for more than {} seconds {}", timeout, self.conn_details);
+                                } else {
+                                    debug!("Dropping. Connection Idle for more than {} seconds {}", timeout, self.conn_details);
+                                    return Ok(());
+                                }
                             }
                             idle_time_seconds *= 2;
                             continue

--- a/shotover-proxy/src/sources/cassandra_source.rs
+++ b/shotover-proxy/src/sources/cassandra_source.rs
@@ -18,6 +18,7 @@ pub struct CassandraConfig {
     pub connection_limit: Option<usize>,
     pub hard_connection_limit: Option<bool>,
     pub tls: Option<TlsConfig>,
+    pub timeout: Option<u64>,
 }
 
 impl CassandraConfig {
@@ -35,6 +36,7 @@ impl CassandraConfig {
                 self.connection_limit,
                 self.hard_connection_limit,
                 self.tls.clone(),
+                self.timeout,
             )
             .await?,
         )])
@@ -57,6 +59,7 @@ impl CassandraSource {
         connection_limit: Option<usize>,
         hard_connection_limit: Option<bool>,
         tls: Option<TlsConfig>,
+        timeout: Option<u64>,
     ) -> Result<CassandraSource> {
         let name = "CassandraSource";
 
@@ -71,6 +74,7 @@ impl CassandraSource {
             Arc::new(Semaphore::new(connection_limit.unwrap_or(512))),
             trigger_shutdown_rx.clone(),
             tls.map(TlsAcceptor::new).transpose()?,
+            timeout,
         )
         .await?;
 

--- a/shotover-proxy/src/sources/redis_source.rs
+++ b/shotover-proxy/src/sources/redis_source.rs
@@ -18,6 +18,7 @@ pub struct RedisConfig {
     pub connection_limit: Option<usize>,
     pub hard_connection_limit: Option<bool>,
     pub tls: Option<TlsConfig>,
+    pub timeout: Option<u64>,
 }
 
 impl RedisConfig {
@@ -34,6 +35,7 @@ impl RedisConfig {
             self.connection_limit,
             self.hard_connection_limit,
             self.tls.clone(),
+            self.timeout,
         )
         .await
         .map(|x| vec![Sources::Redis(x)])
@@ -56,6 +58,7 @@ impl RedisSource {
         connection_limit: Option<usize>,
         hard_connection_limit: Option<bool>,
         tls: Option<TlsConfig>,
+        timeout: Option<u64>,
     ) -> Result<RedisSource> {
         info!("Starting Redis source on [{}]", listen_addr);
         let name = "RedisSource";
@@ -69,6 +72,7 @@ impl RedisSource {
             Arc::new(Semaphore::new(connection_limit.unwrap_or(512))),
             trigger_shutdown_rx.clone(),
             tls.map(TlsAcceptor::new).transpose()?,
+            timeout,
         )
         .await?;
 


### PR DESCRIPTION
Change the timeout in `TcpCodecListener` to more closely replicate the behaviour of the source that's representing. 

- Redis by [default](https://redis.io/docs/reference/clients/#client-timeouts) has no timeout but the user can configure one.
- Cassandra by [default](https://github.com/apache/cassandra/blob/e0247d6833f59901e6849e168f6e2363351c6f4c/conf/cassandra.yaml#L801) has no timeout either but the user can configure one.  