### PR TITLE
cassandra_int_tests: add standard_test_suite helper

### DIFF
--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -278,7 +278,12 @@ async fn test_cassandra_redis_cache(#[case] driver: CassandraDriver) {
     let mut redis_connection = shotover_manager.redis_connection(6379);
     let connection = CassandraConnection::new("127.0.0.1", 9042, driver).await;
 
-    standard_test_suite(&connection, driver).await;
+    keyspace::test(&connection).await;
+    table::test(&connection).await;
+    udt::test(&connection).await;
+    functions::test(&connection).await;
+    prepared_statements::test(&connection).await;
+    batch_statements::test(&connection).await;
     cache::test(&connection, &mut redis_connection, &snapshotter).await;
 }
 

--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -39,6 +39,17 @@ mod protect;
 mod table;
 mod udt;
 
+async fn standard_test_suite(connection: &CassandraConnection, driver: CassandraDriver) {
+    keyspace::test(connection).await;
+    table::test(connection).await;
+    udt::test(connection).await;
+    native_types::test(connection).await;
+    collections::test(connection, driver).await;
+    functions::test(connection).await;
+    prepared_statements::test(connection).await;
+    batch_statements::test(connection).await;
+}
+
 #[rstest]
 #[case(CdrsTokio)]
 #[cfg_attr(feature = "cassandra-cpp-driver-tests", case(Datastax))]
@@ -52,14 +63,7 @@ async fn test_passthrough(#[case] driver: CassandraDriver) {
 
     let connection = CassandraConnection::new("127.0.0.1", 9042, driver).await;
 
-    keyspace::test(&connection).await;
-    table::test(&connection).await;
-    udt::test(&connection).await;
-    native_types::test(&connection).await;
-    collections::test(&connection, driver).await;
-    functions::test(&connection).await;
-    prepared_statements::test(&connection).await;
-    batch_statements::test(&connection).await;
+    standard_test_suite(&connection, driver).await;
 }
 
 #[cfg(feature = "cassandra-cpp-driver-tests")]
@@ -90,14 +94,7 @@ async fn test_source_tls_and_single_tls(#[case] driver: CassandraDriver) {
 
     let connection = CassandraConnection::new_tls("127.0.0.1", 9043, ca_cert, driver);
 
-    keyspace::test(&connection).await;
-    table::test(&connection).await;
-    udt::test(&connection).await;
-    native_types::test(&connection).await;
-    collections::test(&connection, driver).await;
-    functions::test(&connection).await;
-    prepared_statements::test(&connection).await;
-    batch_statements::test(&connection).await;
+    standard_test_suite(&connection, driver).await;
 }
 
 #[cfg(feature = "cassandra-cpp-driver-tests")]
