### PR TITLE
Update to rust 1.63

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.62"
+channel = "1.63"
 components = [ "rustfmt", "clippy" ]

--- a/shotover-proxy/src/lib.rs
+++ b/shotover-proxy/src/lib.rs
@@ -17,6 +17,8 @@
 //! * [`transforms::Transforms`], the enum to register with (add a variant) for enabling your own transform.
 //! * [`transforms::TransformsConfig`], the enum to register with (add a variant) for configuring your own transform.
 
+#![allow(clippy::derive_partial_eq_without_eq)]
+
 pub mod codec;
 mod concurrency;
 pub mod config;

--- a/shotover-proxy/src/message/mod.rs
+++ b/shotover-proxy/src/message/mod.rs
@@ -278,9 +278,9 @@ impl Message {
                 bytes,
                 message_type,
             } => match message_type {
-                MessageType::Cassandra => Ok(Metadata::Cassandra(cassandra::raw_frame::metadata(
-                    &*bytes,
-                )?)),
+                MessageType::Cassandra => {
+                    Ok(Metadata::Cassandra(cassandra::raw_frame::metadata(bytes)?))
+                }
                 MessageType::Redis => Ok(Metadata::Redis),
                 MessageType::None => Ok(Metadata::None),
             },

--- a/shotover-proxy/src/transforms/protect/crypto.rs
+++ b/shotover-proxy/src/transforms/protect/crypto.rs
@@ -20,7 +20,7 @@ pub async fn encrypt(
     key_management: &KeyManager,
     key_id: &str,
 ) -> Result<Operand> {
-    let value = MessageValue::from(&*value);
+    let value = MessageValue::from(value);
 
     let sym_key = key_management.cached_get_key(key_id, None, None).await?;
 


### PR DESCRIPTION
I opted to disable the new derive_partial_eq_without_eq lint, because blanket enforcing full Eq seems like a bad idea when the type might not meet the semantics of Eq