### PR TITLE
CassandraSinkCluster: Fix system.peers rpc_address

### DIFF
--- a/shotover-proxy/src/transforms/cassandra/sink_cluster/mod.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_cluster/mod.rs
@@ -579,7 +579,6 @@ impl CassandraSinkCluster {
                                     MessageValue::Uuid(shotover_peer.host_id)
                                 } else if colspec.name == preferred_ip_alias
                                     || colspec.name == preferred_port_alias
-                                    || colspec.name == rpc_address_alias
                                 {
                                     MessageValue::Null
                                 } else if colspec.name == native_address_alias {
@@ -589,7 +588,9 @@ impl CassandraSinkCluster {
                                         shotover_peer.address.port() as i64,
                                         IntSize::I32,
                                     )
-                                } else if colspec.name == peer_alias {
+                                } else if colspec.name == peer_alias
+                                    || colspec.name == rpc_address_alias
+                                {
                                     MessageValue::Inet(shotover_peer.address.ip())
                                 } else if colspec.name == peer_port_alias {
                                     MessageValue::Integer(7000, IntSize::I32)

--- a/shotover-proxy/tests/cassandra_int_tests/cluster_multi_rack.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cluster_multi_rack.rs
@@ -13,7 +13,8 @@ async fn test_rewrite_system_peers(connection: &CassandraConnection) {
         // rack is non-determistic because we dont know which node this will be
         ResultValue::Any,
         ResultValue::Varchar("4.0.6".into()),
-        ResultValue::Null,
+        // rpc_address is non-determistic because we dont know which node this will be
+        ResultValue::Any,
         // schema_version is non deterministic so we cant assert on it.
         ResultValue::Any,
         // Unfortunately token generation appears to be non-deterministic but we can at least assert that
@@ -96,7 +97,7 @@ async fn test_rewrite_system_local(connection: &CassandraConnection) {
     let star_results = [
         ResultValue::Varchar("local".into()),
         ResultValue::Varchar("COMPLETED".into()),
-        // broadcast address is non-deterministic because we dont know which node this will be
+        // broadcast address is non-deterministic because we dont know which shotover node this will be
         ResultValue::Any,
         ResultValue::Int(7000),
         ResultValue::Varchar("TestCluster".into()),
@@ -104,13 +105,14 @@ async fn test_rewrite_system_local(connection: &CassandraConnection) {
         ResultValue::Varchar("dc1".into()),
         // gossip_generation is non deterministic cant assert on it
         ResultValue::Any,
-        // host_id is non-deterministic because we dont know which node this will be
+        // host_id is non-deterministic because we dont know which shotover node this will be
         ResultValue::Any,
-        ResultValue::Inet("127.0.0.1".parse().unwrap()),
+        // listen_address is non-deterministic because we dont know which shotover node this will be
+        ResultValue::Any,
         ResultValue::Int(7000),
         ResultValue::Varchar("5".into()),
         ResultValue::Varchar("org.apache.cassandra.dht.Murmur3Partitioner".into()),
-        // rack is non-deterministic because we dont know which node this will be
+        // rack is non-deterministic because we dont know which shotover node this will be
         ResultValue::Any,
         ResultValue::Varchar("4.0.6".into()),
         ResultValue::Inet("0.0.0.0".parse().unwrap()),

--- a/shotover-proxy/tests/cassandra_int_tests/cluster_single_rack_v3.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cluster_single_rack_v3.rs
@@ -10,7 +10,8 @@ async fn test_rewrite_system_peers_dummy_peers(connection: &CassandraConnection)
         ResultValue::Null,
         ResultValue::Varchar("rack1".into()),
         ResultValue::Varchar("3.11.13".into()),
-        ResultValue::Null,
+        // rpc_address is non-determistic because we dont know which node this will be
+        ResultValue::Any,
         // schema_version is non deterministic so we cant assert on it.
         ResultValue::Any,
         // Unfortunately token generation appears to be non-deterministic but we can at least assert that
@@ -24,7 +25,8 @@ async fn test_rewrite_system_peers_dummy_peers(connection: &CassandraConnection)
         ResultValue::Null,
         ResultValue::Varchar("rack1".into()),
         ResultValue::Varchar("3.11.13".into()),
-        ResultValue::Null,
+        // rpc_address is non-determistic because we dont know which node this will be
+        ResultValue::Any,
         // schema_version is non deterministic so we cant assert on it.
         ResultValue::Any,
         // Unfortunately token generation appears to be non-deterministic but we can at least assert that

--- a/shotover-proxy/tests/cassandra_int_tests/cluster_single_rack_v4.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cluster_single_rack_v4.rs
@@ -58,7 +58,8 @@ async fn test_rewrite_system_peers_dummy_peers(connection: &CassandraConnection)
         ResultValue::Null,
         ResultValue::Varchar("rack1".into()),
         ResultValue::Varchar("4.0.6".into()),
-        ResultValue::Null,
+        // rpc_address is non-determistic because we dont know which node this will be
+        ResultValue::Any,
         // schema_version is non deterministic so we cant assert on it.
         ResultValue::Any,
         // Unfortunately token generation appears to be non-deterministic but we can at least assert that
@@ -72,7 +73,8 @@ async fn test_rewrite_system_peers_dummy_peers(connection: &CassandraConnection)
         ResultValue::Null,
         ResultValue::Varchar("rack1".into()),
         ResultValue::Varchar("4.0.6".into()),
-        ResultValue::Null,
+        // rpc_address is non-determistic because we dont know which node this will be
+        ResultValue::Any,
         // schema_version is non deterministic so we cant assert on it.
         ResultValue::Any,
         // Unfortunately token generation appears to be non-deterministic but we can at least assert that


### PR DESCRIPTION
rpc_address is a field in system.peers but not system.peers_v2
Driver's often still use system.peers instead of system.peers_v2 for routing.
So this field turned out to actually be important but we were just setting it to null.

As expected I had to change rpc_address fields in the integration tests.
However I also had to change the system.local listen_address in cluster_multi_rack, I assume that this change is now allowing the driver to properly route between multiple shotover instances resulting in different listen_address values.