### PR TITLE
refactor prepared_statements helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2789,8 +2789,7 @@ checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
 [[package]]
 name = "scylla"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345a33a39eb25c82e48f7e82cb7378ec724e72a48579bb9c83e1c511d5b44fb6"
+source = "git+https://github.com/scylladb/scylla-rust-driver#5de785eb07ba320b9dac803f8ee01ee63b32ce40"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2823,8 +2822,7 @@ dependencies = [
 [[package]]
 name = "scylla-cql"
 version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f01015d74993239c1ad6fa89e4c0baed8af37efaaaf1fb9a5abecc119a7e31c6"
+source = "git+https://github.com/scylladb/scylla-rust-driver#5de785eb07ba320b9dac803f8ee01ee63b32ce40"
 dependencies = [
  "bigdecimal 0.2.2",
  "byteorder",
@@ -2843,8 +2841,7 @@ dependencies = [
 [[package]]
 name = "scylla-macros"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc0caffb1274feb3df615e3260cb71a5a7a5d579adc49ba5544c87950a701c"
+source = "git+https://github.com/scylladb/scylla-rust-driver#5de785eb07ba320b9dac803f8ee01ee63b32ce40"
 dependencies = [
  "quote",
  "syn",

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -92,7 +92,7 @@ nix = "0.25.0"
 reqwest = "0.11.6"
 metrics-util = "0.14.0"
 cdrs-tokio = { git = "https://github.com/krojew/cdrs-tokio", branch = "8.0-dev" }
-scylla = { version = "0.6.0", features = ["ssl"] }
+scylla = { git = "https://github.com/scylladb/scylla-rust-driver", features = ["ssl"] }
 rstest = "0.15.0"
 
 [[bench]]

--- a/shotover-proxy/tests/cassandra_int_tests/prepared_statements.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/prepared_statements.rs
@@ -10,7 +10,9 @@ async fn delete(session: &CassandraConnection) {
         .await;
 
     assert_eq!(
-        session.execute_prepared(&prepared, Some(1)).await,
+        session
+            .execute_prepared(&prepared, &[ResultValue::Int(1)])
+            .await,
         Vec::<Vec<ResultValue>>::new()
     );
 
@@ -28,17 +30,23 @@ async fn insert(session: &CassandraConnection) {
         .await;
 
     assert_eq!(
-        session.execute_prepared(&prepared, Some(1)).await,
+        session
+            .execute_prepared(&prepared, &[ResultValue::Int(1)])
+            .await,
         Vec::<Vec<ResultValue>>::new()
     );
 
     assert_eq!(
-        session.execute_prepared(&prepared, Some(2)).await,
+        session
+            .execute_prepared(&prepared, &[ResultValue::Int(2)])
+            .await,
         Vec::<Vec<ResultValue>>::new()
     );
 
     assert_eq!(
-        session.execute_prepared(&prepared, Some(2)).await,
+        session
+            .execute_prepared(&prepared, &[ResultValue::Int(3)])
+            .await,
         Vec::<Vec<ResultValue>>::new()
     );
 }
@@ -48,7 +56,9 @@ async fn select(session: &CassandraConnection) {
         .prepare("SELECT id FROM test_prepare_statements.table_1 WHERE id = ?")
         .await;
 
-    let result_rows = session.execute_prepared(&prepared, Some(1)).await;
+    let result_rows = session
+        .execute_prepared(&prepared, &[ResultValue::Int(1)])
+        .await;
 
     assert_rows(result_rows, &[&[ResultValue::Int(1)]]);
 }
@@ -68,11 +78,15 @@ async fn select_cross_connection<Fut>(
     let connection_after = connection_creator().await;
 
     assert_rows(
-        connection_before.execute_prepared(&prepared, Some(1)).await,
+        connection_before
+            .execute_prepared(&prepared, &[ResultValue::Int(1)])
+            .await,
         &[&[ResultValue::Int(1), ResultValue::Int(1)]],
     );
     assert_rows(
-        connection_after.execute_prepared(&prepared, Some(1)).await,
+        connection_after
+            .execute_prepared(&prepared, &[ResultValue::Int(1)])
+            .await,
         &[&[ResultValue::Int(1), ResultValue::Int(1)]],
     );
 }
@@ -89,7 +103,9 @@ async fn use_statement(session: &CassandraConnection) {
 
     // observe query completing against the original keyspace without errors
     assert_eq!(
-        session.execute_prepared(&prepared, Some(358)).await,
+        session
+            .execute_prepared(&prepared, &[ResultValue::Int(358)])
+            .await,
         Vec::<Vec<ResultValue>>::new()
     );
 
@@ -123,6 +139,6 @@ where
     if session.is(&[CassandraDriver::Scylla, CassandraDriver::CdrsTokio]) {
         let cql = "SELECT * FROM system.local WHERE key = 'local'";
         let prepared = session.prepare(cql).await;
-        session.execute_prepared(&prepared, None).await;
+        session.execute_prepared(&prepared, &[]).await;
     }
 }


### PR DESCRIPTION
prepared_statements now takes a list of values which can be of any cassandra supported type. This will allow for better test coverage.

I will follow this up with a PR that adds a test case which tests every cassandra type in prepared statements.