### PR TITLE
Add DebugLogToFile transform

### DIFF
--- a/shotover-proxy/tests/test-configs/log-to-file/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/log-to-file/docker-compose.yaml
@@ -1,0 +1,6 @@
+version: "3.3"
+services:
+  redis-one:
+    image: library/redis:5.0.9
+    ports:
+      - "1111:6379"

--- a/shotover-proxy/tests/test-configs/log-to-file/topology.yaml
+++ b/shotover-proxy/tests/test-configs/log-to-file/topology.yaml
@@ -1,0 +1,13 @@
+---
+sources:
+  redis_prod:
+    Redis:
+      listen_addr: "127.0.0.1:6379"
+chain_config:
+  redis_chain:
+    - DebugLogToFile
+    - RedisSinkSingle:
+        remote_address: "127.0.0.1:1111"
+        connect_timeout_ms: 3000
+source_to_chain_mapping:
+  redis_prod: redis_chain

--- a/shotover-proxy/tests/transforms/log_to_file.rs
+++ b/shotover-proxy/tests/transforms/log_to_file.rs
@@ -1,0 +1,32 @@
+use crate::redis_int_tests::assert::assert_ok;
+use serial_test::serial;
+use test_helpers::connection::redis_connection;
+use test_helpers::docker_compose::docker_compose;
+use test_helpers::shotover_process::ShotoverProcessBuilder;
+
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn log_to_file() {
+    let _compose = docker_compose("tests/test-configs/log-to-file/docker-compose.yaml");
+    let shotover =
+        ShotoverProcessBuilder::new_with_topology("tests/test-configs/log-to-file/topology.yaml")
+            .start()
+            .await;
+
+    let mut connection = redis_connection::new_async(6379).await;
+
+    assert_ok(redis::cmd("SET").arg("foo").arg(42), &mut connection).await;
+    // skip connection 1 as that comes from the redis_connection::new_async creating a dummy connection to the server to see if its awake yet
+    let request = std::fs::read("message-log/2/requests/message1.bin").unwrap();
+    assert_eq!(
+        request,
+        "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$2\r\n42\r\n".as_bytes()
+    );
+
+    let response = std::fs::read("message-log/2/responses/message1.bin").unwrap();
+    assert_eq!(response, "+OK\r\n".as_bytes());
+
+    shotover.shutdown_and_then_consume_events(&[]).await;
+
+    std::fs::remove_dir_all("message-log").unwrap();
+}

--- a/shotover-proxy/tests/transforms/mod.rs
+++ b/shotover-proxy/tests/transforms/mod.rs
@@ -1,2 +1,4 @@
+#[cfg(feature = "alpha-transforms")]
+pub mod log_to_file;
 pub mod query_type_filter;
 pub mod tee;

