### PR TITLE
Let docker-compose handle building docker images for us

### DIFF
--- a/shotover-proxy/build/install_ubuntu_packages.sh
+++ b/shotover-proxy/build/install_ubuntu_packages.sh
@@ -10,6 +10,11 @@ sudo apt-get install -y gcc-aarch64-linux-gnu
 # Install dependencies of the cpp-driver even if they are already on CI so that we can run this locally
 sudo apt-get install -y libuv1 libuv1-dev cmake g++ libssl-dev zlib1g-dev
 
+# older docker-compose on ubuntu lacks support for docker-compose build field
+pip install pip --upgrade
+pip install pyopenssl --upgrade
+pip install docker-compose==1.29.2
+
 # set VERSION to one of the tags here: https://github.com/datastax/cpp-driver/tags
 VERSION=2.16.2
 

--- a/shotover-proxy/example-configs/cassandra-cluster-multi-rack/docker-compose.yaml
+++ b/shotover-proxy/example-configs/cassandra-cluster-multi-rack/docker-compose.yaml
@@ -11,6 +11,7 @@ networks:
 
 services:
   cassandra-one:
+    build: &build example-configs/docker-images/cassandra-4.0.6
     image: &image shotover-int-tests/cassandra:4.0.6
     networks:
       cluster_subnet:
@@ -33,6 +34,7 @@ services:
     command: &command cassandra -f -Dcassandra.initial_token="$$CASSANDRA_INITIAL_TOKENS"
 
   cassandra-two:
+    build: *build
     image: *image
     networks:
       cluster_subnet:
@@ -45,6 +47,7 @@ services:
     command: *command
 
   cassandra-three:
+    build: *build
     image: *image
     networks:
       cluster_subnet:

--- a/shotover-proxy/example-configs/cassandra-cluster-tls/docker-compose.yaml
+++ b/shotover-proxy/example-configs/cassandra-cluster-tls/docker-compose.yaml
@@ -11,6 +11,7 @@ networks:
 
 services:
   cassandra-one:
+    build: &build example-configs/docker-images/cassandra-tls-4.0.6
     image: &image shotover-int-tests/cassandra-tls:4.0.6
     networks:
       cluster_subnet:
@@ -33,6 +34,7 @@ services:
     command: &command cassandra -f -Dcassandra.initial_token="$$CASSANDRA_INITIAL_TOKENS"
 
   cassandra-two:
+    build: *build
     image: *image
     networks:
       cluster_subnet:
@@ -44,6 +46,7 @@ services:
     command: *command
 
   cassandra-three:
+    build: *build
     image: *image
     networks:
       cluster_subnet:

--- a/shotover-proxy/example-configs/cassandra-cluster-v3/docker-compose.yaml
+++ b/shotover-proxy/example-configs/cassandra-cluster-v3/docker-compose.yaml
@@ -11,6 +11,7 @@ networks:
 
 services:
   cassandra-one:
+    build: &build example-configs/docker-images/cassandra-3.11.13
     image: &image shotover-int-tests/cassandra:3.11.13
     networks:
       cluster_subnet:
@@ -33,6 +34,7 @@ services:
     command: &command cassandra -f -Dcassandra.initial_token="$$CASSANDRA_INITIAL_TOKENS"
 
   cassandra-two:
+    build: *build
     image: *image
     networks:
       cluster_subnet:
@@ -44,6 +46,7 @@ services:
     command: *command
 
   cassandra-three:
+    build: *build
     image: *image
     networks:
       cluster_subnet:

--- a/shotover-proxy/example-configs/cassandra-cluster-v4/docker-compose.yaml
+++ b/shotover-proxy/example-configs/cassandra-cluster-v4/docker-compose.yaml
@@ -11,6 +11,7 @@ networks:
 
 services:
   cassandra-one:
+    build: &build example-configs/docker-images/cassandra-4.0.6
     image: &image shotover-int-tests/cassandra:4.0.6
     networks:
       cluster_subnet:
@@ -34,6 +35,7 @@ services:
     command: &command cassandra -f -Dcassandra.initial_token="$$CASSANDRA_INITIAL_TOKENS" -Dcassandra.native_transport_port=9044
 
   cassandra-two:
