### PR TITLE
CassandraSinkCluster rewrite system.local

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3389,6 +3389,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
 dependencies = [
+ "getrandom",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2795,6 +2795,7 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "uuid 1.1.2",
+ "version-compare",
 ]
 
 [[package]]
@@ -3404,6 +3405,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version-compare"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe88247b92c1df6b6de80ddc290f3976dbdf2f5f5d3fd049a9fb598c6dd5ca73"
 
 [[package]]
 name = "version_check"

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -46,7 +46,7 @@ serde_json = "1.0"
 serde_yaml = "0.8.21"
 bincode = "1.3.1"
 num = { version = "0.4.0", features = ["serde"] }
-uuid = { version = "1.0.0", features = ["serde"] }
+uuid = { version = "1.0.0", features = ["serde", "v4"] }
 bigdecimal = {version ="0.3.0", features = ["serde"] }
 base64 = "0.13.0"
 

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -34,6 +34,7 @@ openssl = { version = "0.10.36", features = ["vendored"] }
 async-recursion = "1.0"
 governor = { version = "0.4.2", default-features = false, features = ["std", "jitter", "quanta"] }
 nonzero_ext = "0.3.0"
+version-compare = "0.1"
 
 # Error handling
 thiserror = "1.0"

--- a/shotover-proxy/benches/chain_benches.rs
+++ b/shotover-proxy/benches/chain_benches.rs
@@ -30,6 +30,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let wrapper = Wrapper::new_with_chain_name(
             vec![Message::from_frame(Frame::None)],
             chain.name.clone(),
+            "127.0.0.1:6379".parse().unwrap(),
         );
 
         group.bench_function("null", |b| {
@@ -68,6 +69,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 ]))),
             ],
             chain.name.clone(),
+            "127.0.0.1:6379".parse().unwrap(),
         );
 
         group.bench_function("redis_filter", |b| {
@@ -103,6 +105,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 RedisFrame::BulkString(Bytes::from_static(b"bar")),
             ])))],
             chain.name.clone(),
+            "127.0.0.1:6379".parse().unwrap(),
         );
 
         group.bench_function("redis_timestamp_tagger_untagged", |b| {
@@ -123,6 +126,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 RedisFrame::BulkString(Bytes::from_static(b"foo")),
             ])))],
             chain.name.clone(),
+            "127.0.0.1:6379".parse().unwrap(),
         );
 
         group.bench_function("redis_timestamp_tagger_tagged", |b| {
@@ -153,6 +157,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 RedisFrame::BulkString(Bytes::from_static(b"bar")),
             ])))],
             chain.name.clone(),
+            "127.0.0.1:6379".parse().unwrap(),
         );
 
         group.bench_function("redis_cluster_ports_rewrite", |b| {
@@ -196,6 +201,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 MessageType::Cassandra,
             )],
             chain.name.clone(),
+            "127.0.0.1:6379".parse().unwrap(),
         );
 
         group.bench_function("cassandra_request_throttling_unparsed", |b| {
@@ -251,6 +257,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 MessageType::Cassandra,
             )],
             "bench".into(),
+            "127.0.0.1:6379".parse().unwrap(),
         );
 
         group.bench_function("cassandra_rewrite_peers_passthrough", |b| {
@@ -349,6 +356,7 @@ fn cassandra_parsed_query(query: &str) -> Wrapper {
             },
         }))],
         "bench".into(),
+        "127.0.0.1:6379".parse().unwrap(),
     )
 }
 

--- a/shotover-proxy/example-configs/cassandra-cluster-tls/topology.yaml
+++ b/shotover-proxy/example-configs/cassandra-cluster-tls/topology.yaml
@@ -12,6 +12,8 @@ chain_config:
     - CassandraSinkCluster:
         first_contact_points: ["172.16.1.2:9042", "172.16.1.3:9042"]
         data_center: "dc1"
+        rack: "rack1"
+        host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
         tls:
           certificate_authority_path: "example-configs/cassandra-tls/certs/localhost_CA.crt"
           certificate_path: "example-configs/cassandra-tls/certs/localhost.crt"

