### PR TITLE
CassandraSinkCluster system.peers rewrite

### DIFF
--- a/shotover-proxy/example-configs/cassandra-cluster-multi-rack/topology_rack1.yaml
+++ b/shotover-proxy/example-configs/cassandra-cluster-multi-rack/topology_rack1.yaml
@@ -7,10 +7,12 @@ chain_config:
   main_chain:
     - CassandraSinkCluster:
         first_contact_points: ["172.16.1.2:9042", "172.16.1.3:9042"]
-        data_center: "dc1"
-        rack: "rack1"
-        host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
-        shotover_peers:
+        local_shotover_host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
+        shotover_nodes:
+          - address: "127.0.0.1:9042"
+            data_center: "dc1"
+            rack: "rack1"
+            host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
           - address: "127.0.0.2:9042"
             data_center: "dc1"
             rack: "rack2"

--- a/shotover-proxy/example-configs/cassandra-cluster-multi-rack/topology_rack2.yaml
+++ b/shotover-proxy/example-configs/cassandra-cluster-multi-rack/topology_rack2.yaml
@@ -10,5 +10,14 @@ chain_config:
         data_center: "dc1"
         rack: "rack2"
         host_id: "3c3c4e2d-ba74-4f76-b52e-fb5bcee6a9f4"
+        shotover_peers:
+          - address: "127.0.0.1:9042"
+            data_center: "dc1"
+            rack: "rack1"
+            host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
+          - address: "127.0.0.3:9042"
+            data_center: "dc1"
+            rack: "rack3"
+            host_id: "fa74d7ec-1223-472b-97de-04a32ccdb70b"
 source_to_chain_mapping:
   cassandra_prod: main_chain

--- a/shotover-proxy/example-configs/cassandra-cluster-multi-rack/topology_rack2.yaml
+++ b/shotover-proxy/example-configs/cassandra-cluster-multi-rack/topology_rack2.yaml
@@ -7,14 +7,16 @@ chain_config:
   main_chain:
     - CassandraSinkCluster:
         first_contact_points: ["172.16.1.2:9042", "172.16.1.3:9042"]
-        data_center: "dc1"
-        rack: "rack2"
-        host_id: "3c3c4e2d-ba74-4f76-b52e-fb5bcee6a9f4"
-        shotover_peers:
+        local_shotover_host_id: "3c3c4e2d-ba74-4f76-b52e-fb5bcee6a9f4"
+        shotover_nodes:
           - address: "127.0.0.1:9042"
             data_center: "dc1"
             rack: "rack1"
             host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
+          - address: "127.0.0.2:9042"
+            data_center: "dc1"
+            rack: "rack2"
+            host_id: "3c3c4e2d-ba74-4f76-b52e-fb5bcee6a9f4"
           - address: "127.0.0.3:9042"
             data_center: "dc1"
             rack: "rack3"

--- a/shotover-proxy/example-configs/cassandra-cluster-multi-rack/topology_rack3.yaml
+++ b/shotover-proxy/example-configs/cassandra-cluster-multi-rack/topology_rack3.yaml
@@ -7,10 +7,8 @@ chain_config:
   main_chain:
     - CassandraSinkCluster:
         first_contact_points: ["172.16.1.2:9042", "172.16.1.3:9042"]
-        data_center: "dc1"
-        rack: "rack3"
-        host_id: "fa74d7ec-1223-472b-97de-04a32ccdb70b"
-        shotover_peers:
+        local_shotover_host_id: "fa74d7ec-1223-472b-97de-04a32ccdb70b"
+        shotover_nodes:
           - address: "127.0.0.1:9042"
             data_center: "dc1"
             rack: "rack1"
@@ -19,5 +17,9 @@ chain_config:
             data_center: "dc1"
             rack: "rack2"
             host_id: "3c3c4e2d-ba74-4f76-b52e-fb5bcee6a9f4"
+          - address: "127.0.0.3:9042"
+            data_center: "dc1"
+            rack: "rack3"
+            host_id: "fa74d7ec-1223-472b-97de-04a32ccdb70b"
 source_to_chain_mapping:
   cassandra_prod: main_chain

