### PR TITLE
remove unused from_topology_file_without_observability

### DIFF
--- a/shotover-proxy/tests/helpers/mod.rs
+++ b/shotover-proxy/tests/helpers/mod.rs
@@ -49,29 +49,6 @@ impl ShotoverManager {
         }
     }
 
-    #[allow(dead_code)] // to make clippy happy
-    pub fn from_topology_file_without_observability(topology_path: &str) -> ShotoverManager {
-        let opts = ConfigOpts {
-            topology_file: topology_path.into(),
-            config_file: "tests/helpers/config.yaml".into(),
-            ..ConfigOpts::default()
-        };
-        let spawn = Runner::new(opts)
-            .unwrap_or_else(|x| panic!("{x} occurred processing {topology_path:?}"))
-            .run_spawn();
-
-        // If we allow the tracing_guard to be dropped then the following tests in the same file will not get tracing so we mem::forget it.
-        // This is because tracing can only be initialized once in the same execution, secondary attempts to initalize tracing will silently fail.
-        std::mem::forget(spawn.tracing_guard);
-
-        ShotoverManager {
-            runtime: spawn.runtime,
-            runtime_handle: spawn.runtime_handle,
-            join_handle: Some(spawn.join_handle),
-            trigger_shutdown_tx: spawn.trigger_shutdown_tx,
-        }
-    }
-
     // false unused warning caused by https://github.com/rust-lang/rust/issues/46379
     #[allow(unused)]
     pub fn redis_connection(&self, port: u16) -> redis::Connection {


### PR DESCRIPTION
Because of the hacky way this file is imported every method needs  `#[allow(unused)]`  which allowed this dead code to go unnoticed.

We could additionally remove the `with_observability_interface` builder style API from `Runner` but I would rather leave that as is because it demonstrates a design I would like to explore with shotover later on.