### PR TITLE
Remove manual redis volumes from docker-compose.yml

### DIFF
--- a/docs/src/examples/redis-clustering-aware.md
+++ b/docs/src/examples/redis-clustering-aware.md
@@ -28,8 +28,6 @@ redis-node-0:
   networks:
     cluster_subnet:
       ipv4_address: 172.16.1.2
-  volumes:
-    - redis-cluster_data-0:/bitnami/redis/data
   environment:
     - 'ALLOW_EMPTY_PASSWORD=yes'
     - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2'

--- a/shotover-proxy/example-configs-docker/redis-cluster-ports-rewrite/docker-compose.yml
+++ b/shotover-proxy/example-configs-docker/redis-cluster-ports-rewrite/docker-compose.yml
@@ -5,8 +5,6 @@ services:
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.2
-    volumes:
-      - redis-cluster_data-0:/bitnami/redis/data
     environment:
       - 'ALLOW_EMPTY_PASSWORD=yes'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
@@ -16,8 +14,6 @@ services:
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.3
-    volumes:
-      - redis-cluster_data-1:/bitnami/redis/data
     environment:
       - 'ALLOW_EMPTY_PASSWORD=yes'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
@@ -27,8 +23,6 @@ services:
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.4
-    volumes:
-      - redis-cluster_data-2:/bitnami/redis/data
     environment:
       - 'ALLOW_EMPTY_PASSWORD=yes'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
@@ -37,9 +31,7 @@ services:
     image: docker.io/bitnami/redis-cluster:6.0-debian-10
     networks:
       cluster_subnet:
-          ipv4_address: 172.16.1.5
-    volumes:
-      - redis-cluster_data-3:/bitnami/redis/data
+        ipv4_address: 172.16.1.5
     environment:
       - 'ALLOW_EMPTY_PASSWORD=yes'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
@@ -49,8 +41,6 @@ services:
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.6
-    volumes:
-      - redis-cluster_data-4:/bitnami/redis/data
     environment:
       - 'ALLOW_EMPTY_PASSWORD=yes'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
@@ -60,8 +50,6 @@ services:
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.7
-    volumes:
-      - redis-cluster_data-5:/bitnami/redis/data
     environment:
       - 'ALLOW_EMPTY_PASSWORD=yes'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
@@ -149,20 +137,6 @@ services:
       - type: bind
         source: $PWD
         target: /config
-
-volumes:
-  redis-cluster_data-0:
-    driver: local
-  redis-cluster_data-1:
-    driver: local
-  redis-cluster_data-2:
-    driver: local
-  redis-cluster_data-3:
-    driver: local
-  redis-cluster_data-4:
-    driver: local
-  redis-cluster_data-5:
-    driver: local
 
 networks:
   cluster_subnet:

--- a/shotover-proxy/example-configs-docker/redis-cluster/docker-compose.yml
+++ b/shotover-proxy/example-configs-docker/redis-cluster/docker-compose.yml
@@ -4,8 +4,6 @@ services:
     image: docker.io/bitnami/redis-cluster:6.0-debian-10
     ports:
       - "2220:6379"
-    volumes:
-      - redis-cluster_data-0:/bitnami/redis/data
     environment:
       - 'ALLOW_EMPTY_PASSWORD=yes'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
@@ -14,8 +12,6 @@ services:
     image: docker.io/bitnami/redis-cluster:6.0-debian-10
     ports:
       - "2221:6379"
-    volumes:
-      - redis-cluster_data-1:/bitnami/redis/data
     environment:
       - 'ALLOW_EMPTY_PASSWORD=yes'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
@@ -24,8 +20,6 @@ services:
     image: docker.io/bitnami/redis-cluster:6.0-debian-10
     ports:
       - "2222:6379"
-    volumes:
-      - redis-cluster_data-2:/bitnami/redis/data
     environment:
       - 'ALLOW_EMPTY_PASSWORD=yes'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
@@ -34,8 +28,6 @@ services:
     image: docker.io/bitnami/redis-cluster:6.0-debian-10
     ports:
       - "2223:6379"
-    volumes:
-      - redis-cluster_data-3:/bitnami/redis/data
     environment:
       - 'ALLOW_EMPTY_PASSWORD=yes'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
