### PR TITLE
CassandraSinkCluster: Control connection always connects to configured dc/rack

### DIFF
--- a/shotover-proxy/src/transforms/cassandra/sink_cluster/node.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_cluster/node.rs
@@ -10,7 +10,7 @@ use tokio::sync::{mpsc, oneshot};
 #[derive(Debug, Clone)]
 pub struct CassandraNode {
     pub address: IpAddr,
-    pub _rack: String,
+    pub rack: String,
     pub _tokens: Vec<String>,
     pub outbound: Option<CassandraConnection>,
 }

--- a/shotover-proxy/tests/cassandra_int_tests/cluster.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cluster.rs
@@ -155,7 +155,7 @@ pub async fn test_topology_task(ca_path: Option<&str>) {
             .expect("Node did not contain a unique expected address");
         possible_addresses.remove(address_index);
 
-        assert_eq!(node._rack, "rack1");
+        assert_eq!(node.rack, "rack1");
         assert_eq!(node._tokens.len(), 128);
     }
 }

--- a/shotover-proxy/tests/cassandra_int_tests/cluster_multi_rack.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cluster_multi_rack.rs
@@ -133,7 +133,7 @@ pub async fn test_topology_task(ca_path: Option<&str>) {
 
         let rack_index = possible_racks
             .iter()
-            .position(|x| *x == node._rack)
+            .position(|x| *x == node.rack)
             .expect("Node did not contain a unique expected rack");
         possible_racks.remove(rack_index);
 


### PR DESCRIPTION
closes https://github.com/shotover/shotover-proxy/issues/758

The new logic looks like:

1. when we receive our first message populate local_nodes immediately if possible (if not now then we have to wait till handshake is complete)
2. process handshake
3. when we receive confirmation that handshake is complete:
    1. send handshake to topology task
    2. if local_nodes is empty then 
        1. populate local_nodes blocking until topology task has completed once. (on my machine in int tests this takes ~50ms)
        2. replace control connection with a new connection guaranteed to be from the dc/rack
5. system.local queries are always routed to a dc/rack node giving us more correctness and allowing us to remove some unneeded logic.

This didnt end up cleaning up as much code as I had originally hoped, the system.peers rewriting still needs to perform its own system.local and system.peers queries regardless, but I think it is still the most correct approach.
I think that the consistency of always having our control connection connect to our dc/rack should help avoid some nasty and hard to detect edge cases.