### PR TITLE
Add test_cluster_multi_rack

### DIFF
--- a/shotover-proxy/example-configs/cassandra-cluster-multi-rack/docker-compose.yml
+++ b/shotover-proxy/example-configs/cassandra-cluster-multi-rack/docker-compose.yml
@@ -1,0 +1,73 @@
+version: "3.3"
+networks:
+  cluster_subnet:
+    name: cluster_subnet
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.16.1.0/24
+          gateway: 172.16.1.1
+
+services:
+  cassandra-one:
+    image: bitnami/cassandra:3.11
+    networks:
+      cluster_subnet:
+        ipv4_address: 172.16.1.2
+    healthcheck:
+      &healthcheck
+      test: [ "CMD", "cqlsh", "-e", "describe keyspaces" ]
+      interval: 5s
+      timeout: 5s
+      retries: 60
+    environment:
+      CASSANDRA_SEEDS: "cassandra-one,cassandra-two"
+      CASSANDRA_CLUSTER_NAME: TestCluster
+      CASSANDRA_DC: dc1
+      CASSANDRA_RACK: rack1
+      CASSANDRA_ENDPOINT_SNITCH: GossipingPropertyFileSnitch
+      CASSANDRA_NUM_TOKENS: 128
+      MAX_HEAP_SIZE: "400M"
+      MIN_HEAP_SIZE: "400M"
+      HEAP_NEWSIZE: "48M"
+      CASSANDRA_ENABLE_SCRIPTED_USER_DEFINED_FUNCTIONS: "true"
+      CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS: "true"
+
+  cassandra-two:
+    image: bitnami/cassandra:3.11
+    networks:
+      cluster_subnet:
+        ipv4_address: 172.16.1.3
+    healthcheck: *healthcheck
+    environment:
+      CASSANDRA_SEEDS: "cassandra-one,cassandra-two"
+      CASSANDRA_CLUSTER_NAME: TestCluster
+      CASSANDRA_DC: dc1
+      CASSANDRA_RACK: rack2
+      CASSANDRA_ENDPOINT_SNITCH: GossipingPropertyFileSnitch
+      CASSANDRA_NUM_TOKENS: 128
+      MAX_HEAP_SIZE: "400M"
+      MIN_HEAP_SIZE: "400M"
+      HEAP_NEWSIZE: "48M"
+      CASSANDRA_ENABLE_SCRIPTED_USER_DEFINED_FUNCTIONS: "true"
+      CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS: "true"
+
+  cassandra-three:
+    image: bitnami/cassandra:3.11
+    networks:
+      cluster_subnet:
+        ipv4_address: 172.16.1.4
+    healthcheck: *healthcheck
+    environment:
+      CASSANDRA_SEEDS: "cassandra-one,cassandra-two"
+      CASSANDRA_CLUSTER_NAME: TestCluster
+      CASSANDRA_DC: dc1
+      CASSANDRA_RACK: rack3
+      CASSANDRA_ENDPOINT_SNITCH: GossipingPropertyFileSnitch
+      CASSANDRA_NUM_TOKENS: 128
+      MAX_HEAP_SIZE: "400M"
+      MIN_HEAP_SIZE: "400M"
+      HEAP_NEWSIZE: "48M"
+      CASSANDRA_ENABLE_SCRIPTED_USER_DEFINED_FUNCTIONS: "true"
+      CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS: "true"

--- a/shotover-proxy/example-configs/cassandra-cluster-multi-rack/topology_rack1.yaml
+++ b/shotover-proxy/example-configs/cassandra-cluster-multi-rack/topology_rack1.yaml
@@ -1,0 +1,14 @@
+---
+sources:
+  cassandra_prod:
+    Cassandra:
+      listen_addr: "127.0.0.1:9042"
+chain_config:
+  main_chain:
+    - CassandraSinkCluster:
+        first_contact_points: ["172.16.1.2:9042", "172.16.1.3:9042"]
+        data_center: "dc1"
+        rack: "rack1"
+        host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
+source_to_chain_mapping:
+  cassandra_prod: main_chain

--- a/shotover-proxy/example-configs/cassandra-cluster-multi-rack/topology_rack2.yaml
+++ b/shotover-proxy/example-configs/cassandra-cluster-multi-rack/topology_rack2.yaml
@@ -1,0 +1,14 @@
+---
+sources:
+  cassandra_prod:
+    Cassandra:
+      listen_addr: "127.0.0.2:9042"
+chain_config:
+  main_chain:
+    - CassandraSinkCluster:
+        first_contact_points: ["172.16.1.2:9042", "172.16.1.3:9042"]
+        data_center: "dc1"
+        rack: "rack2"
+        host_id: "3c3c4e2d-ba74-4f76-b52e-fb5bcee6a9f4"
+source_to_chain_mapping:
+  cassandra_prod: main_chain

--- a/shotover-proxy/example-configs/cassandra-cluster-multi-rack/topology_rack3.yaml
+++ b/shotover-proxy/example-configs/cassandra-cluster-multi-rack/topology_rack3.yaml
@@ -1,0 +1,14 @@
+---
+sources:
+  cassandra_prod:
+    Cassandra:
+      listen_addr: "127.0.0.3:9042"
+chain_config:
+  main_chain:
+    - CassandraSinkCluster:
+        first_contact_points: ["172.16.1.2:9042", "172.16.1.3:9042"]
+        data_center: "dc1"
+        rack: "rack3"
+        host_id: "fa74d7ec-1223-472b-97de-04a32ccdb70b"
+source_to_chain_mapping:
+  cassandra_prod: main_chain

