### PR TITLE
Add CassandraSinkCluster

### DIFF
--- a/shotover-proxy/example-configs/cassandra-cluster/docker-compose.yml
+++ b/shotover-proxy/example-configs/cassandra-cluster/docker-compose.yml
@@ -1,0 +1,52 @@
+version: "3.3"
+networks:
+  cluster_subnet:
+    name: cluster_subnet
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.16.1.0/24
+          gateway: 172.16.1.1
+
+services:
+  cassandra-one:
+    image: bitnami/cassandra:3.11
+    networks:
+      cluster_subnet:
+        ipv4_address: 172.16.1.2
+    healthcheck:
+      &healthcheck
+      test: [ "CMD", "cqlsh", "-e", "describe keyspaces" ]
+      interval: 5s
+      timeout: 5s
+      retries: 60
+    environment:
+      &environment
+      CASSANDRA_SEEDS: "cassandra-one,cassandra-two"
+      CASSANDRA_CLUSTER_NAME: TestCluster
+      CASSANDRA_DC: dc1
+      CASSANDRA_RACK: rack1
+      CASSANDRA_ENDPOINT_SNITCH: GossipingPropertyFileSnitch
+      CASSANDRA_NUM_TOKENS: 128
+      MAX_HEAP_SIZE: "400M"
+      MIN_HEAP_SIZE: "400M"
+      HEAP_NEWSIZE: "48M"
+      CASSANDRA_ENABLE_SCRIPTED_USER_DEFINED_FUNCTIONS: "true"
+      CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS: "true"
+
+  cassandra-two:
+    image: bitnami/cassandra:3.11
+    networks:
+      cluster_subnet:
+        ipv4_address: 172.16.1.3
+    healthcheck: *healthcheck
+    environment: *environment
+
+  cassandra-three:
+    image: bitnami/cassandra:3.11
+    networks:
+      cluster_subnet:
+        ipv4_address: 172.16.1.4
+    healthcheck: *healthcheck
+    environment: *environment

--- a/shotover-proxy/example-configs/cassandra-cluster/topology.yaml
+++ b/shotover-proxy/example-configs/cassandra-cluster/topology.yaml
@@ -1,0 +1,12 @@
+---
+sources:
+  cassandra_prod:
+    Cassandra:
+      listen_addr: "127.0.0.1:9042"
+chain_config:
+  main_chain:
+    - CassandraSinkCluster:
+        first_contact_points: ["172.16.1.2:9042", "172.16.1.3:9042"]
+        data_center: "dc1"
+source_to_chain_mapping:
+  cassandra_prod: main_chain

--- a/shotover-proxy/src/transforms/cassandra/mod.rs
+++ b/shotover-proxy/src/transforms/cassandra/mod.rs
@@ -1,3 +1,4 @@
 mod connection;
 pub mod peers_rewrite;
+pub mod sink_cluster;
 pub mod sink_single;

