### PR TITLE
Bench CI speedups

### DIFF
--- a/.github/workflows/bench_run.yml
+++ b/.github/workflows/bench_run.yml
@@ -21,8 +21,14 @@ jobs:
     - uses: actions/checkout@v3
     - uses: Swatinem/rust-cache@v2
       with:
-        # Unique key is used to avoid collisions with the Testing workflow
-        key: 'ubuntu-18.04-benchmark'
+        # PRs do not share caches, instead each PR initially pulls from the cache of the main branch for the first run.
+        # This workflow does not run on main, so to make use of a cache before this workflow has completed once on a PR,
+        # we need to manually recreate the key used by ubuntu-18.04 release builds.
+        shared-key: "ubuntu-18.04 - --release-build_and_test"
+        # TODO: while we want to leach off this cache we dont want to overwrite it
+        #       so once something like https://github.com/Swatinem/rust-cache/issues/66 becomes available,
+        #       we should do something like this:
+        # save-if: false
     - name: Install ubuntu packages
       run: shotover-proxy/build/install_ubuntu_packages.sh
     - name: Run benchmarks

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -78,7 +78,7 @@ generic-array = { version = "0.14", features = ["serde"] }
 
 [dev-dependencies]
 rayon = "1.5.1"
-criterion = { git = "https://github.com/shotover/criterion.rs", branch = "version-0.4", version = "0.3", features = ["async_tokio", "html_reports"] }
+criterion = { git = "https://github.com/shotover/criterion.rs", branch = "version-0.4", version = "0.3", features = ["async_tokio"] }
 redis = { version = "0.21.0", features = ["tokio-comp", "cluster"] }
 pcap = "0.10.0"
 pktparse = { version = "0.7.0", features = ["serde"] }


### PR DESCRIPTION
# CI Change
Fixes an issue where bench_run does not use a cache when a PR is first submitted.

PRs do not share caches, instead each PR initially pulls from the cache of the main branch for the first run.
The bench_run workflow does not run on main, so to make use of a cache before this workflow has completed once on a PR, we need to manually recreate the key used by ubuntu-18.04 release builds.

This has the risk of the cache being overwritten by the run_bench workflow, but worst case the cache gets some extra bench logs included, Swatinem/rust-cache will not cache final binary output so we dont have to worry about losing that.
But I added a TODO to make use of a feature that will completely eliminate any risk here.

# Criterion change
Criterion's `html_reports` feature is generating ~15mb of html files across all of our benchmarks.
Neither me or Conor have ever used it so I suggest to remove it to save the space and cpu cycles, if anyone ever wants it they can go and manually enable the feature.