### PR TITLE
cassandra_int_tests test node up

### DIFF
--- a/shotover-proxy/example-configs/cassandra-cluster-v4/docker-compose.yaml
+++ b/shotover-proxy/example-configs/cassandra-cluster-v4/docker-compose.yaml
@@ -27,8 +27,9 @@ services:
       MIN_HEAP_SIZE: "400M"
       HEAP_NEWSIZE: "48M"
     volumes:
+      # Using volume instead of tmpfs adds 3 seconds to the runtime of the cassandra standard_test_suite but allows running tests that restart nodes
       &volumes
-      - type: tmpfs
+      - type: volume
         target: /var/lib/cassandra
     command: &command cassandra -f -Dcassandra.initial_token="$$CASSANDRA_INITIAL_TOKENS" -Dcassandra.native_transport_port=9044
 

--- a/shotover-proxy/example-configs/docker-images/cassandra-3.11.13/cassandra.yaml
+++ b/shotover-proxy/example-configs/docker-images/cassandra-3.11.13/cassandra.yaml
@@ -23,7 +23,7 @@ cluster_name: 'Test Cluster'
 #
 # If you already have a cluster with 1 token per node, and wish to migrate to 
 # multiple tokens per node, see http://wiki.apache.org/cassandra/Operations
-num_tokens: 256
+num_tokens: 128
 
 # Triggers automatic allocation of num_tokens tokens for this node. The allocation
 # algorithm attempts to choose tokens in a way that optimizes replicated load over

--- a/shotover-proxy/example-configs/docker-images/cassandra-4.0.6/cassandra.yaml
+++ b/shotover-proxy/example-configs/docker-images/cassandra-4.0.6/cassandra.yaml
@@ -24,7 +24,7 @@ cluster_name: 'Test Cluster'
 # See https://cassandra.apache.org/doc/latest/getting_started/production.html#tokens for
 # best practice information about num_tokens.
 #
-#num_tokens: 16
+num_tokens: 128
 
 # Triggers automatic allocation of num_tokens tokens for this node. The allocation
 # algorithm attempts to choose tokens in a way that optimizes replicated load over
@@ -47,7 +47,7 @@ allocate_tokens_for_local_replication_factor: 3
 # vnodes (num_tokens > 1, above) -- in which case you should provide a 
 # comma-separated list -- it's primarily used when adding nodes to legacy clusters 
 # that do not have vnodes enabled.
-initial_token: 0
+#initial_token: 0
 
 # May either be "true" or "false" to enable globally
 hinted_handoff_enabled: true

--- a/shotover-proxy/example-configs/docker-images/cassandra-tls-4.0.6/cassandra.yaml
+++ b/shotover-proxy/example-configs/docker-images/cassandra-tls-4.0.6/cassandra.yaml
@@ -24,7 +24,7 @@ cluster_name: 'Test Cluster'
 # See https://cassandra.apache.org/doc/latest/getting_started/production.html#tokens for
 # best practice information about num_tokens.
 #
-#num_tokens: 16
+num_tokens: 128
 
 # Triggers automatic allocation of num_tokens tokens for this node. The allocation
 # algorithm attempts to choose tokens in a way that optimizes replicated load over
@@ -47,7 +47,7 @@ allocate_tokens_for_local_replication_factor: 3
 # vnodes (num_tokens > 1, above) -- in which case you should provide a 
 # comma-separated list -- it's primarily used when adding nodes to legacy clusters 
 # that do not have vnodes enabled.
-initial_token: 0
+#initial_token: 0
 
 # May either be "true" or "false" to enable globally
 hinted_handoff_enabled: true

--- a/shotover-proxy/src/transforms/cassandra/sink_cluster/node_pool.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_cluster/node_pool.rs
@@ -69,7 +69,7 @@ impl NodePool {
         for node in self.nodes.drain(..) {
             if let Some(outbound) = node.outbound {
                 for new_node in &mut new_nodes {
-                    if new_node.host_id == node.host_id {
+                    if new_node.host_id == node.host_id && new_node.is_up {
                         new_node.outbound = Some(outbound);
                         break;
                     }

--- a/test-helpers/src/docker_compose.rs
+++ b/test-helpers/src/docker_compose.rs
@@ -106,6 +106,17 @@ impl DockerCompose {
         .unwrap();
     }
 
+    /// Restarts the container with the provided service name
+    pub fn start_service(&self, service_name: &str) {
+        run_command(
+            "docker-compose",
+            &["-f", &self.file_path, "start", service_name],
+        )
+        .unwrap();
+
+        // TODO: call wait_for_containers_to_startup
+    }
+
     fn wait_for_containers_to_startup(&self) {
         match self.file_path.as_ref() {
             "tests/transforms/docker-compose-moto.yaml" => {


### PR DESCRIPTION
Prereq: https://github.com/shotover/shotover-proxy/pull/917

Instead of changing tmpfs to volume, we could make a separate cassandra-cluster-v4/docker-compose.yaml for persistent tests but it doesn't seem worth it yet.

The `cassandra.yaml` changes are needed to make the cassandra nodes persistent on restart, not sure why they fix the problem but I have verified that they do not cause any regressions in test runtime.

The new integration test discovered a bug in `node_pool.rs` where we were accidentally copying over dead connections, so this PR fixes that as well.