--- a/shotover-proxy/tests/cassandra_int_tests/cluster_multi_rack.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cluster_multi_rack.rs
@@ -1,0 +1,102 @@
+use crate::cassandra_int_tests::cluster::run_topology_task;
+use crate::helpers::cassandra::{assert_query_result, CassandraConnection, ResultValue};
+use std::net::IpAddr;
+
+async fn test_rewrite_system_peers(connection: &CassandraConnection) {
+    let all_columns = "peer, data_center, host_id, preferred_ip, rack, release_version, rpc_address, schema_version, tokens";
+    assert_query_result(connection, "SELECT * FROM system.peers;", &[]).await;
+    assert_query_result(
+        connection,
+        &format!("SELECT {all_columns} FROM system.peers;"),
+        &[],
+    )
+    .await;
+    assert_query_result(
+        connection,
+        &format!("SELECT {all_columns}, {all_columns} FROM system.peers;"),
+        &[],
+    )
+    .await;
+}
+
+async fn test_rewrite_system_local(connection: &CassandraConnection) {
+    let star_results = [
+        ResultValue::Varchar("local".into()),
+        ResultValue::Varchar("COMPLETED".into()),
+        // broadcast address is non-deterministic because we dont know which node this will be
+        ResultValue::Any,
+        ResultValue::Varchar("TestCluster".into()),
+        ResultValue::Varchar("3.4.4".into()),
+        ResultValue::Varchar("dc1".into()),
+        // gossip_generation is non deterministic cant assert on it
+        ResultValue::Any,
+        // host_id is non-deterministic because we dont know which node this will be
+        ResultValue::Any,
+        ResultValue::Inet("127.0.0.1".parse().unwrap()),
+        ResultValue::Varchar("4".into()),
+        ResultValue::Varchar("org.apache.cassandra.dht.Murmur3Partitioner".into()),
+        // rack is non-deterministic because we dont know which node this will be
+        ResultValue::Any,
+        ResultValue::Varchar("3.11.13".into()),
+        ResultValue::Inet("0.0.0.0".parse().unwrap()),
+        // schema_version is non deterministic so we cant assert on it.
+        ResultValue::Any,
+        // thrift_version isnt used anymore so I dont really care what it maps to
+        ResultValue::Any,
+        // Unfortunately token generation appears to be non-deterministic but we can at least assert that
+        // there are 128 tokens per node
+        ResultValue::Set(std::iter::repeat(ResultValue::Any).take(128).collect()),
+        ResultValue::Map(vec![]),
+    ];
+
+    let all_columns =
+        "key, bootstrapped, broadcast_address, cluster_name, cql_version, data_center,
+        gossip_generation, host_id, listen_address, native_protocol_version, partitioner, rack,
+        release_version, rpc_address, schema_version, thrift_version, tokens, truncated_at";
+
+    assert_query_result(connection, "SELECT * FROM system.local;", &[&star_results]).await;
+    assert_query_result(
+        connection,
+        &format!("SELECT {all_columns} FROM system.local;"),
+        &[&star_results],
+    )
+    .await;
+    assert_query_result(
+        connection,
+        &format!("SELECT {all_columns}, {all_columns} FROM system.local;"),
+        &[&[star_results.as_slice(), star_results.as_slice()].concat()],
+    )
+    .await;
+}
+
+pub async fn test(connection: &CassandraConnection) {
+    test_rewrite_system_local(connection).await;
+    test_rewrite_system_peers(connection).await;
+}
+
+pub async fn test_topology_task(ca_path: Option<&str>) {
+    let nodes = run_topology_task(ca_path).await;
+
+    assert_eq!(nodes.len(), 3);
+    let mut possible_addresses: Vec<IpAddr> = vec![
+        "172.16.1.2".parse().unwrap(),
+        "172.16.1.3".parse().unwrap(),
+        "172.16.1.4".parse().unwrap(),
+    ];
+    let mut possible_racks: Vec<&str> = vec!["rack1", "rack2", "rack3"];
+    for node in &nodes {
+        let address_index = possible_addresses
+            .iter()
+            .position(|x| *x == node.address)
+            .expect("Node did not contain a unique expected address");
+        possible_addresses.remove(address_index);
+
+        let rack_index = possible_racks
+            .iter()
+            .position(|x| *x == node._rack)
+            .expect("Node did not contain a unique expected rack");
+        possible_racks.remove(rack_index);
+
+        assert_eq!(node._tokens.len(), 128);
+    }
+}

--- a/test-helpers/src/docker_compose.rs
+++ b/test-helpers/src/docker_compose.rs
@@ -127,6 +127,7 @@ impl DockerCompose {
             }
             "example-configs-docker/cassandra-peers-rewrite/docker-compose.yml"
             | "example-configs/cassandra-cluster/docker-compose.yml"
+            | "example-configs/cassandra-cluster-multi-rack/docker-compose.yml"
             | "example-configs/cassandra-cluster-tls/docker-compose.yml" => {
                 self.wait_for_log("Startup complete", 3, 180)
             }


### PR DESCRIPTION
Pulled out of https://github.com/shotover/shotover-proxy/pull/756
Should reduce the scope of 756 a bit and will also let me test and fix a preexisting issue.

Introduced a new integration test `test_cluster_multi_rack` it tests all the same cases as `test_cluster` but each cassandra node is on a different rack and each cassandra node has its own shotover instance in front of it.

The fix to the issue is not complete but a full fix will require deciding between:
1. changing the design of the transform such that providing a node outside of the datacenter/rack in the contact points will cause shotover to return errors to every incoming message as upholding our invariants in that case is too tricky.
2. rewrite system.local rewriting to send an additional system.local

This PR makes enough progress to 2 to fix the test failure but does not commit to sending an additional system.local message yet.

Lets land this PR, its strictly an improvement to both implementation and integration tests, and we can decide between 1 or 2 later on.