### PR TITLE
Refactor TCP connection logic

### DIFF
--- a/shotover-proxy/src/lib.rs
+++ b/shotover-proxy/src/lib.rs
@@ -28,5 +28,6 @@ mod observability;
 pub mod runner;
 mod server;
 pub mod sources;
+pub mod tcp;
 pub mod tls;
 pub mod transforms;

--- a/shotover-proxy/src/tcp.rs
+++ b/shotover-proxy/src/tcp.rs
@@ -1,0 +1,19 @@
+use anyhow::{anyhow, Result};
+use std::time::Duration;
+use tokio::{
+    net::{TcpStream, ToSocketAddrs},
+    time::timeout,
+};
+
+pub async fn tcp_stream<A: ToSocketAddrs + std::fmt::Debug>(destination: A) -> Result<TcpStream> {
+    timeout(Duration::from_secs(3), TcpStream::connect(&destination))
+        .await
+        .map_err(|_| {
+            anyhow!(
+                "destination {destination:?} did not respond to connection attempt within 3 seconds"
+            )
+        })?
+        .map_err(|e| {
+            anyhow!(e).context(format!("Failed to connect to destination {destination:?}"))
+        })
+}

--- a/shotover-proxy/src/transforms/redis/mod.rs
+++ b/shotover-proxy/src/transforms/redis/mod.rs
@@ -1,6 +1,5 @@
-use std::io;
-
 use crate::transforms::util::ConnectionError;
+use anyhow::Error;
 
 pub mod cache;
 pub mod cluster_ports_rewrite;
@@ -43,10 +42,10 @@ pub enum TransformError {
     Protocol(String),
 
     #[error("io error: {0}")]
-    IO(io::Error),
+    IO(Error),
 
     #[error("TLS error: {0}")]
-    TLS(anyhow::Error),
+    TLS(Error),
 
     #[error(transparent)]
     Other(#[from] anyhow::Error),

--- a/shotover-proxy/src/transforms/util/mod.rs
+++ b/shotover-proxy/src/transforms/util/mod.rs
@@ -1,6 +1,5 @@
 use anyhow::{Error, Result};
 use std::fmt;
-use std::io;
 
 use crate::message::Message;
 
@@ -23,7 +22,7 @@ pub struct Response {
 #[derive(thiserror::Error, Debug)]
 pub enum ConnectionError<E: fmt::Debug + fmt::Display> {
     #[error("io error: {0}")]
-    IO(io::Error),
+    IO(Error),
 
     #[error("TLS error: {0}")]
     TLS(Error),

--- a/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
+++ b/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
@@ -6,11 +6,12 @@ use rand_distr::Alphanumeric;
 use redis::aio::Connection;
 use redis::cluster::ClusterConnection;
 use redis::{AsyncCommands, Commands, ErrorKind, RedisError, Value};
+use shotover_proxy::tcp;
 use std::collections::{HashMap, HashSet};
 use std::thread::sleep;
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::TcpStream;
+
 use tokio::time::timeout;
 use tracing::trace;
 
@@ -1279,10 +1280,7 @@ pub async fn test_trigger_transform_failure_driver(connection: &mut Connection) 
 pub async fn test_trigger_transform_failure_raw() {
     // Send invalid redis command
     // To correctly handle this shotover should close the connection
-    let mut connection = timeout(Duration::from_secs(3), TcpStream::connect("127.0.0.1:6379"))
-        .await
-        .unwrap()
-        .unwrap();
+    let mut connection = tcp::tcp_stream("127.0.0.1:6379").await.unwrap();
 
     connection.write_all(b"*1\r\n$4\r\nping\r\n").await.unwrap();
 
@@ -1301,10 +1299,7 @@ pub async fn test_trigger_transform_failure_raw() {
 pub async fn test_invalid_frame() {
     // Send invalid redis command
     // To correctly handle this shotover should close the connection
-    let mut connection = timeout(Duration::from_secs(3), TcpStream::connect("127.0.0.1:6379"))
-        .await
-        .unwrap()
-        .unwrap();
+    let mut connection = tcp::tcp_stream("127.0.0.1:6379").await.unwrap();
 
     connection
         .write_all(b"invalid_redis_frame\r\n")


### PR DESCRIPTION
prereq to https://github.com/shotover/shotover-proxy/pull/899

Every connection needs this same basic error handling so we should move it into a helper to give us consistent error messages and to ensure we never forget to implement the timeout.
It will also allow us to call this logic from within the tls connector in 899.