### PR TITLE
Fix cassandra_cpp rpc_address warning

### DIFF
--- a/shotover-proxy/example-configs/docker-images/cassandra-3.11.13/cassandra.yaml
+++ b/shotover-proxy/example-configs/docker-images/cassandra-3.11.13/cassandra.yaml
@@ -692,7 +692,7 @@ start_rpc: false
 # set broadcast_rpc_address to a value other than 0.0.0.0.
 #
 # For security reasons, you should not expose this port to the internet.  Firewall it if needed.
-rpc_address: localhost
+#rpc_address: localhost
 
 # Set rpc_address OR rpc_interface, not both. Interfaces must correspond
 # to a single address, IP aliasing is not supported.

--- a/shotover-proxy/example-configs/docker-images/cassandra-4.0.6/cassandra.yaml
+++ b/shotover-proxy/example-configs/docker-images/cassandra-4.0.6/cassandra.yaml
@@ -748,7 +748,7 @@ native_transport_allow_older_protocols: true
 # set broadcast_rpc_address to a value other than 0.0.0.0.
 #
 # For security reasons, you should not expose this port to the internet.  Firewall it if needed.
-rpc_address: localhost
+#rpc_address: localhost
 
 # Set rpc_address OR rpc_interface, not both. Interfaces must correspond
 # to a single address, IP aliasing is not supported.

--- a/shotover-proxy/example-configs/docker-images/cassandra-tls-4.0.6/cassandra.yaml
+++ b/shotover-proxy/example-configs/docker-images/cassandra-tls-4.0.6/cassandra.yaml
@@ -748,7 +748,7 @@ native_transport_allow_older_protocols: true
 # set broadcast_rpc_address to a value other than 0.0.0.0.
 #
 # For security reasons, you should not expose this port to the internet.  Firewall it if needed.
-rpc_address: localhost
+#rpc_address: localhost
 
 # Set rpc_address OR rpc_interface, not both. Interfaces must correspond
 # to a single address, IP aliasing is not supported.

--- a/shotover-proxy/tests/cassandra_int_tests/cluster_multi_rack.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cluster_multi_rack.rs
@@ -115,7 +115,8 @@ async fn test_rewrite_system_local(connection: &CassandraConnection) {
         // rack is non-deterministic because we dont know which shotover node this will be
         ResultValue::Any,
         ResultValue::Varchar("4.0.6".into()),
-        ResultValue::Inet("0.0.0.0".parse().unwrap()),
+        // rpc_address is non deterministic so we cant assert on it
+        ResultValue::Any,
         ResultValue::Int(9042),
         // schema_version is non deterministic so we cant assert on it.
         ResultValue::Any,

--- a/shotover-proxy/tests/cassandra_int_tests/cluster_single_rack_v3.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cluster_single_rack_v3.rs
@@ -74,7 +74,8 @@ async fn test_rewrite_system_local(connection: &CassandraConnection) {
         ResultValue::Varchar("org.apache.cassandra.dht.Murmur3Partitioner".into()),
         ResultValue::Varchar("rack1".into()),
         ResultValue::Varchar("3.11.13".into()),
-        ResultValue::Inet("0.0.0.0".parse().unwrap()),
+        // rpc_address is non deterministic so we cant assert on it
+        ResultValue::Any,
         // schema_version is non deterministic so we cant assert on it.
         ResultValue::Any,
         // thrift_version isnt used anymore so I dont really care what it maps to

--- a/shotover-proxy/tests/cassandra_int_tests/cluster_single_rack_v4.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cluster_single_rack_v4.rs
@@ -184,7 +184,8 @@ async fn test_rewrite_system_local(connection: &CassandraConnection) {
         ResultValue::Varchar("org.apache.cassandra.dht.Murmur3Partitioner".into()),
         ResultValue::Varchar("rack1".into()),
         ResultValue::Varchar("4.0.6".into()),
-        ResultValue::Inet("0.0.0.0".parse().unwrap()),
+        // rpc_address is non deterministic so we cant assert on it
+        ResultValue::Any,
         ResultValue::Int(9042),
         // schema_version is non deterministic so we cant assert on it.
         ResultValue::Any,


### PR DESCRIPTION
Fixes warnings like:
```
1665705034.217 [WARN] (host.cpp:151:void datastax::internal::core::Host::set(const datastax::internal::core::Row*, bool)): Found host with 'bind any' for rpc_address; using listen_address (127.0.0.1) to contact instead. If this is incorrect you should configure a specific interface for rpc_address on the server.
```
that get logged every time a new connection is made with cassandra_cpp.

Looking at the comments above the `rpc_address: localhost` I can see that the default setting is actually invalid.
Setting localhost results in an rpc_address of 0.0.0.0 which the comment explicitly calls out as invalid.
The comment also says that leaving out the setting entirely will make it just do the right thing of setting rpc_address to the nodes ip address, so that is what I have done.

Its also worth noting that rpc_address IS the field used to set the address where the client connects to, despite `rpc` making it sound like it has to do with the old thrift stuff.
The old name is just kept for legacy reasons.