### PR TITLE
Detect panics in integration tests

### DIFF
--- a/shotover-proxy/src/transforms/filter.rs
+++ b/shotover-proxy/src/transforms/filter.rs
@@ -49,7 +49,12 @@ impl Transform for QueryTypeFilter {
             .await
             .map(|mut messages| {
                 for (i, message) in removed_indexes.into_iter() {
-                    messages.insert(i, message);
+                    if i <= messages.len() {
+                        messages.insert(i, message);
+                    }
+                    else {
+                        tracing::error!("The current filter transform implementation does not obey the current transform invariants. see https://github.com/shotover/shotover-proxy/issues/499")
+                    }
                 }
                 messages
             })

--- a/shotover-proxy/tests/helpers/mod.rs
+++ b/shotover-proxy/tests/helpers/mod.rs
@@ -6,6 +6,7 @@ use shotover_proxy::runner::{ConfigOpts, Runner};
 use shotover_proxy::tls::{TlsConfig, TlsConnector};
 use std::fs::read_to_string;
 use std::pin::Pin;
+use std::sync::mpsc;
 use std::time::Duration;
 use tokio::runtime::{Handle as RuntimeHandle, Runtime};
 use tokio::sync::watch;
@@ -21,44 +22,50 @@ pub struct ShotoverManager {
     pub runtime_handle: RuntimeHandle,
     pub join_handle: Option<JoinHandle<Result<()>>>,
     pub trigger_shutdown_tx: watch::Sender<bool>,
+    panic_occured_rx: mpsc::Receiver<()>,
 }
 
+// false unused warnings caused by https://github.com/rust-lang/rust/issues/46379
 impl ShotoverManager {
-    #[allow(dead_code)] // to make clippy happy
+    #[allow(dead_code)]
     pub fn from_topology_file(topology_path: &str) -> ShotoverManager {
-        let opts = ConfigOpts {
-            topology_file: topology_path.into(),
-            config_file: "tests/helpers/config.yaml".into(),
-            ..ConfigOpts::default()
-        };
-        let spawn = Runner::new(opts)
-            .unwrap_or_else(|x| panic!("{x} occurred processing {topology_path:?}"))
-            .with_observability_interface()
-            .unwrap_or_else(|x| panic!("{x} occurred processing {topology_path:?}"))
-            .run_spawn();
-
-        // If we allow the tracing_guard to be dropped then the following tests in the same file will not get tracing so we mem::forget it.
-        // This is because tracing can only be initialized once in the same execution, secondary attempts to initalize tracing will silently fail.
-        std::mem::forget(spawn.tracing_guard);
-
-        ShotoverManager {
-            runtime: spawn.runtime,
-            runtime_handle: spawn.runtime_handle,
-            join_handle: Some(spawn.join_handle),
-            trigger_shutdown_tx: spawn.trigger_shutdown_tx,
-        }
+        ShotoverManager::from_topology_file_inner(topology_path, true)
     }
 
-    #[allow(dead_code)] // to make clippy happy
+    #[allow(dead_code)]
     pub fn from_topology_file_without_observability(topology_path: &str) -> ShotoverManager {
+        ShotoverManager::from_topology_file_inner(topology_path, false)
+    }
+
+    fn from_topology_file_inner(topology_path: &str, observability: bool) -> ShotoverManager {
+        // std does not yet support doing this without a race condition.
+        // See: https://github.com/rust-lang/rust/issues/92649
+        let prev_hook = std::panic::take_hook();
+        let (tx, panic_occured_rx) = mpsc::sync_channel(10);
+        std::panic::set_hook(Box::new(move |panic_info| {
+            // This panic hook will outlive the Receiver.
+            // so we should just ignore failures to send as that is expected once the Receiver drops.
+            let _ = tx.try_send(());
+
+            prev_hook(panic_info)
+        }));
+
         let opts = ConfigOpts {
             topology_file: topology_path.into(),
             config_file: "tests/helpers/config.yaml".into(),
             ..ConfigOpts::default()
         };
-        let spawn = Runner::new(opts)
-            .unwrap_or_else(|x| panic!("{x} occurred processing {topology_path:?}"))
-            .run_spawn();
+        let spawn = if observability {
+            Runner::new(opts)
+                .unwrap_or_else(|x| panic!("{x} occurred processing {topology_path:?}"))
+                .with_observability_interface()
+                .unwrap_or_else(|x| panic!("{x} occurred processing {topology_path:?}"))
+                .run_spawn()
+        } else {
+            Runner::new(opts)
+                .unwrap_or_else(|x| panic!("{x} occurred processing {topology_path:?}"))
+                .run_spawn()
+        };
 
         // If we allow the tracing_guard to be dropped then the following tests in the same file will not get tracing so we mem::forget it.
         // This is because tracing can only be initialized once in the same execution, secondary attempts to initalize tracing will silently fail.
@@ -69,10 +76,10 @@ impl ShotoverManager {
             runtime_handle: spawn.runtime_handle,
             join_handle: Some(spawn.join_handle),
             trigger_shutdown_tx: spawn.trigger_shutdown_tx,
+            panic_occured_rx,
         }
     }
 
-    // false unused warning caused by https://github.com/rust-lang/rust/issues/46379
     #[allow(unused)]
     pub fn redis_connection(&self, port: u16) -> redis::Connection {
         let address = "127.0.0.1";
@@ -192,6 +199,13 @@ impl Drop for ShotoverManager {
             }
         } else {
             self.shutdown_shotover().unwrap();
+
+            // When a panic occurs in a shotover tokio task that isnt joined on, tokio will catch the panic, print the panic message and shotover will continue running happily.
+            // This behaviour is reasonable and makes shotover more robust but in our integration tests we want to ensure that panics never ever occur.
+            // As a result we need the following assertion to detect panics that occur within tasks.
+            if let Ok(()) = self.panic_occured_rx.try_recv() {
+                panic!("Panic occured within a shotover task during integration test.\nPlease refer to the panic message that should have been already been logged to stdout by tokio when the panic occured.")
+            }
         }
     }
 }


### PR DESCRIPTION
closes https://github.com/shotover/shotover-proxy/issues/498 - although the design ended up different to what I initially described in that issue
I went through many design and implementation attempts before finally landing on this one.
Some other things I tried that didnt work out:
* always joining + unwrapping every task. Gave up on this because holding the JoinHandle around to do that is very tricky for long running tasks.
* writing a #[cfg(debug_assertions)] wrapper of tokio::spawn that catches panics in the task before it reaches tokio. I never got this working and the design it also relied on the developer to always call the wrapper.

But I'm now quite happy with the design I ended up with.
By using set_hook we can ensure that any panic at all will fail an integration test without any affect on the functionality of real shotover and without introducing any difference in functionality between tests and real shotover.
This leaves us free to choose to join or not join tasks purely based on if it makes sense from the perspective of achieving the desired logic.
This design also means shotover is more robust as a single panic wont bubble all the way up and cause shotover to shutdown.

Ideally I would fix the Filter transform issue that the panic was exposing but the solution will likely be complicated and require a lot of design work.
So instead I just downgraded it from a panic to an `error!` so we can land this important improvement to our test framework.
The real problem will continue to be tracked by https://github.com/shotover/shotover-proxy/issues/499