### PR TITLE
cassandra_int_tests: add test_node_going_down

### DIFF
--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -200,12 +200,7 @@ async fn test_cluster_single_rack_v4(#[case] driver: CassandraDriver) {
 
     let shotover_manager =
         ShotoverManager::from_topology_file("example-configs/cassandra-cluster/topology-v4.yaml");
-    cluster_single_rack_v4::test_events_filtering(
-        compose,
-        shotover_manager,
-        CassandraDriver::CdrsTokio,
-    )
-    .await;
+    cluster_single_rack_v4::test_node_going_down(compose, shotover_manager, driver).await;
 }
 
 #[cfg(feature = "cassandra-cpp-driver-tests")]

--- a/shotover-proxy/tests/helpers/cassandra.rs
+++ b/shotover-proxy/tests/helpers/cassandra.rs
@@ -222,7 +222,7 @@ impl CassandraConnection {
         );
     }
 
-    async fn await_schema_agreement(&self) {
+    pub async fn await_schema_agreement(&self) {
         let schema_awaiter = match self {
             #[cfg(feature = "cassandra-cpp-driver-tests")]
             Self::Datastax { schema_awaiter, .. } => schema_awaiter,


### PR DESCRIPTION
test_events_filtering is renamed to test_node_going_down and extended to test that shotover can continue to process incoming messages after a node goes down.
Currently this only tests connections created after a node goes down as that is all that shotover currently handles.
But I have added TODO's to test connections created before a node goes down for once shotover does handle that.

I also made the event assertions more robust by handling the `StatusChangeType::Up` event that can occur by reordering the test cases.