### PR TITLE
Implement proper NO_METADATA support for cassandra protocol

### DIFF
--- a/shotover-proxy/example-configs/cassandra-cluster-v4/topology.yaml
+++ b/shotover-proxy/example-configs/cassandra-cluster-v4/topology.yaml
@@ -5,6 +5,9 @@ sources:
       listen_addr: "127.0.0.1:9042"
 chain_config:
   main_chain:
+    - DebugForceEncode:
+        encode_requests: true
+        encode_responses: true
     - CassandraSinkCluster:
         first_contact_points: ["172.16.1.2:9044", "172.16.1.3:9044"]
         local_shotover_host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"

--- a/shotover-proxy/src/frame/cassandra.rs
+++ b/shotover-proxy/src/frame/cassandra.rs
@@ -224,10 +224,11 @@ impl CassandraFrame {
                                         .into_iter()
                                         .map(|row| {
                                             row.into_iter()
-                                                .map(|row_content| {
-                                                    MessageValue::Bytes(
-                                                        row_content.into_bytes().unwrap().into(),
-                                                    )
+                                                .map(|row_content| match row_content.into_bytes() {
+                                                    None => MessageValue::Null,
+                                                    Some(value) => {
+                                                        MessageValue::Bytes(value.into())
+                                                    }
                                                 })
                                                 .collect()
                                         })

--- a/shotover-proxy/tests/cassandra_int_tests/prepared_statements_simple.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/prepared_statements_simple.rs
@@ -1,4 +1,3 @@
-use crate::helpers::cassandra::CassandraDriver;
 use crate::helpers::cassandra::{
     assert_query_result, assert_rows, run_query, CassandraConnection, ResultValue,
 };
@@ -136,9 +135,7 @@ where
     delete(session).await;
     use_statement(session).await;
 
-    if session.is(&[CassandraDriver::Scylla, CassandraDriver::CdrsTokio]) {
-        let cql = "SELECT * FROM system.local WHERE key = 'local'";
-        let prepared = session.prepare(cql).await;
-        session.execute_prepared(&prepared, &[]).await;
-    }
+    let cql = "SELECT * FROM system.local WHERE key = 'local'";
+    let prepared = session.prepare(cql).await;
+    session.execute_prepared(&prepared, &[]).await;
 }


### PR DESCRIPTION
closes https://github.com/shotover/shotover-proxy/issues/905

I originally thought this would be more involved because I thought the encode logic needed to special case NO_METADATA just like we do for decoding.
But it turns out that the standard implementation for encoding null and bytes data types works just fine with the null and bytes types that we generate for NO_METADATA decoding.

To prove this I added `DebugForceEncode` to cassandra-cluster-v4.
I think its fine to add this to an existing test because we have the very similar cassandra-cluster-multi-rack test case which will test CassandraSinkCluster without the DebugForceEncode.