### PR TITLE
redis bulkstring handling fixes

### DIFF
--- a/shotover-proxy/src/transforms/redis/cluster_ports_rewrite.rs
+++ b/shotover-proxy/src/transforms/redis/cluster_ports_rewrite.rs
@@ -155,6 +155,9 @@ fn rewrite_port_node(frame: &mut Frame, new_port: u16) -> Result<()> {
 
                 let split = ip.split(|c| c == ':' || c == '@').collect::<Vec<&str>>();
 
+                if split.len() < 3 {
+                    bail!("IP address not in valid format: {ip}");
+                }
                 let new_ip = format!("{}:{}@{}", split[0], new_port, split[2]);
 
                 writer.write_field(&*new_ip)?;
@@ -335,12 +338,9 @@ f9553ea7fc23905476efec1f949b4b3e41a44103 :1234@0 slave,noaddr c852007a1c3b726534
         let mut raw_frame = Frame::Redis(RedisFrame::BulkString(Bytes::from_static(bulk_string)));
         rewrite_port_node(&mut raw_frame, 1234).unwrap();
 
-        let rewritten = if let Frame::Redis(RedisFrame::BulkString(string)) = raw_frame.clone() {
-            string
-        } else {
-            panic!("bad input: {raw_frame:?}")
-        };
-
-        assert_eq!(rewritten, Bytes::from_static(expected_string));
+        assert_eq!(
+            raw_frame,
+            Frame::Redis(RedisFrame::BulkString(Bytes::from_static(expected_string)))
+        );
     }
 }

--- a/shotover-proxy/src/transforms/redis/sink_cluster.rs
+++ b/shotover-proxy/src/transforms/redis/sink_cluster.rs
@@ -784,7 +784,8 @@ fn build_slot_to_server(
     ensure!(frames.len() >= 2, "expected at least two fields");
 
     let ip = if let RedisFrame::BulkString(ref ip) = frames[0] {
-        String::from_utf8_lossy(ip.as_ref()).to_string()
+        std::str::from_utf8(ip.as_ref())
+            .map_err(|e| anyhow!("Failed to parse IP address as utf8 {e}"))?
     } else {
         bail!("unexpected type for ip");
     };

--- a/shotover-proxy/src/transforms/redis/sink_cluster.rs
+++ b/shotover-proxy/src/transforms/redis/sink_cluster.rs
@@ -784,8 +784,7 @@ fn build_slot_to_server(
     ensure!(frames.len() >= 2, "expected at least two fields");
 
     let ip = if let RedisFrame::BulkString(ref ip) = frames[0] {
-        std::str::from_utf8(ip.as_ref())
-            .map_err(|e| anyhow!("Failed to parse IP address as utf8 {e}"))?
+        std::str::from_utf8(ip.as_ref()).context("Failed to parse IP address as utf8")?
     } else {
         bail!("unexpected type for ip");
     };


### PR DESCRIPTION
closes https://github.com/shotover/shotover-proxy/issues/174

Looks like all the actually worrying cases had already been fixed by other work.

That leaves us with the following cases that are worth fixing but are extremely rare:

* length checks - check the length of any array/vec before addressing it or use `.get` to ensure panics cannot be caused maliciously
* String::from_utf8_lossy -> str::from_utf8 - in this case we are processing a server reply, so we should assume the server will provide utf8 data but we should also not panic when its not in case something malicious is going on.