--- a/shotover-proxy/example-configs/cassandra-cluster-multi-rack/topology_rack3.yaml
+++ b/shotover-proxy/example-configs/cassandra-cluster-multi-rack/topology_rack3.yaml
@@ -10,5 +10,14 @@ chain_config:
         data_center: "dc1"
         rack: "rack3"
         host_id: "fa74d7ec-1223-472b-97de-04a32ccdb70b"
+        shotover_peers:
+          - address: "127.0.0.1:9042"
+            data_center: "dc1"
+            rack: "rack1"
+            host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
+          - address: "127.0.0.2:9042"
+            data_center: "dc1"
+            rack: "rack2"
+            host_id: "3c3c4e2d-ba74-4f76-b52e-fb5bcee6a9f4"
 source_to_chain_mapping:
   cassandra_prod: main_chain

--- a/shotover-proxy/example-configs/cassandra-cluster-tls/topology.yaml
+++ b/shotover-proxy/example-configs/cassandra-cluster-tls/topology.yaml
@@ -14,6 +14,7 @@ chain_config:
         data_center: "dc1"
         rack: "rack1"
         host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
+        shotover_peers: []
         tls:
           certificate_authority_path: "example-configs/cassandra-tls/certs/localhost_CA.crt"
           certificate_path: "example-configs/cassandra-tls/certs/localhost.crt"

--- a/shotover-proxy/example-configs/cassandra-cluster-tls/topology.yaml
+++ b/shotover-proxy/example-configs/cassandra-cluster-tls/topology.yaml
@@ -11,10 +11,13 @@ chain_config:
   main_chain:
     - CassandraSinkCluster:
         first_contact_points: ["172.16.1.2:9042", "172.16.1.3:9042"]
-        data_center: "dc1"
-        rack: "rack1"
         host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
-        shotover_peers: []
+        local_shotover_host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
+        shotover_nodes:
+          - address: "127.0.0.1:9042"
+            data_center: "dc1"
+            rack: "rack1"
+            host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
         tls:
           certificate_authority_path: "example-configs/cassandra-tls/certs/localhost_CA.crt"
           certificate_path: "example-configs/cassandra-tls/certs/localhost.crt"

--- a/shotover-proxy/example-configs/cassandra-cluster/topology-dummy-peers.yaml
+++ b/shotover-proxy/example-configs/cassandra-cluster/topology-dummy-peers.yaml
@@ -10,14 +10,18 @@ chain_config:
         data_center: "dc1"
         rack: "rack1"
         host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
+        # These peers dont really make sense, its pointing at the same address as this shotover instance.
+        # It is however useful for testing the functionality of the system.peers rewriting.
+        # We can make stronger assertions against the values returned by system.peers with this config because
+        # more system.peers fields are static due to always being queried against this one shotover instance.
         shotover_peers:
-          - address: "127.0.0.2:9042"
+          - address: "127.0.0.1:9042"
             data_center: "dc1"
-            rack: "rack2"
+            rack: "rack1"
             host_id: "3c3c4e2d-ba74-4f76-b52e-fb5bcee6a9f4"
-          - address: "127.0.0.3:9042"
+          - address: "127.0.0.1:9042"
             data_center: "dc1"
-            rack: "rack3"
+            rack: "rack1"
             host_id: "fa74d7ec-1223-472b-97de-04a32ccdb70b"
 source_to_chain_mapping:
   cassandra_prod: main_chain

--- a/shotover-proxy/example-configs/cassandra-cluster/topology-dummy-peers.yaml
+++ b/shotover-proxy/example-configs/cassandra-cluster/topology-dummy-peers.yaml
@@ -7,14 +7,16 @@ chain_config:
   main_chain:
     - CassandraSinkCluster:
         first_contact_points: ["172.16.1.2:9042", "172.16.1.3:9042"]
-        data_center: "dc1"
-        rack: "rack1"
-        host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
-        # These peers dont really make sense, its pointing at the same address as this shotover instance.
-        # It is however useful for testing the functionality of the system.peers rewriting.
-        # We can make stronger assertions against the values returned by system.peers with this config because
-        # more system.peers fields are static due to always being queried against this one shotover instance.
-        shotover_peers:
+        local_shotover_host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
+        shotover_nodes:
+          - address: "127.0.0.1:9042"
+            data_center: "dc1"
+            rack: "rack1"
+            host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
+          # These extra nodes dont really make sense, its pointing at the same address as the local shotover node.
+          # It is however useful for testing the functionality of the system.peers rewriting.
+          # We can make stronger assertions against the values returned by system.peers with this config because
+          # more system.peers fields are static due to always being queried against this one shotover instance.
           - address: "127.0.0.1:9042"
             data_center: "dc1"
             rack: "rack1"

