### PR TITLE
Implement system.peers_v2 rewriting in CassandraSinkCluster

### DIFF
--- a/shotover-proxy/benches/chain_benches.rs
+++ b/shotover-proxy/benches/chain_benches.rs
@@ -214,7 +214,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     {
         let chain = TransformChain::new(
             vec![
-                Transforms::CassandraPeersRewrite(CassandraPeersRewrite::new(9042)),
+                Transforms::CassandraPeersRewrite(CassandraPeersRewrite::new(9042, false)),
                 Transforms::Null(Null::default()),
             ],
             "bench".into(),

--- a/shotover-proxy/tests/cassandra_int_tests/peers_rewrite.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/peers_rewrite.rs
@@ -1,0 +1,89 @@
+use crate::helpers::cassandra::{assert_query_result, execute_query, ResultValue};
+use cassandra_cpp::Session;
+
+pub fn test_rewrite_port(normal_connection: &Session, rewrite_port_connection: &Session) {
+    {
+        assert_query_result(
+            normal_connection,
+            "SELECT data_center, native_port, rack FROM system.peers_v2;",
+            &[&[
+                ResultValue::Varchar("dc1".into()),
+                ResultValue::Int(9042),
+                ResultValue::Varchar("West".into()),
+            ]],
+        );
+        assert_query_result(
+            normal_connection,
+            "SELECT native_port FROM system.peers_v2;",
+            &[&[ResultValue::Int(9042)]],
+        );
+
+        assert_query_result(
+            normal_connection,
+            "SELECT native_port as foo FROM system.peers_v2;",
+            &[&[ResultValue::Int(9042)]],
+        );
+    }
+
+    {
+        assert_query_result(
+            rewrite_port_connection,
+            "SELECT data_center, native_port, rack FROM system.peers_v2;",
+            &[&[
+                ResultValue::Varchar("dc1".into()),
+                ResultValue::Int(9044),
+                ResultValue::Varchar("West".into()),
+            ]],
+        );
+
+        assert_query_result(
+            rewrite_port_connection,
+            "SELECT native_port FROM system.peers_v2;",
+            &[&[ResultValue::Int(9044)]],
+        );
+
+        assert_query_result(
+            rewrite_port_connection,
+            "SELECT native_port as foo FROM system.peers_v2;",
+            &[&[ResultValue::Int(9044)]],
+        );
+
+        assert_query_result(
+            rewrite_port_connection,
+            "SELECT native_port, native_port FROM system.peers_v2;",
+            &[&[ResultValue::Int(9044), ResultValue::Int(9044)]],
+        );
+
+        assert_query_result(
+            rewrite_port_connection,
+            "SELECT native_port, native_port as some_port FROM system.peers_v2;",
+            &[&[ResultValue::Int(9044), ResultValue::Int(9044)]],
+        );
+
+        let result = execute_query(rewrite_port_connection, "SELECT * FROM system.peers_v2;");
+        assert_eq!(result[0][5], ResultValue::Int(9044));
+    }
+}
+
+pub fn test_assign_token_range(normal_connection: &Session, rewrite_connection: &Session) {
+    assert_query_result(rewrite_connection, "SELECT * FROM system.peers", &[]);
+    assert_query_result(rewrite_connection, "SELECT * FROM system.peers_v2", &[]);
+
+    assert_query_result(
+        normal_connection,
+        "SELECT data_center, rack FROM system.peers",
+        &[&[
+            ResultValue::Varchar("dc1".into()),
+            ResultValue::Varchar("West".into()),
+        ]],
+    );
+    assert_query_result(
+        normal_connection,
+        "SELECT data_center, native_port, rack FROM system.peers_v2;",
+        &[&[
+            ResultValue::Varchar("dc1".into()),
+            ResultValue::Int(9042),
+            ResultValue::Varchar("West".into()),
+        ]],
+    );
+}

--- a/shotover-proxy/tests/test-configs/cassandra-peers-rewrite/topology.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra-peers-rewrite/topology.yaml
@@ -8,15 +8,29 @@ sources:
     Cassandra:
       listen_addr: "127.0.0.1:9044"
 
+  cassandra_prod_3:
+    Cassandra:
+      listen_addr: "127.0.0.1:9045"
+
 chain_config:
   main_chain:
     - CassandraSinkSingle:
         remote_address: "172.16.1.2:9042"
+
   peers_rewrite_port:
     - CassandraPeersRewrite:
         port: 9044
     - CassandraSinkSingle:
         remote_address: "172.16.1.2:9042"
+
+  peers_assign_token_range:
+    - CassandraPeersRewrite:
+        port: 9044
+        assign_token_range: true
+    - CassandraSinkSingle:
+        remote_address: "172.16.1.2:9042"
+
 source_to_chain_mapping:
   cassandra_prod_1: main_chain
   cassandra_prod_2: peers_rewrite_port
+  cassandra_prod_3: peers_assign_token_range


### PR DESCRIPTION
Opening a draft for some early feedback. 

Just removing the peers table entirely will assign ourselves the entire token range. In the future we might need to actually fill this table with the Shotover nodes. I've allowed the use of both the new port field and this option for that reason, you will want to assign token ranges and specify the port of the Shotover nodes.

I could rename this to cluster hiding to more closely match the Redis one?
 
TODO:
- [x] unit tests
- [ ] update documentation