### PR TITLE
Fix another intermittent cluster failure

### DIFF
--- a/shotover-proxy/tests/cassandra_int_tests/functions.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/functions.rs
@@ -18,12 +18,12 @@ fn drop_function(session: &CassandraConnection) {
     );
 }
 
-async fn create_function(session: &CassandraConnection, direct_connections: &SchemaAwaiter) {
+async fn create_function(session: &CassandraConnection, schema_awaiter: &SchemaAwaiter) {
     run_query(
         session,
         "CREATE FUNCTION test_function_keyspace.my_function (a int, b int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE javascript AS 'a * b';",
     );
-    direct_connections.await_schema_agreement().await;
+    schema_awaiter.await_schema_agreement().await;
     assert_query_result(
         session,
         "SELECT test_function_keyspace.my_function(x, y) FROM test_function_keyspace.test_function_table;",
@@ -31,7 +31,7 @@ async fn create_function(session: &CassandraConnection, direct_connections: &Sch
     );
 }
 
-pub async fn test(session: &CassandraConnection, direct_connections: &SchemaAwaiter) {
+pub async fn test(session: &CassandraConnection, schema_awaiter: &SchemaAwaiter) {
     run_query(
         session,
         "CREATE KEYSPACE test_function_keyspace WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };"
@@ -49,6 +49,6 @@ INSERT INTO test_function_keyspace.test_function_table (id, x, y) VALUES (3, 4, 
 APPLY BATCH;"#,
     );
 
-    create_function(session, direct_connections).await;
+    create_function(session, schema_awaiter).await;
     drop_function(session);
 }

--- a/shotover-proxy/tests/cassandra_int_tests/schema_awaiter.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/schema_awaiter.rs
@@ -5,22 +5,30 @@ use scylla::{Session, SessionBuilder};
 // But for cases like adding a new function we hit issues where the function is not yet propagated to all nodes.
 // So we make use of the scylla drivers await_schema_agreement logic to wait until all nodes are on the same schema.
 pub struct SchemaAwaiter {
-    session: Session,
+    session: Option<Session>,
 }
 
 impl SchemaAwaiter {
     pub async fn new(node: &str) -> Self {
         SchemaAwaiter {
-            session: SessionBuilder::new()
-                .known_node(node)
-                .user("cassandra", "cassandra")
-                .build()
-                .await
-                .unwrap(),
+            session: Some(
+                SessionBuilder::new()
+                    .known_node(node)
+                    .user("cassandra", "cassandra")
+                    .build()
+                    .await
+                    .unwrap(),
+            ),
         }
     }
 
+    pub fn new_noop() -> Self {
+        SchemaAwaiter { session: None }
+    }
+
     pub async fn await_schema_agreement(&self) {
-        self.session.await_schema_agreement().await.unwrap();
+        if let Some(session) = &self.session {
+            session.await_schema_agreement().await.unwrap();
+        }
     }
 }

--- a/shotover-proxy/tests/cassandra_int_tests/udt.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/udt.rs
@@ -1,3 +1,4 @@
+use crate::cassandra_int_tests::schema_awaiter::SchemaAwaiter;
 use crate::helpers::cassandra::{run_query, CassandraConnection};
 
 fn test_create_udt(session: &CassandraConnection) {
@@ -15,19 +16,21 @@ fn test_create_udt(session: &CassandraConnection) {
     );
 }
 
-fn test_drop_udt(session: &CassandraConnection) {
+async fn test_drop_udt(session: &CassandraConnection, schema_awaiter: &SchemaAwaiter) {
     run_query(
         session,
         "CREATE TYPE test_udt_keyspace.test_type_drop_me (foo text, bar int)",
     );
+    schema_awaiter.await_schema_agreement().await;
     run_query(session, "DROP TYPE test_udt_keyspace.test_type_drop_me;");
+    schema_awaiter.await_schema_agreement().await;
     let statement = "CREATE TABLE test_udt_keyspace.test_delete_table (id int PRIMARY KEY, foo test_type_drop_me);";
     let result = session.execute_expect_err(statement).to_string();
     assert_eq!(result, "Cassandra detailed error SERVER_INVALID_QUERY: Unknown type test_udt_keyspace.test_type_drop_me");
 }
 
-pub fn test(session: &CassandraConnection) {
+pub async fn test(session: &CassandraConnection, schema_awaiter: &SchemaAwaiter) {
     run_query(session, "CREATE KEYSPACE test_udt_keyspace WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };");
     test_create_udt(session);
-    test_drop_udt(session);
+    test_drop_udt(session, schema_awaiter).await;
 }


### PR DESCRIPTION
Fixes https://github.com/shotover/shotover-proxy/runs/7739411831?check_suite_focus=true

This time the problem is in table::test
... and another showed up in udt::test

The problem is because we arent waiting for the cluster to reach schema agreement before running certain commands, so we can fix it by using the SchemaAwaiter like we do in functions::test

Rather than remove another test case from the TLS tests I reintroduced the previously removed functions::test case by adding a new_noop constructor