### PR TITLE
fix test

### DIFF
--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -67,6 +67,7 @@ async fn test_passthrough(#[case] driver: CassandraDriver) {
     standard_test_suite(&connection, driver).await;
 }
 
+#[cfg(feature = "alpha-transforms")]
 #[rstest]
 #[case(CdrsTokio)]
 #[cfg_attr(feature = "cassandra-cpp-driver-tests", case(Datastax))]


### PR DESCRIPTION
If you run `cargo test` an error will appear because the force encode transform is behind `alpha-transforms`.