@@ -44,8 +36,6 @@ services:
     image: docker.io/bitnami/redis-cluster:6.0-debian-10
     ports:
       - "2224:6379"
-    volumes:
-      - redis-cluster_data-4:/bitnami/redis/data
     environment:
       - 'ALLOW_EMPTY_PASSWORD=yes'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
@@ -54,8 +44,6 @@ services:
     image: docker.io/bitnami/redis-cluster:6.0-debian-10
     ports:
       - "2225:6379"
-    volumes:
-      - redis-cluster_data-5:/bitnami/redis/data
     environment:
       - 'ALLOW_EMPTY_PASSWORD=yes'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
@@ -84,17 +72,3 @@ services:
       - type: bind
         source: $PWD
         target: /config
-
-volumes:
-  redis-cluster_data-0:
-    driver: local
-  redis-cluster_data-1:
-    driver: local
-  redis-cluster_data-2:
-    driver: local
-  redis-cluster_data-3:
-    driver: local
-  redis-cluster_data-4:
-    driver: local
-  redis-cluster_data-5:
-    driver: local

--- a/shotover-proxy/example-configs/redis-cluster-dr/docker-compose.yml
+++ b/shotover-proxy/example-configs/redis-cluster-dr/docker-compose.yml
@@ -4,9 +4,8 @@ services:
     image: &image docker.io/bitnami/redis-cluster:6.0-debian-10
     ports:
       - "2220:6379"
-    volumes:
-      - redis-cluster_data-0:/bitnami/redis/data
-    environment: &node-environment
+    environment:
+      &node-environment
       - 'REDIS_PASSWORD=shotover'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
 
@@ -14,40 +13,30 @@ services:
     image: *image
     ports:
       - "2221:6379"
-    volumes:
-      - redis-cluster_data-1:/bitnami/redis/data
     environment: *node-environment
 
   redis-node-2:
     image: *image
     ports:
       - "2222:6379"
-    volumes:
-      - redis-cluster_data-2:/bitnami/redis/data
     environment: *node-environment
 
   redis-node-3:
     image: *image
     ports:
       - "2223:6379"
-    volumes:
-      - redis-cluster_data-3:/bitnami/redis/data
     environment: *node-environment
 
   redis-node-4:
     image: *image
     ports:
       - "2224:6379"
-    volumes:
-      - redis-cluster_data-4:/bitnami/redis/data
     environment: *node-environment
 
   redis-node-5:
     image: *image
     ports:
       - "2225:6379"
-    volumes:
-      - redis-cluster_data-5:/bitnami/redis/data
     environment: *node-environment
 
   redis-cluster-init:
@@ -70,9 +59,8 @@ services:
     image: *image
     ports:
       - "2120:6379"
-    volumes:
-      - redis-cluster_data-0-dr:/bitnami/redis/data
-    environment: &dr-environment
+    environment:
+      &dr-environment
       - 'REDIS_PASSWORD=shotover'
       - 'REDIS_NODES=redis-node-0-dr redis-node-1-dr redis-node-2-dr redis-node-3-dr redis-node-4-dr redis-node-5-dr'
 
@@ -80,40 +68,30 @@ services:
     image: *image
     ports:
       - "2121:6379"
-    volumes:
-      - redis-cluster_data-1-dr:/bitnami/redis/data
     environment: *dr-environment
 
   redis-node-2-dr:
     image: *image
     ports:
       - "2122:6379"
-    volumes:
-      - redis-cluster_data-2-dr:/bitnami/redis/data
     environment: *dr-environment
 
   redis-node-3-dr:
     image: *image
     ports:
       - "2123:6379"
-    volumes:
-      - redis-cluster_data-3-dr:/bitnami/redis/data
     environment: *dr-environment
 
   redis-node-4-dr:
     image: *image
     ports:
       - "2124:6379"
-    volumes:
-      - redis-cluster_data-4-dr:/bitnami/redis/data
     environment: *dr-environment
 
   redis-node-5-dr:
     image: *image
     ports:
       - "2125:6379"
-    volumes:
-      - redis-cluster_data-5-dr:/bitnami/redis/data
     environment: *dr-environment
 
   redis-cluster-init-dr:
