### PR TITLE
CassandraSinkCluster query system.local for local node info

### DIFF
--- a/shotover-proxy/tests/cassandra_int_tests/cluster.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cluster.rs
@@ -41,7 +41,7 @@ pub async fn test() {
     }
 
     // make assertions on the nodes list
-    assert_eq!(nodes.len(), 2);
+    assert_eq!(nodes.len(), 3);
     let mut possible_addresses: Vec<IpAddr> = vec![
         "172.16.1.2".parse().unwrap(),
         "172.16.1.3".parse().unwrap(),


### PR DESCRIPTION
The change to the integration test demonstrates the change: we are now representing the entire cluster in the nodes list, previously we only included the 2 peers of the node we are querying but now we include the node itself as well.

Additionally I improved the error handling by:
* system_peers_into_node now returns errors for cases that are unrecoverable instead of silently ignoring the case.
   + A nice improvement this will bring is `CassandraOperation::Error`s are now logged - a possible case that could cause that is an auth error which is a realistic case.
* Retry querying the same peer 3 times and then move onto another handshake provided by another clients connection.

The old QueryParams values were blindly copy pasted in and on closer inspection they are not very good. e.g. page_size and timestamp should not be set.
I used the QueryParams::default because all of the default values happen to be exactly what we want.
