### PR TITLE
store response as single Message instead of Vec<Message>

### DIFF
--- a/shotover-proxy/src/transforms/cassandra/connection.rs
+++ b/shotover-proxy/src/transforms/cassandra/connection.rs
@@ -114,7 +114,7 @@ async fn rx_process<C: CodecReadHalf, T: AsyncRead>(
                                         return_message_map.insert(stream_id, m);
                                     },
                                     Some((return_tx, original)) => {
-                                        return_tx.send(Response {original, response: Ok(vec![m]) })
+                                        return_tx.send(Response {original, response: Ok(m) })
                                         .map_err(|_| anyhow!("couldn't send message"))?;
                                     }
                                 }
@@ -134,7 +134,7 @@ async fn rx_process<C: CodecReadHalf, T: AsyncRead>(
                         return_channel_map.insert(message_id, (return_chan, message));
                     }
                     Some(m) => {
-                        return_chan.send(Response { original: message, response: Ok(vec![m]) })
+                        return_chan.send(Response { original: message, response: Ok(m) })
                             .map_err(|_| anyhow!("couldn't send message"))?;
                     }
                 };

--- a/shotover-proxy/src/transforms/cassandra/sink_single.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_single.rs
@@ -114,19 +114,17 @@ impl CassandraSinkSingle {
                             Ok(Some(prelim)) => {
                                 match prelim? {
                                     Response {
-                                        response: Ok(mut resp),
+                                        response: Ok(message),
                                         ..
                                     } => {
-                                        for message in &resp {
-                                            if let Some(raw_bytes) = message.as_raw_bytes() {
-                                                if let Ok(Opcode::Error) =
-                                                    cassandra::raw_frame::get_opcode(raw_bytes)
-                                                {
-                                                    self.failed_requests.increment(1);
-                                                }
+                                        if let Some(raw_bytes) = message.as_raw_bytes() {
+                                            if let Ok(Opcode::Error) =
+                                                cassandra::raw_frame::get_opcode(raw_bytes)
+                                            {
+                                                self.failed_requests.increment(1);
                                             }
                                         }
-                                        responses.append(&mut resp);
+                                        responses.push(message);
                                     }
                                     Response {
                                         mut original,

--- a/shotover-proxy/src/transforms/util/cluster_connection_pool.rs
+++ b/shotover-proxy/src/transforms/util/cluster_connection_pool.rs
@@ -271,7 +271,7 @@ async fn rx_process<C: CodecReadHalf, R: AsyncRead + Unpin + Send + 'static>(
                         // If the receiver hangs up, just silently ignore
                         let _ = ret.send(Response {
                             original: message,
-                            response: Ok(vec![m]),
+                            response: Ok(m),
                         });
                     }
                 }

--- a/shotover-proxy/src/transforms/util/mod.rs
+++ b/shotover-proxy/src/transforms/util/mod.rs
@@ -1,8 +1,7 @@
-use anyhow::Error;
+use anyhow::{Error, Result};
 use std::fmt;
 use std::io;
 
-use crate::error::ChainResponse;
 use crate::message::Message;
 
 pub mod cluster_connection_pool;
@@ -17,8 +16,8 @@ pub struct Request {
 /// Represents a `Response` to a `Request`
 #[derive(Debug)]
 pub struct Response {
-    pub original: Message,       // Original `Message` that this `Response` is to
-    pub response: ChainResponse, // Response to the original `Message`
+    pub original: Message,         // Original `Message` that this `Response` is to
+    pub response: Result<Message>, // Response to the original `Message`
 }
 
 #[derive(thiserror::Error, Debug)]


### PR DESCRIPTION
Only one message was ever stored and allowing for multiple messages is incorrect when the `original` field only has one Message.