### PR TITLE
remove depends_on from Cassandra docker clusters

### DIFF
--- a/docs/src/examples/cassandra-cluster-shotover-sidecar.md
+++ b/docs/src/examples/cassandra-cluster-shotover-sidecar.md
@@ -28,9 +28,7 @@ Below we can see an example of a Cassandra node and it's Shotover sidecar, notic
         ipv4_address: 172.16.1.3
     healthcheck: *healthcheck
     environment: *environment
-    depends_on:
-      - cassandra-one
-
+    
   shotover-one:
     restart: always
     depends_on:

--- a/shotover-proxy/example-configs-docker/cassandra-peers-rewrite/docker-compose.yml
+++ b/shotover-proxy/example-configs-docker/cassandra-peers-rewrite/docker-compose.yml
@@ -34,8 +34,6 @@ services:
         ipv4_address: 172.16.1.3
     healthcheck: *healthcheck
     environment: *environment
-    depends_on:
-      - cassandra-one
 
   cassandra-three:
     image: bitnami/cassandra:4.0
@@ -44,8 +42,6 @@ services:
         ipv4_address: 172.16.1.4
     healthcheck: *healthcheck
     environment: *environment
-    depends_on:
-      - cassandra-two
 
   shotover-one:
     restart: always

--- a/shotover-proxy/tests/test-configs/cassandra-peers-rewrite/docker-compose-3.11-cassandra.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra-peers-rewrite/docker-compose-3.11-cassandra.yaml
@@ -42,5 +42,3 @@ services:
         ipv4_address: 172.16.1.3
     healthcheck: *healthcheck
     environment: *environment
-    depends_on:
-      - cassandra-one

--- a/shotover-proxy/tests/test-configs/cassandra-peers-rewrite/docker-compose-4.0-cassandra.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra-peers-rewrite/docker-compose-4.0-cassandra.yaml
@@ -42,5 +42,3 @@ services:
         ipv4_address: 172.16.1.3
     healthcheck: *healthcheck
     environment: *environment
-    depends_on:
-      - cassandra-one


### PR DESCRIPTION
@rukai noticed we don't need this and it gives us a speedup on test runtime.