### PR TITLE
Refactor Protect transform

### DIFF
--- a/shotover-proxy/src/transforms/protect/aws_kms.rs
+++ b/shotover-proxy/src/transforms/protect/aws_kms.rs
@@ -1,4 +1,4 @@
-use crate::transforms::protect::KeyMaterial;
+use crate::transforms::protect::key_management::KeyMaterial;
 use anyhow::anyhow;
 use anyhow::Result;
 use bytes::Bytes;

--- a/shotover-proxy/src/transforms/protect/crypto.rs
+++ b/shotover-proxy/src/transforms/protect/crypto.rs
@@ -1,0 +1,66 @@
+use crate::message::MessageValue;
+use crate::transforms::protect::key_management::KeyManager;
+use anyhow::{anyhow, bail, Result};
+use serde::{Deserialize, Serialize};
+use sodiumoxide::crypto::secretbox;
+use sodiumoxide::crypto::secretbox::Nonce;
+use sqlparser::ast::Value as SQLValue;
+
+// A protected value meets the following properties:
+// https://doc.libsodium.org/secret-key_cryptography/secretbox
+// This all relies on crypto_secretbox_easy which takes care of
+// all padding, copying and timing issues associated with crypto
+#[derive(Serialize, Deserialize)]
+struct Protected {
+    cipher: Vec<u8>,
+    nonce: Nonce,
+    enc_dek: Vec<u8>,
+    kek_id: String,
+}
+
+pub async fn encrypt(
+    value: &SQLValue,
+    key_management: &KeyManager,
+    key_id: &str,
+) -> Result<SQLValue> {
+    let value = MessageValue::from(&*value);
+
+    let sym_key = key_management.cached_get_key(key_id, None, None).await?;
+
+    let ser = bincode::serialize(&value)?;
+    let nonce = secretbox::gen_nonce();
+    let cipher = secretbox::seal(&ser, &nonce, &sym_key.plaintext);
+
+    let protected = Protected {
+        cipher,
+        nonce,
+        enc_dek: sym_key.ciphertext_blob.to_vec(),
+        kek_id: sym_key.key_id,
+    };
+
+    Ok(SQLValue::SingleQuotedString(serde_json::to_string(
+        &protected,
+    )?))
+}
+
+pub async fn decrypt(
+    value: &MessageValue,
+    key_management: &KeyManager,
+    key_id: &str,
+) -> Result<MessageValue> {
+    let varchar = match value {
+        MessageValue::Varchar(varchar) => varchar,
+        _ => bail!("expected varchar to decrypt but was {:?}", value),
+    };
+    let protected: Protected = serde_json::from_str(varchar)?;
+
+    let sym_key = key_management
+        .cached_get_key(key_id, Some(protected.enc_dek), Some(protected.kek_id))
+        .await?;
+
+    let decrypted_bytes = secretbox::open(&protected.cipher, &protected.nonce, &sym_key.plaintext)
+        .map_err(|_| anyhow!("couldn't open box"))?;
+
+    //TODO make error handing better here - failure here indicates an authenticity failure
+    bincode::deserialize(&decrypted_bytes).map_err(|_| anyhow!("couldn't open box"))
+}

--- a/shotover-proxy/src/transforms/protect/local_kek.rs
+++ b/shotover-proxy/src/transforms/protect/local_kek.rs
@@ -1,6 +1,5 @@
-use crate::transforms::protect::KeyMaterial;
-use anyhow::anyhow;
-use anyhow::Result;
+use crate::transforms::protect::key_management::KeyMaterial;
+use anyhow::{anyhow, Result};
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use sodiumoxide::crypto::secretbox;

--- a/shotover-proxy/src/transforms/protect/mod.rs
+++ b/shotover-proxy/src/transforms/protect/mod.rs
@@ -3,147 +3,25 @@ use crate::frame::{CassandraFrame, CassandraOperation, CassandraResult, Frame};
 use crate::message::MessageValue;
 use crate::transforms::protect::key_management::{KeyManager, KeyManagerConfig};
 use crate::transforms::{Transform, Transforms, Wrapper};
-use anyhow::anyhow;
 use anyhow::Result;
 use async_trait::async_trait;
-use bytes::Bytes;
 use itertools::Itertools;
-use serde::{Deserialize, Serialize};
-use sodiumoxide::crypto::secretbox;
-use sodiumoxide::crypto::secretbox::{Key, Nonce};
+use serde::Deserialize;
 use sqlparser::ast::{Assignment, Expr, Ident, Query, SetExpr, Statement, Value as SQLValue};
 use std::borrow::BorrowMut;
 use std::collections::HashMap;
 use tracing::warn;
 
 mod aws_kms;
