### PR TITLE
fix redis error reporting

### DIFF
--- a/shotover-proxy/src/config/topology.rs
+++ b/shotover-proxy/src/config/topology.rs
@@ -61,7 +61,7 @@ impl Topology {
         }
 
         if !chain_errors.is_empty() {
-            return Err(anyhow!(format!("Topology errors\n{chain_errors}")));
+            return Err(anyhow!("Topology errors\n{chain_errors}"));
         }
 
         for (source_name, chain_name) in &self.source_to_chain_mapping {


### PR DESCRIPTION
Using {} instead of {:?} was preventing the full error chain from being logged.
Also replaced some custom string formatting with anyhow context method.