### PR TITLE
docker-compose: Store cassandra db in tmpfs

### DIFF
--- a/shotover-proxy/example-configs/cassandra-cluster-multi-rack/docker-compose.yml
+++ b/shotover-proxy/example-configs/cassandra-cluster-multi-rack/docker-compose.yml
@@ -36,6 +36,10 @@ services:
       CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS: "true"
       CASSANDRA_INIT_MAX_RETRIES: "500"
       CASSANDRA_INIT_SLEEP_TIME: "1"
+    volumes:
+      &volumes
+      - type: tmpfs
+        target: /bitnami/cassandra
 
   cassandra-two:
     image: *image
@@ -46,6 +50,7 @@ services:
     environment:
       <<: *environment
       CASSANDRA_RACK: rack2
+    volumes: *volumes
 
   cassandra-three:
     image: *image
@@ -56,3 +61,4 @@ services:
     environment:
       <<: *environment
       CASSANDRA_RACK: rack3
+    volumes: *volumes

--- a/shotover-proxy/example-configs/cassandra-cluster-tls/docker-compose.yml
+++ b/shotover-proxy/example-configs/cassandra-cluster-tls/docker-compose.yml
@@ -43,6 +43,8 @@ services:
       &volumes
       - ../cassandra-tls/certs/keystore.p12:/bitnami/cassandra/secrets/keystore
       - ../cassandra-tls/certs/truststore.p12:/bitnami/cassandra/secrets/truststore
+      - type: tmpfs
+        target: /bitnami/cassandra
 
   cassandra-two:
     image: *image

--- a/shotover-proxy/example-configs/cassandra-cluster/docker-compose-cassandra-v3.yml
+++ b/shotover-proxy/example-configs/cassandra-cluster/docker-compose-cassandra-v3.yml
@@ -36,6 +36,10 @@ services:
       CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS: "true"
       CASSANDRA_INIT_MAX_RETRIES: "500"
       CASSANDRA_INIT_SLEEP_TIME: "1"
+    volumes:
+      &volumes
+      - type: tmpfs
+        target: /bitnami/cassandra
 
   cassandra-two:
     image: *image
@@ -44,6 +48,7 @@ services:
         ipv4_address: 172.16.1.3
     healthcheck: *healthcheck
     environment: *environment
+    volumes: *volumes
 
   cassandra-three:
     image: *image
@@ -52,3 +57,4 @@ services:
         ipv4_address: 172.16.1.4
     healthcheck: *healthcheck
     environment: *environment
+    volumes: *volumes

--- a/shotover-proxy/example-configs/cassandra-cluster/docker-compose-cassandra-v4.yml
+++ b/shotover-proxy/example-configs/cassandra-cluster/docker-compose-cassandra-v4.yml
@@ -37,6 +37,10 @@ services:
       CASSANDRA_INIT_MAX_RETRIES: "500"
       CASSANDRA_INIT_SLEEP_TIME: "1"
       CASSANDRA_CQL_PORT_NUMBER: 9044
+    volumes:
+      &volumes
+      - type: tmpfs
+        target: /bitnami/cassandra
 
   cassandra-two:
     image: *image
@@ -45,6 +49,7 @@ services:
         ipv4_address: 172.16.1.3
     healthcheck: *healthcheck
     environment: *environment
+    volumes: *volumes
 
   cassandra-three:
     image: *image
@@ -53,3 +58,4 @@ services:
         ipv4_address: 172.16.1.4
     healthcheck: *healthcheck
     environment: *environment
+    volumes: *volumes

--- a/shotover-proxy/example-configs/cassandra-passthrough/docker-compose.yml
+++ b/shotover-proxy/example-configs/cassandra-passthrough/docker-compose.yml
@@ -8,3 +8,6 @@ services:
       MAX_HEAP_SIZE: "400M"
       MIN_HEAP_SIZE: "400M"
       HEAP_NEWSIZE: "48M"
+    volumes:
+      - type: tmpfs
+        target: /var/lib/cassandra

--- a/shotover-proxy/example-configs/cassandra-protect-aws/docker-compose.yml
+++ b/shotover-proxy/example-configs/cassandra-protect-aws/docker-compose.yml
@@ -8,3 +8,6 @@ services:
       MAX_HEAP_SIZE: "400M"
       MIN_HEAP_SIZE: "400M"
       HEAP_NEWSIZE: "48M"
+    volumes:
+      - type: tmpfs
+        target: /var/lib/cassandra