+mod crypto;
 mod key_management;
 mod local_kek;
 mod pkcs_11;
-
-#[derive(Clone)]
-pub struct Protect {
-    keyspace_table_columns: HashMap<String, HashMap<String, Vec<String>>>,
-    key_source: KeyManager,
-    // TODO this should be a function to create key_ids based on "something", e.g. primary key
-    // for the moment this is just a string
-    key_id: String,
-}
-
-#[derive(Clone)]
-pub struct KeyMaterial {
-    pub ciphertext_blob: Bytes,
-    pub key_id: String,
-    pub plaintext: Key,
-}
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct ProtectConfig {
     pub keyspace_table_columns: HashMap<String, HashMap<String, Vec<String>>>,
     pub key_manager: KeyManagerConfig,
-}
-
-// A protected value meets the following properties:
-// https://doc.libsodium.org/secret-key_cryptography/secretbox
-// This all relies on crypto_secretbox_easy which takes care of
-// all padding, copying and timing issues associated with crypto
-#[derive(Serialize, Deserialize)]
-pub enum Protected {
-    Plaintext(MessageValue),
-    Ciphertext {
-        cipher: Vec<u8>,
-        nonce: Nonce,
-        enc_dek: Vec<u8>,
-        kek_id: String,
-    },
-}
-
-fn encrypt(plaintext: Vec<u8>, sym_key: &Key) -> (Vec<u8>, Nonce) {
-    let nonce = secretbox::gen_nonce();
-    let ciphertext = secretbox::seal(&plaintext, &nonce, sym_key);
-    (ciphertext, nonce)
-}
-
-fn decrypt(ciphertext: Vec<u8>, nonce: Nonce, sym_key: &Key) -> Result<MessageValue> {
-    let decrypted_bytes =
-        secretbox::open(&ciphertext, &nonce, sym_key).map_err(|_| anyhow!("couldn't open box"))?;
-    //TODO make error handing better here - failure here indicates a authenticity failure
-    let decrypted_value: MessageValue = serde_json::from_slice(decrypted_bytes.as_slice())
-        .map_err(|_| anyhow!("couldn't open box"))?;
-    // let decrypted_value: MessageValue =
-    //     bincode::deserialize(&decrypted_bytes).map_err(|_| anyhow!("couldn't open box"))?;
-    Ok(decrypted_value)
-}
-
-// TODO: Switch to something smaller/more efficient like bincode - Need the new cassandra AST first so we can create Blob's in the ast
-impl From<Protected> for MessageValue {
-    fn from(p: Protected) -> Self {
-        match p {
-            Protected::Plaintext(_) => panic!(
-                "tried to move unencrypted value to plaintext without explicitly calling decrypt"
-            ),
-            Protected::Ciphertext { .. } => {
-                MessageValue::Bytes(Bytes::from(serde_json::to_vec(&p).unwrap()))
-                //MessageValue::Bytes(Bytes::from(bincode::serialize(&p).unwrap()))
-            }
-        }
-    }
-}
-
-impl Protected {
-    pub async fn from_encrypted_bytes_value(value: &MessageValue) -> Result<Protected> {
-        match value {
-            MessageValue::Bytes(b) => {
-                // let protected_something: Protected = serde_json::from_slice(b.bytes())?;
-                let protected_something: Protected = bincode::deserialize(b)?;
-                Ok(protected_something)
-            }
-            _ => Err(anyhow!(
-                "Could not get bytes to decrypt - wrong value type {:?}",
-                value
-            )),
-        }
-    }
-    // TODO should this actually return self (we are sealing the plaintext value, but we don't swap out the plaintext??
-    pub async fn protect(self, key_management: &KeyManager, key_id: &str) -> Result<Protected> {
-        let sym_key = key_management
-            .cached_get_key(key_id.to_string(), None, None)
-            .await?;
-        match &self {
-            Protected::Plaintext(p) => {
-                // let (cipher, nonce) = encrypt(serde_json::to_string(p).unwrap(), &sym_key.plaintext);
-                let (cipher, nonce) = encrypt(bincode::serialize(&p).unwrap(), &sym_key.plaintext);
-                Ok(Protected::Ciphertext {
-                    cipher,
-                    nonce,
-                    enc_dek: sym_key.ciphertext_blob.to_vec(),
-                    kek_id: sym_key.key_id,
-                })
-            }
-            Protected::Ciphertext { .. } => Ok(self),
-        }
-    }
-
-    pub async fn unprotect(
-        self,
-        key_management: &KeyManager,
-        key_id: &str,
-    ) -> Result<MessageValue> {
-        match self {
-            Protected::Plaintext(p) => Ok(p),
-            Protected::Ciphertext {
-                cipher,
-                nonce,
-                enc_dek,
-                kek_id,
-            } => {
-                let sym_key = key_management
-                    .cached_get_key(key_id.to_string(), Some(enc_dek), Some(kek_id))
-                    .await?;
-                decrypt(cipher, nonce, &sym_key.plaintext)
-            }
-        }
-    }
 }
 
 impl ProtectConfig {
@@ -154,6 +32,15 @@ impl ProtectConfig {
             key_id: "XXXXXXX".to_string(),
         }))
     }