--- a/shotover-proxy/example-configs/cassandra-cluster/topology.yaml
+++ b/shotover-proxy/example-configs/cassandra-cluster/topology.yaml
@@ -7,9 +7,12 @@ chain_config:
   main_chain:
     - CassandraSinkCluster:
         first_contact_points: ["172.16.1.2:9042", "172.16.1.3:9042"]
-        data_center: "dc1"
-        rack: "rack1"
-        host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
-        shotover_peers: []
+        local_shotover_host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
+        shotover_nodes:
+          - address: "127.0.0.1:9042"
+            data_center: "dc1"
+            rack: "rack1"
+            host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
+
 source_to_chain_mapping:
   cassandra_prod: main_chain

--- a/shotover-proxy/example-configs/cassandra-cluster/topology.yaml
+++ b/shotover-proxy/example-configs/cassandra-cluster/topology.yaml
@@ -10,5 +10,6 @@ chain_config:
         data_center: "dc1"
         rack: "rack1"
         host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
+        shotover_peers: []
 source_to_chain_mapping:
   cassandra_prod: main_chain

--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -124,6 +124,20 @@ async fn test_cluster_single_rack() {
         native_types::test(&connection2).await;
     }
 
+    {
+        let shotover_manager = ShotoverManager::from_topology_file(
+            "example-configs/cassandra-cluster/topology-dummy-peers.yaml",
+        );
+
+        let mut connection = shotover_manager
+            .cassandra_connection("127.0.0.1", 9042)
+            .await;
+        connection
+            .enable_schema_awaiter("172.16.1.2:9042", None)
+            .await;
+        cluster::test_dummy_peers(&connection).await;
+    }
+
     cluster::test_topology_task(None).await;
 }
 


### PR DESCRIPTION
Introduced a new integration test `test_cluster_multi_rack` it tests all the same cases as `test_cluster` but each cassandra node is on a different rack and each cassandra node has its own shotover instance in front of it.
The existing `test_cluster` was renamed to `test_cluster_single_rack` and now runs two shotover test cases against the cassandra cluster.
One to test an empty peers list and one to test a consistent peers list.

The derived fields of system.peers should be non controversial as its the same as system.local.

## Config design thoughts
This PR configures the configurable fields with the following configuration:
```yaml
    - CassandraSinkCluster:
        first_contact_points: ["172.16.1.2:9042", "172.16.1.3:9042"]
        data_center: "dc1"
        rack: "rack1"
        host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
        shotover_peers:
          - address: "127.0.0.2:9042"
            data_center: "dc1"
            rack: "rack2"
            host_id: "3c3c4e2d-ba74-4f76-b52e-fb5bcee6a9f4"
          - address: "127.0.0.3:9042"
            data_center: "dc2"
            rack: "rack1"
            host_id: "fa74d7ec-1223-472b-97de-04a32ccdb70b"
```

I am strongly considering changing this such that each config specifies a complete list of nodes and then specifies which node is the local node:
```yaml
    - CassandraSinkCluster:
        first_contact_points: ["172.16.1.2:9042", "172.16.1.3:9042"]
        local_host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
        nodes:
          - address: "127.0.0.1:9042"
            data_center: "dc1"
            rack: "rack1"
            host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
          - address: "127.0.0.2:9042"
            data_center: "dc1"
            rack: "rack2"
            host_id: "3c3c4e2d-ba74-4f76-b52e-fb5bcee6a9f4"
          - address: "127.0.0.3:9042"
            data_center: "dc2"
            rack: "rack1"
            host_id: "fa74d7ec-1223-472b-97de-04a32ccdb70b"
```
This should make config generation/authoring drastically simpler for multi shotover instance setups but at the cost of some complexity for single shotover instance setups.

However I would like to land this PR with the first implementation as its a lot simpler to implement, then we can move to the second implementation (if we agree) post MVP.