### PR TITLE
Implement basic cassandra cluster routing

### DIFF
--- a/shotover-proxy/src/transforms/cassandra/connection.rs
+++ b/shotover-proxy/src/transforms/cassandra/connection.rs
@@ -14,7 +14,7 @@ use futures::StreamExt;
 use halfbrown::HashMap;
 use std::time::Duration;
 use tokio::io::{split, AsyncRead, AsyncWrite, ReadHalf, WriteHalf};
-use tokio::net::TcpStream;
+use tokio::net::{TcpStream, ToSocketAddrs};
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::timeout;
 use tokio_stream::wrappers::UnboundedReceiverStream;
@@ -36,8 +36,8 @@ pub struct CassandraConnection {
 }
 
 impl CassandraConnection {
-    pub async fn new<C: Codec + 'static>(
-        host: String,
+    pub async fn new<C: Codec + 'static, A: ToSocketAddrs>(
+        host: A,
         codec: C,
         mut tls: Option<TlsConnector>,
         pushed_messages_tx: Option<mpsc::UnboundedSender<Messages>>,

--- a/shotover-proxy/src/transforms/cassandra/sink_cluster.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_cluster.rs
@@ -2,22 +2,24 @@ use super::connection::CassandraConnection;
 use crate::codec::cassandra::CassandraCodec;
 use crate::concurrency::FuturesOrdered;
 use crate::error::ChainResponse;
+use crate::frame::cassandra::parse_statement_single;
 use crate::frame::{CassandraFrame, CassandraOperation, CassandraResult, Frame};
 use crate::message::{Message, MessageValue, Messages};
 use crate::tls::{TlsConnector, TlsConnectorConfig};
 use crate::transforms::{Transform, Transforms, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
-use cql3_parser::cassandra_statement::CassandraStatement;
+use cassandra_protocol::consistency::Consistency;
+use cassandra_protocol::frame::Version;
+use cassandra_protocol::query::QueryParams;
 use cql3_parser::common::{FQName, Identifier};
-use cql3_parser::select::SelectElement;
 use metrics::{register_counter, Counter};
 use rand::prelude::*;
 use serde::Deserialize;
-use std::collections::HashMap;
 use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::net::ToSocketAddrs;
 use tokio::sync::{mpsc, oneshot, RwLock};
 
 #[derive(Deserialize, Debug, Clone)]
@@ -43,9 +45,10 @@ impl CassandraSinkClusterConfig {
 
 pub struct CassandraSinkCluster {
     contact_points: Vec<String>,
-    contact_point_handshake: Vec<Message>,
-    contact_point_handshake_complete: bool,
     contact_point_connection: Option<CassandraConnection>,
+    init_handshake: Vec<Message>,
+    init_handshake_address: Option<String>,
+    init_handshake_complete: bool,
     chain_name: String,
     failed_requests: Counter,
     tls: Option<TlsConnector>,
@@ -53,18 +56,24 @@ pub struct CassandraSinkCluster {
     read_timeout: Option<Duration>,
     peer_table: FQName,
     data_center: String,
-    nodes: Vec<CassandraNode>,
-    nodes_shared: Arc<RwLock<Vec<CassandraNode>>>,
+    /// A local clone of topology_task_nodes
+    /// Internally stores connections to the nodes
+    local_nodes: Vec<CassandraNode>,
+    /// Only written to by the topology task
+    /// Transform instances should never write to this.
+    topology_task_nodes: Arc<RwLock<Vec<CassandraNode>>>,
     rng: SmallRng,
+    task_handshake_tx: mpsc::Sender<TaskHandshake>,
 }
 
 impl Clone for CassandraSinkCluster {
     fn clone(&self) -> Self {
         CassandraSinkCluster {
             contact_points: self.contact_points.clone(),
-            contact_point_handshake: vec![],
-            contact_point_handshake_complete: false,
             contact_point_connection: None,
+            init_handshake: vec![],
+            init_handshake_address: None,
+            init_handshake_complete: false,
             chain_name: self.chain_name.clone(),
             tls: self.tls.clone(),
             failed_requests: self.failed_requests.clone(),
@@ -72,9 +81,10 @@ impl Clone for CassandraSinkCluster {
             read_timeout: self.read_timeout,
             peer_table: self.peer_table.clone(),
             data_center: self.data_center.clone(),
-            nodes: vec![],
-            nodes_shared: self.nodes_shared.clone(),
+            local_nodes: vec![],
+            topology_task_nodes: self.topology_task_nodes.clone(),
             rng: SmallRng::from_rng(rand::thread_rng()).unwrap(),
+            task_handshake_tx: self.task_handshake_tx.clone(),
         }
     }
 }
@@ -90,11 +100,22 @@ impl CassandraSinkCluster {
         let failed_requests = register_counter!("failed_requests", "chain" => chain_name.clone(), "transform" => "CassandraSinkCluster");
         let receive_timeout = timeout.map(Duration::from_secs);
 
+        let nodes_shared = Arc::new(RwLock::new(vec![]));
+
+        let (task_handshake_tx, task_handshake_rx) = mpsc::channel(1);
+        create_topology_task(
+            tls.clone(),
+            nodes_shared.clone(),
+            task_handshake_rx,
+            data_center.clone(),
+        );
+
         CassandraSinkCluster {
             contact_points,
-            contact_point_handshake: vec![],
-            contact_point_handshake_complete: false,
             contact_point_connection: None,
+            init_handshake: vec![],
+            init_handshake_address: None,
+            init_handshake_complete: false,
             chain_name,
             failed_requests,
             tls,
@@ -102,23 +123,21 @@ impl CassandraSinkCluster {
             read_timeout: receive_timeout,
             peer_table: FQName::new("system", "peers"),
             data_center,
-            nodes: vec![],
-            nodes_shared: Arc::new(RwLock::new(vec![])),
+            local_nodes: vec![],
+            topology_task_nodes: nodes_shared,
             rng: SmallRng::from_rng(rand::thread_rng()).unwrap(),
+            task_handshake_tx,
         }
     }
 }
 
 impl CassandraSinkCluster {
-    async fn send_message(&mut self, mut messages: Messages) -> ChainResponse {
+    async fn send_message(&mut self, messages: Messages) -> ChainResponse {
         // Create the initial connection.
         // Messages will be sent through this connection until we have extracted the handshake and list of nodes
+        // TODO: initial connection should come from node list too
         if self.contact_point_connection.is_none() {
-            let random_point = self
-                .contact_points
-                .choose_mut(&mut self.rng)
-                .unwrap()
-                .clone();
+            let random_point = self.contact_points.choose(&mut self.rng).unwrap();
             self.contact_point_connection = Some(
                 CassandraConnection::new(
                     random_point,
@@ -128,43 +147,48 @@ impl CassandraSinkCluster {
                 )
                 .await?,
             );
+            self.init_handshake_address = Some(random_point.clone());
         }
 
         // Attempt to populate nodes list if we still dont have one yet
-        if self.nodes.is_empty() {
-            let nodes_shared = self.nodes_shared.read().await;
-            self.nodes.extend(nodes_shared.iter().cloned());
+        if self.local_nodes.is_empty() {
+            let nodes_shared = self.topology_task_nodes.read().await;
+            self.local_nodes.extend(nodes_shared.iter().cloned());
         }
 
-        let system_peers_index = self.get_system_peers_index(&mut messages);
-
-        for message in &messages {
-            if let Some(last) = self.contact_point_handshake.last_mut() {
-                if let Some(Frame::Cassandra(CassandraFrame {
-                    operation: CassandraOperation::AuthResponse(_),
-                    ..
-                })) = last.frame()
-                {
-                    self.contact_point_handshake_complete = true;
-                    break;
+        if !self.init_handshake_complete {
+            for message in &messages {
+                if let Some(last) = self.init_handshake.last_mut() {
+                    if let Some(Frame::Cassandra(CassandraFrame {
+                        operation: CassandraOperation::AuthResponse(_),
+                        ..
+                    })) = last.frame()
+                    {
+                        // Only send a handshake if the task really needs it
+                        // i.e. when the channel of size 1 is empty
+                        if let Ok(permit) = self.task_handshake_tx.try_reserve() {
+                            permit.send(TaskHandshake {
+                                handshake: self.init_handshake.clone(),
+                                address: self.init_handshake_address.as_ref().unwrap().clone(),
+                            })
+                        }
+                        self.init_handshake_complete = true;
+                        break;
+                    }
                 }
+                self.init_handshake.push(message.clone());
             }
-            self.contact_point_handshake.push(message.clone());
         }
 
         let mut responses_future = FuturesOrdered::new();
         for message in messages {
             let (return_chan_tx, return_chan_rx) = oneshot::channel();
-            if self.nodes.is_empty() || !self.contact_point_handshake_complete {
+            if self.local_nodes.is_empty() || !self.init_handshake_complete {
                 self.contact_point_connection.as_mut().unwrap()
             } else {
-                let random_node = self.nodes.choose_mut(&mut self.rng).unwrap();
+                let random_node = self.local_nodes.choose_mut(&mut self.rng).unwrap();
                 random_node
-                    .get_connection(
-                        &self.contact_point_handshake,
-                        &self.tls,
-                        &self.pushed_messages_tx,
-                    )
+                    .get_connection(&self.init_handshake, &self.tls, &self.pushed_messages_tx)
                     .await?
             }
             .send(message, return_chan_tx)?;
@@ -172,90 +196,90 @@ impl CassandraSinkCluster {
             responses_future.push(return_chan_rx)
         }
 
-        let mut responses =
+        let responses =
             super::connection::receive(self.read_timeout, &self.failed_requests, responses_future)
                 .await?;
 
-        if let Some(query_occured) = system_peers_index {
-            if let Some(response) = responses.get_mut(query_occured.message_index) {
-                let new_nodes = get_nodes_from_system_peers(
-                    response,
-                    query_occured.alias_to_name,
-                    &self.data_center,
-                );
-                if new_nodes.len() > 1 {
-                    self.nodes.clear();
-                    self.nodes.extend(new_nodes.iter().cloned());
-
-                    let mut write_lock = self.nodes_shared.write().await;
-                    let expensive_drop = std::mem::replace(&mut *write_lock, new_nodes);
-
-                    // Make sure to drop write_lock before the expensive_drop which may have to perform many deallocations.
-                    std::mem::drop(write_lock);
-                    std::mem::drop(expensive_drop);
-                }
-            }
-        }
-
         Ok(responses)
     }
+}
 
-    fn get_system_peers_index(&self, messages: &mut [Message]) -> Option<QueryOccured> {
-        let mut system_peers_index: Option<QueryOccured> = None;
-        for (message_index, message) in messages.iter_mut().enumerate() {
-            if let Some(Frame::Cassandra(cassandra)) = message.frame() {
-                // No need to handle Batch as selects can only occur on Query
-                if let CassandraOperation::Query { query, .. } = &cassandra.operation {
-                    if let CassandraStatement::Select(select) = query.as_ref() {
-                        if select.where_clause.is_empty() && select.table_name == self.peer_table {
-                            let mut alias_to_name = HashMap::new();
-                            for select_element in &select.columns {
-                                match select_element {
-                                    SelectElement::Star => {
-                                        // Always overwrite, give priority to * entries
-                                        return Some(QueryOccured {
-                                            message_index,
-                                            alias_to_name,
-                                        });
-                                    }
-                                    SelectElement::Column(ident) => {
-                                        if let Some(alias) = &ident.alias {
-                                            alias_to_name.insert(alias.clone(), ident.name.clone());
-                                        }
-                                    }
-                                    _ => {}
-                                }
-                            }
-                            // Give priority to existing entry in the hope that its a * entry
-                            if system_peers_index.is_none() {
-                                system_peers_index = Some(QueryOccured {
-                                    message_index,
-                                    alias_to_name,
-                                })
-                            }
-                        }
-                    }
-                }
+fn create_topology_task(
+    tls: Option<TlsConnector>,
+    nodes: Arc<RwLock<Vec<CassandraNode>>>,
+    mut handshake_rx: mpsc::Receiver<TaskHandshake>,
+    data_center: String,
+) {
+    tokio::spawn(async move {
+        while let Some(handshake) = handshake_rx.recv().await {
+            if let Err(err) = topology_task_process(&tls, &nodes, handshake, &data_center).await {
+                tracing::error!("{err:?}");
             }
+
+            // Sleep for an hour.
+            // TODO: This is a crude way to ensure we dont overload the transforms with too many topology changes.
+            // This will be replaced with:
+            // * the task subscribes to events
+            // * the transforms request a reload when they hit connection errors
+            tokio::time::sleep(std::time::Duration::from_secs(60 * 60)).await;
         }
-        system_peers_index
-    }
+    });
+}
+
+async fn topology_task_process(
+    tls: &Option<TlsConnector>,
+    nodes: &Arc<RwLock<Vec<CassandraNode>>>,
+    handshake: TaskHandshake,
+    data_center: &str,
+) -> Result<()> {
+    let outbound = new_connection(handshake.address, &handshake.handshake, tls, &None).await?;
+
+    let (return_chan_tx, return_chan_rx) = oneshot::channel();
+    outbound.send(
+        Message::from_frame(Frame::Cassandra(CassandraFrame {
+            version: Version::V4,
+            stream_id: 0,
+            tracing_id: None,
+            warnings: vec![],
+            operation: CassandraOperation::Query {
+                query: Box::new(parse_statement_single("SELECT * FROM system.peers")),
+                params: Box::new(QueryParams {
+                    consistency: Consistency::One,
+                    with_names: false,
+                    values: None,
+                    page_size: Some(5000),
+                    paging_state: None,
+                    serial_consistency: None,
+                    timestamp: Some(1643855761086585),
+                    keyspace: None,
+                    now_in_seconds: None,
+                }),
+            },
+        })),
+        return_chan_tx,
+    )?;
+    let mut response = return_chan_rx.await?.response?;
+    let new_nodes = get_nodes_from_system_peers(&mut response, data_center);
+
+    let mut write_lock = nodes.write().await;
+    let expensive_drop = std::mem::replace(&mut *write_lock, new_nodes);
+
+    // Make sure to drop write_lock before the expensive_drop which will have to perform many deallocations.
+    std::mem::drop(write_lock);
+    std::mem::drop(expensive_drop);
+
+    Ok(())
 }
 
 fn get_nodes_from_system_peers(
     response: &mut Message,
-    mut alias_to_name: HashMap<Identifier, Identifier>,
     config_data_center: &str,
 ) -> Vec<CassandraNode> {
     let mut new_nodes = vec![];
-    fn ident(name: &str, map: &mut HashMap<Identifier, Identifier>) -> Identifier {
-        let ident = Identifier::Unquoted(name.into());
-        map.remove(&ident).unwrap_or(ident)
-    }
-    let peer_ident = ident("peer", &mut alias_to_name);
-    let rack_ident = ident("rack", &mut alias_to_name);
-    let data_center_ident = ident("data_center", &mut alias_to_name);
-    let tokens_ident = ident("tokens", &mut alias_to_name);
+    let peer_ident = Identifier::Unquoted("peer".into());
+    let rack_ident = Identifier::Unquoted("rack".into());
+    let data_center_ident = Identifier::Unquoted("data_center".into());
+    let tokens_ident = Identifier::Unquoted("tokens".into());
 
     if let Some(Frame::Cassandra(frame)) = response.frame() {
         // CassandraOperation::Error(_) is another possible case, we should silently ignore such cases
@@ -327,17 +351,17 @@ impl Transform for CassandraSinkCluster {
     }
 }
 
-struct QueryOccured {
-    message_index: usize,
-    alias_to_name: HashMap<Identifier, Identifier>,
-}
-
 #[derive(Debug, Clone)]
 struct CassandraNode {
     address: IpAddr,
     _rack: String,
     _tokens: Vec<String>,
     outbound: Option<CassandraConnection>,
+}
+
+struct TaskHandshake {
+    handshake: Vec<Message>,
+    address: String,
 }
 
 impl CassandraNode {
@@ -349,25 +373,33 @@ impl CassandraNode {
     ) -> Result<&mut CassandraConnection> {
         if self.outbound.is_none() {
             self.outbound = Some(
-                CassandraConnection::new(
-                    (self.address, 9042),
-                    CassandraCodec::new(),
-                    tls.clone(),
-                    pushed_messages_tx.clone(),
-                )
-                .await?,
-            );
-        }
-
-        for handshake_message in handshake {
-            let (return_chan_tx, return_chan_rx) = oneshot::channel();
-            self.outbound
-                .as_ref()
-                .unwrap()
-                .send(handshake_message.clone(), return_chan_tx)?;
-            return_chan_rx.await?;
+                new_connection((self.address, 9042), handshake, tls, pushed_messages_tx).await?,
+            )
         }
 
         Ok(self.outbound.as_mut().unwrap())
     }
+}
+
+async fn new_connection<A: ToSocketAddrs>(
+    address: A,
+    handshake: &[Message],
+    tls: &Option<TlsConnector>,
+    pushed_messages_tx: &Option<mpsc::UnboundedSender<Messages>>,
+) -> Result<CassandraConnection> {
+    let outbound = CassandraConnection::new(
+        address,
+        CassandraCodec::new(),
+        tls.clone(),
+        pushed_messages_tx.clone(),
+    )
+    .await?;
+
+    for handshake_message in handshake {
+        let (return_chan_tx, return_chan_rx) = oneshot::channel();
+        outbound.send(handshake_message.clone(), return_chan_tx)?;
+        return_chan_rx.await?;
+    }
+
+    Ok(outbound)
 }

--- a/shotover-proxy/src/transforms/cassandra/sink_cluster.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_cluster.rs
@@ -2,17 +2,23 @@ use super::connection::CassandraConnection;
 use crate::codec::cassandra::CassandraCodec;
 use crate::concurrency::FuturesOrdered;
 use crate::error::ChainResponse;
-use crate::message::Messages;
+use crate::frame::{CassandraFrame, CassandraOperation, CassandraResult, Frame};
+use crate::message::{Message, MessageValue, Messages};
 use crate::tls::{TlsConnector, TlsConnectorConfig};
-use crate::transforms::util::Response;
 use crate::transforms::{Transform, Transforms, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
+use cql3_parser::cassandra_statement::CassandraStatement;
+use cql3_parser::common::{FQName, Identifier};
+use cql3_parser::select::SelectElement;
 use metrics::{register_counter, Counter};
+use rand::prelude::*;
 use serde::Deserialize;
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::{mpsc, oneshot};
-use tracing::trace;
+use tokio::sync::{mpsc, oneshot, RwLock};
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct CassandraSinkClusterConfig {
@@ -28,6 +34,7 @@ impl CassandraSinkClusterConfig {
         Ok(Transforms::CassandraSinkCluster(CassandraSinkCluster::new(
             self.first_contact_points.clone(),
             chain_name,
+            self.data_center.clone(),
             tls,
             self.read_timeout,
         )))
@@ -36,24 +43,38 @@ impl CassandraSinkClusterConfig {
 
 pub struct CassandraSinkCluster {
     contact_points: Vec<String>,
-    outbound: Option<CassandraConnection>,
+    contact_point_handshake: Vec<Message>,
+    contact_point_handshake_complete: bool,
+    contact_point_connection: Option<CassandraConnection>,
     chain_name: String,
     failed_requests: Counter,
     tls: Option<TlsConnector>,
     pushed_messages_tx: Option<mpsc::UnboundedSender<Messages>>,
     read_timeout: Option<Duration>,
+    peer_table: FQName,
+    data_center: String,
+    nodes: Vec<CassandraNode>,
+    nodes_shared: Arc<RwLock<Vec<CassandraNode>>>,
+    rng: SmallRng,
 }
 
 impl Clone for CassandraSinkCluster {
     fn clone(&self) -> Self {
         CassandraSinkCluster {
             contact_points: self.contact_points.clone(),
-            outbound: None,
+            contact_point_handshake: vec![],
+            contact_point_handshake_complete: false,
+            contact_point_connection: None,
             chain_name: self.chain_name.clone(),
             tls: self.tls.clone(),
             failed_requests: self.failed_requests.clone(),
             pushed_messages_tx: None,
             read_timeout: self.read_timeout,
+            peer_table: self.peer_table.clone(),
+            data_center: self.data_center.clone(),
+            nodes: vec![],
+            nodes_shared: self.nodes_shared.clone(),
+            rng: SmallRng::from_rng(rand::thread_rng()).unwrap(),
         }
     }
 }
@@ -62,6 +83,7 @@ impl CassandraSinkCluster {
     pub fn new(
         contact_points: Vec<String>,
         chain_name: String,
+        data_center: String,
         tls: Option<TlsConnector>,
         timeout: Option<u64>,
     ) -> CassandraSinkCluster {
@@ -70,23 +92,36 @@ impl CassandraSinkCluster {
 
         CassandraSinkCluster {
             contact_points,
-            outbound: None,
+            contact_point_handshake: vec![],
+            contact_point_handshake_complete: false,
+            contact_point_connection: None,
             chain_name,
             failed_requests,
             tls,
             pushed_messages_tx: None,
             read_timeout: receive_timeout,
+            peer_table: FQName::new("system", "peers"),
+            data_center,
+            nodes: vec![],
+            nodes_shared: Arc::new(RwLock::new(vec![])),
+            rng: SmallRng::from_rng(rand::thread_rng()).unwrap(),
         }
     }
 }
 
 impl CassandraSinkCluster {
-    async fn send_message(&mut self, messages: Messages) -> ChainResponse {
-        if self.outbound.is_none() {
-            trace!("creating outbound connection {:?}", self.contact_points);
-            self.outbound = Some(
+    async fn send_message(&mut self, mut messages: Messages) -> ChainResponse {
+        // Create the initial connection.
+        // Messages will be sent through this connection until we have extracted the handshake and list of nodes
+        if self.contact_point_connection.is_none() {
+            let random_point = self
+                .contact_points
+                .choose_mut(&mut self.rng)
+                .unwrap()
+                .clone();
+            self.contact_point_connection = Some(
                 CassandraConnection::new(
-                    self.contact_points[0].clone(),
+                    random_point,
                     CassandraCodec::new(),
                     self.tls.clone(),
                     self.pushed_messages_tx.clone(),
@@ -95,20 +130,186 @@ impl CassandraSinkCluster {
             );
         }
 
-        let outbound = self.outbound.as_mut().unwrap();
-        let responses_future: Result<FuturesOrdered<oneshot::Receiver<Response>>> = messages
-            .into_iter()
-            .map(|m| {
-                let (return_chan_tx, return_chan_rx) = oneshot::channel();
-                outbound.send(m, return_chan_tx)?;
+        // Attempt to populate nodes list if we still dont have one yet
+        if self.nodes.is_empty() {
+            let nodes_shared = self.nodes_shared.read().await;
+            self.nodes.extend(nodes_shared.iter().cloned());
+        }
 
-                Ok(return_chan_rx)
-            })
-            .collect();
+        let system_peers_index = self.get_system_peers_index(&mut messages);
 
-        super::connection::receive(self.read_timeout, &self.failed_requests, responses_future?)
-            .await
+        for message in &messages {
+            if let Some(last) = self.contact_point_handshake.last_mut() {
+                if let Some(Frame::Cassandra(CassandraFrame {
+                    operation: CassandraOperation::AuthResponse(_),
+                    ..
+                })) = last.frame()
+                {
+                    self.contact_point_handshake_complete = true;
+                    break;
+                }
+            }
+            self.contact_point_handshake.push(message.clone());
+        }
+
+        let mut responses_future = FuturesOrdered::new();
+        for message in messages {
+            let (return_chan_tx, return_chan_rx) = oneshot::channel();
+            if self.nodes.is_empty() || !self.contact_point_handshake_complete {
+                self.contact_point_connection.as_mut().unwrap()
+            } else {
+                let random_node = self.nodes.choose_mut(&mut self.rng).unwrap();
+                random_node
+                    .get_connection(
+                        &self.contact_point_handshake,
+                        &self.tls,
+                        &self.pushed_messages_tx,
+                    )
+                    .await?
+            }
+            .send(message, return_chan_tx)?;
+
+            responses_future.push(return_chan_rx)
+        }
+
+        let mut responses =
+            super::connection::receive(self.read_timeout, &self.failed_requests, responses_future)
+                .await?;
+
+        if let Some(query_occured) = system_peers_index {
+            if let Some(response) = responses.get_mut(query_occured.message_index) {
+                let new_nodes = get_nodes_from_system_peers(
+                    response,
+                    query_occured.alias_to_name,
+                    &self.data_center,
+                );
+                if new_nodes.len() > 1 {
+                    self.nodes.clear();
+                    self.nodes.extend(new_nodes.iter().cloned());
+
+                    let mut write_lock = self.nodes_shared.write().await;
+                    let expensive_drop = std::mem::replace(&mut *write_lock, new_nodes);
+
+                    // Make sure to drop write_lock before the expensive_drop which may have to perform many deallocations.
+                    std::mem::drop(write_lock);
+                    std::mem::drop(expensive_drop);
+                }
+            }
+        }
+
+        Ok(responses)
     }
+
+    fn get_system_peers_index(&self, messages: &mut [Message]) -> Option<QueryOccured> {
+        let mut system_peers_index: Option<QueryOccured> = None;
+        for (message_index, message) in messages.iter_mut().enumerate() {
+            if let Some(Frame::Cassandra(cassandra)) = message.frame() {
+                // No need to handle Batch as selects can only occur on Query
+                if let CassandraOperation::Query { query, .. } = &cassandra.operation {
+                    if let CassandraStatement::Select(select) = query.as_ref() {
+                        if select.where_clause.is_empty() && select.table_name == self.peer_table {
+                            let mut alias_to_name = HashMap::new();
+                            for select_element in &select.columns {
+                                match select_element {
+                                    SelectElement::Star => {
+                                        // Always overwrite, give priority to * entries
+                                        return Some(QueryOccured {
+                                            message_index,
+                                            alias_to_name,
+                                        });
+                                    }
+                                    SelectElement::Column(ident) => {
+                                        if let Some(alias) = &ident.alias {
+                                            alias_to_name.insert(alias.clone(), ident.name.clone());
+                                        }
+                                    }
+                                    _ => {}
+                                }
+                            }
+                            // Give priority to existing entry in the hope that its a * entry
+                            if system_peers_index.is_none() {
+                                system_peers_index = Some(QueryOccured {
+                                    message_index,
+                                    alias_to_name,
+                                })
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        system_peers_index
+    }
+}
+
+fn get_nodes_from_system_peers(
+    response: &mut Message,
+    mut alias_to_name: HashMap<Identifier, Identifier>,
+    config_data_center: &str,
+) -> Vec<CassandraNode> {
+    let mut new_nodes = vec![];
+    fn ident(name: &str, map: &mut HashMap<Identifier, Identifier>) -> Identifier {
+        let ident = Identifier::Unquoted(name.into());
+        map.remove(&ident).unwrap_or(ident)
+    }
+    let peer_ident = ident("peer", &mut alias_to_name);
+    let rack_ident = ident("rack", &mut alias_to_name);
+    let data_center_ident = ident("data_center", &mut alias_to_name);
+    let tokens_ident = ident("tokens", &mut alias_to_name);
+
+    if let Some(Frame::Cassandra(frame)) = response.frame() {
+        // CassandraOperation::Error(_) is another possible case, we should silently ignore such cases
+        if let CassandraOperation::Result(CassandraResult::Rows {
+            value: MessageValue::Rows(rows),
+            metadata,
+        }) = &mut frame.operation
+        {
+            for row in rows.iter() {
+                let mut address = None;
+                let mut rack = None;
+                let mut data_center = None;
+                let mut tokens = vec![];
+                for (i, col) in metadata.col_specs.iter().enumerate() {
+                    let ident = Identifier::parse(&col.name);
+                    if ident == peer_ident {
+                        if let Some(MessageValue::Inet(value)) = row.get(i) {
+                            address = Some(*value);
+                        }
+                    } else if ident == rack_ident {
+                        if let Some(MessageValue::Varchar(value)) = row.get(i) {
+                            rack = Some(value.clone());
+                        }
+                    } else if ident == data_center_ident {
+                        if let Some(MessageValue::Varchar(value)) = row.get(i) {
+                            data_center = Some(value.clone());
+                        }
+                    } else if ident == tokens_ident {
+                        if let Some(MessageValue::List(list)) = row.get(i) {
+                            tokens = list
+                                .iter()
+                                .filter_map(|x| match x {
+                                    MessageValue::Varchar(a) => Some(a.clone()),
+                                    _ => None,
+                                })
+                                .collect();
+                        }
+                    }
+                }
+                if let (Some(address), Some(rack), Some(data_center)) = (address, rack, data_center)
+                {
+                    if data_center == config_data_center {
+                        new_nodes.push(CassandraNode {
+                            address,
+                            _rack: rack,
+                            _tokens: tokens,
+                            outbound: None,
+                        });
+                    }
+                }
+            }
+        }
+    }
+    new_nodes
 }
 
 #[async_trait]
@@ -123,5 +324,50 @@ impl Transform for CassandraSinkCluster {
 
     fn add_pushed_messages_tx(&mut self, pushed_messages_tx: mpsc::UnboundedSender<Messages>) {
         self.pushed_messages_tx = Some(pushed_messages_tx);
+    }
+}
+
+struct QueryOccured {
+    message_index: usize,
+    alias_to_name: HashMap<Identifier, Identifier>,
+}
+
+#[derive(Debug, Clone)]
+struct CassandraNode {
+    address: IpAddr,
+    _rack: String,
+    _tokens: Vec<String>,
+    outbound: Option<CassandraConnection>,
+}
+
+impl CassandraNode {
+    async fn get_connection(
+        &mut self,
+        handshake: &[Message],
+        tls: &Option<TlsConnector>,
+        pushed_messages_tx: &Option<mpsc::UnboundedSender<Messages>>,
+    ) -> Result<&mut CassandraConnection> {
+        if self.outbound.is_none() {
+            self.outbound = Some(
+                CassandraConnection::new(
+                    (self.address, 9042),
+                    CassandraCodec::new(),
+                    tls.clone(),
+                    pushed_messages_tx.clone(),
+                )
+                .await?,
+            );
+        }
+
+        for handshake_message in handshake {
+            let (return_chan_tx, return_chan_rx) = oneshot::channel();
+            self.outbound
+                .as_ref()
+                .unwrap()
+                .send(handshake_message.clone(), return_chan_tx)?;
+            return_chan_rx.await?;
+        }
+
+        Ok(self.outbound.as_mut().unwrap())
     }
 }

--- a/shotover-proxy/src/transforms/cassandra/sink_cluster.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_cluster.rs
@@ -204,7 +204,7 @@ impl CassandraSinkCluster {
     }
 }
 
-fn create_topology_task(
+pub fn create_topology_task(
     tls: Option<TlsConnector>,
     nodes: Arc<RwLock<Vec<CassandraNode>>>,
     mut handshake_rx: mpsc::Receiver<TaskHandshake>,
@@ -352,16 +352,17 @@ impl Transform for CassandraSinkCluster {
 }
 
 #[derive(Debug, Clone)]
-struct CassandraNode {
-    address: IpAddr,
-    _rack: String,
-    _tokens: Vec<String>,
+pub struct CassandraNode {
+    pub address: IpAddr,
+    pub _rack: String,
+    pub _tokens: Vec<String>,
     outbound: Option<CassandraConnection>,
 }
 
-struct TaskHandshake {
-    handshake: Vec<Message>,
-    address: String,
+#[derive(Debug)]
+pub struct TaskHandshake {
+    pub handshake: Vec<Message>,
+    pub address: String,
 }
 
 impl CassandraNode {

--- a/shotover-proxy/tests/cassandra_int_tests/cluster.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cluster.rs
@@ -1,0 +1,81 @@
+use cassandra_protocol::frame::Version;
+use shotover_proxy::frame::{CassandraFrame, CassandraOperation, Frame};
+use shotover_proxy::message::Message;
+use shotover_proxy::transforms::cassandra::sink_cluster::{create_topology_task, TaskHandshake};
+use std::net::IpAddr;
+use std::sync::Arc;
+use tokio::sync::{mpsc, RwLock};
+
+pub async fn test() {
+    // Directly test the internal topology task
+    let nodes_shared = Arc::new(RwLock::new(vec![]));
+    let (task_handshake_tx, task_handshake_rx) = mpsc::channel(1);
+    create_topology_task(
+        None,
+        nodes_shared.clone(),
+        task_handshake_rx,
+        "dc1".to_string(),
+    );
+
+    // Give the handshake task a hardcoded handshake.
+    // Normally the handshake is the handshake that the client gave shotover.
+    task_handshake_tx
+        .send(TaskHandshake {
+            address: "172.16.1.2:9042".to_string(),
+            handshake: create_handshake(),
+        })
+        .await
+        .unwrap();
+
+    // keep attempting to read the nodes list until it is populated.
+    let mut nodes = vec![];
+    let mut tries = 0;
+    while nodes.is_empty() {
+        nodes = nodes_shared.read().await.clone();
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+
+        if tries > 2000 {
+            panic!("Ran out of retries for the topology task to write the nodes list");
+        }
+        tries += 1;
+    }
+
+    // make assertions on the nodes list
+    assert_eq!(nodes.len(), 2);
+    let mut possible_addresses: Vec<IpAddr> = vec![
+        "172.16.1.2".parse().unwrap(),
+        "172.16.1.3".parse().unwrap(),
+        "172.16.1.4".parse().unwrap(),
+    ];
+    for node in &nodes {
+        let address_index = possible_addresses
+            .iter()
+            .position(|x| *x == node.address)
+            .expect("Node did not contain a unique expected address");
+        possible_addresses.remove(address_index);
+
+        assert_eq!(node._rack, "rack1");
+        assert_eq!(node._tokens.len(), 128);
+    }
+}
+
+fn create_handshake() -> Vec<Message> {
+    vec![
+        Message::from_frame(Frame::Cassandra(CassandraFrame {
+            version: Version::V4,
+            stream_id: 64,
+            tracing_id: None,
+            warnings: vec![],
+            operation: CassandraOperation::Startup(b"\0\x01\0\x0bCQL_VERSION\0\x053.0.0".to_vec()),
+        })),
+        Message::from_frame(Frame::Cassandra(CassandraFrame {
+            version: Version::V4,
+            stream_id: 128,
+            tracing_id: None,
+            warnings: vec![],
+            operation: CassandraOperation::AuthResponse(
+                b"\0\0\0\x14\0cassandra\0cassandra".to_vec(),
+            ),
+        })),
+    ]
+}

--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -92,17 +92,20 @@ async fn test_cluster() {
     let shotover_manager =
         ShotoverManager::from_topology_file("example-configs/cassandra-cluster/topology.yaml");
 
-    let connection = shotover_manager.cassandra_connection("127.0.0.1", 9042);
+    let connection1 = shotover_manager.cassandra_connection("127.0.0.1", 9042);
     let schema_awaiter = SchemaAwaiter::new("172.16.1.2:9042").await;
+    keyspace::test(&connection1);
+    table::test(&connection1);
+    udt::test(&connection1);
+    native_types::test(&connection1);
+    collections::test(&connection1);
+    functions::test(&connection1, &schema_awaiter).await;
+    prepared_statements::test(&connection1);
+    batch_statements::test(&connection1);
 
-    keyspace::test(&connection);
-    table::test(&connection);
-    udt::test(&connection);
-    native_types::test(&connection);
-    collections::test(&connection);
-    functions::test(&connection, &schema_awaiter).await;
-    prepared_statements::test(&connection);
-    batch_statements::test(&connection);
+    //Check for bugs in cross connection state
+    let connection2 = shotover_manager.cassandra_connection("127.0.0.1", 9042);
+    native_types::test(&connection2);
 }
 
 #[test]

--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -94,7 +94,8 @@ async fn test_cluster() {
 
     let connection1 = shotover_manager.cassandra_connection("127.0.0.1", 9042);
     let schema_awaiter = SchemaAwaiter::new("172.16.1.2:9042").await;
-    keyspace::test(&connection1);
+    // TODO: uncomment once we implement `USE` routing
+    //keyspace::test(&connection1);
     table::test(&connection1);
     udt::test(&connection1);
     native_types::test(&connection1);
@@ -133,7 +134,8 @@ fn test_source_tls_and_cluster_tls() {
 
     let connection = shotover_manager.cassandra_connection_tls("127.0.0.1", 9042, ca_cert);
 
-    keyspace::test(&connection);
+    // TODO: uncomment once we implement `USE` routing
+    //keyspace::test(&connection);
     table::test(&connection);
     udt::test(&connection);
     native_types::test(&connection);

--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -18,6 +18,8 @@ use tokio::time::{sleep, timeout, Duration};
 
 mod batch_statements;
 mod cache;
+#[cfg(feature = "alpha-transforms")]
+mod cluster;
 mod collections;
 mod functions;
 mod keyspace;
@@ -89,24 +91,28 @@ fn test_source_tls_and_single_tls() {
 async fn test_cluster() {
     let _compose = DockerCompose::new("example-configs/cassandra-cluster/docker-compose.yml");
 
-    let shotover_manager =
-        ShotoverManager::from_topology_file("example-configs/cassandra-cluster/topology.yaml");
+    {
+        let shotover_manager =
+            ShotoverManager::from_topology_file("example-configs/cassandra-cluster/topology.yaml");
 
-    let connection1 = shotover_manager.cassandra_connection("127.0.0.1", 9042);
-    let schema_awaiter = SchemaAwaiter::new("172.16.1.2:9042").await;
-    // TODO: uncomment once we implement `USE` routing
-    //keyspace::test(&connection1);
-    table::test(&connection1);
-    udt::test(&connection1);
-    native_types::test(&connection1);
-    collections::test(&connection1);
-    functions::test(&connection1, &schema_awaiter).await;
-    prepared_statements::test(&connection1);
-    batch_statements::test(&connection1);
+        let connection1 = shotover_manager.cassandra_connection("127.0.0.1", 9042);
+        let schema_awaiter = SchemaAwaiter::new("172.16.1.2:9042").await;
+        // TODO: uncomment once we implement `USE` routing
+        //keyspace::test(&connection1);
+        table::test(&connection1);
+        udt::test(&connection1);
+        native_types::test(&connection1);
+        collections::test(&connection1);
+        functions::test(&connection1, &schema_awaiter).await;
+        prepared_statements::test(&connection1);
+        batch_statements::test(&connection1);
 
-    //Check for bugs in cross connection state
-    let connection2 = shotover_manager.cassandra_connection("127.0.0.1", 9042);
-    native_types::test(&connection2);
+        //Check for bugs in cross connection state
+        let connection2 = shotover_manager.cassandra_connection("127.0.0.1", 9042);
+        native_types::test(&connection2);
+    }
+
+    cluster::test().await;
 }
 
 #[test]

--- a/shotover-proxy/tests/cassandra_int_tests/native_types.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/native_types.rs
@@ -113,4 +113,5 @@ date_test date,
 
     insert(session);
     select(session);
+    run_query(session, "DROP KEYSPACE test_native_types_keyspace");
 }


### PR DESCRIPTION
Messages are never routed to the initial contact point as it is not considered a peer.
I consider this a bug but i'm not addressing it in this PR to keep the scope down 

<!--
Only supports system.peers, the C++ driver seems to only support that.
I suspect we will need to implement support for system.peers_v2 for the java driver but that can go in a follow up PR.
-->

<!--
I found I had to share node state between transform instances as the c++ driver will reuse system.peers results between connections. I have been careful with my use of RwLock to ensure we dont keep locks alive longer than we have to.-->

I had previously mentioned implementing round robin for this PR but considering the final goal is "best of two choices", just doing a single random selection seemed like the best step towards that while still being a sound decision for an MVP.

<!--
The system.peers processing is fairly robust and can handle SELECT queries that use aliases. The returned metadata uses the alias name instead of the actual name so the response processing logic needs to know any alias names that were used.-->

I pulled the receive logic out of the two sink transforms and into connection.rs