### PR TITLE
Reject non-array redis commands

### DIFF
--- a/shotover-proxy/src/codec/redis.rs
+++ b/shotover-proxy/src/codec/redis.rs
@@ -37,7 +37,7 @@ pub fn redis_query_type(frame: &RedisFrame) -> QueryType {
 }
 
 impl RedisCodec {
-    pub fn new(direction: RedisDirection) -> RedisCodec {
+    pub fn new(direction: RedisDirection) -> Self {
         RedisCodec {
             messages: vec![],
             direction,
@@ -62,7 +62,7 @@ impl Decoder for RedisCodec {
                         if let Some(frame) = message.frame() {
                             validate_command(frame)?;
                         } else {
-                            return Err(anyhow!("redis message could not be parsed as a message"));
+                            return Err(anyhow!("redis frame could not be parsed"));
                         }
                     }
                     self.messages.push(message);
@@ -95,7 +95,7 @@ fn validate_command(frame: &Frame) -> Result<()> {
             }
             frame => Err(anyhow!("Redis command must be an array but was {frame:?}")),
         },
-        _ => unreachable!("Message from a redis codec must be a redis message"),
+        _ => unreachable!("Message from a redis codec will always be a redis message"),
     }
 }
 

--- a/shotover-proxy/src/sources/redis_source.rs
+++ b/shotover-proxy/src/sources/redis_source.rs
@@ -1,4 +1,4 @@
-use crate::codec::redis::RedisCodec;
+use crate::codec::redis::{RedisCodec, RedisDirection};
 use crate::server::TcpCodecListener;
 use crate::sources::Sources;
 use crate::tls::{TlsAcceptor, TlsConfig};
@@ -66,7 +66,7 @@ impl RedisSource {
             name.to_string(),
             listen_addr.clone(),
             hard_connection_limit.unwrap_or(false),
-            RedisCodec::new(),
+            RedisCodec::new(RedisDirection::Source),
             Arc::new(Semaphore::new(connection_limit.unwrap_or(512))),
             trigger_shutdown_rx.clone(),
             tls.map(TlsAcceptor::new).transpose()?,

--- a/shotover-proxy/src/transforms/redis/cluster_ports_rewrite.rs
+++ b/shotover-proxy/src/transforms/redis/cluster_ports_rewrite.rs
@@ -207,7 +207,7 @@ fn is_cluster_slots(frame: &Frame) -> bool {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::codec::redis::RedisCodec;
+    use crate::codec::redis::{RedisCodec, RedisDirection};
     use crate::transforms::redis::sink_cluster::parse_slots;
     use tokio_util::codec::Decoder;
 
@@ -270,7 +270,7 @@ mod test {
     #[test]
     fn test_rewrite_port_slots() {
         let slots_pcap: &[u8] = b"*3\r\n*4\r\n:10923\r\n:16383\r\n*3\r\n$12\r\n192.168.80.6\r\n:6379\r\n$40\r\n3a7c357ed75d2aa01fca1e14ef3735a2b2b8ffac\r\n*3\r\n$12\r\n192.168.80.3\r\n:6379\r\n$40\r\n77c01b0ddd8668fff05e3f6a8aaf5f3ccd454a79\r\n*4\r\n:5461\r\n:10922\r\n*3\r\n$12\r\n192.168.80.5\r\n:6379\r\n$40\r\n969c6215d064e68593d384541ceeb57e9520dbed\r\n*3\r\n$12\r\n192.168.80.2\r\n:6379\r\n$40\r\n3929f69990a75be7b2d49594c57fe620862e6fd6\r\n*4\r\n:0\r\n:5460\r\n*3\r\n$12\r\n192.168.80.7\r\n:6379\r\n$40\r\n15d52a65d1fc7a53e34bf9193415aa39136882b2\r\n*3\r\n$12\r\n192.168.80.4\r\n:6379\r\n$40\r\ncd023916a3528fae7e606a10d8289a665d6c47b0\r\n";
-        let mut codec = RedisCodec::new();
+        let mut codec = RedisCodec::new(RedisDirection::Sink);
         let mut message = codec
             .decode(&mut slots_pcap.into())
             .unwrap()

--- a/shotover-proxy/src/transforms/redis/sink_cluster.rs
+++ b/shotover-proxy/src/transforms/redis/sink_cluster.rs
@@ -1,4 +1,4 @@
-use crate::codec::redis::RedisCodec;
+use crate::codec::redis::{RedisCodec, RedisDirection};
 use crate::concurrency::FuturesOrdered;
 use crate::error::ChainResponse;
 use crate::frame::{Frame, RedisFrame};
@@ -93,7 +93,11 @@ impl RedisSinkCluster {
     ) -> Result<Self> {
         let authenticator = RedisAuthenticator {};
 
-        let connection_pool = ConnectionPool::new_with_auth(RedisCodec::new(), authenticator, tls)?;
+        let connection_pool = ConnectionPool::new_with_auth(
+            RedisCodec::new(RedisDirection::Sink),
+            authenticator,
+            tls,
+        )?;
 
         let sink_cluster = RedisSinkCluster {
             first_contact_points,
@@ -1054,7 +1058,7 @@ mod test {
         // Wireshark capture from a Redis cluster with 3 masters and 3 replicas.
         let slots_pcap: &[u8] = b"*3\r\n*4\r\n:10923\r\n:16383\r\n*3\r\n$12\r\n192.168.80.6\r\n:6379\r\n$40\r\n3a7c357ed75d2aa01fca1e14ef3735a2b2b8ffac\r\n*3\r\n$12\r\n192.168.80.3\r\n:6379\r\n$40\r\n77c01b0ddd8668fff05e3f6a8aaf5f3ccd454a79\r\n*4\r\n:5461\r\n:10922\r\n*3\r\n$12\r\n192.168.80.5\r\n:6379\r\n$40\r\n969c6215d064e68593d384541ceeb57e9520dbed\r\n*3\r\n$12\r\n192.168.80.2\r\n:6379\r\n$40\r\n3929f69990a75be7b2d49594c57fe620862e6fd6\r\n*4\r\n:0\r\n:5460\r\n*3\r\n$12\r\n192.168.80.7\r\n:6379\r\n$40\r\n15d52a65d1fc7a53e34bf9193415aa39136882b2\r\n*3\r\n$12\r\n192.168.80.4\r\n:6379\r\n$40\r\ncd023916a3528fae7e606a10d8289a665d6c47b0\r\n";
 
-        let mut codec = RedisCodec::new();
+        let mut codec = RedisCodec::new(RedisDirection::Sink);
 
         let mut message = codec
             .decode(&mut slots_pcap.into())

--- a/shotover-proxy/src/transforms/util/cluster_connection_pool.rs
+++ b/shotover-proxy/src/transforms/util/cluster_connection_pool.rs
@@ -300,7 +300,7 @@ mod test {
     use tokio::time::timeout;
 
     use super::spawn_read_write_tasks;
-    use crate::codec::redis::RedisCodec;
+    use crate::codec::redis::{RedisCodec, RedisDirection};
 
     #[tokio::test]
     async fn test_remote_shutdown() {
@@ -325,7 +325,7 @@ mod test {
 
         let stream = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
         let (rx, tx) = stream.into_split();
-        let codec = RedisCodec::new();
+        let codec = RedisCodec::new(RedisDirection::Sink);
         let sender = spawn_read_write_tasks(&codec, rx, tx);
 
         assert!(remote.await.unwrap());
@@ -365,7 +365,7 @@ mod test {
 
         let stream = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
         let (rx, tx) = stream.into_split();
-        let codec = RedisCodec::new();
+        let codec = RedisCodec::new(RedisDirection::Sink);
 
         // Drop sender immediately.
         std::mem::drop(spawn_read_write_tasks(&codec, rx, tx));


### PR DESCRIPTION
closes https://github.com/shotover/shotover-proxy/issues/702

In order to catch invalid commands I inserted a validation check both just after the command is decoded and just before it is encoded.

This seems like a reasonable way to do it:
* we catch invalid commands from the client asap
* we catch invalid commands generated by transforms
* If a transform really wants to for performance reasons it can bypass the check by directly generating bytes

Previously RedisSinkSingle was dropping errors on send, so I changed that to bubble up the error to make this PR work.
The effect of this is if we encounter a connection/protocol error when sending to the redis instance, shotover will now:
* terminate the connection when RedisSinkSingle is used directly in a chain 
* log a cache failure and keep running when RedisSinkSingle is in the cache chain of SimpleRedisCache

You can observe the new validation logic functioning correctly by running `cargo test cassandra_int_tests::test_cassandra_redis_cache`
and observing the output log:
`Cache error: Redis command must be an array but was BulkString(b"FLUSHDB")`