### PR TITLE
CassandraSinkCluster keyspace based routing - handle use statements

### DIFF
--- a/shotover-proxy/src/frame/cassandra.rs
+++ b/shotover-proxy/src/frame/cassandra.rs
@@ -69,6 +69,7 @@ pub mod raw_frame {
             version: frame.version,
             stream_id: frame.stream_id,
             tracing_id: frame.tracing_id,
+            opcode: frame.opcode,
         })
     }
 
@@ -83,20 +84,13 @@ pub mod raw_frame {
             _ => nonzero!(1u32),
         })
     }
-
-    pub(crate) fn get_opcode(bytes: &[u8]) -> Result<Opcode> {
-        if bytes.len() < 9 {
-            bail!("Cassandra frame too short, needs at least 9 bytes for header");
-        }
-        let opcode = Opcode::try_from(bytes[4])?;
-        Ok(opcode)
-    }
 }
 
-pub(crate) struct CassandraMetadata {
+pub struct CassandraMetadata {
     pub version: Version,
     pub stream_id: StreamId,
     pub tracing_id: Option<Uuid>,
+    pub opcode: Opcode,
     // missing `warnings` field because we are not using it currently
 }
 
@@ -117,6 +111,7 @@ impl CassandraFrame {
             version: self.version,
             stream_id: self.stream_id,
             tracing_id: self.tracing_id,
+            opcode: self.operation.to_opcode(),
         }
     }
 

--- a/shotover-proxy/src/message/mod.rs
+++ b/shotover-proxy/src/message/mod.rs
@@ -32,7 +32,7 @@ use std::net::IpAddr;
 use std::num::NonZeroU32;
 use uuid::Uuid;
 
-enum Metadata {
+pub enum Metadata {
     Cassandra(CassandraMetadata),
     Redis,
     None,
@@ -171,16 +171,6 @@ impl Message {
         }
     }
 
-    /// Only use for messages read straight from the socket
-    /// that are definitely in an unparsed state
-    /// (haven't passed through any transforms where they might have been parsed or modified)
-    pub(crate) fn as_raw_bytes(&self) -> Option<&Bytes> {
-        match self.inner.as_ref().unwrap() {
-            MessageInner::RawBytes { bytes, .. } => Some(bytes),
-            _ => None,
-        }
-    }
-
     /// Batch messages have a cell count of 1 cell per inner message.
     /// Cell count is determined as follows:
     /// * Regular message - 1 cell
@@ -270,7 +260,7 @@ impl Message {
     }
 
     /// Get metadata for this `Message`
-    fn metadata(&self) -> Result<Metadata> {
+    pub fn metadata(&self) -> Result<Metadata> {
         match self.inner.as_ref().unwrap() {
             MessageInner::RawBytes {
                 bytes,

--- a/shotover-proxy/src/transforms/cassandra/sink_cluster/mod.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_cluster/mod.rs
@@ -722,7 +722,6 @@ impl CassandraSinkCluster {
         }
     }
 
-    // TODO: handle use statement state
     fn is_system_query(&self, request: &mut Message) -> bool {
         if let Some(Frame::Cassandra(frame)) = request.frame() {
             if let CassandraOperation::Query { query, .. } = &mut frame.operation {

--- a/shotover-proxy/tests/cassandra_int_tests/cluster_single_rack_v4.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cluster_single_rack_v4.rs
@@ -6,7 +6,7 @@ use tokio::time::{sleep, timeout};
 
 use crate::cassandra_int_tests::cluster::run_topology_task;
 use crate::helpers::cassandra::{
-    assert_query_result, CassandraConnection, CassandraDriver, ResultValue,
+    assert_query_result, run_query, CassandraConnection, CassandraDriver, ResultValue,
 };
 use crate::helpers::ShotoverManager;
 use std::net::SocketAddr;
@@ -32,6 +32,10 @@ async fn test_rewrite_system_peers(connection: &CassandraConnection) {
 async fn test_rewrite_system_peers_v2(connection: &CassandraConnection) {
     let all_columns = "peer, peer_port, data_center, host_id, native_address, native_port, preferred_ip, preferred_port, rack, release_version, schema_version, tokens";
     assert_query_result(connection, "SELECT * FROM system.peers_v2;", &[]).await;
+
+    run_query(connection, "USE system;").await;
+    assert_query_result(connection, "SELECT * FROM peers_v2;", &[]).await;
+
     assert_query_result(
         connection,
         &format!("SELECT {all_columns} FROM system.peers_v2;"),


### PR DESCRIPTION
This PR handles use statements in every case except one:
* operates on both batch operations and query operations. 
* messages are modified such that if a keyspace is not specified the `use` keyspace is used, this ensures a single source of truth for transforms.
* messages are modified at the codec level ensuring all layers of shotover observe the same keyspace.

The one case we arent handling is prepared statements.
use statements also affect prepared statements, but currently shotover does not support parsing prepared statements so I have just left that functionality as a TODO.

There is a performance concern: calling metadata is currently more expensive than it needs to be due to internally copying the entire message body and then dropping it.
But that can be addressed later on in a follow up PR.

Making this change caused the `.as_raw_bytes()` hack to start blowing up due to the message already being parsed, so I also changed all instances of it to just use `.metadata()` instead.