### PR TITLE
Fix a (different) intermittent failure

### DIFF
--- a/shotover-proxy/tests/cassandra_int_tests/functions.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/functions.rs
@@ -8,12 +8,9 @@ async fn drop_function(session: &CassandraConnection) {
     ).await;
     run_query(session, "DROP FUNCTION test_function_keyspace.my_function").await;
 
-    let statement = "SELECT test_function_keyspace.my_function(x) FROM test_function_keyspace.test_function_table WHERE id=1;";
-    let result = session.execute_expect_err(statement).to_string();
-
-    assert_eq!(
-        result,
-        "Cassandra detailed error SERVER_INVALID_QUERY: Unknown function 'test_function_keyspace.my_function'"
+    session.execute_expect_err_contains(
+        "SELECT test_function_keyspace.my_function(x) FROM test_function_keyspace.test_function_table WHERE id=1;",
+        "Unknown function 'test_function_keyspace.my_function'",
     );
 }
 

--- a/shotover-proxy/tests/cassandra_int_tests/udt.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/udt.rs
@@ -25,9 +25,10 @@ async fn test_drop_udt(session: &CassandraConnection) {
     )
     .await;
     run_query(session, "DROP TYPE test_udt_keyspace.test_type_drop_me;").await;
-    let statement = "CREATE TABLE test_udt_keyspace.test_delete_table (id int PRIMARY KEY, foo test_type_drop_me);";
-    let result = session.execute_expect_err(statement).to_string();
-    assert_eq!(result, "Cassandra detailed error SERVER_INVALID_QUERY: Unknown type test_udt_keyspace.test_type_drop_me");
+    session.execute_expect_err_contains(
+        "CREATE TABLE test_udt_keyspace.test_delete_table (id int PRIMARY KEY, foo test_type_drop_me);",
+        "Unknown type test_udt_keyspace.test_type_drop_me",
+    );
 }
 
 pub async fn test(session: &CassandraConnection) {

--- a/shotover-proxy/tests/helpers/cassandra.rs
+++ b/shotover-proxy/tests/helpers/cassandra.rs
@@ -110,6 +110,15 @@ impl CassandraConnection {
     }
 
     #[allow(unused)]
+    pub fn execute_expect_err_contains(&self, query: &str, contains: &str) {
+        let result = self.execute_expect_err(query).to_string();
+        assert!(
+            result.contains(contains),
+            "Expected the error to contain '{contains}' but it did not and was instead '{result}'"
+        );
+    }
+
+    #[allow(unused)]
     pub fn prepare(&self, query: &str) -> PreparedStatement {
         match self {
             CassandraConnection::Datastax { session, .. } => {


### PR DESCRIPTION
This one is a lot rarer.
Heres a screenshot of it occuring.
![image](https://user-images.githubusercontent.com/5120858/184296293-cd1cb4fe-b0c4-4d7b-875f-172912ae6c5b.png)

I suspect the difference in error message is caused by the error occurring on a query that the coordinator has routed onto another node rather than just being run locally by the coordinator.
Thats just a guess though and it doesnt really matter the cause, the error can be different sometimes so we just need to change the assert to a contains check rather than an equals check.