### PR TITLE
Faster DockerCompose drop

### DIFF
--- a/test-helpers/src/docker_compose.rs
+++ b/test-helpers/src/docker_compose.rs
@@ -186,8 +186,8 @@ impl DockerCompose {
     fn clean_up(file_path: &str) -> Result<()> {
         trace!("bringing down docker compose {}", file_path);
 
+        run_command("docker-compose", &["-f", file_path, "kill"])?;
         run_command("docker-compose", &["-f", file_path, "down", "-v"])?;
-        run_command("docker-compose", &["-f", file_path, "rm", "-f", "-s", "-v"])?;
 
         thread::sleep(time::Duration::from_secs(1));
 


### PR DESCRIPTION
On my local machine this cuts 10s off the time to complete the test.
There is no need to be polite to these docker containers as we never intend to use them again and we dont care about cleanly closing connections to clients once the test is over.
We still need the call to `docker-compose down` as that will cleanup any left over networks for us.

I'm not sure what `docker-compose rm` was for, from looking at the documentation it seems to do the same thing as our call to `docker compose down`.
I traced it back to: https://github.com/shotover/shotover-proxy/commit/efb50e696313478844d8a1a68f3b73dd2e305f55#diff-6d1e3ec7ab6aaf7a94f9c1e9a423db6de6e4a1bec380dae17cc6e635f1db8854
Probably just a mistake.