### PR TITLE
Cut CI bench compile time by a few minutes

### DIFF
--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -94,17 +94,5 @@ cdrs-tokio = { git = "https://github.com/krojew/cdrs-tokio" }
 scylla = { version = "0.5.0", features = ["ssl"] }
 
 [[bench]]
-name = "redis_benches"
-harness = false
-
-[[bench]]
-name = "chain_benches"
-harness = false
-
-[[bench]]
-name = "cassandra_benches"
-harness = false
-
-[[bench]]
-name = "codec_benches"
+name = "benches"
 harness = false

--- a/shotover-proxy/benches/benches/cassandra.rs
+++ b/shotover-proxy/benches/benches/cassandra.rs
@@ -1,13 +1,10 @@
+use crate::helpers::cassandra::CassandraConnection;
+use crate::helpers::ShotoverManager;
 use cassandra_cpp::{stmt, Cluster, Session, Statement};
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, Criterion};
 use test_helpers::cert::generate_cassandra_test_certs;
 use test_helpers::docker_compose::DockerCompose;
 use test_helpers::lazy::new_lazy_shared;
-
-#[path = "../tests/helpers/mod.rs"]
-mod helpers;
-use helpers::cassandra::CassandraConnection;
-use helpers::ShotoverManager;
 
 struct Query {
     name: &'static str,
@@ -247,7 +244,6 @@ fn cassandra(c: &mut Criterion) {
 }
 
 criterion_group!(benches, cassandra);
-criterion_main!(benches);
 
 pub struct BenchResources {
     _compose: DockerCompose,

--- a/shotover-proxy/benches/benches/chain.rs
+++ b/shotover-proxy/benches/benches/chain.rs
@@ -2,7 +2,7 @@ use bytes::Bytes;
 use cassandra_protocol::{
     compression::Compression, consistency::Consistency, frame::Version, query::QueryParams,
 };
-use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use criterion::{criterion_group, BatchSize, Criterion};
 use hex_literal::hex;
 use shotover_proxy::frame::cassandra::parse_statement_single;
 use shotover_proxy::frame::RedisFrame;
@@ -376,4 +376,3 @@ impl<'a> BenchInput<'a> {
 }
 
 criterion_group!(benches, criterion_benchmark);
-criterion_main!(benches);

--- a/shotover-proxy/benches/benches/codec.rs
+++ b/shotover-proxy/benches/benches/codec.rs
@@ -3,7 +3,7 @@ use cassandra_protocol::frame::message_result::{
     ColSpec, ColType, ColTypeOption, ColTypeOptionValue, RowsMetadata, RowsMetadataFlags, TableSpec,
 };
 use cassandra_protocol::{frame::Version, query::QueryParams};
-use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use criterion::{black_box, criterion_group, BatchSize, Criterion};
 use shotover_proxy::codec::cassandra::CassandraCodec;
 use shotover_proxy::frame::cassandra::parse_statement_single;
 use shotover_proxy::frame::{CassandraFrame, CassandraOperation, CassandraResult, Frame};
@@ -17,7 +17,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     {
         let messages = vec![Message::from_frame(Frame::Cassandra(CassandraFrame {
             version: Version::V4,
-            stream_id: 0,
+            stream_id: 1,
             tracing_id: None,
             warnings: vec![],
             operation: CassandraOperation::Query {
@@ -67,7 +67,6 @@ fn criterion_benchmark(c: &mut Criterion) {
 }
 
 criterion_group!(benches, criterion_benchmark);
-criterion_main!(benches);
 
 fn peers_v2_result() -> CassandraResult {
     CassandraResult::Rows {

--- a/shotover-proxy/benches/benches/main.rs
+++ b/shotover-proxy/benches/benches/main.rs
@@ -1,0 +1,15 @@
+use criterion::criterion_main;
+
+mod cassandra;
+mod chain;
+mod codec;
+#[path = "../../tests/helpers/mod.rs"]
+mod helpers;
+mod redis;
+
+criterion_main!(
+    cassandra::benches,
+    redis::benches,
+    chain::benches,
+    codec::benches,
+);

--- a/shotover-proxy/benches/benches/redis.rs
+++ b/shotover-proxy/benches/benches/redis.rs
@@ -1,12 +1,10 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, Criterion};
 use redis::Cmd;
 use std::path::Path;
 use test_helpers::docker_compose::DockerCompose;
 use test_helpers::lazy::new_lazy_shared;
 
-#[path = "../tests/helpers/mod.rs"]
-mod helpers;
-use helpers::ShotoverManager;
+use crate::helpers::ShotoverManager;
 
 struct Query {
     name: &'static str,
@@ -144,7 +142,6 @@ fn redis(c: &mut Criterion) {
 }
 
 criterion_group!(benches, redis);
-criterion_main!(benches);
 
 struct BenchResources {
     _compose: DockerCompose,

--- a/shotover-proxy/tests/scripts/bench_against_master.sh
+++ b/shotover-proxy/tests/scripts/bench_against_master.sh
@@ -15,15 +15,12 @@ fi
 echo -e "\nBenchmarking main as a baseline"
 git fetch origin
 git checkout origin/$GITHUB_BASE_REF
-cargo bench --all-features --bench redis_benches -- --save-baseline master --noplot
-cargo bench --all-features --bench chain_benches -- --save-baseline master --noplot
-cargo bench --all-features --bench cassandra_benches -- --save-baseline master --noplot
+# Need to specify `--bench benches` becauses otherwise it tries to pass --save-baseline to something else (possibly a test) and blows up
+cargo bench --all-features --bench benches -- --save-baseline master --noplot
 
 echo -e "\nBenchmarking PR branch against main as a baseline"
 git checkout $ORIGINAL_REF
-cargo bench --all-features --bench redis_benches -- --baseline-lenient master --noplot | tee benches_log.txt -a
-cargo bench --all-features --bench chain_benches -- --baseline-lenient master --noplot | tee benches_log.txt -a
-cargo bench --all-features --bench cassandra_benches -- --baseline-lenient master --noplot | tee benches_log.txt -a
+cargo bench --all-features --bench benches -- --baseline-lenient master --noplot | tee benches_log.txt -a
 
 # grep returns non zero exit code when it doesnt find anything so we need to disable pipefail
 set +o pipefail


### PR DESCRIPTION
Every bench file in shotover-proxy/benches is individually compiled into its own binary.
This is really expensive because the compiler needs to reapply all the crazy optimizations for each binary.

Locally on my machine it takes ~1m 40s for each of these to compile.
Because I have plenty of cores this is all done in parallel and the fact that each binary takes so long to compile causes no slow down for me.
With this change it still takes the same ~1m 40s to compile all of the binaries.

However in CI we only have 2 cores, so having 4 benchmarks to compile doubles the time to compile from 2m to 4m.
So I expect this PR to cut off about ~2 minutes from our benchmark build time.

This also fixes the codec_benches not running in CI due to not being manually included in bench_against_master.sh.
Unfortunately this means we will need to force merge this PR as it relies on the main branch containing the `benches` bench.