@@ -119,14 +116,7 @@ async fn test_cluster_single_rack_v3(#[case] driver: CassandraDriver) {
         connection1
             .enable_schema_awaiter("172.16.1.2:9042", None)
             .await;
-        keyspace::test(&connection1).await;
-        table::test(&connection1).await;
-        udt::test(&connection1).await;
-        native_types::test(&connection1).await;
-        collections::test(&connection1, driver).await;
-        functions::test(&connection1).await;
-        prepared_statements::test(&connection1).await;
-        batch_statements::test(&connection1).await;
+        standard_test_suite(&connection1, driver).await;
         cluster_single_rack_v3::test_dummy_peers(&connection1).await;
 
         //Check for bugs in cross connection state
@@ -160,14 +150,7 @@ async fn test_cluster_single_rack_v4(#[case] driver: CassandraDriver) {
             .enable_schema_awaiter("172.16.1.2:9044", None)
             .await;
 
-        keyspace::test(&connection1).await;
-        table::test(&connection1).await;
-        udt::test(&connection1).await;
-        native_types::test(&connection1).await;
-        collections::test(&connection1, driver).await;
-        functions::test(&connection1).await;
-        prepared_statements::test(&connection1).await;
-        batch_statements::test(&connection1).await;
+        standard_test_suite(&connection1, driver).await;
         cluster_single_rack_v4::test(&connection1).await;
 
         //Check for bugs in cross connection state
@@ -218,14 +201,7 @@ async fn test_cluster_multi_rack(#[case] driver: CassandraDriver) {
         connection1
             .enable_schema_awaiter("172.16.1.2:9042", None)
             .await;
-        keyspace::test(&connection1).await;
-        table::test(&connection1).await;
-        udt::test(&connection1).await;
-        native_types::test(&connection1).await;
-        collections::test(&connection1, driver).await;
-        functions::test(&connection1).await;
-        prepared_statements::test(&connection1).await;
-        batch_statements::test(&connection1).await;
+        standard_test_suite(&connection1, driver).await;
         cluster_multi_rack::test(&connection1).await;
 
         //Check for bugs in cross connection state
@@ -277,14 +253,7 @@ async fn test_source_tls_and_cluster_tls(#[case] driver: CassandraDriver) {
             .enable_schema_awaiter("172.16.1.2:9042", Some(ca_cert))
             .await;
 
-        keyspace::test(&connection).await;
-        table::test(&connection).await;
-        udt::test(&connection).await;
-        native_types::test(&connection).await;
-        functions::test(&connection).await;
-        collections::test(&connection, driver).await;
-        prepared_statements::test(&connection).await;
-        batch_statements::test(&connection).await;
+        standard_test_suite(&connection, driver).await;
         cluster_single_rack_v4::test(&connection).await;
     }
 
@@ -309,12 +278,7 @@ async fn test_cassandra_redis_cache(#[case] driver: CassandraDriver) {
     let mut redis_connection = shotover_manager.redis_connection(6379);
     let connection = CassandraConnection::new("127.0.0.1", 9042, driver).await;
 
-    keyspace::test(&connection).await;
-    table::test(&connection).await;
-    udt::test(&connection).await;
-    functions::test(&connection).await;
-    prepared_statements::test(&connection).await;
-    batch_statements::test(&connection).await;
+    standard_test_suite(&connection, driver).await;
     cache::test(&connection, &mut redis_connection, &snapshotter).await;
 }
 
@@ -335,13 +299,7 @@ async fn test_cassandra_protect_transform_local(#[case] driver: CassandraDriver)
     let shotover_connection = CassandraConnection::new("127.0.0.1", 9042, driver).await;
     let direct_connection = CassandraConnection::new("127.0.0.1", 9043, driver).await;
 
-    keyspace::test(&shotover_connection).await;
-    table::test(&shotover_connection).await;
-    udt::test(&shotover_connection).await;
-    native_types::test(&shotover_connection).await;
-    collections::test(&shotover_connection, driver).await;
-    functions::test(&shotover_connection).await;
-    batch_statements::test(&shotover_connection).await;
+    standard_test_suite(&shotover_connection, driver).await;
     protect::test(&shotover_connection, &direct_connection).await;
 }
 
@@ -362,13 +320,7 @@ async fn test_cassandra_protect_transform_aws(#[case] driver: CassandraDriver) {
     let shotover_connection = CassandraConnection::new("127.0.0.1", 9042, driver).await;
     let direct_connection = CassandraConnection::new("127.0.0.1", 9043, driver).await;
 
-    keyspace::test(&shotover_connection).await;
-    table::test(&shotover_connection).await;
-    udt::test(&shotover_connection).await;
-    native_types::test(&shotover_connection).await;
-    collections::test(&shotover_connection, driver).await;
-    functions::test(&shotover_connection).await;
-    batch_statements::test(&shotover_connection).await;
+    standard_test_suite(&shotover_connection, driver).await;
     protect::test(&shotover_connection, &direct_connection).await;
 }
 


### PR DESCRIPTION
starting to see a pattern where many tests run a standard test suite against their db/shotover combination so lets pull that standard test suite into a helper method