### PR TITLE
Close connection on transform error

### DIFF
--- a/shotover-proxy/src/transforms/redis/sink_single.rs
+++ b/shotover-proxy/src/transforms/redis/sink_single.rs
@@ -93,10 +93,7 @@ impl Transform for RedisSinkSingle {
 
         // self.outbound is gauranteed to be Some by the previous block
         let outbound_framed_codec = self.outbound.as_mut().unwrap();
-        outbound_framed_codec
-            .send(message_wrapper.messages)
-            .await
-            .ok();
+        outbound_framed_codec.send(message_wrapper.messages).await?;
 
         match outbound_framed_codec.next().fuse().await {
             Some(mut a) => {


### PR DESCRIPTION
Discovered while investigating https://github.com/shotover/shotover-proxy/pull/706 but quite likely unrelated.

I had previously expected that when a transform returns a `Result::Err` the connection would be immediately dropped.
Upon writing an integration test to prove this, I discovered that it is in fact not the case.
Currently a transform returning `Result::Err` will result in no reply sent to the client and the connection remaining open, very likely resulting in the client waiting indefinitely for a response.

So this PR changes shotover to drop the connection immediately when a transform returns a `Result::Err`.
If a transform wishes to avoid dropping the connection when encountering an error they should handle the error internally.

There was also some changes needed to ensure the send/receive tasks are terminated when the main task is terminated

## flushing

I hit an issue where the final messages sent were being lost.
The fix for that was to flush any pending messages before terminating the send task.

This was very tricky to track down because of the connection closing logic needed by cassandra version handling.
It looked like the problem was caused by a bug in that complicated logic, but it was actually that that logic was often exposing the bug due to its timing of message sending -> connection close.

<!--
            // The cassandra protocol needs to:
            // 1. receive bad version init
            // 2. reply with error
            // 3. receive another message
            // 4. kill the connection:
            //     1. codec returns Err
            //     2. rx task receives Err, logging it and returning
            //     3. rx task ends dropping the in_tx
            //     4. main task receives None from in_rx causing it to return
            //     5. main task ends resulting in drop running terminate_tasks_tx.send(())
            //
            // I suspect that:
            // Sender is backlogged and gets killed before it can process everything so 2 never occurs
-->