### PR TITLE
TLS: Use destination as hostname instead of hardcoded localhost

### DIFF
--- a/shotover-proxy/example-configs/cassandra-cluster-tls/topology.yaml
+++ b/shotover-proxy/example-configs/cassandra-cluster-tls/topology.yaml
@@ -22,6 +22,6 @@ chain_config:
           certificate_authority_path: "example-configs/docker-images/cassandra-tls-4.0.6/certs/localhost_CA.crt"
           certificate_path: "example-configs/docker-images/cassandra-tls-4.0.6/certs/localhost.crt"
           private_key_path: "example-configs/docker-images/cassandra-tls-4.0.6/certs/localhost.key"
-          verify_hostname: true
+          verify_hostname: false
 source_to_chain_mapping:
   cassandra_prod: main_chain

--- a/shotover-proxy/example-configs/cassandra-tls/topology-with-key.yaml
+++ b/shotover-proxy/example-configs/cassandra-tls/topology-with-key.yaml
@@ -10,7 +10,7 @@ sources:
 chain_config:
   main_chain:
     - CassandraSinkSingle:
-        remote_address: "127.0.0.1:9042"
+        remote_address: "localhost:9042"
         connect_timeout_ms: 3000
         tls:
           certificate_authority_path: "example-configs/docker-images/cassandra-tls-4.0.6/certs/localhost_CA.crt"

--- a/shotover-proxy/example-configs/cassandra-tls/topology.yaml
+++ b/shotover-proxy/example-configs/cassandra-tls/topology.yaml
@@ -10,10 +10,10 @@ sources:
 chain_config:
   main_chain:
     - CassandraSinkSingle:
-        remote_address: "127.0.0.1:9042"
+        remote_address: "localhost:9042"
         connect_timeout_ms: 3000
         tls:
           certificate_authority_path: "example-configs/docker-images/cassandra-tls-4.0.6/certs/localhost_CA.crt"
-          verify_hostname: false
+          verify_hostname: true
 source_to_chain_mapping:
   cassandra_prod: main_chain

--- a/shotover-proxy/example-configs/redis-cluster-tls/topology-with-key.yaml
+++ b/shotover-proxy/example-configs/redis-cluster-tls/topology-with-key.yaml
@@ -12,6 +12,6 @@ chain_config:
           certificate_authority_path: "example-configs/redis-tls/certs/ca.crt"
           certificate_path: "example-configs/redis-tls/certs/redis.crt"
           private_key_path: "example-configs/redis-tls/certs/redis.key"
-          verify_hostname: true
+          verify_hostname: false
 source_to_chain_mapping:
   redis_prod: redis_chain

--- a/shotover-proxy/example-configs/redis-cluster-tls/topology.yaml
+++ b/shotover-proxy/example-configs/redis-cluster-tls/topology.yaml
@@ -10,6 +10,6 @@ chain_config:
         connect_timeout_ms: 3000
         tls:
           certificate_authority_path: "example-configs/redis-tls/certs/ca.crt"
-          verify_hostname: true
+          verify_hostname: false
 source_to_chain_mapping:
   redis_prod: redis_chain

--- a/shotover-proxy/example-configs/redis-tls/topology.yaml
+++ b/shotover-proxy/example-configs/redis-tls/topology.yaml
@@ -13,13 +13,13 @@ sources:
 chain_config:
   redis_chain_tls:
     - RedisSinkSingle:
-        remote_address: "127.0.0.1:1111"
+        remote_address: "localhost:1111"
         connect_timeout_ms: 3000
         tls:
           certificate_authority_path: "example-configs/redis-tls/certs/ca.crt"
           certificate_path: "example-configs/redis-tls/certs/redis.crt"
           private_key_path: "example-configs/redis-tls/certs/redis.key"
-          verify_hostname: false
+          verify_hostname: true
 source_to_chain_mapping:
   redis_prod: redis_chain_tls
   redis_prod_tls: redis_chain_tls

--- a/shotover-proxy/src/transforms/cassandra/sink_cluster/node.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_cluster/node.rs
@@ -1,7 +1,7 @@
 use crate::codec::cassandra::CassandraCodec;
 use crate::frame::Frame;
 use crate::message::{Message, Messages};
-use crate::tls::TlsConnector;
+use crate::tls::{TlsConnector, ToHostname};
 use crate::transforms::cassandra::connection::CassandraConnection;
 use anyhow::{anyhow, Result};
 use cassandra_protocol::frame::Version;
@@ -100,7 +100,7 @@ impl ConnectionFactory {
         }
     }
 
-    pub async fn new_connection<A: ToSocketAddrs + std::fmt::Debug>(
+    pub async fn new_connection<A: ToSocketAddrs + ToHostname + std::fmt::Debug>(
         &self,
         address: A,
     ) -> Result<CassandraConnection> {

--- a/shotover-proxy/src/transforms/redis/sink_single.rs
+++ b/shotover-proxy/src/transforms/redis/sink_single.rs
@@ -108,12 +108,14 @@ impl Transform for RedisSinkSingle {
         }
 
         if self.connection.is_none() {
-            let tcp_stream = tcp::tcp_stream(self.connect_timeout, self.address.clone()).await?;
-
             let generic_stream = if let Some(tls) = self.tls.as_mut() {
-                let tls_stream = tls.connect(tcp_stream).await?;
+                let tls_stream = tls
+                    .connect(self.connect_timeout, self.address.clone())
+                    .await?;
                 Box::pin(tls_stream) as Pin<Box<dyn AsyncStream + Send + Sync>>
             } else {
+                let tcp_stream =
+                    tcp::tcp_stream(self.connect_timeout, self.address.clone()).await?;
                 Box::pin(tcp_stream) as Pin<Box<dyn AsyncStream + Send + Sync>>
             };
 

--- a/shotover-proxy/tests/helpers/mod.rs
+++ b/shotover-proxy/tests/helpers/mod.rs
@@ -117,11 +117,11 @@ impl ShotoverManager {
         let address = "127.0.0.1";
         test_helpers::wait_for_socket_to_open(address, port);
 
-        let tcp_stream = tokio::net::TcpStream::connect((address, port))
+        let connector = TlsConnector::new(config).unwrap();
+        let tls_stream = connector
+            .connect(Duration::from_secs(3), (address, port))
             .await
             .unwrap();
-        let connector = TlsConnector::new(config).unwrap();
-        let tls_stream = connector.connect(tcp_stream).await.unwrap();
         ShotoverManager::redis_connection_async_inner(
             Box::pin(tls_stream) as Pin<Box<dyn AsyncStream + Send + Sync>>
         )

--- a/shotover-proxy/tests/redis_int_tests/mod.rs
+++ b/shotover-proxy/tests/redis_int_tests/mod.rs
@@ -81,7 +81,7 @@ async fn source_tls_and_single_tls() {
         certificate_authority_path: "example-configs/redis-tls/certs/ca.crt".into(),
         certificate_path: Some("example-configs/redis-tls/certs/redis.crt".into()),
         private_key_path: Some("example-configs/redis-tls/certs/redis.key".into()),
-        verify_hostname: true,
+        verify_hostname: false,
     };
 
     let mut connection = shotover_manager


### PR DESCRIPTION
Theres a few things going on here:
* TlsConnector::connect now creates its own TcpStream - this enforces that the hostname is derived from the address.
* All cluster examples have verify_hostname disabled because clusters rely on ip address communication and openssl hostname verification will fail verification on IP addresses (it only allows domain names)