@@ -129,32 +107,5 @@ services:
       - 'REDIS_PASSWORD=shotover'
       - 'REDISCLI_AUTH=shotover'
       - 'REDIS_CLUSTER_REPLICAS=1'
-      - 'REDIS_NODES=redis-node-0-dr redis-node-1-dr redis-node-2-dr
-        redis-node-3-dr redis-node-4-dr redis-node-5-dr'
+      - 'REDIS_NODES=redis-node-0-dr redis-node-1-dr redis-node-2-dr redis-node-3-dr redis-node-4-dr redis-node-5-dr'
       - 'REDIS_CLUSTER_CREATOR=yes'
-
-volumes:
-  redis-cluster_data-0:
-    driver: local
-  redis-cluster_data-1:
-    driver: local
-  redis-cluster_data-2:
-    driver: local
-  redis-cluster_data-3:
-    driver: local
-  redis-cluster_data-4:
-    driver: local
-  redis-cluster_data-5:
-    driver: local
-  redis-cluster_data-0-dr:
-    driver: local
-  redis-cluster_data-1-dr:
-    driver: local
-  redis-cluster_data-2-dr:
-    driver: local
-  redis-cluster_data-3-dr:
-    driver: local
-  redis-cluster_data-4-dr:
-    driver: local
-  redis-cluster_data-5-dr:
-    driver: local

--- a/shotover-proxy/example-configs/redis-cluster-handling/docker-compose.yml
+++ b/shotover-proxy/example-configs/redis-cluster-handling/docker-compose.yml
@@ -4,9 +4,8 @@ services:
     image: &image docker.io/bitnami/redis-cluster:6.0-debian-10
     ports:
       - "2220:6379"
-    volumes:
-      - redis-cluster_data-0:/bitnami/redis/data
-    environment: &environment
+    environment:
+      &environment
       - 'ALLOW_EMPTY_PASSWORD=yes'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
 
@@ -14,40 +13,30 @@ services:
     image: *image
     ports:
       - "2221:6379"
-    volumes:
-      - redis-cluster_data-1:/bitnami/redis/data
     environment: *environment
 
   redis-node-2:
     image: *image
     ports:
       - "2222:6379"
-    volumes:
-      - redis-cluster_data-2:/bitnami/redis/data
     environment: *environment
 
   redis-node-3:
     image: *image
     ports:
       - "2223:6379"
-    volumes:
-      - redis-cluster_data-3:/bitnami/redis/data
     environment: *environment
 
   redis-node-4:
     image: *image
     ports:
       - "2224:6379"
-    volumes:
-      - redis-cluster_data-4:/bitnami/redis/data
     environment: *environment
 
   redis-node-5:
     image: *image
     ports:
       - "2225:6379"
-    volumes:
-      - redis-cluster_data-5:/bitnami/redis/data
     environment: *environment
 
   redis-cluster-init:
@@ -64,17 +53,3 @@ services:
       - 'REDIS_CLUSTER_REPLICAS=1'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
       - 'REDIS_CLUSTER_CREATOR=yes'
-
-volumes:
-  redis-cluster_data-0:
-    driver: local
-  redis-cluster_data-1:
-    driver: local
-  redis-cluster_data-2:
-    driver: local
-  redis-cluster_data-3:
-    driver: local
-  redis-cluster_data-4:
-    driver: local
-  redis-cluster_data-5:
-    driver: local

--- a/shotover-proxy/example-configs/redis-cluster-hiding/docker-compose.yml
+++ b/shotover-proxy/example-configs/redis-cluster-hiding/docker-compose.yml
@@ -4,9 +4,8 @@ services:
     image: &image docker.io/bitnami/redis-cluster:6.0-debian-10
     ports:
       - "2220:6379"
-    volumes:
-      - redis-cluster_data-0:/bitnami/redis/data
-    environment: &environment
+    environment:
+      &environment
       - 'ALLOW_EMPTY_PASSWORD=yes'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
 
@@ -14,40 +13,30 @@ services:
     image: *image
     ports:
       - "2221:6379"
-    volumes:
-      - redis-cluster_data-1:/bitnami/redis/data
     environment: *environment
 
   redis-node-2:
     image: *image
     ports:
       - "2222:6379"
