### PR TITLE
Update GA actions

### DIFF
--- a/.github/workflows/bench_run.yml
+++ b/.github/workflows/bench_run.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-18.04
     name: Benchmarks
     steps:
-    - uses: actions/checkout@v2
-    - uses: Swatinem/rust-cache@v1
+    - uses: actions/checkout@v3
+    - uses: Swatinem/rust-cache@v2
       with:
         # Unique key is used to avoid collisions with the Testing workflow
         key: 'ubuntu-18.04-benchmark'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         # We purposefully dont cache here as build_and_test will always be the bottleneck
         # so we should leave the cache alone so build_and_test can make more use of it.
       - name: Install ubuntu packages

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -44,8 +44,8 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: Swatinem/rust-cache@v1
+    - uses: actions/checkout@v3
+    - uses: Swatinem/rust-cache@v2
       with:
         # rust-cache already handles all the sane defaults for caching rust builds.
         # However because we are running seperate debug/release builds in parallel,

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -20,6 +20,6 @@ jobs:
     runs-on: ubuntu-22.04
     name: License Check
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: cargo install --locked cargo-deny
       - run: cargo deny check licenses

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Push image
         run: |
           docker build -t shotover/shotover-proxy:latest -t shotover/shotover-proxy:${GITHUB_REF/refs\/tags\//} .
@@ -27,15 +27,7 @@ jobs:
     name: "Publish Binary to GitHub"
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-            # `toolchain: stable` results in the latest stable toolchain being installed.
-            # However as soon as we use cargo the real version specified in rust-toolchain.toml replaces the stable toolchain.
-            #
-            # When something like https://github.com/actions-rs/toolchain/pull/184 lands we can delete this line and get a nice speedup
-            profile: minimal
-            toolchain: stable
+      - uses: actions/checkout@v3
       - name: Install ubuntu packages
         run: shotover-proxy/build/install_ubuntu_packages.sh
       - name: Build & test


### PR DESCRIPTION
Motivation: I wanted to make use of a feature in rust-cache@v2 but figured I may as well keep other actions up to date, so we can easily try more recent features without having to update.

Updated checkout and rust-cache to latest versions.
Removed a stray `actions-rs/toolchain@v1`, not needed anymore as github actions images now have rustup installed by default.

The cache key format seems to have changed from v1 to v2, so I'll rerun CI to confirm its caching properly.