### PR TITLE
update serde_yaml to 0.9 (by adding `!` everywhere)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,12 +1317,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "lock_api"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2544,9 +2538,9 @@ checksum = "a2333e6df6d6598f2b1974829f853c2b4c5f4a6e503c10af918081aa6f8564e1"
 
 [[package]]
 name = "serde"
-version = "1.0.138"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1578c6245786b9d168c5447eeacfb96856573ca56c9d68fdcf394be134882a47"
+checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
 dependencies = [
  "serde_derive",
 ]
@@ -2563,9 +2557,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.138"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "023e9b1467aef8a10fb88f25611870ada9800ef7e22afce356bb0d2387b6f27c"
+checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2597,14 +2591,15 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.24"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707d15895415db6628332b737c838b88c598522e4dc70647e59b72312924aebc"
+checksum = "79b7c9017c64a49806c6e8df8ef99b92446d09c92457f85f91835b01a8064ae0"
 dependencies = [
  "indexmap",
+ "itoa 1.0.2",
  "ryu",
  "serde",
- "yaml-rust",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -3310,6 +3305,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "931179334a56395bcf64ba5e0ff56781381c1a5832178280c7d7f91d1679aeb0"
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3563,15 +3564,6 @@ name = "xml-rs"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
-]
 
 [[package]]
 name = "yasna"

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -44,7 +44,7 @@ anyhow = "1.0.31"
 cql3-parser = "0.3.0"
 serde = { version = "1.0.111", features = ["derive"] }
 serde_json = "1.0"
-serde_yaml = "0.8.21"
+serde_yaml = "0.9.4"
 bincode = "1.3.1"
 num = { version = "0.4.0", features = ["serde"] }
 uuid = { version = "1.0.0", features = ["serde"] }

--- a/shotover-proxy/tests/test-configs/invalid_subchains.yaml
+++ b/shotover-proxy/tests/test-configs/invalid_subchains.yaml
@@ -1,27 +1,27 @@
 ---
 sources:
   redis_prod:
-    Redis:
+    !Redis
       listen_addr: "127.0.0.1:6379"
 chain_config:
   a_first_chain:
-    - Null
-    - Null
-    - DebugPrinter
+    - !Null
+    - !Null
+    - !DebugPrinter
   b_second_chain:
-    - DebugPrinter
-    - ConsistentScatter:
+    - !DebugPrinter
+    - !ConsistentScatter
         read_consistency: 1
         write_consistency: 1
         route_map:
           a_chain_1:
-            - Null
-            - DebugPrinter
+            - !Null
+            - !DebugPrinter
           b_chain_2:
-            - Null
-            - Null
+            - !Null
+            - !Null
           c_chain_3:
-            - ConsistentScatter:
+            - !ConsistentScatter
                 read_consistency: 1
                 write_consistency: 1
                 route_map:


### PR DESCRIPTION
Just publishing this to demonstrate the new serialization format of serde_yaml.
We will have to decide if we want to actually upgrade to this new format, find an alternative crate or just stick to the old version of serde_yaml.

The changes to invalid_subchains.yaml allows `cargo test test_validate_chain_multiple_subchains` to pass.