### PR TITLE
Improve DebugPrinter

### DIFF
--- a/shotover-proxy/src/frame/mod.rs
+++ b/shotover-proxy/src/frame/mod.rs
@@ -5,6 +5,7 @@ pub use redis_protocol::resp2::types::Frame as RedisFrame;
 
 use anyhow::{anyhow, Result};
 use bytes::Bytes;
+use std::fmt::{Display, Formatter, Result as FmtResult};
 
 #[derive(PartialEq, Debug, Clone, Copy)]
 pub enum MessageType {
@@ -75,6 +76,16 @@ impl Frame {
                 "Expected cassandra frame but received {} frame",
                 frame.name()
             )),
+        }
+    }
+}
+
+impl Display for Frame {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Frame::Cassandra(frame) => write!(f, "Cassandra {}", frame),
+            Frame::Redis(frame) => write!(f, "Redis {:?})", frame),
+            Frame::None => write!(f, "None"),
         }
     }
 }

--- a/shotover-proxy/src/message/mod.rs
+++ b/shotover-proxy/src/message/mod.rs
@@ -347,6 +347,20 @@ impl Message {
             None => None,
         }
     }
+
+    pub fn to_high_level_string(&mut self) -> String {
+        if let Some(response) = self.frame() {
+            format!("{}", response)
+        } else if let Some(MessageInner::RawBytes {
+            bytes,
+            message_type,
+        }) = &self.inner
+        {
+            format!("Unparseable {:?} message {:?}", message_type, bytes)
+        } else {
+            unreachable!("self.frame() failed so MessageInner must still be RawBytes")
+        }
+    }
 }
 
 /// There are 3 levels of processing the message can be in.

--- a/shotover-proxy/src/transforms/debug/printer.rs
+++ b/shotover-proxy/src/transforms/debug/printer.rs
@@ -23,11 +23,17 @@ impl DebugPrinter {
 
 #[async_trait]
 impl Transform for DebugPrinter {
-    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> ChainResponse {
-        info!("Request content: {:?}", message_wrapper.messages);
+    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> ChainResponse {
+        for request in &mut message_wrapper.messages {
+            info!("Request: {}", request.to_high_level_string());
+        }
+
         self.counter += 1;
-        let response = message_wrapper.call_next_transform().await;
-        info!("Response content: {:?}", response);
-        response
+        let mut responses = message_wrapper.call_next_transform().await?;
+
+        for response in &mut responses {
+            info!("Response: {}", response.to_high_level_string());
+        }
+        Ok(responses)
     }
 }

--- a/shotover-proxy/src/transforms/mod.rs
+++ b/shotover-proxy/src/transforms/mod.rs
@@ -39,7 +39,6 @@ use anyhow::Result;
 use async_recursion::async_recursion;
 use async_trait::async_trait;
 use core::fmt;
-use core::fmt::Display;
 use futures::Future;
 use metrics::{counter, histogram};
 use serde::Deserialize;
@@ -398,12 +397,6 @@ impl<'a> Clone for Wrapper<'a> {
             local_addr: self.local_addr,
             flush: false,
         }
-    }
-}
-
-impl<'a> Display for Wrapper<'a> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
-        f.write_fmt(format_args!("{:#?}", self.messages))
     }
 }
 


### PR DESCRIPTION
There are two benefits here:
* users of the DebugPrinter transform are given a much higher level message log.
* developers get access to much more succinct debug logs with `tracing::error!("look at this {}", message.to_high_level_string())`. In particular I was overwhelmed by all the log noise when investigating the failure on https://github.com/shotover/shotover-proxy/pull/812

In order to allow parsing the message I couldnt implement Display for Message due to needing mutable access, so instead I added a `to_high_level_string` method.

While writing the format I wanted to prioritize both terseness and including every underlying field in some way.
To do this I was willing to introduce ambiguity in many places, but that is ok because its a format for humans to read not computers.
Some instances where this came up is:
* Options display nothing when None
* Vecs display nothing when empty
* cql query is unparsed text instead of AST
* some fields arent labelled when the meaning should be obvious (assuming you are already familiar with the field)

The result metadata types formatting are not great right now but I want to refactor the underlying types there sometime so not too fussed about that atm.

Many message types are just stubbed to give the standard "{:?}" debug output, I expect we will want to come back and implement those properly later on.


## Here is some before and afters:

system.local query/response before:
![image](https://user-images.githubusercontent.com/5120858/191168578-b54b389b-cd3d-4da1-b975-de1cf7d8c733.png)

system.local query/response after:
![image](https://user-images.githubusercontent.com/5120858/191168730-ea0b9101-f181-4bf2-adde-cabec7650e54.png)

And a bonus one, that demonstrates multi-row results that I couldnt find a before screenshot for:
![image](https://user-images.githubusercontent.com/5120858/191166037-12f89146-8c99-43f7-8397-e9c749da1abd.png)