### PR TITLE
Fix BenchResources drop order

### DIFF
--- a/shotover-proxy/benches/benches/cassandra.rs
+++ b/shotover-proxy/benches/benches/cassandra.rs
@@ -261,9 +261,9 @@ criterion_group!(benches, cassandra);
 criterion_main!(benches);
 
 pub struct BenchResources {
-    _compose: DockerCompose,
-    _shotover_manager: ShotoverManager,
     connection: CassandraConnection,
+    _shotover_manager: ShotoverManager,
+    _compose: DockerCompose,
     queries: HashMap<String, Statement>,
 }
 

--- a/shotover-proxy/benches/benches/redis.rs
+++ b/shotover-proxy/benches/benches/redis.rs
@@ -144,9 +144,9 @@ fn redis(c: &mut Criterion) {
 criterion_group!(benches, redis);
 
 struct BenchResources {
-    _compose: DockerCompose,
-    _shotover_manager: ShotoverManager,
     connection: redis::Connection,
+    _shotover_manager: ShotoverManager,
+    _compose: DockerCompose,
 }
 
 impl BenchResources {


### PR DESCRIPTION
The fields of a struct are dropped in the order that they are defined: https://stackoverflow.com/questions/41053542/forcing-the-order-in-which-struct-fields-are-dropped

Reordering the BenchResources fields such that we drop the `ShotoverManager` before we drop the `DockerCompose` avoids errors like the following from being logged:
```
2022-10-13T02:14:52.562355Z ERROR connection{id=4 source="CassandraSource"}: shotover_proxy::transforms::cassandra::connection: tx_process task terminated

Caused by:
    channel closed
2022-10-13T02:14:52.562396Z ERROR connection{id=4 source="CassandraSource"}: shotover_proxy::server: connection was unexpectedly terminated

Caused by:
    0: chain failed to send and/or receive messages
    1: channel closed
```