### PR TITLE
cassandra_int_tests: specify every node in CASSANDRA_SEEDS

### DIFF
--- a/shotover-proxy/example-configs-docker/cassandra-peers-rewrite/docker-compose.yml
+++ b/shotover-proxy/example-configs-docker/cassandra-peers-rewrite/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       retries: 60
     environment:
       &environment
-      CASSANDRA_SEEDS: "cassandra-one,cassandra-two"
+      CASSANDRA_SEEDS: "cassandra-one,cassandra-two,cassandra-three"
       MAX_HEAP_SIZE: "400M"
       MIN_HEAP_SIZE: "400M"
       HEAP_NEWSIZE: "48M"

--- a/shotover-proxy/example-configs/cassandra-cluster-multi-rack/docker-compose.yml
+++ b/shotover-proxy/example-configs/cassandra-cluster-multi-rack/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       retries: 60
     environment:
       &environment
-      CASSANDRA_SEEDS: "cassandra-one,cassandra-two"
+      CASSANDRA_SEEDS: "cassandra-one,cassandra-two,cassandra-three"
       CASSANDRA_CLUSTER_NAME: TestCluster
       CASSANDRA_RACK: rack1
       CASSANDRA_DC: dc1

--- a/shotover-proxy/example-configs/cassandra-cluster-tls/docker-compose.yml
+++ b/shotover-proxy/example-configs/cassandra-cluster-tls/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       retries: 60
     environment:
       &environment
-      CASSANDRA_SEEDS: "cassandra-one,cassandra-two"
+      CASSANDRA_SEEDS: "cassandra-one,cassandra-two,cassandra-three"
       CASSANDRA_CLUSTER_NAME: TestCluster
       CASSANDRA_DC: dc1
       CASSANDRA_RACK: rack1

--- a/shotover-proxy/example-configs/cassandra-cluster/docker-compose-cassandra-v3.yml
+++ b/shotover-proxy/example-configs/cassandra-cluster/docker-compose-cassandra-v3.yml
@@ -23,7 +23,7 @@ services:
       retries: 60
     environment:
       &environment
-      CASSANDRA_SEEDS: "cassandra-one,cassandra-two"
+      CASSANDRA_SEEDS: "cassandra-one,cassandra-two,cassandra-three"
       CASSANDRA_CLUSTER_NAME: TestCluster
       CASSANDRA_DC: dc1
       CASSANDRA_RACK: rack1

--- a/shotover-proxy/example-configs/cassandra-cluster/docker-compose-cassandra-v4.yml
+++ b/shotover-proxy/example-configs/cassandra-cluster/docker-compose-cassandra-v4.yml
@@ -23,7 +23,7 @@ services:
       retries: 60
     environment:
       &environment
-      CASSANDRA_SEEDS: "cassandra-one,cassandra-two"
+      CASSANDRA_SEEDS: "cassandra-one,cassandra-two,cassandra-three"
       CASSANDRA_CLUSTER_NAME: TestCluster
       CASSANDRA_DC: dc1
       CASSANDRA_RACK: rack1


### PR DESCRIPTION
on my local machine this improves 3 instance cassandra cluster startup time by 40s

This seems to result in total 3-4mins speedup for cassandra_int_tests workflow in CI
There is no effect on benchmarks workflow because they all use single instance clusters.