### PR TITLE
CassandraSinkCluster fix connecting to non-local clusters

### DIFF
--- a/shotover-proxy/src/transforms/cassandra/sink_cluster/mod.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_cluster/mod.rs
@@ -774,7 +774,7 @@ async fn topology_task_process(
             warnings: vec![],
             operation: CassandraOperation::Query {
                 query: Box::new(parse_statement_single(
-                    "SELECT listen_address, rack, data_center, tokens FROM system.local",
+                    "SELECT broadcast_address, rack, data_center, tokens FROM system.local",
                 )),
                 params: Box::new(QueryParams::default()),
             },


### PR DESCRIPTION
closes https://github.com/shotover/shotover-proxy/issues/767

The problem was caused by `TcpStream::connect` blocking indefinitely when given a meaningless local ip instead of the global ip that we actually meant to give it.
The fix is: when generating the node list we need to query the correct system.local field `broadcast_address` that gives us the global ip that we actually wanted, instead of `listen_address` which gives us the local ip.