--- a/shotover-proxy/src/transforms/cassandra/sink_cluster.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_cluster.rs
@@ -1,0 +1,165 @@
+use super::connection::CassandraConnection;
+use crate::codec::cassandra::CassandraCodec;
+use crate::concurrency::FuturesOrdered;
+use crate::error::ChainResponse;
+use crate::frame::cassandra;
+use crate::message::Messages;
+use crate::tls::TlsConfig;
+use crate::tls::TlsConnector;
+use crate::transforms::util::Response;
+use crate::transforms::{Transform, Transforms, Wrapper};
+use anyhow::Result;
+use async_trait::async_trait;
+use cassandra_protocol::frame::Opcode;
+use metrics::{register_counter, Counter};
+use serde::Deserialize;
+use std::time::Duration;
+use tokio::sync::{mpsc, oneshot};
+use tokio::time::timeout;
+use tokio_stream::StreamExt;
+use tracing::{error, trace};
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct CassandraSinkClusterConfig {
+    pub first_contact_points: Vec<String>,
+    pub data_center: String,
+    pub tls: Option<TlsConfig>,
+}
+
+impl CassandraSinkClusterConfig {
+    pub async fn get_transform(&self, chain_name: String) -> Result<Transforms> {
+        let tls = self.tls.clone().map(TlsConnector::new).transpose()?;
+        Ok(Transforms::CassandraSinkCluster(CassandraSinkCluster::new(
+            self.first_contact_points.clone(),
+            chain_name,
+            tls,
+        )))
+    }
+}
+
+pub struct CassandraSinkCluster {
+    contact_points: Vec<String>,
+    outbound: Option<CassandraConnection>,
+    chain_name: String,
+    failed_requests: Counter,
+    tls: Option<TlsConnector>,
+    pushed_messages_tx: Option<mpsc::UnboundedSender<Messages>>,
+}
+
+impl Clone for CassandraSinkCluster {
+    fn clone(&self) -> Self {
+        CassandraSinkCluster {
+            contact_points: self.contact_points.clone(),
+            outbound: None,
+            chain_name: self.chain_name.clone(),
+            tls: self.tls.clone(),
+            failed_requests: self.failed_requests.clone(),
+            pushed_messages_tx: None,
+        }
+    }
+}
+
+impl CassandraSinkCluster {
+    pub fn new(
+        contact_points: Vec<String>,
+        chain_name: String,
+        tls: Option<TlsConnector>,
+    ) -> CassandraSinkCluster {
+        let failed_requests = register_counter!("failed_requests", "chain" => chain_name.clone(), "transform" => "CassandraSinkCluster");
+
+        CassandraSinkCluster {
+            contact_points,
+            outbound: None,
+            chain_name,
+            failed_requests,
+            tls,
+            pushed_messages_tx: None,
+        }
+    }
+}
+
+impl CassandraSinkCluster {
+    async fn send_message(&mut self, messages: Messages) -> ChainResponse {
+        if self.outbound.is_none() {
+            trace!("creating outbound connection {:?}", self.contact_points);
+            self.outbound = Some(
+                CassandraConnection::new(
+                    self.contact_points[0].clone(),
+                    CassandraCodec::new(),
+                    self.tls.clone(),
+                    self.pushed_messages_tx.clone(),
+                )
+                .await?,
+            );
+        }
+
+        let outbound = self.outbound.as_mut().unwrap();
+        let expected_size = messages.len();
+        let results: Result<FuturesOrdered<oneshot::Receiver<Response>>> = messages
+            .into_iter()
+            .map(|m| {
+                let (return_chan_tx, return_chan_rx) = oneshot::channel();
+                outbound.send(m, return_chan_tx)?;
+
+                Ok(return_chan_rx)
+            })
+            .collect();
+
+        let mut responses = Vec::with_capacity(expected_size);
+        let mut results = results?;
+
+        loop {
+            match timeout(Duration::from_secs(5), results.next()).await {
+                Ok(Some(prelim)) => {
+                    match prelim? {
+                        Response {
+                            response: Ok(message),
+                            ..
+                        } => {
+                            if let Some(raw_bytes) = message.as_raw_bytes() {
+                                if let Ok(Opcode::Error) =
+                                    cassandra::raw_frame::get_opcode(raw_bytes)
+                                {
+                                    self.failed_requests.increment(1);
+                                }
+                            }
+                            responses.push(message);
+                        }
+                        Response {
+                            mut original,
+                            response: Err(err),
+                        } => {
+                            original.set_error(err.to_string());
+                            responses.push(original);
+                        }
+                    };
+                }
+                Ok(None) => break,
+                Err(_) => {
+                    error!(
+                        "timed out waiting for responses, received {:?} responses but expected {:?} responses",
+                        responses.len(),
+                        expected_size
+                    );
+                }
+            }
+        }
+
+        Ok(responses)
+    }
+}
+
+#[async_trait]
+impl Transform for CassandraSinkCluster {
+    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> ChainResponse {
+        self.send_message(message_wrapper.messages).await
+    }
+
+    fn is_terminating(&self) -> bool {
+        true
+    }
+
+    fn add_pushed_messages_tx(&mut self, pushed_messages_tx: mpsc::UnboundedSender<Messages>) {
+        self.pushed_messages_tx = Some(pushed_messages_tx);
+    }
+}

--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -49,6 +49,27 @@ fn test_passthrough() {
 
 #[test]
 #[serial]
+#[cfg(feature = "alpha-transforms")]
+fn test_cluster() {
+    let _compose = DockerCompose::new("example-configs/cassandra-cluster/docker-compose.yml");
+
+    let shotover_manager =
+        ShotoverManager::from_topology_file("example-configs/cassandra-cluster/topology.yaml");
+
+    let connection = shotover_manager.cassandra_connection("127.0.0.1", 9042);
+
+    keyspace::test(&connection);
+    table::test(&connection);
+    udt::test(&connection);
+    native_types::test(&connection);
+    collections::test(&connection);
+    functions::test(&connection);
+    prepared_statements::test(&connection);
+    batch_statements::test(&connection);
+}
+
+#[test]
+#[serial]
 fn test_source_tls_and_single_tls() {
     test_helpers::cert::generate_cassandra_test_certs();
     let _compose = DockerCompose::new("example-configs/cassandra-tls/docker-compose.yml");

--- a/test-helpers/src/docker_compose.rs
+++ b/test-helpers/src/docker_compose.rs
@@ -124,7 +124,8 @@ impl DockerCompose {
             | "tests/test-configs/cassandra-peers-rewrite/docker-compose-3.11-cassandra.yaml" => {
                 self.wait_for_log("Startup complete", 2, 110)
             }
-            "example-configs-docker/cassandra-peers-rewrite/docker-compose.yml" => {
+            "example-configs-docker/cassandra-peers-rewrite/docker-compose.yml"
+            | "example-configs/cassandra-cluster/docker-compose.yml" => {
                 self.wait_for_log("Startup complete", 3, 180)
             }
             path => unimplemented!(


### PR DESCRIPTION
Introduces the CassandraSinkCluster behind the alpha-transforms feature so that we can start collaboratively working on it.
Is currently identical to the implementation of CassandraSinkSingle except for the config which reflects the final config we want to have for CassandraSinkCluster.
Currently has the same integration test cases as CassandraSinkSingle but test cases will be added and removed as needed in future PRs.