### PR TITLE
RedisSinkCluster ChannelResult and short_circuit refactor

### DIFF
--- a/shotover-proxy/src/transforms/mod.rs
+++ b/shotover-proxy/src/transforms/mod.rs
@@ -538,4 +538,4 @@ pub trait Transform: Send {
     }
 }
 
-pub type ResponseFuture = Pin<Box<dyn Future<Output = Result<util::Response>> + std::marker::Send>>;
+pub type ResponseFuture = Pin<Box<dyn Future<Output = Result<util::Response>> + Send + Sync>>;


### PR DESCRIPTION
There are two parts to this refactor:
1. ChannelResult is removed - instead of returning a ChannelResult in get_channels that describes how we should use the channel we just directly use the channel.
    * its easier to follow what each case is doing in dispatch_message_hiding - just check the inner function call rather than having to backtrack
    * its more flexible for uniquely handling a case without having to add a new hyperspecific ChannelResult variant. e.g. we can now directly send a single message which was impossible before.
    * the dispatch_message_handling approach used in https://github.com/shotover/shotover-proxy/pull/642/files is more feasible
        * we can just directly use the direct_connection channel without having to feed it through ChannelResult somehow.
    * returning proper error messages to the redis client that describe what went wrong should now be easier.
2. the message sending functions no longer take a one_tx and instead just construct one internally and return a `Result<ResponseFuture>`
    * The logic for immediate_responder and send_frame_response now live in short_circuit
    * The benefit here should be obvious, the API for sending a response back to the client is a lot simpler and doesn't require constructing oneshots all over the place.
    * This will result in slightly more allocations due to the Box in ResponseFuture - but I think the improved API is worth it.
         + I think there might be ways to remove the Box that we can investigate later.
    * If you are having trouble reviewing this PR let me know and I can pull this part into its own prereq PR.
    
There should be no functional changes caused by this PR, with the exception of some improved or changed error messages.
Please report any possible functional changes you might find.