### PR TITLE
cassandra_int_tests add case that forces cassandra message encoding

### DIFF
--- a/shotover-proxy/example-configs/cassandra-passthrough/topology-encode.yaml
+++ b/shotover-proxy/example-configs/cassandra-passthrough/topology-encode.yaml
@@ -1,0 +1,14 @@
+---
+sources:
+  cassandra_prod:
+    Cassandra:
+      listen_addr: "127.0.0.1:9042"
+chain_config:
+  main_chain:
+    - DebugForceEncode:
+        encode_requests: true
+        encode_responses: true
+    - CassandraSinkSingle:
+        remote_address: "127.0.0.1:9043"
+source_to_chain_mapping:
+  cassandra_prod: main_chain

--- a/shotover-proxy/src/transforms/mod.rs
+++ b/shotover-proxy/src/transforms/mod.rs
@@ -9,7 +9,7 @@ use crate::transforms::chain::TransformChain;
 use crate::transforms::coalesce::{Coalesce, CoalesceConfig};
 use crate::transforms::debug::force_parse::DebugForceParse;
 #[cfg(feature = "alpha-transforms")]
-use crate::transforms::debug::force_parse::DebugForceParseConfig;
+use crate::transforms::debug::force_parse::{DebugForceEncodeConfig, DebugForceParseConfig};
 use crate::transforms::debug::printer::DebugPrinter;
 use crate::transforms::debug::random_delay::DebugRandomDelay;
 use crate::transforms::debug::returner::{DebugReturner, DebugReturnerConfig};
@@ -310,6 +310,8 @@ pub enum TransformsConfig {
     Protect(ProtectConfig),
     #[cfg(feature = "alpha-transforms")]
     DebugForceParse(DebugForceParseConfig),
+    #[cfg(feature = "alpha-transforms")]
+    DebugForceEncode(DebugForceEncodeConfig),
     ParallelMap(ParallelMapConfig),
     //PoolConnections(ConnectionBalanceAndPoolConfig),
     Coalesce(CoalesceConfig),
@@ -343,6 +345,8 @@ impl TransformsConfig {
             TransformsConfig::Protect(p) => p.get_transform().await,
             #[cfg(feature = "alpha-transforms")]
             TransformsConfig::DebugForceParse(d) => d.get_transform().await,
+            #[cfg(feature = "alpha-transforms")]
+            TransformsConfig::DebugForceEncode(d) => d.get_transform().await,
             TransformsConfig::RedisSinkCluster(r) => r.get_transform(chain_name).await,
             TransformsConfig::ParallelMap(s) => s.get_transform().await,
             //TransformsConfig::PoolConnections(s) => s.get_transform().await,

--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -67,6 +67,23 @@ async fn test_passthrough(#[case] driver: CassandraDriver) {
     standard_test_suite(&connection, driver).await;
 }
 
+#[rstest]
+#[case(CdrsTokio)]
+#[cfg_attr(feature = "cassandra-cpp-driver-tests", case(Datastax))]
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn test_passthrough_encode(#[case] driver: CassandraDriver) {
+    let _compose = DockerCompose::new("example-configs/cassandra-passthrough/docker-compose.yml");
+
+    let _shotover_manager = ShotoverManager::from_topology_file(
+        "example-configs/cassandra-passthrough/topology-encode.yaml",
+    );
+
+    let connection = CassandraConnection::new("127.0.0.1", 9042, driver).await;
+
+    standard_test_suite(&connection, driver).await;
+}
+
 #[cfg(feature = "cassandra-cpp-driver-tests")]
 #[rstest]
 //#[case(CdrsTokio)] // TODO


### PR DESCRIPTION
I wanted a way to better test the encoding code path of changes like: https://github.com/shotover/shotover-proxy/pull/802
So I added this integration test which will exercise the encoding code path against all of our cassandra test cases.