--- a/shotover-proxy/example-configs/cassandra-cluster/topology.yaml
+++ b/shotover-proxy/example-configs/cassandra-cluster/topology.yaml
@@ -8,5 +8,7 @@ chain_config:
     - CassandraSinkCluster:
         first_contact_points: ["172.16.1.2:9042", "172.16.1.3:9042"]
         data_center: "dc1"
+        rack: "rack1"
+        host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
 source_to_chain_mapping:
   cassandra_prod: main_chain

--- a/shotover-proxy/src/message/mod.rs
+++ b/shotover-proxy/src/message/mod.rs
@@ -43,7 +43,7 @@ pub type Messages = Vec<Message>;
 /// Usually a message is received and starts off containing just raw bytes (or possibly raw bytes + frame)
 /// This can be immediately sent off to the destination without any processing cost.
 ///
-/// However if a transform wants to query the contents of the message it must call `Message::frame()q which will cause the raw bytes to be processed into a raw bytes + Frame.
+/// However if a transform wants to query the contents of the message it must call `Message::frame()` which will cause the raw bytes to be processed into a raw bytes + Frame.
 /// The first call to frame has an expensive one time cost.
 ///
 /// The transform may also go one step further and modify the message's Frame + call `Message::invalidate_cache()`.

--- a/shotover-proxy/src/server.rs
+++ b/shotover-proxy/src/server.rs
@@ -478,6 +478,8 @@ impl<C: Codec + 'static> Handler<C> {
         let (in_tx, mut in_rx) = mpsc::unbounded_channel::<Messages>();
         let (out_tx, out_rx) = mpsc::unbounded_channel::<Messages>();
 
+        let local_addr = stream.local_addr()?;
+
         if let Some(tls) = &self.tls {
             let tls_stream = tls.accept(stream).await?;
             let (rx, tx) = tokio::io::split(tls_stream);
@@ -550,6 +552,7 @@ impl<C: Codec + 'static> Handler<C> {
                 messages,
                 self.client_details.clone(),
                 self.chain.name.clone(),
+                local_addr,
             );
 
             let modified_messages = if reverse_chain {

--- a/shotover-proxy/src/transforms/mod.rs
+++ b/shotover-proxy/src/transforms/mod.rs
@@ -379,6 +379,7 @@ pub struct Wrapper<'a> {
     pub messages: Messages,
     transforms: IterMut<'a, Transforms>,
     pub client_details: String,
+    /// Contains the shotover source's ip address and port which the message was received on
     pub local_addr: SocketAddr,
     chain_name: String,
     /// When true transforms must flush any buffered messages into the messages field.

--- a/shotover-proxy/src/transforms/mod.rs
+++ b/shotover-proxy/src/transforms/mod.rs
@@ -45,6 +45,7 @@ use futures::Future;
 use metrics::{counter, histogram};
 use serde::Deserialize;
 use std::fmt::{Debug, Formatter};
+use std::net::SocketAddr;
 use std::pin::Pin;
 use strum_macros::IntoStaticStr;
 use tokio::sync::mpsc;
@@ -378,6 +379,7 @@ pub struct Wrapper<'a> {
     pub messages: Messages,
     transforms: IterMut<'a, Transforms>,
     pub client_details: String,
+    pub local_addr: SocketAddr,
     chain_name: String,
     /// When true transforms must flush any buffered messages into the messages field.
     /// This can occur at any time but will always occur before the transform is destroyed due to either
@@ -395,6 +397,7 @@ impl<'a> Clone for Wrapper<'a> {
             transforms: [].iter_mut(),
             client_details: self.client_details.clone(),
             chain_name: self.chain_name.clone(),
+            local_addr: self.local_addr,
             flush: false,
         }
     }
@@ -467,16 +470,18 @@ impl<'a> Wrapper<'a> {
             messages: m,
             transforms: [].iter_mut(),
             client_details: "".to_string(),
+            local_addr: "127.0.0.1:8000".parse().unwrap(),
             chain_name: "".to_string(),
             flush: false,
         }
     }
 
