### PR TITLE
topology task info! on init complete

### DIFF
--- a/shotover-proxy/src/transforms/cassandra/sink_cluster/topology.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_cluster/topology.rs
@@ -86,6 +86,11 @@ async fn topology_task_process(
 
     register_for_topology_and_status_events(&connection, version).await?;
 
+    tracing::info!(
+        "Topology task control connection finalized against node at: {:?}",
+        connection_info.address
+    );
+
     loop {
         // Wait for events to come in from the cassandra node.
         // If all the nodes receivers are closed then immediately stop listening and shutdown the task


### PR DESCRIPTION
We already have a log like this in the per connection control connection.
An example use case of this log is identifying when issues are caused due to the topology task control connection destination going down undetected.