### PR TITLE
Nodes list is filtered by rack

### DIFF
--- a/shotover-proxy/example-configs/cassandra-cluster-tls/topology.yaml
+++ b/shotover-proxy/example-configs/cassandra-cluster-tls/topology.yaml
@@ -12,6 +12,7 @@ chain_config:
     - CassandraSinkCluster:
         first_contact_points: ["172.16.1.2:9042", "172.16.1.3:9042"]
         data_center: "dc1"
+        rack: "rack1"
         tls:
           certificate_authority_path: "example-configs/cassandra-tls/certs/localhost_CA.crt"
           certificate_path: "example-configs/cassandra-tls/certs/localhost.crt"

--- a/shotover-proxy/example-configs/cassandra-cluster/topology.yaml
+++ b/shotover-proxy/example-configs/cassandra-cluster/topology.yaml
@@ -8,5 +8,6 @@ chain_config:
     - CassandraSinkCluster:
         first_contact_points: ["172.16.1.2:9042", "172.16.1.3:9042"]
         data_center: "dc1"
+        rack: "rack1"
 source_to_chain_mapping:
   cassandra_prod: main_chain

--- a/shotover-proxy/src/transforms/cassandra/sink_cluster/node.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_cluster/node.rs
@@ -10,7 +10,6 @@ use tokio::sync::{mpsc, oneshot};
 #[derive(Debug, Clone)]
 pub struct CassandraNode {
     pub address: IpAddr,
-    pub _rack: String,
     pub _tokens: Vec<String>,
     pub outbound: Option<CassandraConnection>,
 }

--- a/shotover-proxy/tests/cassandra_int_tests/cluster.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cluster.rs
@@ -15,6 +15,7 @@ pub async fn test() {
         nodes_shared.clone(),
         task_handshake_rx,
         "dc1".to_string(),
+        "rack1".to_string(),
     );
 
     // Give the handshake task a hardcoded handshake.
@@ -54,7 +55,6 @@ pub async fn test() {
             .expect("Node did not contain a unique expected address");
         possible_addresses.remove(address_index);
 
-        assert_eq!(node._rack, "rack1");
         assert_eq!(node._tokens.len(), 128);
     }
 }


### PR DESCRIPTION
As per our design each shotover instance should proxy to a single cassandra rack.
However we havent yet taken that into account in our implementation.

This PR adds a config field for the user to specify which rack the shotover instance is proxying to.
Then we use that configured rack to filter out any nodes outside of that rack.