+}
+
+#[derive(Clone)]
+pub struct Protect {
+    keyspace_table_columns: HashMap<String, HashMap<String, Vec<String>>>,
+    key_source: KeyManager,
+    // TODO this should be a function to create key_ids based on "something", e.g. primary key
+    // for the moment this is just a string
+    key_id: String,
 }
 
 pub fn get_values_from_insert_or_update_mut(ast: &mut Statement) -> HashMap<String, &mut SQLValue> {
@@ -216,14 +103,12 @@ impl Transform for Protect {
                                             get_values_from_insert_or_update_mut(query);
                                         for col in columns {
                                             if let Some(value) = values.get_mut(col) {
-                                                let mut protected = Protected::Plaintext(
-                                                    MessageValue::from(&**value),
-                                                );
-                                                protected = protected
-                                                    .protect(&self.key_source, &self.key_id)
-                                                    .await?;
-                                                **value =
-                                                    SQLValue::from(&MessageValue::from(protected));
+                                                **value = crypto::encrypt(
+                                                    value,
+                                                    &self.key_source,
+                                                    &self.key_id,
+                                                )
+                                                .await?;
                                                 invalidate_cache = true;
                                             }
                                         }
@@ -278,18 +163,12 @@ impl Transform for Protect {
                                                 for index in &mut positions {
                                                     if let Some(v) = row.get_mut(*index) {
                                                         if let MessageValue::Bytes(_) = v {
-                                                            let protected =
-                                                            Protected::from_encrypted_bytes_value(
+                                                            *v = crypto::decrypt(
                                                                 v,
+                                                                &self.key_source,
+                                                                &self.key_id,
                                                             )
                                                             .await?;
-                                                            let new_value: MessageValue = protected
-                                                                .unprotect(
-                                                                    &self.key_source,
-                                                                    &self.key_id,
-                                                                )
-                                                                .await?;
-                                                            *v = new_value;
                                                             invalidate_cache = true;
                                                         } else {
                                                             warn!(

--- a/shotover-proxy/tests/cassandra_int_tests/basic_driver_tests.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/basic_driver_tests.rs
@@ -1254,7 +1254,7 @@ mod protect {
             "SELECT pk, cluster, col1, col2, col3 FROM test_protect_keyspace.test_table",
         );
         if let ResultValue::Varchar(value) = &result[0][2] {
-            assert!(value.starts_with("{\"Ciphertext"));
+            assert!(value.starts_with("{\"cipher"), "but was {:?}", value);
         } else {
             panic!("expectected 3rd column to be ResultValue::Varchar in {result:?}");
         }
@@ -1269,7 +1269,7 @@ mod protect {
         assert_eq!(result[0][0], ResultValue::Varchar("pk1".into()));
         assert_eq!(result[0][1], ResultValue::Varchar("cluster".into()));
         if let ResultValue::Varchar(value) = &result[0][2] {
-            assert!(value.starts_with("{\"Ciphertext"));
+            assert!(value.starts_with("{\"cipher"), "but was {:?}", value);
         } else {
             panic!("expectected 3rd column to be ResultValue::Varchar in {result:?}");
         }


### PR DESCRIPTION
Refactor pulled out of https://github.com/shotover/shotover-proxy/pull/661

This should have no functional changes.
Technically the serialization format for protected values has changed making it a breaking change, (as can be seen in the changed integration test) but its impossible to use this transform in production yet anyway.

Changes included in this refactor:
* private_cached_fetch key_id an `&str` now to save an allocation as we never needed a String anyway (key_id only ever gets used in a `format!()`)
* KeyMaterial is moved into the key_management module - its pretty closely related to KeyManager, so makes sense to keep it together.
* All the encryption/decryption logic is moved into its own module and is reduced into a simple encrypt/decrypt pair of functions.
   + the logic is now much simpler, so we can follow the entire encryption or decryption process in just 15 lines instead of 50 lines spread across different functions
   + the logic is now stateless making it less bug prone. Previously we had to rely on asserts to know that encryption/decryption was actually occuring, now it just happens.