### PR TITLE
RedisSinkCluster handle attempts to use RESP3

### DIFF
--- a/shotover-proxy/src/transforms/redis/sink_cluster.rs
+++ b/shotover-proxy/src/transforms/redis/sink_cluster.rs
@@ -495,7 +495,7 @@ impl RedisSinkCluster {
         warn!("Could not route request - short circuiting");
         if let Err(e) = self.send_error_response(
             one_tx,
-            "ERR Shotover RedisSinkCluster does not not support this command used in this way",
+            "ERR unknown command - Shotover RedisSinkCluster does not not support this command",
         ) {
             trace!("short circuiting - couldn't send error - {:?}", e);
         }
@@ -664,6 +664,7 @@ impl RoutingInfo {
             // We just need a single redis node to handle this for us so shotover can pretend to be a single node.
             // So we just pick a node at random.
             b"ECHO" | b"PING" => RoutingInfo::Random,
+            b"HELLO" => RoutingInfo::Unsupported,
             _ => match args.get(1) {
                 Some(key) => RoutingInfo::for_key(key).unwrap_or(RoutingInfo::Unsupported),
                 None => RoutingInfo::Random,

--- a/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
+++ b/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
@@ -150,7 +150,20 @@ async fn test_time_cluster(connection: &mut Connection) {
             .unwrap_err()
             .detail()
             .unwrap(),
-        "Shotover RedisSinkCluster does not not support this command used in this way".to_string(),
+        "unknown command - Shotover RedisSinkCluster does not not support this command".to_string(),
+    );
+}
+
+async fn test_hello_cluster(connection: &mut Connection) {
+    // The Lettuce client relies on the error message here containing the string "unknown" to detect that shotover does not support RESP3
+    assert_eq!(
+        redis::cmd("HELLO")
+            .query_async::<_, ()>(connection)
+            .await
+            .unwrap_err()
+            .detail()
+            .unwrap(),
+        "unknown command - Shotover RedisSinkCluster does not not support this command".to_string(),
     );
 }
 
@@ -1423,6 +1436,7 @@ async fn run_all_cluster_safe(connection: &mut Connection) {
     test_save(connection).await;
     test_ping_echo(connection).await;
     test_time_cluster(connection).await;
+    test_hello_cluster(connection).await;
 }
 
 async fn run_all(connection: &mut Connection) {


### PR DESCRIPTION
Closes https://github.com/shotover/shotover-proxy/issues/656

The way to enable RESP3 is to send a "HELLO 3" message - https://redis.io/commands/hello/
The lettuce client attempts that by default but fallsback to resp2 if the error message contains "unknown" - an attempt to match against the `-ERR unknown command 'hello'` error message.

I believe the best way for shotover's RedisSinkCluster transform to handle RESP3 is to just tell clients that we dont support it.
Handling RESP3 would be fairly tricky due to the extra state that needs to be taken into account in our connection pool.

RedisSinkSingle on the other hand could much more easily support RESP3 but doesnt yet.
Currently RedisSinkSingle will also break if it receives a "HELLO 3" but I would rather add proper RESP3 support there and dont want to have to force message parsing just to force rejection of "HELLO 3".
So that problem is left for later.

Relevant lettuce logic can be seen here:
* https://github.com/lettuce-io/lettuce-core/blob/5d3310d79967a580d172af7f6d9718ec9ed0325f/src/main/java/io/lettuce/core/RedisHandshake.java#L262
* https://github.com/lettuce-io/lettuce-core/blob/5d3310d79967a580d172af7f6d9718ec9ed0325f/src/main/java/io/lettuce/core/RedisHandshake.java#L102