-    volumes:
-      - redis-cluster_data-2:/bitnami/redis/data
     environment: *environment
 
   redis-node-3:
     image: *image
     ports:
       - "2223:6379"
-    volumes:
-      - redis-cluster_data-3:/bitnami/redis/data
     environment: *environment
 
   redis-node-4:
     image: *image
     ports:
       - "2224:6379"
-    volumes:
-      - redis-cluster_data-4:/bitnami/redis/data
     environment: *environment
 
   redis-node-5:
     image: *image
     ports:
       - "2225:6379"
-    volumes:
-      - redis-cluster_data-5:/bitnami/redis/data
     environment: *environment
 
   redis-cluster-init:
@@ -64,17 +53,3 @@ services:
       - 'REDIS_CLUSTER_REPLICAS=1'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
       - 'REDIS_CLUSTER_CREATOR=yes'
-
-volumes:
-  redis-cluster_data-0:
-    driver: local
-  redis-cluster_data-1:
-    driver: local
-  redis-cluster_data-2:
-    driver: local
-  redis-cluster_data-3:
-    driver: local
-  redis-cluster_data-4:
-    driver: local
-  redis-cluster_data-5:
-    driver: local

--- a/shotover-proxy/example-configs/redis-cluster-tls/docker-compose-with-key.yml
+++ b/shotover-proxy/example-configs/redis-cluster-tls/docker-compose-with-key.yml
@@ -5,10 +5,10 @@ services:
     ports:
       - "2220:6379"
     volumes:
-      - redis-cluster_data-0:/bitnami/redis/data
       - &keys ../redis-tls/certs:/usr/local/etc/redis/certs
 
-    environment: &node_environment
+    environment:
+      &node_environment
       - 'ALLOW_EMPTY_PASSWORD=yes'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
       - 'REDIS_TLS_PORT=6379'
@@ -23,7 +23,6 @@ services:
     ports:
       - "2221:6379"
     volumes:
-      - redis-cluster_data-1:/bitnami/redis/data
       - *keys
     environment: *node_environment
 
@@ -32,7 +31,6 @@ services:
     ports:
       - "2222:6379"
     volumes:
-      - redis-cluster_data-2:/bitnami/redis/data
       - *keys
     environment: *node_environment
 
@@ -41,7 +39,6 @@ services:
     ports:
       - "2223:6379"
     volumes:
-      - redis-cluster_data-3:/bitnami/redis/data
       - *keys
     environment: *node_environment
 
@@ -50,7 +47,6 @@ services:
     ports:
       - "2224:6379"
     volumes:
-      - redis-cluster_data-4:/bitnami/redis/data
       - *keys
     environment: *node_environment
 
@@ -59,7 +55,6 @@ services:
     ports:
       - "2225:6379"
     volumes:
-      - redis-cluster_data-5:/bitnami/redis/data
       - *keys
     environment: *node_environment
 
@@ -84,17 +79,3 @@ services:
       - 'REDIS_TLS_CERT_FILE=/usr/local/etc/redis/certs/redis.crt'
       - 'REDIS_TLS_KEY_FILE=/usr/local/etc/redis/certs/redis.key'
       - 'REDIS_TLS_CA_FILE=/usr/local/etc/redis/certs/ca.crt'
-
-volumes:
-  redis-cluster_data-0:
-    driver: local
-  redis-cluster_data-1:
-    driver: local
-  redis-cluster_data-2:
-    driver: local
-  redis-cluster_data-3:
-    driver: local
-  redis-cluster_data-4:
-    driver: local
-  redis-cluster_data-5:
-    driver: local

--- a/shotover-proxy/example-configs/redis-cluster-tls/docker-compose.yml
+++ b/shotover-proxy/example-configs/redis-cluster-tls/docker-compose.yml
@@ -5,10 +5,10 @@ services:
     ports:
       - "2220:6379"
     volumes:
-      - redis-cluster_data-0:/bitnami/redis/data
       - &keys ../redis-tls/certs:/usr/local/etc/redis/certs
 
-    environment: &node_environment
+    environment:
+      &node_environment
       - 'ALLOW_EMPTY_PASSWORD=yes'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
       - 'REDIS_TLS_PORT=6379'
