### PR TITLE
Route cassandra_cpp logs -> log -> tracing

### DIFF
--- a/shotover-proxy/tests/helpers/cassandra.rs
+++ b/shotover-proxy/tests/helpers/cassandra.rs
@@ -104,6 +104,7 @@ impl CassandraConnection {
         match driver {
             #[cfg(feature = "cassandra-cpp-driver-tests")]
             CassandraDriver::Datastax => {
+                cassandra_cpp::set_log_logger();
                 let mut cluster = Cluster::default();
                 cluster.set_contact_points(contact_points).unwrap();
                 cluster.set_credentials("cassandra", "cassandra").unwrap();


### PR DESCRIPTION
Not ready for review until the cassandra_cpp changes are upstreamed: 

Cassandra cpp logs to the log crate which is mapped to tracing via tracing-log.
tracing-log is internally initialized by tracing-subscriber.

The cassandra_cpp logs are now:
* in the standard output format the rest of our logs are in
* more compact
* filterable by tracing filters.

screenshot:
![image](https://user-images.githubusercontent.com/5120858/194795824-ec2aec78-4be7-439d-a4cc-935e6526b79c.png)
