### PR TITLE
Avoid creating AST for queries in CassandraSinkCluster

### DIFF
--- a/shotover-proxy/src/transforms/cassandra/sink_cluster/mod.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_cluster/mod.rs
@@ -195,6 +195,8 @@ fn create_query_with_generated_stream_id(
         tracing_id: None,
         warnings: vec![],
         operation: CassandraOperation::Query {
+            // Using CassandraStatement::Unknown in a non sink transform would cause problems because the query would be inaccessible to transforms further down the chain.
+            // However using it in a sink transform is a performance hack that is safe because no further transforms need access to the AST.
             query: Box::new(CassandraStatement::Unknown(query)),
             params: Box::new(QueryParams::default()),
         },
@@ -210,6 +212,8 @@ fn create_query(query: String, version: Version, stream_id: i16) -> Message {
         tracing_id: None,
         warnings: vec![],
         operation: CassandraOperation::Query {
+            // Using CassandraStatement::Unknown in a non sink transform would cause problems because the query would be inaccessible to transforms further down the chain.
+            // However using it in a sink transform is a performance hack that is safe because no further transforms need access to the AST.
             query: Box::new(CassandraStatement::Unknown(query)),
             params: Box::new(QueryParams::default()),
         },

--- a/shotover-proxy/src/transforms/cassandra/sink_cluster/topology.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_cluster/topology.rs
@@ -1,10 +1,10 @@
 use super::node::{CassandraNode, ConnectionFactory};
-use crate::frame::cassandra::parse_statement_single;
 use crate::frame::{CassandraFrame, CassandraOperation, CassandraResult, Frame};
 use crate::message::{Message, MessageValue};
 use anyhow::{anyhow, Result};
 use cassandra_protocol::frame::Version;
 use cassandra_protocol::query::QueryParams;
+use cql3_parser::cassandra_statement::CassandraStatement;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot, RwLock};
@@ -60,8 +60,8 @@ async fn topology_task_process(
             tracing_id: None,
             warnings: vec![],
             operation: CassandraOperation::Query {
-                query: Box::new(parse_statement_single(
-                    "SELECT peer, rack, data_center, tokens FROM system.peers",
+                query: Box::new(CassandraStatement::Unknown(
+                    "SELECT peer, rack, data_center, tokens FROM system.peers".into(),
                 )),
                 params: Box::new(QueryParams::default()),
             },
@@ -77,8 +77,8 @@ async fn topology_task_process(
             tracing_id: None,
             warnings: vec![],
             operation: CassandraOperation::Query {
-                query: Box::new(parse_statement_single(
-                    "SELECT broadcast_address, rack, data_center, tokens FROM system.local",
+                query: Box::new(CassandraStatement::Unknown(
+                    "SELECT broadcast_address, rack, data_center, tokens FROM system.local".into(),
                 )),
                 params: Box::new(QueryParams::default()),
             },


### PR DESCRIPTION
Creating the AST is pretty expensive. Since we are defining the queries ourselves and know they are not batch statements we can skip that check.