### PR TITLE
Cleanup cassandra protocol negotiation

### DIFF
--- a/shotover-proxy/src/message/mod.rs
+++ b/shotover-proxy/src/message/mod.rs
@@ -53,7 +53,6 @@ pub struct Message {
     /// It is an invariant that this field must remain Some at all times.
     /// The only reason it is an Option is to allow temporarily taking ownership of the value from an &mut T
     inner: Option<MessageInner>,
-    pub return_to_sender: bool,
 
     // TODO: Not a fan of this field and we could get rid of it by making TimestampTagger an implicit part of ConsistentScatter
     // This metadata field is only used for communication between transforms and should not be touched by sinks or sources
@@ -71,7 +70,6 @@ impl Message {
                 bytes,
                 message_type,
             }),
-            return_to_sender: false,
             meta_timestamp: None,
         }
     }
@@ -82,7 +80,6 @@ impl Message {
     pub fn from_bytes_and_frame(bytes: Bytes, frame: Frame) -> Self {
         Message {
             inner: Some(MessageInner::Parsed { bytes, frame }),
-            return_to_sender: false,
             meta_timestamp: None,
         }
     }
@@ -93,7 +90,6 @@ impl Message {
     pub fn from_frame(frame: Frame) -> Self {
         Message {
             inner: Some(MessageInner::Modified { frame }),
-            return_to_sender: false,
             meta_timestamp: None,
         }
     }

--- a/shotover-proxy/src/transforms/cassandra/connection.rs
+++ b/shotover-proxy/src/transforms/cassandra/connection.rs
@@ -153,7 +153,7 @@ async fn rx_process_fallible<T: AsyncRead>(
                         }
                     }
                     Err(e) => {
-                        return Err(e.context("Encountered error while communicating with destination cassandra node"));
+                        return Err(anyhow!("{:?}", e).context("Encountered error while communicating with destination cassandra node"));
                     }
                 }
             },

--- a/shotover-proxy/src/transforms/redis/sink_single.rs
+++ b/shotover-proxy/src/transforms/redis/sink_single.rs
@@ -3,6 +3,7 @@ use crate::error::ChainResponse;
 use crate::frame::Frame;
 use crate::frame::RedisFrame;
 use crate::message::{Message, Messages};
+use crate::server::CodecReadError;
 use crate::tls::{AsyncStream, TlsConnector, TlsConnectorConfig};
 use crate::transforms::{Transform, Transforms, Wrapper};
 use anyhow::{anyhow, Context, Result};
@@ -213,7 +214,7 @@ async fn server_response_processing_task(
 
 /// returns true when the task should shutdown
 async fn process_server_response(
-    responses: Option<Result<Messages>>,
+    responses: Option<Result<Messages, CodecReadError>>,
     subscribe_tx: &Option<mpsc::UnboundedSender<Messages>>,
     response_messages_tx: &mpsc::UnboundedSender<Message>,
     is_subscribed: &mut bool,


### PR DESCRIPTION
Improves error reporting and makes the cassandra protocol implementation easier to understand.
Downgrades the warnings caused by cassandra protocol negotiation to `info!` level.
It certainly makes the integration tests quieter, but maybe the slight performance loss of protocol negotiation is worth a warning?

Theres some magic trait type stuff going on here:
In these lines:
```rust
pub trait CodecReadHalf: Decoder<Item = Messages, Error = CodecReadError> + Clone + Send {}
impl<T: Decoder<Item = Messages, Error = CodecReadError> + Clone + Send> CodecReadHalf for T {}
```
We can set any type to be the Error as long as it implements `From<std::io::Error>`.
Internally tokio then uses that implementation to generate errors in our type when it hits an `io::Error` while receiving from the TcpStream.
So while we never create a `CodecReadError::Io` directly, tokio will return those sometimes when we call `FrameRead::next`.