### PR TITLE
Build aarch64 in CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,6 @@ rustflags = [
   "-C", "link-arg=-undefined",
   "-C", "link-arg=dynamic_lookup",
 ]
+
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,43 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+# Cancel already running jobs
+concurrency:
+  group: build_${{ github.head_ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - name: Ubuntu 22.04 - Release - x86_64
+            runner: ubuntu-22.04
+            cargo_flags: --release
+          - name: Ubuntu 22.04 - Release - aarch64
+            runner: ubuntu-22.04
+            cargo_flags: --target aarch64-unknown-linux-gnu --release
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v2
+        # We purposefully dont cache here as build_and_test will always be the bottleneck
+        # so we should leave the cache alone so build_and_test can make more use of it.
+      - name: Install ubuntu packages
+        run: shotover-proxy/build/install_ubuntu_packages.sh
+      - name: Install cargo-hack
+        run: cargo install cargo-hack --version 0.5.8
+      - name: Ensure that shotover-proxy compiles and has no warnings under every possible combination of features
+        # some things to explicitly point out:
+        # * clippy also reports rustc warnings and errors
+        # * clippy --all-targets is not run so we only build the shotover_proxy executable
+        run: cargo hack --feature-powerset clippy --locked ${{ matrix.cargo_flags }} -- -D warnings

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,4 +1,4 @@
-name: Testing
+name: Build and Test
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
 
 # Cancel already running jobs
 concurrency:
-  group: testing_${{ github.head_ref }}
+  group: build_and_test_${{ github.head_ref }}
   cancel-in-progress: true
 
 env:
@@ -60,32 +60,3 @@ jobs:
           git status
           exit 1
         fi
-
-  # We purposefully dont cache here as build_and_test takes far longer
-  # so we should leave the cache alone so build_and_test can make more use of it.
-  build_only:
-    strategy:
-      matrix:
-        include:
-          - name: Ubuntu 22.04 - Debug - x86_64
-            runner: ubuntu-22.04
-            cargo_flags:
-          - name: Ubuntu 22.04 - Debug - aarch64
-            runner: ubuntu-22.04
-            cargo_flags: --target aarch64-unknown-linux-gnu
-    name: ${{ matrix.name }}
-    runs-on: ${{ matrix.runner }}
-    steps:
-      - name: Install cargo-hack
-        run: cargo install cargo-hack --version 0.5.8
-      - name: Ensure that all crates compile and have no warnings under every possible combination of features
-        # some things to explicitly point out:
-        # * clippy also reports rustc warnings and errors
-        # * clippy --all-targets causes clippy to run against tests and examples which it doesnt do by default.
-        run: cargo hack --feature-powerset clippy --all-targets --locked ${{ matrix.cargo_flags }} -- -D warnings
-
-  license_check:
-    name: License Check
-      run: |
-        cargo install --locked cargo-deny
-        cargo deny check licenses

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -1,0 +1,25 @@
+name: License Check
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+# Cancel already running jobs
+concurrency:
+  group: license_check_${{ github.head_ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  license_check:
+    runs-on: ubuntu-22.04
+    name: License Check
+    steps:
+      - uses: actions/checkout@v2
+      - run: cargo install --locked cargo-deny
+      - run: cargo deny check licenses

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,19 +16,17 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  build:
+  build_and_test:
     strategy:
       matrix:
         include:
+          # the cassandra cpp driver is only supported on 18.04
           - name: Ubuntu 18.04 - Release
             runner: ubuntu-18.04
-            cargo_profile: --release
+            cargo_flags: --release
           - name: Ubuntu 18.04 - Debug
             runner: ubuntu-18.04
-            cargo_profile:
-          - name: Ubuntu 20.04 - Debug
-            runner: ubuntu-20.04
-            cargo_profile:
+            cargo_flags:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
     steps:
@@ -50,11 +48,9 @@ jobs:
       # some things to explicitly point out:
       # * clippy also reports rustc warnings and errors
       # * clippy --all-targets causes clippy to run against tests and examples which it doesnt do by default.
-      run: cargo hack --feature-powerset clippy --all-targets --locked ${{ matrix.cargo_profile }} -- -D warnings
+      run: cargo hack --feature-powerset clippy --all-targets --locked ${{ matrix.cargo_flags }} -- -D warnings
     - name: Ensure that tests pass
-      run: cargo test ${{ matrix.cargo_profile }} --all-features -- --include-ignored --show-output --nocapture
-      # can not run tests if cpp driver not installed
-      if: ${{ matrix.runner == 'ubuntu-18.04' }}
+      run: cargo test ${{ matrix.cargo_flags }} --all-features -- --include-ignored --show-output --nocapture
     - name: Ensure that custom benches run
       run: cargo run --release --example cassandra_bench -- --config-dir example-configs/cassandra-passthrough --rate 1000
       if: ${{ matrix.name == 'Ubuntu 18.04 - Release' }}
@@ -64,8 +60,32 @@ jobs:
           git status
           exit 1
         fi
-    - name: License Check
+
+  # We purposefully dont cache here as build_and_test takes far longer
+  # so we should leave the cache alone so build_and_test can make more use of it.
+  build_only:
+    strategy:
+      matrix:
+        include:
+          - name: Ubuntu 22.04 - Debug - x86_64
+            runner: ubuntu-22.04
+            cargo_flags:
+          - name: Ubuntu 22.04 - Debug - aarch64
+            runner: ubuntu-22.04
+            cargo_flags: --target aarch64-unknown-linux-gnu
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Install cargo-hack
+        run: cargo install cargo-hack --version 0.5.8
+      - name: Ensure that all crates compile and have no warnings under every possible combination of features
+        # some things to explicitly point out:
+        # * clippy also reports rustc warnings and errors
+        # * clippy --all-targets causes clippy to run against tests and examples which it doesnt do by default.
+        run: cargo hack --feature-powerset clippy --all-targets --locked ${{ matrix.cargo_flags }} -- -D warnings
+
+  license_check:
+    name: License Check
       run: |
         cargo install --locked cargo-deny
         cargo deny check licenses
-      if: ${{ matrix.name == 'Ubuntu 20.04 - Debug' }}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "1.63"
 components = [ "rustfmt", "clippy" ]
+targets = [ "aarch64-unknown-linux-gnu" ]

--- a/shotover-proxy/build/install_ubuntu_packages.sh
+++ b/shotover-proxy/build/install_ubuntu_packages.sh
@@ -3,7 +3,7 @@
 set -e
 
 sudo apt-get update
-sudo apt-get install -y libpcap-dev wget
+sudo apt-get install -y libpcap-dev wget gcc-aarch64-linux-gnu
 
 . /etc/lsb-release
 


### PR DESCRIPTION
In order to build shotover for aarch64 locally I needed to add:
```toml
[target.aarch64-unknown-linux-gnu]
linker = "aarch64-linux-gnu-gcc"
```
and install the aarch64 gcc

Adding the aarch64 to CI resulted in imo one too many magic CI if statements so I refactored test.yml into 3 separate workflows