### PR TITLE
add message_to_high_level_string debug helper

### DIFF
--- a/shotover/src/transforms/mod.rs
+++ b/shotover/src/transforms/mod.rs
@@ -391,6 +391,18 @@ impl<'a> Wrapper<'a> {
         }
     }
 
+    /// Helper for writing debug logs while testing
+    /// feature flagged behind alpha-transforms as this call is too expensive to ever make it into production
+    #[cfg(feature = "alpha-transforms")]
+    pub fn messages_to_high_level_string(&mut self) -> String {
+        let messages = self
+            .messages
+            .iter_mut()
+            .map(|x| x.to_high_level_string())
+            .collect::<Vec<_>>();
+        format!("{:?}", messages)
+    }
+
     pub fn reset(&mut self, transforms: &'a mut [Transforms]) {
         self.transforms = TransformIter::new_forwards(transforms);
     }


### PR DESCRIPTION
Allows quickly debugging including high level message representations in debug logs when debugging transforms.

For example now we can just write:
```rust
tracing::error!("messages: {}", message_wrapper.messages_to_high_level_string());
```

Instead of:
```rust
tracing::error!(
    "messages: {}",
    message_wrapper.
            .messages
            .iter_mut()
            .map(|x| x.to_high_level_string())
            .collect::<Vec<_>>()
);
```

Starting the method name with `messages_` means that the method will be suggested when the user writes: 
`tracing::error!("messages: {}", message_wrapper.messages`