### PR TITLE
remove drop function test

### DIFF
--- a/shotover-proxy/tests/cassandra_int_tests/functions.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/functions.rs
@@ -7,11 +7,6 @@ async fn drop_function(session: &CassandraConnection) {
         &[&[ResultValue::Int(4)]]
     ).await;
     run_query(session, "DROP FUNCTION test_function_keyspace.my_function").await;
-
-    session.execute_expect_err_contains(
-        "SELECT test_function_keyspace.my_function(x) FROM test_function_keyspace.test_function_table WHERE id=1;",
-        "Unknown function 'test_function_keyspace.my_function'",
-    );
 }
 
 async fn create_function(session: &CassandraConnection) {


### PR DESCRIPTION
Main is failing with this error: 
```
2022-08-25T12:24:54.7233573Z thread 'cassandra_int_tests::test_cluster_multi_rack' panicked at 'Expected the error to contain 'Unknown function 'test_function_keyspace.my_function'' but it did not and was instead 'Cassandra detailed error SERVER_INVALID_QUERY: Invalid number of arguments in call to function
```

I can't find any mention of functions in the schema version agreement docs so that leads me to believe that awaiting for schema agreement does not include functions.

Decided to remove this test rather than implement something to wait for changes to functions to propagate throughout the cluster since it's not testing any particular edge case.