--- a/shotover/src/codec/cassandra.rs
+++ b/shotover/src/codec/cassandra.rs
@@ -897,8 +897,8 @@ impl CassandraEncoder {
     }
 
     fn encode_envelope(&mut self, m: Message, envelope_compresson: Compression) -> Result<Bytes> {
-        // TODO: always check if cassandra message
-        Ok(match m.into_encodable(MessageType::Cassandra)? {
+        m.ensure_message_type(MessageType::Cassandra)?;
+        Ok(match m.into_encodable() {
             Encodable::Bytes(bytes) => {
                 // TODO this is a weird side effect to keep in this function
                 // check if the message is a startup message and set the codec's compression

--- a/shotover/src/codec/kafka.rs
+++ b/shotover/src/codec/kafka.rs
@@ -134,10 +134,9 @@ impl Encoder<Messages> for KafkaEncoder {
     fn encode(&mut self, item: Messages, dst: &mut BytesMut) -> Result<(), Self::Error> {
         item.into_iter().try_for_each(|m| {
             let start = dst.len();
-            let result = match m
-                .into_encodable(MessageType::Kafka)
-                .map_err(CodecWriteError::Encoder)?
-            {
+            m.ensure_message_type(MessageType::Kafka)
+                .map_err(CodecWriteError::Encoder)?;
+            let result = match m.into_encodable() {
                 Encodable::Bytes(bytes) => {
                     dst.extend_from_slice(&bytes);
                     Ok(())

--- a/shotover/src/codec/redis.rs
+++ b/shotover/src/codec/redis.rs
@@ -89,10 +89,9 @@ impl Encoder<Messages> for RedisEncoder {
     fn encode(&mut self, item: Messages, dst: &mut BytesMut) -> Result<(), Self::Error> {
         item.into_iter().try_for_each(|m| {
             let start = dst.len();
-            let result = match m
-                .into_encodable(MessageType::Redis)
-                .map_err(CodecWriteError::Encoder)?
-            {
+            m.ensure_message_type(MessageType::Redis)
+                .map_err(CodecWriteError::Encoder)?;
+            let result = match m.into_encodable() {
                 Encodable::Bytes(bytes) => {
                     dst.extend_from_slice(&bytes);
                     Ok(())

--- a/shotover/src/transforms/debug/log_to_file.rs
+++ b/shotover/src/transforms/debug/log_to_file.rs
@@ -1,0 +1,109 @@
+use crate::message::{Encodable, Message};
+use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use tracing::{error, info};
+
+#[derive(Deserialize, Debug)]
+pub struct DebugLogToFileConfig;
+
+#[cfg(feature = "alpha-transforms")]
+#[typetag::deserialize(name = "DebugLogToFile")]
+#[async_trait(?Send)]
+impl crate::transforms::TransformConfig for DebugLogToFileConfig {
+    async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
+        // This transform is used for debugging a specific run, so we clean out any logs left over from the previous run
+        std::fs::remove_dir_all("message-log").ok();
+
+        Ok(Box::new(DebugLogToFileBuilder {
+            connection_counter: Arc::new(AtomicU64::new(0)),
+        }))
+    }
+}
+
+pub struct DebugLogToFileBuilder {
+    connection_counter: Arc<AtomicU64>,
+}
+
+impl TransformBuilder for DebugLogToFileBuilder {
+    fn build(&self) -> Transforms {
+        self.connection_counter.fetch_add(1, Ordering::Relaxed);
+        let connection_current = self.connection_counter.load(Ordering::Relaxed);
+
+        let connection_dir = connection_current.to_string();
+        let requests = Path::new("message-log")
+            .join(&connection_dir)
+            .join("requests");
+        let responses = Path::new("message-log")
+            .join(&connection_dir)
+            .join("responses");
+
+        std::fs::create_dir_all(&requests)
+            .context("failed to create directory for logging requests")
+            .unwrap();
+        std::fs::create_dir_all(&responses)
+            .context("failed to create directory for logging responses")
+            .unwrap();
+
+        Transforms::DebugLogToFile(DebugLogToFile {
+            request_counter: 0,
+            response_counter: 0,
+            requests,
+            responses,
+        })
+    }
+
+    fn get_name(&self) -> &'static str {
+        "DebugLogToFile"
+    }
+}
+
+pub struct DebugLogToFile {
+    request_counter: u64,
+    response_counter: u64,
+    requests: PathBuf,
+    responses: PathBuf,
+}
+
+#[async_trait]
+impl Transform for DebugLogToFile {
+    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Vec<Message>> {
+        for message in &message_wrapper.messages {
+            self.request_counter += 1;
+            let path = self
+                .requests
+                .join(format!("message{}.bin", self.request_counter));
+            log_message(message, path.as_path()).await?;
+        }
+
+        let response = message_wrapper.call_next_transform().await?;
+
+        for message in &response {
+            self.response_counter += 1;
+            let path = self
+                .responses
+                .join(format!("message{}.bin", self.response_counter));
+            log_message(message, path.as_path()).await?;
+        }
+        Ok(response)
+    }
+}
+
+async fn log_message(message: &Message, path: &Path) -> Result<()> {
+    info!("Logged message to {:?}", path);
+    match message.clone().into_encodable() {
+        Encodable::Bytes(bytes) => {
+            tokio::fs::write(path, bytes).await.map_err(|e| {
+                anyhow!(e).context(format!("failed to write message to disk at {path:?}"))
+            })?;
+        }
+        Encodable::Frame(_) => {
+            error!("Failed to log message because it was a frame. Ensure this Transform is the first transform in the main chain to ensure it only receives unmodified messages.")
+        }
+    }
+    Ok(())
+}

--- a/shotover/src/transforms/debug/mod.rs
+++ b/shotover/src/transforms/debug/mod.rs
@@ -1,4 +1,5 @@
 pub mod force_parse;
+pub mod log_to_file;
 pub mod printer;
 pub mod random_delay;
 pub mod returner;

--- a/shotover/src/transforms/mod.rs
+++ b/shotover/src/transforms/mod.rs
@@ -6,6 +6,7 @@ use crate::transforms::cassandra::sink_cluster::CassandraSinkCluster;
 use crate::transforms::cassandra::sink_single::CassandraSinkSingle;
 use crate::transforms::coalesce::Coalesce;
 use crate::transforms::debug::force_parse::DebugForceParse;
+use crate::transforms::debug::log_to_file::DebugLogToFile;
 use crate::transforms::debug::printer::DebugPrinter;
 use crate::transforms::debug::random_delay::DebugRandomDelay;
 use crate::transforms::debug::returner::DebugReturner;
@@ -102,6 +103,7 @@ pub enum Transforms {
     DebugReturner(DebugReturner),
     DebugRandomDelay(DebugRandomDelay),
     DebugPrinter(DebugPrinter),
+    DebugLogToFile(DebugLogToFile),
     DebugForceParse(DebugForceParse),
     ParallelMap(ParallelMap),
     PoolConnections(ConnectionBalanceAndPool),
@@ -128,6 +130,7 @@ impl Transforms {
             Transforms::RedisCache(r) => r.transform(message_wrapper).await,
             Transforms::Tee(m) => m.transform(message_wrapper).await,
             Transforms::DebugPrinter(p) => p.transform(message_wrapper).await,
+            Transforms::DebugLogToFile(p) => p.transform(message_wrapper).await,
             Transforms::DebugForceParse(p) => p.transform(message_wrapper).await,
             Transforms::NullSink(n) => n.transform(message_wrapper).await,
             Transforms::Loopback(n) => n.transform(message_wrapper).await,
@@ -158,6 +161,7 @@ impl Transforms {
             Transforms::RedisCache(r) => r.transform_pushed(message_wrapper).await,
             Transforms::Tee(m) => m.transform_pushed(message_wrapper).await,
             Transforms::DebugPrinter(p) => p.transform_pushed(message_wrapper).await,
+            Transforms::DebugLogToFile(p) => p.transform_pushed(message_wrapper).await,
             Transforms::DebugForceParse(p) => p.transform_pushed(message_wrapper).await,
             Transforms::NullSink(n) => n.transform_pushed(message_wrapper).await,
             Transforms::Loopback(n) => n.transform_pushed(message_wrapper).await,
@@ -200,6 +204,7 @@ impl Transforms {
             Transforms::RedisTimestampTagger(r) => r.set_pushed_messages_tx(pushed_messages_tx),
             Transforms::RedisClusterPortsRewrite(r) => r.set_pushed_messages_tx(pushed_messages_tx),
             Transforms::DebugPrinter(p) => p.set_pushed_messages_tx(pushed_messages_tx),
+            Transforms::DebugLogToFile(p) => p.set_pushed_messages_tx(pushed_messages_tx),
             Transforms::DebugForceParse(p) => p.set_pushed_messages_tx(pushed_messages_tx),
             Transforms::NullSink(n) => n.set_pushed_messages_tx(pushed_messages_tx),
             Transforms::RedisSinkCluster(r) => r.set_pushed_messages_tx(pushed_messages_tx),


### PR DESCRIPTION
A usecase I have in mind is extracting messages for the purposes of benchmarking parsing/encoding.
I think it could also be useful for debugging.

Each incoming connection to shotover results in a new numbered directory created in `message-log`.
Within those directories is a `request` and `response` directory in which messages are logged to disk under a `messageN.bin` name.
The easiest way to see what the log looks like is to comment out `std::fs::remove_dir_all("message-log").unwrap();` in `log_to_file` integration test and run it.

The comment:
```rust
    // TODO: Considering we already have the expected message type here maybe we should perform any required conversions and return a Result<Bytes> here.
    // I've left it as is to keep the PR simpler and there could be a need for codecs to control this process that I havent investigated.
```
has been deleted because the design it is proposing is no good. We need to return the `Encodable` so that the codec can encode the frame directly into the destination buffer.

The `MessageType` check had to be pulled out of `into_encodable` because `LogToFile` needs to operate on all message types unlike the codecs which always need a specific type of message.