### PR TITLE
Add benches for protect transform

### DIFF
--- a/shotover-proxy/benches/chain_benches.rs
+++ b/shotover-proxy/benches/chain_benches.rs
@@ -13,6 +13,7 @@ use shotover_proxy::transforms::chain::TransformChain;
 use shotover_proxy::transforms::debug::returner::{DebugReturner, Response};
 use shotover_proxy::transforms::filter::QueryTypeFilter;
 use shotover_proxy::transforms::null::Null;
+use shotover_proxy::transforms::protect::{KeyManagerConfig, ProtectConfig};
 use shotover_proxy::transforms::redis::cluster_ports_rewrite::RedisClusterPortsRewrite;
 use shotover_proxy::transforms::redis::timestamp_tagging::RedisTimestampTagger;
 use shotover_proxy::transforms::throttling::RequestThrottlingConfig;
@@ -264,6 +265,91 @@ fn criterion_benchmark(c: &mut Criterion) {
             )
         });
     }
+
+    {
+        let chain = TransformChain::new(
+            vec![
+                rt.block_on(
+                    ProtectConfig {
+                        keyspace_table_columns: [(
+                            "test_protect_keyspace".to_string(),
+                            [("protected_table".to_string(), vec!["col1".to_string()])]
+                                .into_iter()
+                                .collect(),
+                        )]
+                        .into_iter()
+                        .collect(),
+                        key_manager: KeyManagerConfig::Local {
+                            kek: "Ht8M1nDO/7fay+cft71M2Xy7j30EnLAsA84hSUMCm1k=".to_string(),
+                            kek_id: "".to_string(),
+                        },
+                    }
+                    .get_transform(),
+                )
+                .unwrap(),
+                Transforms::Null(Null::default()),
+            ],
+            "bench".into(),
+        );
+
+        let wrapper = cassandra_parsed_query(
+            "INSERT INTO test_protect_keyspace.unprotected_table (pk, cluster, col1, col2, col3) VALUES ('pk1', 'cluster', 'I am gonna get encrypted!!', 42, true);"
+        );
+
+        group.bench_function("cassandra_protect_unprotected", |b| {
+            b.to_async(&rt).iter_batched(
+                || BenchInput {
+                    chain: chain.clone(),
+                    wrapper: wrapper.clone(),
+                    client_details: "".into(),
+                },
+                BenchInput::bench,
+                BatchSize::SmallInput,
+            )
+        });
+
+        let wrapper = cassandra_parsed_query(
+            "INSERT INTO test_protect_keyspace.protected_table (pk, cluster, col1, col2, col3) VALUES ('pk1', 'cluster', 'I am gonna get encrypted!!', 42, true);"
+        );
+
+        group.bench_function("cassandra_protect_protected", |b| {
+            b.to_async(&rt).iter_batched(
+                || BenchInput {
+                    chain: chain.clone(),
+                    wrapper: wrapper.clone(),
+                    client_details: "".into(),
+                },
+                BenchInput::bench,
+                BatchSize::SmallInput,
+            )
+        });
+    }
+}
+
+fn cassandra_parsed_query(query: &str) -> Wrapper {
+    Wrapper::new_with_chain_name(
+        vec![Message::from_frame(Frame::Cassandra(CassandraFrame {
+            version: Version::V4,
+            stream_id: 0,
+            tracing_id: None,
+            warnings: vec![],
+            operation: CassandraOperation::Query {
+                query: Box::new(parse_statement_single(query)),
+                params: Box::new(QueryParams {
+                    consistency: Consistency::One,
+                    with_names: false,
+                    values: None,
+                    page_size: Some(5000),
+                    paging_state: None,
+                    serial_consistency: None,
+                    timestamp: Some(1643855761086585),
+                    keyspace: None,
+                    now_in_seconds: None,
+                }),
+            },
+        }))],
+        "bench".into(),
+    )
 }
 
 struct BenchInput<'a> {

--- a/shotover-proxy/src/transforms/protect/mod.rs
+++ b/shotover-proxy/src/transforms/protect/mod.rs
@@ -1,7 +1,8 @@
 use crate::error::ChainResponse;
 use crate::frame::{CassandraFrame, CassandraOperation, CassandraResult, Frame};
 use crate::message::MessageValue;
-use crate::transforms::protect::key_management::{KeyManager, KeyManagerConfig};
+use crate::transforms::protect::key_management::KeyManager;
+pub use crate::transforms::protect::key_management::KeyManagerConfig;
 use crate::transforms::{Transform, Transforms, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;


### PR DESCRIPTION
Adds benches to directly bench the protect transform without going through the full shotover<->cassandra stack
You can confirm that the `cassandra_protect_protected` hits the encryption path by observing that it performs a lot worse than `cassandra_protect_unprotected`

```
transform/cassandra_protect_unprotected
                        time:   [1.7484 us 1.7582 us 1.7666 us]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
transform/cassandra_protect_protected
                        time:   [6.0483 us 6.0769 us 6.1084 us]
```

These benches will help with evaluating the impact of https://github.com/shotover/shotover-proxy/pull/685