### PR TITLE
wrap cassandra_cpp::Session in new CassandraConnection type

### DIFF
--- a/shotover-proxy/benches/cassandra_benches.rs
+++ b/shotover-proxy/benches/cassandra_benches.rs
@@ -6,6 +6,7 @@ use test_helpers::lazy::new_lazy_shared;
 
 #[path = "../tests/helpers/mod.rs"]
 mod helpers;
+use helpers::cassandra::CassandraConnection;
 use helpers::ShotoverManager;
 
 struct Query {
@@ -259,7 +260,8 @@ impl BenchResources {
         let compose = DockerCompose::new(compose_file);
         let shotover_manager = ShotoverManager::from_topology_file(shotover_topology);
 
-        let connection = shotover_manager.cassandra_connection("127.0.0.1", 9042);
+        let CassandraConnection::Datastax(connection) =
+            shotover_manager.cassandra_connection("127.0.0.1", 9042);
 
         let bench_resources = Self {
             _compose: compose,
@@ -277,7 +279,8 @@ impl BenchResources {
 
         let ca_cert = "example-configs/cassandra-tls/certs/localhost_CA.crt";
 
-        let connection = shotover_manager.cassandra_connection_tls("127.0.0.1", 9042, ca_cert);
+        let CassandraConnection::Datastax(connection) =
+            shotover_manager.cassandra_connection_tls("127.0.0.1", 9042, ca_cert);
 
         let bench_resources = Self {
             _compose: compose,

--- a/shotover-proxy/tests/cassandra_int_tests/cache/assert.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cache/assert.rs
@@ -1,5 +1,4 @@
-use crate::helpers::cassandra::{assert_query_result, ResultValue};
-use cassandra_cpp::Session;
+use crate::helpers::cassandra::{assert_query_result, CassandraConnection, ResultValue};
 use metrics_util::debugging::{DebugValue, Snapshotter};
 use redis::Commands;
 use std::collections::HashSet;
@@ -19,7 +18,7 @@ fn get_cache_miss_value(snapshotter: &Snapshotter) -> u64 {
 
 fn assert_increment(
     snapshotter: &Snapshotter,
-    session: &Session,
+    session: &CassandraConnection,
     query: &str,
     expected_rows: &[&[ResultValue]],
 ) {
@@ -35,7 +34,7 @@ fn assert_increment(
 
 fn assert_unchanged(
     snapshotter: &Snapshotter,
-    session: &Session,
+    session: &CassandraConnection,
     query: &str,
     expected_rows: &[&[ResultValue]],
 ) {
@@ -51,7 +50,7 @@ fn assert_unchanged(
 
 pub fn assert_query_is_cached(
     snapshotter: &Snapshotter,
-    session: &Session,
+    session: &CassandraConnection,
     query: &str,
     expected_rows: &[&[ResultValue]],
 ) {
@@ -62,7 +61,7 @@ pub fn assert_query_is_cached(
 
 pub fn assert_query_is_uncacheable(
     snapshotter: &Snapshotter,
-    session: &Session,
+    session: &CassandraConnection,
     query: &str,
     expected_rows: &[&[ResultValue]],
 ) {

--- a/shotover-proxy/tests/cassandra_int_tests/cache/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cache/mod.rs
@@ -1,13 +1,12 @@
 mod assert;
 
-use crate::helpers::cassandra::{run_query, ResultValue};
-use cassandra_cpp::Session;
+use crate::helpers::cassandra::{run_query, CassandraConnection, ResultValue};
 use metrics_util::debugging::Snapshotter;
 use redis::Commands;
 use std::collections::HashSet;
 
 pub fn test(
-    cassandra_session: &Session,
+    cassandra_session: &CassandraConnection,
     redis_connection: &mut redis::Connection,
     snapshotter: &Snapshotter,
 ) {

--- a/shotover-proxy/tests/cassandra_int_tests/collections.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/collections.rs
@@ -1,5 +1,4 @@
-use crate::helpers::cassandra::{assert_query_result, run_query, ResultValue};
-use cassandra_cpp::Session;
+use crate::helpers::cassandra::{assert_query_result, run_query, CassandraConnection, ResultValue};
 use cassandra_protocol::frame::message_result::ColType;
 
 fn get_map_example(value: &str) -> String {
@@ -119,7 +118,7 @@ fn get_type_example_result_value(col_type: ColType) -> ResultValue {
 mod list {
     use super::*;
 
-    fn create(session: &Session) {
+    fn create(session: &CassandraConnection) {
         // create lists of native types
         for (i, col_type) in NATIVE_COL_TYPES.iter().enumerate() {
             run_query(
@@ -164,7 +163,7 @@ mod list {
         }
     }
 
-    fn insert(session: &Session) {
+    fn insert(session: &CassandraConnection) {
         // insert lists of native types
         for (i, col_type) in NATIVE_COL_TYPES.iter().enumerate() {
             let query = format!(
@@ -218,7 +217,7 @@ mod list {
         }
     }
 
-    fn select(session: &Session) {
+    fn select(session: &CassandraConnection) {
         // select lists of native types
         for (i, col_type) in NATIVE_COL_TYPES.iter().enumerate() {
             let query = format!(
@@ -282,7 +281,7 @@ mod list {
         }
     }
 
-    pub fn test(session: &Session) {
+    pub fn test(session: &CassandraConnection) {
         create(session);
         insert(session);
         select(session);
@@ -292,7 +291,7 @@ mod list {
 mod set {
     use super::*;
 
-    fn create(session: &Session) {
+    fn create(session: &CassandraConnection) {
         // create sets of native types
         for (i, col_type) in NATIVE_COL_TYPES.iter().enumerate() {
             run_query(
@@ -329,7 +328,7 @@ mod set {
         }
     }
 
-    fn insert(session: &Session) {
+    fn insert(session: &CassandraConnection) {
         // insert sets of native types
         for (i, col_type) in NATIVE_COL_TYPES.iter().enumerate() {
             let query = format!(
@@ -384,7 +383,7 @@ mod set {
         }
     }
 
-    fn select(session: &Session) {
+    fn select(session: &CassandraConnection) {
         // select sets of native types
         for (i, col_type) in NATIVE_COL_TYPES.iter().enumerate() {
             let query = format!(
@@ -448,7 +447,7 @@ mod set {
         }
     }
 
-    pub fn test(session: &Session) {
+    pub fn test(session: &CassandraConnection) {
         create(session);
         insert(session);
         select(session);
@@ -458,7 +457,7 @@ mod set {
 mod map {
     use super::*;
 
-    fn create(session: &Session) {
+    fn create(session: &CassandraConnection) {
         // create maps of native types
         for (i, col_type) in NATIVE_COL_TYPES.iter().enumerate() {
             run_query(
@@ -503,7 +502,7 @@ mod map {
         }
     }
 
-    fn insert(session: &Session) {
+    fn insert(session: &CassandraConnection) {
         // insert maps of native types
         for (i, col_type) in NATIVE_COL_TYPES.iter().enumerate() {
             let query = format!(
@@ -558,7 +557,7 @@ mod map {
         }
     }
 
-    fn select(session: &Session) {
+    fn select(session: &CassandraConnection) {
         // select sets of native types
         for (i, col_type) in NATIVE_COL_TYPES.iter().enumerate() {
             let query = format!(
@@ -628,14 +627,14 @@ mod map {
         }
     }
 
-    pub fn test(session: &Session) {
+    pub fn test(session: &CassandraConnection) {
         create(session);
         insert(session);
         select(session);
     }
 }
 
-pub fn test(session: &Session) {
+pub fn test(session: &CassandraConnection) {
     run_query(session, "CREATE KEYSPACE test_collections_keyspace WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };");
 
     list::test(session);

--- a/shotover-proxy/tests/cassandra_int_tests/functions.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/functions.rs
@@ -1,17 +1,16 @@
-use crate::helpers::cassandra::{assert_query_result, run_query, ResultValue};
-use cassandra_cpp::{stmt, Session};
+use crate::helpers::cassandra::{assert_query_result, run_query, CassandraConnection, ResultValue};
 
-fn drop_function(session: &Session) {
+fn drop_function(session: &CassandraConnection) {
     assert_query_result(session, "SELECT test_function_keyspace.my_function(x, y) FROM test_function_keyspace.test_function_table WHERE id=1;", &[&[ResultValue::Int(4)]]);
     run_query(session, "DROP FUNCTION test_function_keyspace.my_function");
 
-    let statement = stmt!("SELECT test_function_keyspace.my_function(x) FROM test_function_keyspace.test_function_table WHERE id=1;");
-    let result = session.execute(&statement).wait().unwrap_err().to_string();
+    let statement = "SELECT test_function_keyspace.my_function(x) FROM test_function_keyspace.test_function_table WHERE id=1;";
+    let result = session.execute_expect_err(statement).to_string();
 
     assert_eq!(result, "Cassandra detailed error SERVER_INVALID_QUERY: Unknown function 'test_function_keyspace.my_function'");
 }
 
-fn create_function(session: &Session) {
+fn create_function(session: &CassandraConnection) {
     run_query(
             session,
             "CREATE FUNCTION test_function_keyspace.my_function (a int, b int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE javascript AS 'a * b';",
@@ -19,7 +18,7 @@ fn create_function(session: &Session) {
     assert_query_result(session, "SELECT test_function_keyspace.my_function(x, y) FROM test_function_keyspace.test_function_table;",&[&[ResultValue::Int(4)], &[ResultValue::Int(9)], &[ResultValue::Int(16)]]);
 }
 
-pub fn test(session: &Session) {
+pub fn test(session: &CassandraConnection) {
     run_query(session, "CREATE KEYSPACE test_function_keyspace WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };");
     run_query(
             session,

--- a/shotover-proxy/tests/cassandra_int_tests/keyspace.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/keyspace.rs
@@ -1,9 +1,9 @@
 use crate::helpers::cassandra::{
-    assert_query_result, assert_query_result_contains_row, run_query, ResultValue,
+    assert_query_result, assert_query_result_contains_row, run_query, CassandraConnection,
+    ResultValue,
 };
-use cassandra_cpp::Session;
 
-fn test_create_keyspace(session: &Session) {
+fn test_create_keyspace(session: &CassandraConnection) {
     run_query(session, "CREATE KEYSPACE keyspace_tests_create WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };");
     assert_query_result(
         session,
@@ -17,7 +17,7 @@ fn test_create_keyspace(session: &Session) {
     );
 }
 
-fn test_use_keyspace(session: &Session) {
+fn test_use_keyspace(session: &CassandraConnection) {
     run_query(session, "USE system");
 
     assert_query_result(
@@ -27,7 +27,7 @@ fn test_use_keyspace(session: &Session) {
     );
 }
 
-fn test_drop_keyspace(session: &Session) {
+fn test_drop_keyspace(session: &CassandraConnection) {
     run_query(session, "CREATE KEYSPACE keyspace_tests_delete_me WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };");
     assert_query_result(
             session,
@@ -41,7 +41,7 @@ fn test_drop_keyspace(session: &Session) {
         );
 }
 
-fn test_alter_keyspace(session: &Session) {
+fn test_alter_keyspace(session: &CassandraConnection) {
     run_query(session, "CREATE KEYSPACE keyspace_tests_alter_me WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 } AND DURABLE_WRITES = false;");
     run_query(
         session,
@@ -54,7 +54,7 @@ fn test_alter_keyspace(session: &Session) {
         );
 }
 
-pub fn test(session: &Session) {
+pub fn test(session: &CassandraConnection) {
     test_create_keyspace(session);
     test_use_keyspace(session);
     test_drop_keyspace(session);

--- a/shotover-proxy/tests/cassandra_int_tests/native_types.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/native_types.rs
@@ -1,7 +1,6 @@
-use crate::helpers::cassandra::{assert_query_result, run_query, ResultValue};
-use cassandra_cpp::Session;
+use crate::helpers::cassandra::{assert_query_result, run_query, CassandraConnection, ResultValue};
 
-fn select(session: &Session) {
+fn select(session: &CassandraConnection) {
     assert_query_result(
         session,
         "SELECT * from test_native_types_keyspace.native_types_table WHERE id=1",
@@ -33,7 +32,7 @@ fn select(session: &Session) {
     )
 }
 
-fn insert(session: &Session) {
+fn insert(session: &CassandraConnection) {
     for i in 0..10 {
         run_query(
             session,
@@ -85,7 +84,7 @@ true,
     }
 }
 
-pub fn test(session: &Session) {
+pub fn test(session: &CassandraConnection) {
     run_query(session, "CREATE KEYSPACE test_native_types_keyspace WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };");
     run_query(
         session,

--- a/shotover-proxy/tests/cassandra_int_tests/prepared_statements.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/prepared_statements.rs
@@ -1,16 +1,16 @@
-use crate::helpers::cassandra::{assert_query_result, assert_rows, run_query, ResultValue};
-use cassandra_cpp::Session;
+use crate::helpers::cassandra::{
+    assert_query_result, assert_rows, run_query, CassandraConnection, ResultValue,
+};
 
-fn delete(session: &Session) {
-    let prepared = session
-        .prepare("DELETE FROM test_prepare_statements.table_1 WHERE id = ?;")
-        .unwrap()
-        .wait()
-        .unwrap();
+fn delete(session: &CassandraConnection) {
+    let prepared = session.prepare("DELETE FROM test_prepare_statements.table_1 WHERE id = ?;");
 
     let mut statement = prepared.bind();
     statement.bind_int32(0, 1).unwrap();
-    session.execute(&statement).wait().unwrap();
+    assert_eq!(
+        session.execute_prepared(&statement),
+        Vec::<Vec<ResultValue>>::new()
+    );
 
     assert_query_result(
         session,
@@ -19,49 +19,46 @@ fn delete(session: &Session) {
     );
 }
 
-fn insert(session: &Session) {
+fn insert(session: &CassandraConnection) {
     let prepared = session
-        .prepare("INSERT INTO test_prepare_statements.table_1 (id, x, name) VALUES (?, ?, ?);")
-        .unwrap()
-        .wait()
-        .unwrap();
+        .prepare("INSERT INTO test_prepare_statements.table_1 (id, x, name) VALUES (?, ?, ?);");
 
     let mut statement = prepared.bind();
     statement.bind_int32(0, 1).unwrap();
     statement.bind_int32(1, 11).unwrap();
     statement.bind_string(2, "foo").unwrap();
-    session.execute(&statement).wait().unwrap();
+    assert_eq!(
+        session.execute_prepared(&statement),
+        Vec::<Vec<ResultValue>>::new()
+    );
 
     statement = prepared.bind();
     statement.bind_int32(0, 2).unwrap();
     statement.bind_int32(1, 12).unwrap();
     statement.bind_string(2, "bar").unwrap();
-    session.execute(&statement).wait().unwrap();
+    assert_eq!(
+        session.execute_prepared(&statement),
+        Vec::<Vec<ResultValue>>::new()
+    );
 
     statement = prepared.bind();
     statement.bind_int32(0, 2).unwrap();
     statement.bind_int32(1, 13).unwrap();
     statement.bind_string(2, "baz").unwrap();
-    session.execute(&statement).wait().unwrap();
+    assert_eq!(
+        session.execute_prepared(&statement),
+        Vec::<Vec<ResultValue>>::new()
+    );
 }
 
-fn select(session: &Session) {
-    let prepared = session
-        .prepare("SELECT id, x, name FROM test_prepare_statements.table_1 WHERE id = ?")
-        .unwrap()
-        .wait()
-        .unwrap();
+fn select(session: &CassandraConnection) {
+    let prepared =
+        session.prepare("SELECT id, x, name FROM test_prepare_statements.table_1 WHERE id = ?");
 
     let mut statement = prepared.bind();
     statement.bind_int32(0, 1).unwrap();
 
-    let result_rows = session
-        .execute(&statement)
-        .wait()
-        .unwrap()
-        .into_iter()
-        .map(|x| x.into_iter().map(ResultValue::new).collect())
-        .collect();
+    let result_rows = session.execute_prepared(&statement);
 
     assert_rows(
         result_rows,
@@ -73,7 +70,7 @@ fn select(session: &Session) {
     );
 }
 
-pub fn test(session: &Session) {
+pub fn test(session: &CassandraConnection) {
     run_query(session, "CREATE KEYSPACE test_prepare_statements WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };");
     run_query(
         session,

--- a/shotover-proxy/tests/cassandra_int_tests/table.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/table.rs
@@ -1,10 +1,9 @@
 use crate::helpers::cassandra::{
     assert_query_result, assert_query_result_contains_row, assert_query_result_not_contains_row,
-    run_query, ResultValue,
+    run_query, CassandraConnection, ResultValue,
 };
-use cassandra_cpp::Session;
 
-fn test_create_table(session: &Session) {
+fn test_create_table(session: &CassandraConnection) {
     run_query(
         session,
         "CREATE TABLE test_table_keyspace.my_table (id UUID PRIMARY KEY, name text, age int);",
@@ -16,7 +15,7 @@ fn test_create_table(session: &Session) {
     );
 }
 
-fn test_drop_table(session: &Session) {
+fn test_drop_table(session: &CassandraConnection) {
     run_query(
         session,
         "CREATE TABLE test_table_keyspace.delete_me (id UUID PRIMARY KEY, name text, age int);",
@@ -35,7 +34,7 @@ fn test_drop_table(session: &Session) {
     );
 }
 
-fn test_alter_table(session: &Session) {
+fn test_alter_table(session: &CassandraConnection) {
     run_query(
         session,
         "CREATE TABLE test_table_keyspace.alter_me (id UUID PRIMARY KEY, name text, age int);",
@@ -49,7 +48,7 @@ fn test_alter_table(session: &Session) {
     assert_query_result(session, "SELECT column_name FROM system_schema.columns WHERE keyspace_name = 'test_table_keyspace' AND table_name = 'alter_me' AND column_name = 'new_id';", &[&[ResultValue::Varchar("new_id".into())]]);
 }
 
-pub fn test(session: &Session) {
+pub fn test(session: &CassandraConnection) {
     run_query(session, "CREATE KEYSPACE test_table_keyspace WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };");
     test_create_table(session);
     test_drop_table(session);

--- a/shotover-proxy/tests/cassandra_int_tests/udt.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/udt.rs
@@ -1,7 +1,6 @@
-use crate::helpers::cassandra::run_query;
-use cassandra_cpp::{stmt, Session};
+use crate::helpers::cassandra::{run_query, CassandraConnection};
 
-fn test_create_udt(session: &Session) {
+fn test_create_udt(session: &CassandraConnection) {
     run_query(
         session,
         "CREATE TYPE test_udt_keyspace.test_type_name (foo text, bar int)",
@@ -16,20 +15,18 @@ fn test_create_udt(session: &Session) {
     );
 }
 
-fn test_drop_udt(session: &Session) {
+fn test_drop_udt(session: &CassandraConnection) {
     run_query(
         session,
         "CREATE TYPE test_udt_keyspace.test_type_drop_me (foo text, bar int)",
     );
     run_query(session, "DROP TYPE test_udt_keyspace.test_type_drop_me;");
-    let statement = stmt!(
-            "CREATE TABLE test_udt_keyspace.test_delete_table (id int PRIMARY KEY, foo test_type_drop_me);"
-        );
-    let result = session.execute(&statement).wait().unwrap_err().to_string();
+    let statement = "CREATE TABLE test_udt_keyspace.test_delete_table (id int PRIMARY KEY, foo test_type_drop_me);";
+    let result = session.execute_expect_err(statement).to_string();
     assert_eq!(result, "Cassandra detailed error SERVER_INVALID_QUERY: Unknown type test_udt_keyspace.test_type_drop_me");
 }
 
-pub fn test(session: &Session) {
+pub fn test(session: &CassandraConnection) {
     run_query(session, "CREATE KEYSPACE test_udt_keyspace WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };");
     test_create_udt(session);
     test_drop_udt(session);

--- a/shotover-proxy/tests/examples/mod.rs
+++ b/shotover-proxy/tests/examples/mod.rs
@@ -1,4 +1,4 @@
-use crate::helpers::cassandra::{assert_query_result, cassandra_connection, ResultValue};
+use crate::helpers::cassandra::{assert_query_result, CassandraConnection, ResultValue};
 use serial_test::serial;
 use test_helpers::docker_compose::DockerCompose;
 
@@ -8,7 +8,7 @@ async fn test_cassandra_rewrite_peers_example() {
     let _docker_compose =
         DockerCompose::new("example-configs-docker/cassandra-peers-rewrite/docker-compose.yml");
 
-    let connection = cassandra_connection("172.16.1.2", 9043);
+    let connection = CassandraConnection::new("172.16.1.2", 9043);
 
     assert_query_result(
         &connection,

--- a/shotover-proxy/tests/helpers/mod.rs
+++ b/shotover-proxy/tests/helpers/mod.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use cassandra_cpp::{Cluster, Session, Ssl};
+use cassandra_cpp::{Cluster, Ssl};
 use redis::aio::AsyncStream;
 use redis::Client;
 use shotover_proxy::runner::{ConfigOpts, Runner};
@@ -14,7 +14,7 @@ use tokio::task::JoinHandle;
 use tokio_io_timeout::TimeoutStream;
 
 pub mod cassandra;
-use cassandra::cassandra_connection;
+use cassandra::CassandraConnection;
 
 #[must_use]
 pub struct ShotoverManager {
@@ -148,8 +148,8 @@ impl ShotoverManager {
     }
 
     #[allow(unused)]
-    pub fn cassandra_connection(&self, contact_points: &str, port: u16) -> Session {
-        cassandra_connection(contact_points, port)
+    pub fn cassandra_connection(&self, contact_points: &str, port: u16) -> CassandraConnection {
+        CassandraConnection::new(contact_points, port)
     }
 
     #[allow(unused)]
@@ -158,7 +158,7 @@ impl ShotoverManager {
         contact_points: &str,
         port: u16,
         ca_cert_path: &str,
-    ) -> Session {
+    ) -> CassandraConnection {
         let ca_cert = read_to_string(ca_cert_path).unwrap();
         let mut ssl = Ssl::default();
         Ssl::add_trusted_cert(&mut ssl, &ca_cert).unwrap();
@@ -173,7 +173,8 @@ impl ShotoverManager {
         cluster.set_port(port).ok();
         cluster.set_load_balance_round_robin();
         cluster.set_ssl(&mut ssl);
-        cluster.connect().unwrap()
+
+        CassandraConnection::Datastax(cluster.connect().unwrap())
     }
 
     fn shutdown_shotover(&mut self) -> Result<()> {


### PR DESCRIPTION
This is the first step towards allowing the cassandra integration tests to run against an arbitrary driver.
The CassandraConnection enum will have a variant for every driver that it supports.

Currently CassandraConnection still leaks a lot internals of cassandra_cpp but that will be addressed in future PRs.