-    pub fn new_with_chain_name(m: Messages, chain_name: String) -> Self {
+    pub fn new_with_chain_name(m: Messages, chain_name: String, local_addr: SocketAddr) -> Self {
         Wrapper {
             messages: m,
             transforms: [].iter_mut(),
             client_details: "".to_string(),
+            local_addr,
             chain_name,
             flush: false,
         }
@@ -487,6 +492,8 @@ impl<'a> Wrapper<'a> {
             messages: vec![],
             transforms: [].iter_mut(),
             client_details: "".into(),
+            // The connection is closed so we need to just fake an address here
+            local_addr: "127.0.0.1:10000".parse().unwrap(),
             chain_name,
             flush: true,
         }
@@ -496,11 +503,13 @@ impl<'a> Wrapper<'a> {
         m: Messages,
         client_details: String,
         chain_name: String,
+        local_addr: SocketAddr,
     ) -> Self {
         Wrapper {
             messages: m,
             transforms: [].iter_mut(),
             client_details,
+            local_addr,
             chain_name,
             flush: false,
         }

--- a/shotover-proxy/src/transforms/parallel_map.rs
+++ b/shotover-proxy/src/transforms/parallel_map.rs
@@ -96,7 +96,11 @@ impl Transform for ParallelMap {
             for chain in self.chains.iter_mut() {
                 if let Some(message) = message_iter.next() {
                     future.push(chain.process_request(
-                        Wrapper::new_with_chain_name(vec![message], chain.name.clone()),
+                        Wrapper::new_with_chain_name(
+                            vec![message],
+                            chain.name.clone(),
+                            message_wrapper.local_addr,
+                        ),
                         "Parallel".to_string(),
                     ));
                 }

--- a/shotover-proxy/tests/cassandra_int_tests/cluster.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cluster.rs
@@ -10,8 +10,8 @@ use tokio::sync::{mpsc, RwLock};
 
 async fn test_rewrite_system_local(connection: &CassandraConnection) {
     assert_query_result(connection, "SELECT * FROM system.peers;", &[]).await;
-    assert_query_result(connection, "SELECT *, peer FROM system.peers;", &[]).await;
     assert_query_result(connection, "SELECT peer FROM system.peers;", &[]).await;
+    assert_query_result(connection, "SELECT peer, peer FROM system.peers;", &[]).await;
 
     let star_results = [
         ResultValue::Varchar("local".into()),
@@ -20,6 +20,7 @@ async fn test_rewrite_system_local(connection: &CassandraConnection) {
         ResultValue::Varchar("TestCluster".into()),
         ResultValue::Varchar("3.4.4".into()),
         ResultValue::Varchar("dc1".into()),
+        // gossip_generation is non deterministic cant assert on it
         ResultValue::Any,
         ResultValue::Uuid("2dd022d6-2937-4754-89d6-02d2933a8f7a".parse().unwrap()),
         ResultValue::Inet("127.0.0.1".parse().unwrap()),
@@ -28,6 +29,9 @@ async fn test_rewrite_system_local(connection: &CassandraConnection) {
         ResultValue::Varchar("rack1".into()),
         ResultValue::Varchar("3.11.13".into()),
         ResultValue::Inet("0.0.0.0".parse().unwrap()),
+        // schema_version is non deterministic so we cant assert on it.
+        ResultValue::Any,
+        // thrift_version isnt used anymore so I dont really care what it maps to
         ResultValue::Any,
         // Unfortunately token generation appears to be non-deterministic but we can at least assert that
         // there are 128 tokens per node
@@ -35,22 +39,22 @@ async fn test_rewrite_system_local(connection: &CassandraConnection) {
         ResultValue::Map(vec![]),
     ];
 
+    let all_columns =
+        "key, bootstrapped, broadcast_address, cluster_name, cql_version, data_center,
+        gossip_generation, host_id, listen_address, native_protocol_version, partitioner, rack,
+        release_version, rpc_address, schema_version, thrift_version, tokens, truncated_at";
+
     assert_query_result(connection, "SELECT * FROM system.local;", &[&star_results]).await;
     assert_query_result(
         connection,
-        "SELECT *, key FROM system.local;",
-        &[&[
-            star_results.as_slice(),
-            [ResultValue::Varchar("local".into())].as_slice(),
-        ]
-        .concat()],
+        &format!("SELECT {all_columns} FROM system.local;"),
+        &[&star_results],
     )
     .await;
     assert_query_result(
         connection,
-        "SELECT key, bootstrapped, broadcast_address, cluster_name, cql_version, data_center, gossip_generation, host_id,
-        listen_address, native_protocol_version, partitioner, rack, release_version, rpc_address, schema_version, tokens, truncated_at FROM system.local;",
-        &[&star_results],
+        &format!("SELECT {all_columns}, {all_columns} FROM system.local;"),
+        &[&[star_results.as_slice(), star_results.as_slice()].concat()],
     )
     .await;
 }

--- a/shotover-proxy/tests/cassandra_int_tests/cluster.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cluster.rs
@@ -21,7 +21,7 @@ async fn test_rewrite_system_local(connection: &CassandraConnection) {
         ResultValue::Varchar("3.4.4".into()),
         ResultValue::Varchar("dc1".into()),
         ResultValue::Any,
-        ResultValue::Any,
+        ResultValue::Uuid("2dd022d6-2937-4754-89d6-02d2933a8f7a".parse().unwrap()),
         ResultValue::Inet("127.0.0.1".parse().unwrap()),
         ResultValue::Varchar("4".into()),
         ResultValue::Varchar("org.apache.cassandra.dht.Murmur3Partitioner".into()),
@@ -29,7 +29,9 @@ async fn test_rewrite_system_local(connection: &CassandraConnection) {
         ResultValue::Varchar("3.11.13".into()),
         ResultValue::Inet("0.0.0.0".parse().unwrap()),
         ResultValue::Any,
-        ResultValue::Any,
+        // Unfortunately token generation appears to be non-deterministic but we can at least assert that
+        // there are 128 tokens per node
+        ResultValue::Set(std::iter::repeat(ResultValue::Any).take(3 * 128).collect()),
         ResultValue::Map(vec![]),
     ];
 

--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -110,6 +110,7 @@ async fn test_cluster() {
         functions::test(&connection1).await;
         prepared_statements::test(&connection1).await;
         batch_statements::test(&connection1).await;
+        cluster::test(&connection1).await;
 
         //Check for bugs in cross connection state
         let mut connection2 = shotover_manager
@@ -161,6 +162,7 @@ async fn test_source_tls_and_cluster_tls() {
         collections::test(&connection).await;
         prepared_statements::test(&connection).await;
         batch_statements::test(&connection).await;
+        cluster::test(&connection).await;
     }
 
     cluster::test_topology_task(Some(ca_cert)).await;

--- a/shotover-proxy/tests/cassandra_int_tests/udt.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/udt.rs
@@ -25,10 +25,14 @@ async fn test_drop_udt(session: &CassandraConnection) {
     )
     .await;
     run_query(session, "DROP TYPE test_udt_keyspace.test_type_drop_me;").await;
-    session.execute_expect_err_contains(
-        "CREATE TABLE test_udt_keyspace.test_delete_table (id int PRIMARY KEY, foo test_type_drop_me);",
-        "Unknown type test_udt_keyspace.test_type_drop_me",
-    );
+    // TODO: This exposes a bug in at least cassandra 3
+    // The error is supposed to be a 0x2200 syntax error but rarely cassandra will return a 0x0000 server error instead.
+    // The cpp driver interprets 0x0000 as different to 0x2200 and considers the node as down and will no longer talk to it.
+    // We should eventually reenable this test when we upgrade to cassandra 4 (the bug may also need to be reported and fixed in cassandra 4)
+    // session.execute_expect_err_contains(
+    //     "CREATE TABLE test_udt_keyspace.test_delete_table (id int PRIMARY KEY, foo test_type_drop_me);",
+    //     "Unknown type test_udt_keyspace.test_type_drop_me",
+    // );
 }
 
 pub async fn test(session: &CassandraConnection) {

--- a/shotover-proxy/tests/cassandra_int_tests/udt.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/udt.rs
@@ -28,7 +28,7 @@ async fn test_drop_udt(session: &CassandraConnection) {
     // TODO: This exposes a bug in at least cassandra 3
     // The error is supposed to be a 0x2200 syntax error but rarely cassandra will return a 0x0000 server error instead.
     // The cpp driver interprets 0x0000 as different to 0x2200 and considers the node as down and will no longer talk to it.
-    // We should eventually reenable this test when we upgrade to cassandra 4 (the bug may also need to be reported and fixed in cassandra 4)
+    // We should eventually reenable this test when we upgrade to cassandra 4 (the bug may also need to be reported and fixed in cassandra 3 and/or 4)
     // session.execute_expect_err_contains(
     //     "CREATE TABLE test_udt_keyspace.test_delete_table (id int PRIMARY KEY, foo test_type_drop_me);",
     //     "Unknown type test_udt_keyspace.test_type_drop_me",

--- a/shotover-proxy/tests/helpers/cassandra.rs
+++ b/shotover-proxy/tests/helpers/cassandra.rs
@@ -255,7 +255,10 @@ impl ResultValue {
             ValueType::DOUBLE => ResultValue::Double(value.get_f64().unwrap().into()),
             ValueType::DURATION => ResultValue::Duration(value.get_bytes().unwrap().to_vec()),
             ValueType::FLOAT => ResultValue::Float(value.get_f32().unwrap().into()),
-            ValueType::INET => ResultValue::Inet(value.get_inet().unwrap().to_string()),
+            ValueType::INET => value
+                .get_inet()
+                .map(|x| ResultValue::Inet(x.to_string()))
+                .unwrap_or_else(|_| ResultValue::Inet("NULL address".to_string())),
             ValueType::SMALL_INT => ResultValue::SmallInt(value.get_i16().unwrap()),
             ValueType::TIME => ResultValue::Time(value.get_bytes().unwrap().to_vec()),
             ValueType::TIMESTAMP => ResultValue::Timestamp(value.get_i64().unwrap()),


### PR DESCRIPTION
Misc changes:
* The `v4` uuid feature is needed to enable random uuid generation
* The changes to `ResultValue::new` are needed to allow handling null values in cases that I hit where it wasnt. There are still other null value cases that its not handling properly but I dont know where cassandra will and wont return null values so I'm just leaving the rest to be dealt with when we hit them.
* I introduced an `Any` variant to `ResultValue`, the idea here is to allow `assert_query_results` in cases where there are values that are non deterministic. assert_query_results provides an intuitive way to assert on both the length and the contents of the results so I think `Any` is a lot better approach then just manually doing something like `assert_eq!(results[3], ResultValue::Varchar("blah"))`
* I had to stub out the system.peers table as the cassandra_cpp driver kept routing system.local queries directly to cassandra nodes instead of going through shotover causing my assertions on the system.local table results to fail.

system.local fields:
* release_version - I take the lowest value from any node as this field is most likely to be used for the existence of features so if some nodes dont have a feature then we should consider shotover as not having that feature
* tokens - combine all tokens from nodes in our dc-rack into a single token list, token generation is non-deterministic so we cant hardcode this.
* schema_version - if any peer nodes or the local node (routed to init_handshake_connection) disagree on the schema version a random uuid is returned, otherwise the agreed schema version is returned. DDL queries are also routed to init_handshake_connection which means that a schema disagreement will always be conveyed immediately after a DDL query and it will last until the local node has received gossip that schema agreement has occurred.
* listen_address - extract shotovers address from the client<->shotover socket, this gives us a sane default and the user may still rewrite this address via the CassandraPeersRewrite transform if needed.
* broadcast_address - same as listen_address
* host_id - configured host id. cassandra nodes will generate their own host id and store it without configuration. I didnt take that approach however because we want shotover to be completely stateless. And I think asking the user to manually set a host_id is better than introducing statefulness. Another option is to just randomly generate the host_id each time shotover starts up, but I think its better to be persistent in case drivers rely on that.
* rack - configured rack
* data_center - configured data center
* everything else is just left as is from the init_handshake_connection's response
