### PR TITLE
Remove unneeded Result from source return type

### DIFF
--- a/shotover-proxy/src/runner.rs
+++ b/shotover-proxy/src/runner.rs
@@ -232,11 +232,7 @@ pub async fn run(
 
     match topology.run_chains(trigger_shutdown_rx).await {
         Ok(sources) => {
-            for result in
-                futures::future::join_all(sources.into_iter().map(|x| x.into_join_handle())).await
-            {
-                result.unwrap();
-            }
+            futures::future::join_all(sources.into_iter().map(|x| x.into_join_handle())).await;
             info!("Shotover was shutdown cleanly.");
             Ok(())
         }

--- a/shotover-proxy/src/runner.rs
+++ b/shotover-proxy/src/runner.rs
@@ -232,7 +232,11 @@ pub async fn run(
 
     match topology.run_chains(trigger_shutdown_rx).await {
         Ok(sources) => {
-            futures::future::join_all(sources.into_iter().map(|x| x.into_join_handle())).await;
+            for result in
+                futures::future::join_all(sources.into_iter().map(|x| x.into_join_handle())).await
+            {
+                result.unwrap();
+            }
             info!("Shotover was shutdown cleanly.");
             Ok(())
         }

--- a/shotover-proxy/src/sources/cassandra_source.rs
+++ b/shotover-proxy/src/sources/cassandra_source.rs
@@ -44,7 +44,7 @@ impl CassandraConfig {
 #[derive(Debug)]
 pub struct CassandraSource {
     pub name: &'static str,
-    pub join_handle: JoinHandle<Result<()>>,
+    pub join_handle: JoinHandle<()>,
     pub listen_addr: String,
 }
 
@@ -90,8 +90,6 @@ impl CassandraSource {
                     }
                 }
             }
-
-            Ok(())
         });
 
         Ok(CassandraSource {

--- a/shotover-proxy/src/sources/mod.rs
+++ b/shotover-proxy/src/sources/mod.rs
@@ -16,7 +16,7 @@ pub enum Sources {
 }
 
 impl Sources {
-    pub fn into_join_handle(self) -> JoinHandle<Result<()>> {
+    pub fn into_join_handle(self) -> JoinHandle<()> {
         match self {
             Sources::Cassandra(c) => c.join_handle,
             Sources::Redis(r) => r.join_handle,

--- a/shotover-proxy/src/sources/redis_source.rs
+++ b/shotover-proxy/src/sources/redis_source.rs
@@ -43,7 +43,7 @@ impl RedisConfig {
 #[derive(Debug)]
 pub struct RedisSource {
     pub name: &'static str,
-    pub join_handle: JoinHandle<Result<()>>,
+    pub join_handle: JoinHandle<()>,
     pub listen_addr: String,
 }
 
@@ -88,8 +88,6 @@ impl RedisSource {
                     }
                 }
             }
-
-            Ok(())
         });
 
         Ok(RedisSource {


### PR DESCRIPTION

* ~~runner.rs changes cause panics in sources to unwind all the way up such that shotover terminates.~~
   + ~~This is desirable for integration tests - any panic in shotover should cause the int test to fail.~~
   + ~~I also believe this is desirable for end users, a panic is an unrecoverable error and so should be handled as such.~~
   + ~~Previously it looked like we were getting that behavior in tests but that was just because:~~
      - ~~the test itself was failing due to assertions causing a panic + full unwind~~
      - ~~while tokio was catching the source panic at the task boundary, displaying the error and then never unwinding the rest of the way.~~
* `JoinHandle<Result<()>>` -> `JoinHandle<()>` is changed because there is no expected runtime error for a source. They should be handling all of their errors internally.