--- a/shotover-proxy/example-configs/cassandra-protect-local/docker-compose.yml
+++ b/shotover-proxy/example-configs/cassandra-protect-local/docker-compose.yml
@@ -8,3 +8,6 @@ services:
       MAX_HEAP_SIZE: "400M"
       MIN_HEAP_SIZE: "400M"
       HEAP_NEWSIZE: "48M"
+    volumes:
+      - type: tmpfs
+        target: /var/lib/cassandra

--- a/shotover-proxy/example-configs/cassandra-redis-cache/docker-compose.yml
+++ b/shotover-proxy/example-configs/cassandra-redis-cache/docker-compose.yml
@@ -12,3 +12,6 @@ services:
       MAX_HEAP_SIZE: "400M"
       MIN_HEAP_SIZE: "400M"
       HEAP_NEWSIZE: "48M"
+    volumes:
+      - type: tmpfs
+        target: /var/lib/cassandra

--- a/shotover-proxy/example-configs/cassandra-request-throttling/docker-compose.yml
+++ b/shotover-proxy/example-configs/cassandra-request-throttling/docker-compose.yml
@@ -8,3 +8,6 @@ services:
       MAX_HEAP_SIZE: "400M"
       MIN_HEAP_SIZE: "400M"
       HEAP_NEWSIZE: "48M"
+    volumes:
+      - type: tmpfs
+        target: /var/lib/cassandra

--- a/shotover-proxy/example-configs/cassandra-tls/docker-compose.yml
+++ b/shotover-proxy/example-configs/cassandra-tls/docker-compose.yml
@@ -18,3 +18,5 @@ services:
     volumes:
       - ./certs/keystore.p12:/bitnami/cassandra/secrets/keystore
       - ./certs/truststore.p12:/bitnami/cassandra/secrets/truststore
+      - type: tmpfs
+        target: /bitnami/cassandra

--- a/shotover-proxy/tests/test-configs/cassandra-passthrough-parse-request/docker-compose.yml
+++ b/shotover-proxy/tests/test-configs/cassandra-passthrough-parse-request/docker-compose.yml
@@ -8,3 +8,6 @@ services:
       MAX_HEAP_SIZE: "400M"
       MIN_HEAP_SIZE: "400M"
       HEAP_NEWSIZE: "48M"
+    volumes:
+      - type: tmpfs
+        target: /var/lib/cassandra

--- a/shotover-proxy/tests/test-configs/cassandra-passthrough-parse-response/docker-compose.yml
+++ b/shotover-proxy/tests/test-configs/cassandra-passthrough-parse-response/docker-compose.yml
@@ -8,3 +8,6 @@ services:
       MAX_HEAP_SIZE: "400M"
       MIN_HEAP_SIZE: "400M"
       HEAP_NEWSIZE: "48M"
+    volumes:
+      - type: tmpfs
+        target: /var/lib/cassandra

--- a/shotover-proxy/tests/test-configs/cassandra-peers-rewrite/docker-compose-3.11-cassandra.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra-peers-rewrite/docker-compose-3.11-cassandra.yaml
@@ -36,6 +36,10 @@ services:
       CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS: "true"
       CASSANDRA_INIT_MAX_RETRIES: "500"
       CASSANDRA_INIT_SLEEP_TIME: "1"
+    volumes:
+      &volumes
+      - type: tmpfs
+        target: /bitnami/cassandra
 
   cassandra-two:
     image: *image
@@ -44,3 +48,4 @@ services:
         ipv4_address: 172.16.1.3
     healthcheck: *healthcheck
     environment: *environment
+    volumes: *volumes

--- a/shotover-proxy/tests/test-configs/cassandra-peers-rewrite/docker-compose-4.0-cassandra.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra-peers-rewrite/docker-compose-4.0-cassandra.yaml
@@ -36,6 +36,10 @@ services:
       CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS: "true"
       CASSANDRA_INIT_MAX_RETRIES: "500"
       CASSANDRA_INIT_SLEEP_TIME: "1"
+    volumes:
+      &volumes
+      - type: tmpfs
+        target: /bitnami/cassandra
 
   cassandra-two:
     image: *image
@@ -44,3 +48,4 @@ services:
         ipv4_address: 172.16.1.3
     healthcheck: *healthcheck
     environment: *environment
+    volumes: *volumes


### PR DESCRIPTION
closes: https://github.com/shotover/shotover-proxy/issues/826
I did also investigate redis but from my testing disabling writing to disk didnt observably improve performance so I figured we were better leaving it with the default config.

On my local machine this PR cuts ~10s off each integration test that runs `standard_test_suite`