### PR TITLE
Minor improvements

### DIFF
--- a/shotover-proxy/src/codec/redis.rs
+++ b/shotover-proxy/src/codec/redis.rs
@@ -47,7 +47,7 @@ impl Decoder for RedisCodec {
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>> {
         loop {
-            match decode_mut(src).map_err(|e| anyhow!(e).context("Error decoding redis frame)"))? {
+            match decode_mut(src).map_err(|e| anyhow!(e).context("Error decoding redis frame"))? {
                 Some((frame, _size, bytes)) => {
                     self.messages
                         .push(Message::from_bytes_and_frame(bytes, Frame::Redis(frame)));

--- a/shotover-proxy/src/message/mod.rs
+++ b/shotover-proxy/src/message/mod.rs
@@ -401,7 +401,9 @@ impl MessageInner {
 
 #[derive(Debug)]
 pub enum Encodable {
+    /// The raw bytes the protocol should send
     Bytes(Bytes),
+    /// The Frame that should be processed into bytes and then sent
     Frame(Frame),
 }
 

--- a/shotover-proxy/src/server.rs
+++ b/shotover-proxy/src/server.rs
@@ -386,13 +386,13 @@ fn spawn_read_write_tasks<
                             process_return_to_sender_messages(message, &out_tx);
                         if !remaining_messages.is_empty() {
                             if let Err(error) = in_tx.send(remaining_messages) {
-                                warn!("failed to send message: {}", error);
+                                warn!("failed to pass on received message: {}", error);
                                 return;
                             }
                         }
                     }
                     Err(error) => {
-                        warn!("failed to decode message: {}", error);
+                        warn!("failed to receive or decode message: {:?}", error);
                         return;
                     }
                 }
@@ -405,7 +405,7 @@ fn spawn_read_write_tasks<
         async move {
             let rx_stream = UnboundedReceiverStream::new(out_rx).map(Ok);
             if let Err(err) = rx_stream.forward(writer).await {
-                error!("Stream ended with error {:?}", err);
+                error!("failed to send or encode message: {:?}", err);
             }
         }
         .in_current_span(),


### PR DESCRIPTION
The previous warning `warn!("failed to decode message: {}", error)` resulted in the very confusing output: 

```
WARN request{id=8 source="RedisSource"}: shotover_proxy::server: failed to decode message: Connection reset by peer (os error 104)
```

But now the message acknowledges that the error could also be from receiving.

The previous error `error!("Stream ended with error {:?}", err);` was changed to match the format of the receive/decode message