### PR TITLE
CassandraSinkCluster: filter out Topology and Status events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,6 +237,12 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+
+[[package]]
+name = "bytes"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
@@ -247,7 +253,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e47d3a8076e283f3acd27400535992edb3ba4b5bb72f8891ad8fbe7932a7d4b9"
 dependencies = [
- "bytes",
+ "bytes 1.2.1",
  "either",
 ]
 
@@ -277,7 +283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "751f7f4e7a091545e7f6c65bacc404eaee7e87bfb1f9ece234a1caa173dc16f2"
 dependencies = [
  "cached_proc_macro_types",
- "darling",
+ "darling 0.13.4",
  "quote",
  "syn",
 ]
@@ -352,7 +358,7 @@ source = "git+https://github.com/krojew/cdrs-tokio#33bd4692936e3a2cbe247ed5fb663
 dependencies = [
  "arc-swap",
  "atomic",
- "bytes",
+ "bytes 1.2.1",
  "cassandra-protocol",
  "derivative",
  "derive_more",
@@ -481,12 +487,37 @@ version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
 dependencies = [
- "bytes",
+ "bytes 1.2.1",
  "futures-core",
  "memchr",
  "pin-project-lite",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "containers-api"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bee704f0c9a664c04f6ec23c038302d3ef94f9e040daca2ac5434d55c0038b8"
+dependencies = [
+ "chrono",
+ "flate2",
+ "futures-util",
+ "futures_codec",
+ "http",
+ "hyper",
+ "hyperlocal",
+ "log",
+ "mime",
+ "paste",
+ "pin-project 1.0.12",
+ "serde",
+ "serde_json",
+ "tar",
+ "thiserror",
+ "tokio",
+ "url",
 ]
 
 [[package]]
@@ -533,7 +564,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9662338ec83ade685bf4e5e70d11a505033a3715dc6b1b7b0650a950857778"
 dependencies = [
  "bigdecimal 0.3.0",
- "bytes",
+ "bytes 1.2.1",
  "hex",
  "itertools",
  "num",
@@ -689,8 +720,18 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
+dependencies = [
+ "darling_core 0.14.1",
+ "darling_macro 0.14.1",
 ]
 
 [[package]]
@@ -708,12 +749,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
- "darling_core",
+ "darling_core 0.13.4",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
+dependencies = [
+ "darling_core 0.14.1",
  "quote",
  "syn",
 ]
@@ -783,6 +849,48 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "docker-api"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6818b39f6fc2bd3b858657f89768101b66d498b560666c0d35fed0773f66202c"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes 1.2.1",
+ "chrono",
+ "containers-api",
+ "docker-api-stubs",
+ "flate2",
+ "futures-util",
+ "futures_codec",
+ "http",
+ "hyper",
+ "hyperlocal",
+ "log",
+ "mime",
+ "paste",
+ "pin-project 1.0.12",
+ "serde",
+ "serde_json",
+ "tar",
+ "thiserror",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "docker-api-stubs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "733cb176deec8914bf3ca1c3ee9256fdd227f9c7060cd34b9a958277413ff4fa"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "serde_with",
 ]
 
 [[package]]
@@ -866,6 +974,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94a7bbaa59354bc20dd75b67f23e2797b4490e9d6928203fb105c79e448c86c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1001,6 +1131,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures_codec"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce54d63f8b0c75023ed920d46fd71d0cbbb830b0ee012726b5b4f506fb6dea5b"
+dependencies = [
+ "bytes 0.5.6",
+ "futures",
+ "memchr",
+ "pin-project 0.4.30",
+]
+
+[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,7 +1201,7 @@ version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
 dependencies = [
- "bytes",
+ "bytes 1.2.1",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1154,7 +1296,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
- "bytes",
+ "bytes 1.2.1",
  "fnv",
  "itoa 1.0.3",
 ]
@@ -1165,7 +1307,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
- "bytes",
+ "bytes 1.2.1",
  "http",
  "pin-project-lite",
 ]
@@ -1197,7 +1339,7 @@ version = "0.14.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
 dependencies = [
- "bytes",
+ "bytes 1.2.1",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1221,11 +1363,24 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes",
+ "bytes 1.2.1",
  "hyper",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fafdf7b2b2de7c9784f76e02c0935e65a8117ec3b768644379983ab333ac98c"
+dependencies = [
+ "futures-util",
+ "hex",
+ "hyper",
+ "pin-project 1.0.12",
+ "tokio",
 ]
 
 [[package]]
@@ -1267,6 +1422,7 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -1892,6 +2048,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
+
+[[package]]
 name = "pcap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1956,6 +2118,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "pin-project"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef0f924a5ee7ea9cbcea77529dba45f8a9ba9f622419fe3386ca581a3ae9d5a"
+dependencies = [
+ "pin-project-internal 0.4.30",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+dependencies = [
+ "pin-project-internal 1.0.12",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851c8d0ce9bebe43790dedfc86614c23494ac9f423dd618d3a61fc693eafe61e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2236,7 +2438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "571c252c68d09a2ad3e49edd14e9ee48932f3e0f27b06b4ea4c9b2a706d31103"
 dependencies = [
  "async-trait",
- "bytes",
+ "bytes 1.2.1",
  "combine",
  "crc16",
  "futures-util",
@@ -2257,7 +2459,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c31deddf734dc0a39d3112e73490e88b61a05e83e074d211f348404cee4d2c6"
 dependencies = [
- "bytes",
+ "bytes 1.2.1",
  "bytes-utils",
  "cookie-factory",
  "crc16",
@@ -2327,7 +2529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
 dependencies = [
  "base64",
- "bytes",
+ "bytes 1.2.1",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -2405,7 +2607,7 @@ checksum = "1db30db44ea73551326269adcf7a2169428a054f14faf9e1768f2163494f2fa2"
 dependencies = [
  "async-trait",
  "base64",
- "bytes",
+ "bytes 1.2.1",
  "crc32fast",
  "futures",
  "http",
@@ -2447,7 +2649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e1fc19cfcfd9f6b2f96e36d5b0dddda9004d2cbfc2d17543e3b9f10cc38fce8"
 dependencies = [
  "async-trait",
- "bytes",
+ "bytes 1.2.1",
  "futures",
  "rusoto_core",
  "serde",
@@ -2461,7 +2663,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5ae95491c8b4847931e291b151127eccd6ff8ca13f33603eb3d0035ecb05272"
 dependencies = [
  "base64",
- "bytes",
+ "bytes 1.2.1",
  "chrono",
  "digest",
  "futures",
@@ -2550,7 +2752,7 @@ dependencies = [
  "arc-swap",
  "bigdecimal 0.2.2",
  "byteorder",
- "bytes",
+ "bytes 1.2.1",
  "chrono",
  "dashmap",
  "futures",
@@ -2582,7 +2784,7 @@ checksum = "e2e0ac8202660385589dba16123cc5916cf4eb3078e2dac0ab6af6903d7f5467"
 dependencies = [
  "bigdecimal 0.2.2",
  "byteorder",
- "bytes",
+ "bytes 1.2.1",
  "chrono",
  "lz4_flex",
  "num-bigint 0.3.3",
@@ -2687,6 +2889,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f2d60d049ea019a84dcd6687b0d1e0030fe663ae105039bdf967ed5e6a9a7"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap",
+ "serde",
+ "serde_json",
+ "serde_with_macros",
+ "time 0.3.14",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ccadfacf6cf10faad22bbadf55986bdd0856edfb5d9210aa1dcf1f516e84e93"
+dependencies = [
+ "darling 0.14.1",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2777,7 +3007,7 @@ dependencies = [
  "base64",
  "bigdecimal 0.3.0",
  "bincode",
- "bytes",
+ "bytes 1.2.1",
  "bytes-utils",
  "cached",
  "cassandra-cpp",
@@ -2790,6 +3020,7 @@ dependencies = [
  "criterion",
  "csv",
  "derivative",
+ "docker-api",
  "futures",
  "generic-array",
  "governor",
@@ -2977,6 +3208,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3075,6 +3317,7 @@ dependencies = [
  "itoa 1.0.3",
  "libc",
  "num_threads",
+ "serde",
  "time-macros",
 ]
 
@@ -3130,7 +3373,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89797afd69d206ccd11fb0ea560a44bbb87731d020670e79416d442919257d42"
 dependencies = [
  "autocfg",
- "bytes",
+ "bytes 1.2.1",
  "libc",
  "memchr",
  "mio",
@@ -3204,7 +3447,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
 dependencies = [
- "bytes",
+ "bytes 1.2.1",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
@@ -3635,6 +3878,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "xattr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -94,6 +94,7 @@ metrics-util = "0.14.0"
 cdrs-tokio = { git = "https://github.com/krojew/cdrs-tokio" }
 scylla = { version = "0.5.0", features = ["ssl"] }
 rstest = "0.15.0"
+docker-api = "0.10.1"
 
 [[bench]]
 name = "benches"

--- a/shotover-proxy/tests/cassandra_int_tests/cluster_single_rack_v4.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cluster_single_rack_v4.rs
@@ -1,6 +1,16 @@
+use cassandra_protocol::events::ServerEvent;
+use cassandra_protocol::frame::events::{StatusChange, StatusChangeType};
+use docker_api::Docker;
+use test_helpers::docker_compose::DockerCompose;
+use tokio::time::{sleep, timeout};
+
 use crate::cassandra_int_tests::cluster::run_topology_task;
-use crate::helpers::cassandra::{assert_query_result, CassandraConnection, ResultValue};
+use crate::helpers::cassandra::{
+    assert_query_result, CassandraConnection, CassandraDriver, ResultValue,
+};
+use crate::helpers::ShotoverManager;
 use std::net::SocketAddr;
+use std::time::Duration;
 
 async fn test_rewrite_system_peers(connection: &CassandraConnection) {
     let all_columns = "peer, data_center, host_id, preferred_ip, rack, release_version, rpc_address, schema_version, tokens";
@@ -231,4 +241,67 @@ pub async fn test_topology_task(ca_path: Option<&str>, cassandra_port: Option<u3
         assert_eq!(node.rack, "rack1");
         assert_eq!(node.tokens.len(), 128);
     }
+}
+
+pub async fn test_events_filtering(
+    compose: DockerCompose,
+    shotover_manager: ShotoverManager,
+    driver: CassandraDriver,
+) {
+    let session_direct = CassandraConnection::new("172.16.1.2", 9044, driver).await;
+    let mut event_recv_direct = session_direct.as_cdrs().create_event_receiver();
+
+    let session_shotover = CassandraConnection::new("127.0.0.1", 9042, driver).await;
+    let mut event_recv_shotover = session_shotover.as_cdrs().create_event_receiver();
+
+    // let the driver finish connecting to the cluster and registering for the events
+    sleep(Duration::from_secs(10)).await;
+
+    // stop one of the containers to trigger a status change event
+    let docker = Docker::new("unix:///var/run/docker.sock").unwrap();
+    let containers = docker.containers();
+    let mut found = false;
+    let mut all_names: Vec<String> = vec![];
+    for container in containers.list(&Default::default()).await.unwrap() {
+        let names = container.names.unwrap();
+        // session_direct is connecting to instance one.
+        // So make sure to instead kill instance two.
+        all_names.push(format!("{:?}", names));
+        if names.len() == 1 && names[0] == "/cassandra-cluster-cassandra-two-1" {
+            found = true;
+            let container = containers.get(container.id.unwrap());
+            container.stop(None).await.unwrap();
+        }
+    }
+    assert!(
+        found,
+        "container was not found with expected name, actual names were {:?}",
+        all_names
+    );
+
+    // The direct connection should allow all events to pass through
+    let event = timeout(Duration::from_secs(120), event_recv_direct.recv())
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        event,
+        ServerEvent::StatusChange(StatusChange {
+            change_type: StatusChangeType::Down,
+            addr: cassandra_protocol::types::CInet {
+                addr: "172.16.1.3:9044".parse().unwrap()
+            },
+        })
+    );
+
+    // we have already received an event directly from the cassandra instance so its reasonable to
+    // expect shotover to have processed that event within 10 seconds if it was ever going to
+    timeout(Duration::from_secs(10), event_recv_shotover.recv())
+        .await
+        .expect_err("CassandraSinkCluster must filter out this event");
+
+    // Purposefully dispose of these as we left the underlying cassandra cluster in a non-recoverable state
+    std::mem::drop(compose);
+    std::mem::drop(shotover_manager);
 }

--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -147,7 +147,7 @@ async fn test_cluster_single_rack_v3(#[case] driver: CassandraDriver) {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn test_cluster_single_rack_v4(#[case] driver: CassandraDriver) {
-    let _compose =
+    let compose =
         DockerCompose::new("example-configs/cassandra-cluster/docker-compose-cassandra-v4.yml");
 
     {
@@ -191,6 +191,15 @@ async fn test_cluster_single_rack_v4(#[case] driver: CassandraDriver) {
     }
 
     cluster_single_rack_v4::test_topology_task(None, Some(9044)).await;
+
+    let shotover_manager =
+        ShotoverManager::from_topology_file("example-configs/cassandra-cluster/topology-v4.yaml");
+    cluster_single_rack_v4::test_events_filtering(
+        compose,
+        shotover_manager,
+        CassandraDriver::CdrsTokio,
+    )
+    .await;
 }
 
 #[cfg(feature = "cassandra-cpp-driver-tests")]


### PR DESCRIPTION
Implementation is pretty straightforward.
Just filter out the Topology and Status events to hide underlying cluster topology details from the clients.
Schema changes can still pass through as that is not part of the topology.