### PR TITLE
Shutdown span

### DIFF
--- a/shotover-proxy/src/server.rs
+++ b/shotover-proxy/src/server.rs
@@ -262,6 +262,10 @@ impl<C: Codec + 'static> TcpCodecListener<C> {
                 Wrapper::flush_with_chain_name(self.chain.name.clone()),
                 "".into(),
             )
+            .instrument(tracing::error_span!(
+                "shutdown",
+                source = self.source_name.as_str()
+            ))
             .await
         {
             Ok(_) => info!("source {} was shutdown", self.source_name),

--- a/shotover-proxy/src/sources/cassandra_source.rs
+++ b/shotover-proxy/src/sources/cassandra_source.rs
@@ -6,7 +6,6 @@ use crate::transforms::chain::TransformChain;
 use anyhow::Result;
 use serde::Deserialize;
 use std::sync::Arc;
-use tokio::runtime::Handle;
 use tokio::sync::{watch, Semaphore};
 use tokio::task::JoinHandle;
 use tracing::{error, info};
@@ -76,7 +75,7 @@ impl CassandraSource {
         )
         .await?;
 
-        let join_handle = Handle::current().spawn(async move {
+        let join_handle = tokio::spawn(async move {
             // Check we didn't receive a shutdown signal before the receiver was created
             if !*trigger_shutdown_rx.borrow() {
                 tokio::select! {

--- a/shotover-proxy/src/sources/redis_source.rs
+++ b/shotover-proxy/src/sources/redis_source.rs
@@ -6,7 +6,6 @@ use crate::transforms::chain::TransformChain;
 use anyhow::Result;
 use serde::Deserialize;
 use std::sync::Arc;
-use tokio::runtime::Handle;
 use tokio::sync::{watch, Semaphore};
 use tokio::task::JoinHandle;
 use tracing::{error, info};
@@ -74,7 +73,7 @@ impl RedisSource {
         )
         .await?;
 
-        let join_handle = Handle::current().spawn(async move {
+        let join_handle = tokio::spawn(async move {
             // Check we didn't receive a shutdown signal before the receiver was created
             if !*trigger_shutdown_rx.borrow() {
                 tokio::select! {


### PR DESCRIPTION
Transform logs now get a shutdown span included to help distinguish from logs that correspond to a specific connection.
![image](https://user-images.githubusercontent.com/5120858/203241000-73a858d6-6046-4c3a-b879-ad72528c4a36.png)
The remaining logs without spans are due to a bug in propogating spans across tee'd transforms.

`tokio::spawn` is internally just `Handle::current().spawn` 