### PR TITLE
Move cassandra sink receive logic into connection::receive

### DIFF
--- a/docs/src/transforms.md
+++ b/docs/src/transforms.md
@@ -64,6 +64,11 @@ This transform will take a query, serialise it into a CQL4 compatible format and
     #  certificate_path: "tls/localhost.crt"
     #  # Path to the private key file, typically named with a .key extension.
     #  private_key_path: "tls/localhost.key"
+
+  # Timeout in seconds after which to give up waiting for a response from the destination.
+  # This field is optional, if not provided, timeout will never occur.
+  # When a timeout occurs the connection to the client is immediately closed.
+  # read_timeout: 60
 ```
 
 Note: this will just pass the query to the remote node. No cluster discovery or routing occurs with this transform.

--- a/shotover-proxy/src/transforms/cassandra/connection.rs
+++ b/shotover-proxy/src/transforms/cassandra/connection.rs
@@ -1,3 +1,4 @@
+use crate::concurrency::FuturesOrdered;
 use crate::frame::cassandra;
 use crate::message::Message;
 use crate::server::Codec;
@@ -11,12 +12,14 @@ use cassandra_protocol::frame::Opcode;
 use derivative::Derivative;
 use futures::StreamExt;
 use halfbrown::HashMap;
+use std::time::Duration;
 use tokio::io::{split, AsyncRead, AsyncWrite, ReadHalf, WriteHalf};
 use tokio::net::TcpStream;
 use tokio::sync::{mpsc, oneshot};
+use tokio::time::timeout;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_util::codec::{FramedRead, FramedWrite};
-use tracing::{info, Instrument};
+use tracing::{error, info, Instrument};
 
 /// Represents a `Request` to a `CassandraConnection`
 #[derive(Debug)]
@@ -29,7 +32,6 @@ struct Request {
 #[derive(Clone, Derivative)]
 #[derivative(Debug)]
 pub struct CassandraConnection {
-    host: String,
     connection: mpsc::UnboundedSender<Request>,
 }
 
@@ -60,10 +62,7 @@ impl CassandraConnection {
             );
         };
 
-        Ok(CassandraConnection {
-            host,
-            connection: out_tx,
-        })
+        Ok(CassandraConnection { connection: out_tx })
     }
 
     /// Send a `Message` to this `CassandraConnection` and expect a response on `return_chan`
@@ -157,4 +156,47 @@ async fn rx_process<C: CodecReadHalf, T: AsyncRead>(
         }
     }
     Ok(())
+}
+
+pub async fn receive(
+    failed_requests: &metrics::Counter,
+    mut results: FuturesOrdered<oneshot::Receiver<Response>>,
+) -> Result<Messages> {
+    let expected_size = results.len();
+    let mut responses = Vec::with_capacity(expected_size);
+    loop {
+        match timeout(Duration::from_secs(5), results.next()).await {
+            Ok(Some(prelim)) => {
+                match prelim? {
+                    Response {
+                        response: Ok(message),
+                        ..
+                    } => {
+                        if let Some(raw_bytes) = message.as_raw_bytes() {
+                            if let Ok(Opcode::Error) = cassandra::raw_frame::get_opcode(raw_bytes) {
+                                failed_requests.increment(1);
+                            }
+                        }
+                        responses.push(message);
+                    }
+                    Response {
+                        mut original,
+                        response: Err(err),
+                    } => {
+                        original.set_error(err.to_string());
+                        responses.push(original);
+                    }
+                };
+            }
+            Ok(None) => break,
+            Err(_) => {
+                error!(
+                    "timed out waiting for responses, received {:?} responses but expected {:?} responses",
+                    responses.len(),
+                    expected_size
+                );
+            }
+        }
+    }
+    Ok(responses)
 }

--- a/shotover-proxy/src/transforms/cassandra/sink_cluster.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_cluster.rs
@@ -2,21 +2,16 @@ use super::connection::CassandraConnection;
 use crate::codec::cassandra::CassandraCodec;
 use crate::concurrency::FuturesOrdered;
 use crate::error::ChainResponse;
-use crate::frame::cassandra;
 use crate::message::Messages;
 use crate::tls::{TlsConnector, TlsConnectorConfig};
 use crate::transforms::util::Response;
 use crate::transforms::{Transform, Transforms, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
-use cassandra_protocol::frame::Opcode;
 use metrics::{register_counter, Counter};
 use serde::Deserialize;
-use std::time::Duration;
 use tokio::sync::{mpsc, oneshot};
-use tokio::time::timeout;
-use tokio_stream::StreamExt;
-use tracing::{error, trace};
+use tracing::trace;
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct CassandraSinkClusterConfig {
@@ -93,8 +88,7 @@ impl CassandraSinkCluster {
         }
 
         let outbound = self.outbound.as_mut().unwrap();
-        let expected_size = messages.len();
-        let results: Result<FuturesOrdered<oneshot::Receiver<Response>>> = messages
+        let responses_future: Result<FuturesOrdered<oneshot::Receiver<Response>>> = messages
             .into_iter()
             .map(|m| {
                 let (return_chan_tx, return_chan_rx) = oneshot::channel();
@@ -104,47 +98,7 @@ impl CassandraSinkCluster {
             })
             .collect();
 
-        let mut responses = Vec::with_capacity(expected_size);
-        let mut results = results?;
-
-        loop {
-            match timeout(Duration::from_secs(5), results.next()).await {
-                Ok(Some(prelim)) => {
-                    match prelim? {
-                        Response {
-                            response: Ok(message),
-                            ..
-                        } => {
-                            if let Some(raw_bytes) = message.as_raw_bytes() {
-                                if let Ok(Opcode::Error) =
-                                    cassandra::raw_frame::get_opcode(raw_bytes)
-                                {
-                                    self.failed_requests.increment(1);
-                                }
-                            }
-                            responses.push(message);
-                        }
-                        Response {
-                            mut original,
-                            response: Err(err),
-                        } => {
-                            original.set_error(err.to_string());
-                            responses.push(original);
-                        }
-                    };
-                }
-                Ok(None) => break,
-                Err(_) => {
-                    error!(
-                        "timed out waiting for responses, received {:?} responses but expected {:?} responses",
-                        responses.len(),
-                        expected_size
-                    );
-                }
-            }
-        }
-
-        Ok(responses)
+        super::connection::receive(&self.failed_requests, responses_future?).await
     }
 }
 

--- a/shotover-proxy/src/transforms/cassandra/sink_single.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_single.rs
@@ -10,6 +10,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use metrics::{register_counter, Counter};
 use serde::Deserialize;
+use std::time::Duration;
 use tokio::sync::{mpsc, oneshot};
 use tracing::trace;
 
@@ -18,6 +19,7 @@ pub struct CassandraSinkSingleConfig {
     #[serde(rename = "remote_address")]
     pub address: String,
     pub tls: Option<TlsConnectorConfig>,
+    pub read_timeout: Option<u64>,
 }
 
 impl CassandraSinkSingleConfig {
@@ -27,6 +29,7 @@ impl CassandraSinkSingleConfig {
             self.address.clone(),
             chain_name,
             tls,
+            self.read_timeout,
         )))
     }
 }
@@ -38,6 +41,7 @@ pub struct CassandraSinkSingle {
     failed_requests: Counter,
     tls: Option<TlsConnector>,
     pushed_messages_tx: Option<mpsc::UnboundedSender<Messages>>,
+    read_timeout: Option<Duration>,
 }
 
 impl Clone for CassandraSinkSingle {
@@ -49,6 +53,7 @@ impl Clone for CassandraSinkSingle {
             tls: self.tls.clone(),
             failed_requests: self.failed_requests.clone(),
             pushed_messages_tx: None,
+            read_timeout: self.read_timeout,
         }
     }
 }
@@ -58,8 +63,10 @@ impl CassandraSinkSingle {
         address: String,
         chain_name: String,
         tls: Option<TlsConnector>,
+        timeout: Option<u64>,
     ) -> CassandraSinkSingle {
         let failed_requests = register_counter!("failed_requests", "chain" => chain_name.clone(), "transform" => "CassandraSinkSingle");
+        let receive_timeout = timeout.map(Duration::from_secs);
 
         CassandraSinkSingle {
             address,
@@ -68,6 +75,7 @@ impl CassandraSinkSingle {
             failed_requests,
             tls,
             pushed_messages_tx: None,
+            read_timeout: receive_timeout,
         }
     }
 }
@@ -99,7 +107,8 @@ impl CassandraSinkSingle {
             })
             .collect();
 
-        super::connection::receive(&self.failed_requests, responses_future?).await
+        super::connection::receive(self.read_timeout, &self.failed_requests, responses_future?)
+            .await
     }
 }
 

--- a/shotover-proxy/src/transforms/cassandra/sink_single.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_single.rs
@@ -2,21 +2,16 @@ use super::connection::CassandraConnection;
 use crate::codec::cassandra::CassandraCodec;
 use crate::concurrency::FuturesOrdered;
 use crate::error::ChainResponse;
-use crate::frame::cassandra;
 use crate::message::Messages;
 use crate::tls::{TlsConnector, TlsConnectorConfig};
 use crate::transforms::util::Response;
 use crate::transforms::{Transform, Transforms, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
-use cassandra_protocol::frame::Opcode;
 use metrics::{register_counter, Counter};
 use serde::Deserialize;
-use std::time::Duration;
 use tokio::sync::{mpsc, oneshot};
-use tokio::time::timeout;
-use tokio_stream::StreamExt;
-use tracing::{error, trace};
+use tracing::trace;
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct CassandraSinkSingleConfig {
@@ -94,8 +89,7 @@ impl CassandraSinkSingle {
         trace!("sending frame upstream");
 
         let outbound = self.outbound.as_mut().unwrap();
-        let expected_size = messages.len();
-        let results: Result<FuturesOrdered<oneshot::Receiver<Response>>> = messages
+        let responses_future: Result<FuturesOrdered<oneshot::Receiver<Response>>> = messages
             .into_iter()
             .map(|m| {
                 let (return_chan_tx, return_chan_rx) = oneshot::channel();
@@ -105,47 +99,7 @@ impl CassandraSinkSingle {
             })
             .collect();
 
-        let mut responses = Vec::with_capacity(expected_size);
-        let mut results = results?;
-
-        loop {
-            match timeout(Duration::from_secs(5), results.next()).await {
-                Ok(Some(prelim)) => {
-                    match prelim? {
-                        Response {
-                            response: Ok(message),
-                            ..
-                        } => {
-                            if let Some(raw_bytes) = message.as_raw_bytes() {
-                                if let Ok(Opcode::Error) =
-                                    cassandra::raw_frame::get_opcode(raw_bytes)
-                                {
-                                    self.failed_requests.increment(1);
-                                }
-                            }
-                            responses.push(message);
-                        }
-                        Response {
-                            mut original,
-                            response: Err(err),
-                        } => {
-                            original.set_error(err.to_string());
-                            responses.push(original);
-                        }
-                    };
-                }
-                Ok(None) => break,
-                Err(_) => {
-                    error!(
-                        "timed out waiting for responses, received {:?} responses but expected {:?} responses",
-                        responses.len(),
-                        expected_size
-                    );
-                }
-            }
-        }
-
-        Ok(responses)
+        super::connection::receive(&self.failed_requests, responses_future?).await
     }
 }
 


### PR DESCRIPTION
Pulled out of https://github.com/shotover/shotover-proxy/pull/723

~~receive logic should remain exactly the same it is just refactored into a different function.~~

Receive logic is now modified to use a configurable read_timeout.
Additionally the timeout logic is now changed to immediately close the connection on a timeout.
Previously it would just drop the timedout message and continue normally which breaks the transform invariants.