@@ -23,7 +23,6 @@ services:
     ports:
       - "2221:6379"
     volumes:
-      - redis-cluster_data-1:/bitnami/redis/data
       - *keys
     environment: *node_environment
 
@@ -32,7 +31,6 @@ services:
     ports:
       - "2222:6379"
     volumes:
-      - redis-cluster_data-2:/bitnami/redis/data
       - *keys
     environment: *node_environment
 
@@ -41,7 +39,6 @@ services:
     ports:
       - "2223:6379"
     volumes:
-      - redis-cluster_data-3:/bitnami/redis/data
       - *keys
     environment: *node_environment
 
@@ -50,7 +47,6 @@ services:
     ports:
       - "2224:6379"
     volumes:
-      - redis-cluster_data-4:/bitnami/redis/data
       - *keys
     environment: *node_environment
 
@@ -59,7 +55,6 @@ services:
     ports:
       - "2225:6379"
     volumes:
-      - redis-cluster_data-5:/bitnami/redis/data
       - *keys
     environment: *node_environment
 
@@ -84,17 +79,3 @@ services:
       - 'REDIS_TLS_CERT_FILE=/usr/local/etc/redis/certs/redis.crt'
       - 'REDIS_TLS_KEY_FILE=/usr/local/etc/redis/certs/redis.key'
       - 'REDIS_TLS_CA_FILE=/usr/local/etc/redis/certs/ca.crt'
-
-volumes:
-  redis-cluster_data-0:
-    driver: local
-  redis-cluster_data-1:
-    driver: local
-  redis-cluster_data-2:
-    driver: local
-  redis-cluster_data-3:
-    driver: local
-  redis-cluster_data-4:
-    driver: local
-  redis-cluster_data-5:
-    driver: local

--- a/shotover-proxy/tests/test-configs/redis-cluster-ports-rewrite/docker-compose.yml
+++ b/shotover-proxy/tests/test-configs/redis-cluster-ports-rewrite/docker-compose.yml
@@ -4,9 +4,8 @@ services:
     image: &image docker.io/bitnami/redis-cluster:6.0-debian-10
     ports:
       - "2220:6379"
-    volumes:
-      - redis-cluster_data-0:/bitnami/redis/data
-    environment: &environment
+    environment:
+      &environment
       - 'ALLOW_EMPTY_PASSWORD=yes'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
 
@@ -14,40 +13,30 @@ services:
     image: *image
     ports:
       - "2221:6379"
-    volumes:
-      - redis-cluster_data-1:/bitnami/redis/data
     environment: *environment
 
   redis-node-2:
     image: *image
     ports:
       - "2222:6379"
-    volumes:
-      - redis-cluster_data-2:/bitnami/redis/data
     environment: *environment
 
   redis-node-3:
     image: *image
     ports:
       - "2223:6379"
-    volumes:
-      - redis-cluster_data-3:/bitnami/redis/data
     environment: *environment
 
   redis-node-4:
     image: *image
     ports:
       - "2224:6379"
-    volumes:
-      - redis-cluster_data-4:/bitnami/redis/data
     environment: *environment
 
   redis-node-5:
     image: *image
     ports:
       - "2225:6379"
-    volumes:
-      - redis-cluster_data-5:/bitnami/redis/data
     environment: *environment
 
   redis-cluster-init:
@@ -64,17 +53,3 @@ services:
       - 'REDIS_CLUSTER_REPLICAS=1'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
       - 'REDIS_CLUSTER_CREATOR=yes'
-
-volumes:
-  redis-cluster_data-0:
-    driver: local
-  redis-cluster_data-1:
-    driver: local
-  redis-cluster_data-2:
-    driver: local
-  redis-cluster_data-3:
-    driver: local
-  redis-cluster_data-4:
-    driver: local
-  redis-cluster_data-5:
-    driver: local


### PR DESCRIPTION
I'm not sure why these were here, but removing them doesnt break anything and it makes the config a lot simpler.
It's also a possibility that volumes being kept around is causing our intermittent redis failures.

I did a bit of research and volumes are known to be faster than relying on the container layer, however removing the volumes has no observable affect on the runtime of our integration tests. And if it did help we would probably be better off just entirely avoiding the fs by disabling redis's persistence.