### PR TITLE
Release shotover v0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2727,7 +2727,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "shotover-proxy"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shotover-proxy"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Ben <ben@instaclustr.com>"]
 edition = "2021"
 rust-version = "1.56"


### PR DESCRIPTION
To allow testing to begin on the CassandraSinkCluster MVP