### PR TITLE
Update to rust 1.65

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.64"
+channel = "1.65"
 components = [ "rustfmt", "clippy" ]
 targets = [ "aarch64-unknown-linux-gnu" ]

--- a/shotover-proxy/src/lib.rs
+++ b/shotover-proxy/src/lib.rs
@@ -18,6 +18,7 @@
 //! * [`transforms::TransformsConfig`], the enum to register with (add a variant) for configuring your own transform.
 
 #![allow(clippy::derive_partial_eq_without_eq)]
+#![allow(clippy::bool_to_int_with_if)]
 
 pub mod codec;
 pub mod config;

--- a/shotover-proxy/src/lib.rs
+++ b/shotover-proxy/src/lib.rs
@@ -18,7 +18,6 @@
 //! * [`transforms::TransformsConfig`], the enum to register with (add a variant) for configuring your own transform.
 
 #![allow(clippy::derive_partial_eq_without_eq)]
-#![allow(clippy::bool_to_int_with_if)]
 
 pub mod codec;
 pub mod config;

--- a/shotover-proxy/src/message/mod.rs
+++ b/shotover-proxy/src/message/mod.rs
@@ -634,7 +634,7 @@ impl MessageValue {
                 IntSize::I8 => serialize_bytes(cursor, &(*x as i8).to_be_bytes()),
             },
             MessageValue::Float(f) => serialize_bytes(cursor, &f.into_inner().to_be_bytes()),
-            MessageValue::Boolean(b) => serialize_bytes(cursor, &[if *b { 1 } else { 0 }]),
+            MessageValue::Boolean(b) => serialize_bytes(cursor, &[*b as u8]),
             MessageValue::List(l) => serialize_list(cursor, l),
             MessageValue::Inet(i) => match i {
                 IpAddr::V4(ip) => serialize_bytes(cursor, &ip.octets()),

--- a/shotover-proxy/src/transforms/mod.rs
+++ b/shotover-proxy/src/transforms/mod.rs
@@ -84,7 +84,7 @@ pub enum Transforms {
     Null(Null),
     #[cfg(test)]
     Loopback(Loopback),
-    Protect(Protect),
+    Protect(Box<Protect>),
     ConsistentScatter(ConsistentScatter),
     RedisTimestampTagger(RedisTimestampTagger),
     RedisSinkCluster(RedisSinkCluster),

--- a/shotover-proxy/src/transforms/protect/mod.rs
+++ b/shotover-proxy/src/transforms/protect/mod.rs
@@ -27,7 +27,7 @@ pub struct ProtectConfig {
 
 impl ProtectConfig {
     pub async fn get_transform(&self) -> Result<Transforms> {
-        Ok(Transforms::Protect(Protect {
+        Ok(Transforms::Protect(Box::new(Protect {
             keyspace_table_columns: self
                 .keyspace_table_columns
                 .iter()
@@ -47,7 +47,7 @@ impl ProtectConfig {
                 .collect(),
             key_source: self.key_manager.build()?,
             key_id: "XXXXXXX".to_string(),
-        }))
+        })))
     }
 }
 


### PR DESCRIPTION
I decided to disable the new `clippy::bool_to_int_with_if` lint as IMO it makes the code less clear, as its not obvious what integer values correspond to true/false.
Happy to enable it if people disagree though.