+    build: *build
     image: *image
     networks:
       cluster_subnet:
@@ -45,6 +47,7 @@ services:
     command: *command
 
   cassandra-three:
+    build: *build
     image: *image
     networks:
       cluster_subnet:

--- a/shotover-proxy/example-configs/cassandra-passthrough/docker-compose.yaml
+++ b/shotover-proxy/example-configs/cassandra-passthrough/docker-compose.yaml
@@ -1,6 +1,7 @@
 version: "3.3"
 services:
   cassandra-one:
+    build: example-configs/docker-images/cassandra-4.0.6
     image: shotover-int-tests/cassandra:4.0.6
     ports:
       - "9043:9042"

--- a/shotover-proxy/example-configs/cassandra-protect-aws/docker-compose.yaml
+++ b/shotover-proxy/example-configs/cassandra-protect-aws/docker-compose.yaml
@@ -1,6 +1,7 @@
 version: "3.3"
 services:
   cassandra-one:
+    build: example-configs/docker-images/cassandra-4.0.6
     image: shotover-int-tests/cassandra:4.0.6
     ports:
       - "9043:9042"

--- a/shotover-proxy/example-configs/cassandra-protect-local/docker-compose.yaml
+++ b/shotover-proxy/example-configs/cassandra-protect-local/docker-compose.yaml
@@ -1,6 +1,7 @@
 version: "3.3"
 services:
   cassandra-one:
+    build: example-configs/docker-images/cassandra-4.0.6
     image: shotover-int-tests/cassandra:4.0.6
     ports:
       - "9043:9042"

--- a/shotover-proxy/example-configs/cassandra-redis-cache/docker-compose.yaml
+++ b/shotover-proxy/example-configs/cassandra-redis-cache/docker-compose.yaml
@@ -5,6 +5,7 @@ services:
     ports:
       - "6379:6379"
   cassandra-one:
+    build: example-configs/docker-images/cassandra-4.0.6
     image: shotover-int-tests/cassandra:4.0.6
     ports:
       - "9043:9042"

--- a/shotover-proxy/example-configs/cassandra-request-throttling/docker-compose.yaml
+++ b/shotover-proxy/example-configs/cassandra-request-throttling/docker-compose.yaml
@@ -1,6 +1,7 @@
 version: "3.3"
 services:
   cassandra-one:
+    build: example-configs/docker-images/cassandra-4.0.6
     image: shotover-int-tests/cassandra:4.0.6
     ports:
       - "9043:9042"

--- a/shotover-proxy/example-configs/cassandra-tls/docker-compose.yaml
+++ b/shotover-proxy/example-configs/cassandra-tls/docker-compose.yaml
@@ -1,6 +1,7 @@
 version: "3.3"
 services:
   cassandra-one:
+    build: example-configs/docker-images/cassandra-tls-4.0.6
     image: shotover-int-tests/cassandra-tls:4.0.6
     ports:
       - "9042:9042"

--- a/shotover-proxy/tests/test-configs/cassandra-passthrough-parse-request/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra-passthrough-parse-request/docker-compose.yaml
@@ -1,6 +1,7 @@
 version: "3.3"
 services:
   cassandra-one:
+    build: example-configs/docker-images/cassandra-4.0.6
     image: shotover-int-tests/cassandra:4.0.6
     ports:
       - "9043:9042"

--- a/shotover-proxy/tests/test-configs/cassandra-passthrough-parse-response/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra-passthrough-parse-response/docker-compose.yaml
@@ -1,6 +1,7 @@
 version: "3.3"
 services:
   cassandra-one:
+    build: example-configs/docker-images/cassandra-4.0.6
     image: shotover-int-tests/cassandra:4.0.6
     ports:
       - "9043:9042"

--- a/shotover-proxy/tests/test-configs/cassandra-peers-rewrite/docker-compose-3.11-cassandra.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra-peers-rewrite/docker-compose-3.11-cassandra.yaml
@@ -11,6 +11,7 @@ networks:
 
 services:
   cassandra-one:
+    build: &build example-configs/docker-images/cassandra-3.11.13
     image: &image shotover-int-tests/cassandra:3.11.13
     networks:
       cluster_subnet:
@@ -33,6 +34,7 @@ services:
     command: &command cassandra -f -Dcassandra.initial_token="$$CASSANDRA_INITIAL_TOKENS"
 
   cassandra-two:
+    build: *build
     image: *image
     networks:
       cluster_subnet:

--- a/shotover-proxy/tests/test-configs/cassandra-peers-rewrite/docker-compose-4.0-cassandra.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra-peers-rewrite/docker-compose-4.0-cassandra.yaml
@@ -11,6 +11,7 @@ networks:
 
 services:
   cassandra-one:
+    build: &build example-configs/docker-images/cassandra-4.0.6
     image: &image shotover-int-tests/cassandra:4.0.6
     networks:
       cluster_subnet:
@@ -33,6 +34,7 @@ services:
     command: &command cassandra -f -Dcassandra.initial_token="$$CASSANDRA_INITIAL_TOKENS"
 
   cassandra-two:
+    build: *build
     image: *image
     networks:
       cluster_subnet:

--- a/test-helpers/src/docker_compose.rs
+++ b/test-helpers/src/docker_compose.rs
@@ -2,11 +2,11 @@ use anyhow::{anyhow, Result};
 use regex::Regex;
 use serde_yaml::Value;
 use std::collections::HashMap;
+use std::env;
 use std::fmt::Write;
 use std::io::ErrorKind;
 use std::process::Command;
 use std::time::{self, Duration};
-use std::{env, path::Path};
 use subprocess::{Exec, Redirection};
 use tracing::trace;
 use tracing_subscriber::fmt::TestWriter;
@@ -81,8 +81,6 @@ impl DockerCompose {
         DockerCompose::clean_up(file_path).unwrap();
 
         let service_to_image = DockerCompose::get_service_to_image(file_path);
-
-        DockerCompose::build_images(&service_to_image);
 
         run_command("docker-compose", &["-f", file_path, "up", "-d"]).unwrap();
 
@@ -304,56 +302,6 @@ impl DockerCompose {
             panic!(
                 "At least one container failed to initialize\n{containers}\nFull log\n{full_log}"
             );
-        }
-    }
-
-    fn build_images(service_to_image: &HashMap<String, String>) {
-        if service_to_image
-            .values()
-            .any(|x| x == "shotover-int-tests/cassandra:4.0.6")
-        {
-            run_command(
-                "docker",
-                &[
-                    "build",
-                    "example-configs/docker-images/cassandra-4.0.6",
-                    "--tag",
-                    "shotover-int-tests/cassandra:4.0.6",
-                ],
-            )
-            .unwrap();
-        }
-        if service_to_image
-            .values()
-            .any(|x| x == "shotover-int-tests/cassandra:3.11.13")
-        {
-            run_command(
-                "docker",
-                &[
-                    "build",
-                    "example-configs/docker-images/cassandra-3.11.13",
-                    "--tag",
-                    "shotover-int-tests/cassandra:3.11.13",
-                ],
-            )
-            .unwrap();
-        }
-        if service_to_image
-            .values()
-            .any(|x| x == "shotover-int-tests/cassandra-tls:4.0.6")
-            && Path::new("example-configs/docker-images/cassandra-tls-4.0.6/certs/keystore.p12")
-                .exists()
-        {
-            run_command(
-                "docker",
-                &[
-                    "build",
-                    "example-configs/docker-images/cassandra-tls-4.0.6",
-                    "--tag",
-                    "shotover-int-tests/cassandra-tls:4.0.6",
-                ],
-            )
-            .unwrap();
         }
     }
 


### PR DESCRIPTION
I noticed this docker-compose `build` field which seems like a much better approach than having to manually build each image.
I carefully tested it and observed:
*  no regression in time to build the images from scratch and incrementally.
*  changes to the compose file are immediately picked up next time I run `cargo test ...` (I did have to add the `--build` flag for this to work though)