### PR TITLE
cassandra peers rewrite - rewrite all native_ports

### DIFF
--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -198,7 +198,7 @@ fn test_cassandra_peers_rewrite() {
             assert_query_result(
                 &rewrite_port_connection,
                 "SELECT native_port, native_port FROM system.peers_v2;",
-                &[&[ResultValue::Int(9044), ResultValue::Int(9042)]],
+                &[&[ResultValue::Int(9044), ResultValue::Int(9044)]],
             );
 
             assert_query_result(


### PR DESCRIPTION
Pulled out of https://github.com/shotover/shotover-proxy/pull/598

A bit frivolous by itself, but is clearly more correct in isolation and 598 will get more benefits from it.

Instead of just rewriting the first instance of native_port in a system.peers query we now rewrite every instance of native_port.

The change in output to the existing integration test demonstrates the change well.