### PR TITLE
misc cleanup

### DIFF
--- a/shotover-proxy/src/server.rs
+++ b/shotover-proxy/src/server.rs
@@ -47,13 +47,6 @@ pub trait Codec: CodecReadHalf + CodecWriteHalf {}
 impl<T: CodecReadHalf + CodecWriteHalf> Codec for T {}
 
 pub struct TcpCodecListener<C: Codec> {
-    /// Shared database handle.
-    ///
-    /// Contains the key / value store as well as the broadcast channels for
-    /// pub/sub.
-    ///
-    /// This is a wrapper around an `Arc`. This enables `db` to be cloned and
-    /// passed into the per connection state (`Handler`).
     chain: TransformChain,
 
     source_name: String,
@@ -315,11 +308,6 @@ async fn create_listener(listen_addr: &str) -> Result<TcpListener> {
 }
 
 pub struct Handler<C: Codec> {
-    /// Shared source handle.
-    ///
-    /// When a command is received from `connection`, it is applied with `db`.
-    /// The implementation of the command is in the `cmd` module. Each command
-    /// will need to interact with `db` in order to complete the work.
     chain: TransformChain,
     client_details: String,
     conn_details: String,
@@ -327,15 +315,6 @@ pub struct Handler<C: Codec> {
     #[allow(dead_code)]
     source_details: String,
     codec: C,
-
-    // connection: Framed<S, C>,
-    /// The TCP connection decorated with the redis protocol encoder / decoder
-    /// implemented using a buffered `TcpStream`.
-    ///
-    /// When `Listener` receives an inbound connection, the `TcpStream` is
-    /// passed to `Connection::new`, which initializes the associated buffers.
-    /// `Connection` allows the handler to operate at the "frame" level and keep
-    /// the byte level protocol parsing details encapsulated in `Connection`.
 
     /// Max connection semaphore.
     ///

--- a/shotover-proxy/src/sources/cassandra_source.rs
+++ b/shotover-proxy/src/sources/cassandra_source.rs
@@ -6,7 +6,6 @@ use crate::transforms::chain::TransformChain;
 use anyhow::Result;
 use serde::Deserialize;
 use std::sync::Arc;
-use tokio::runtime::Handle;
 use tokio::sync::{watch, Semaphore};
 use tokio::task::JoinHandle;
 use tracing::{error, info};
@@ -76,7 +75,7 @@ impl CassandraSource {
         )
         .await?;
 
-        let join_handle = Handle::current().spawn(async move {
+        let join_handle = tokio::spawn(async move {
             // Check we didn't receive a shutdown signal before the receiver was created
             if !*trigger_shutdown_rx.borrow() {
                 tokio::select! {

--- a/shotover-proxy/src/sources/redis_source.rs
+++ b/shotover-proxy/src/sources/redis_source.rs
@@ -6,7 +6,6 @@ use crate::transforms::chain::TransformChain;
 use anyhow::Result;
 use serde::Deserialize;
 use std::sync::Arc;
-use tokio::runtime::Handle;
 use tokio::sync::{watch, Semaphore};
 use tokio::task::JoinHandle;
 use tracing::{error, info};
@@ -74,7 +73,7 @@ impl RedisSource {
         )
         .await?;
 
-        let join_handle = Handle::current().spawn(async move {
+        let join_handle = tokio::spawn(async move {
             // Check we didn't receive a shutdown signal before the receiver was created
             if !*trigger_shutdown_rx.borrow() {
                 tokio::select! {

--- a/shotover-proxy/src/transforms/coalesce.rs
+++ b/shotover-proxy/src/transforms/coalesce.rs
@@ -84,11 +84,10 @@ mod test {
     use crate::transforms::coalesce::Coalesce;
     use crate::transforms::loopback::Loopback;
     use crate::transforms::{Transform, Transforms, Wrapper};
-    use anyhow::Result;
     use std::time::{Duration, Instant};
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_count() -> Result<()> {
+    async fn test_count() {
         let mut coalesce = Coalesce {
             flush_when_buffered_message_count: Some(100),
             flush_when_millis_since_last_flush: None,
@@ -102,29 +101,30 @@ mod test {
 
         let mut message_wrapper = Wrapper::new(messages.clone());
         message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await?.len(), 0);
+        assert_eq!(coalesce.transform(message_wrapper).await.unwrap().len(), 0);
 
         let mut message_wrapper = Wrapper::new(messages.clone());
         message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await?.len(), 0);
+        assert_eq!(coalesce.transform(message_wrapper).await.unwrap().len(), 0);
 
         let mut message_wrapper = Wrapper::new(messages.clone());
         message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await?.len(), 0);
+        assert_eq!(coalesce.transform(message_wrapper).await.unwrap().len(), 0);
 
         let mut message_wrapper = Wrapper::new(messages.clone());
         message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await?.len(), 100);
+        assert_eq!(
+            coalesce.transform(message_wrapper).await.unwrap().len(),
+            100
+        );
 
         let mut message_wrapper = Wrapper::new(messages.clone());
         message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await?.len(), 0);
-
-        Ok(())
+        assert_eq!(coalesce.transform(message_wrapper).await.unwrap().len(), 0);
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_wait() -> Result<()> {
+    async fn test_wait() {
         let mut coalesce = Coalesce {
             flush_when_buffered_message_count: None,
             flush_when_millis_since_last_flush: Some(100),
@@ -138,29 +138,27 @@ mod test {
 
         let mut message_wrapper = Wrapper::new(messages.clone());
         message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await?.len(), 0);
+        assert_eq!(coalesce.transform(message_wrapper).await.unwrap().len(), 0);
 
         tokio::time::sleep(Duration::from_millis(10_u64)).await;
 
         let mut message_wrapper = Wrapper::new(messages.clone());
         message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await?.len(), 0);
+        assert_eq!(coalesce.transform(message_wrapper).await.unwrap().len(), 0);
 
         tokio::time::sleep(Duration::from_millis(100_u64)).await;
 
         let mut message_wrapper = Wrapper::new(messages.clone());
         message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await?.len(), 75);
+        assert_eq!(coalesce.transform(message_wrapper).await.unwrap().len(), 75);
 
         let mut message_wrapper = Wrapper::new(messages.clone());
         message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await?.len(), 0);
-
-        Ok(())
+        assert_eq!(coalesce.transform(message_wrapper).await.unwrap().len(), 0);
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_wait_or_count() -> Result<()> {
+    async fn test_wait_or_count() {
         let mut coalesce = Coalesce {
             flush_when_buffered_message_count: Some(100),
             flush_when_millis_since_last_flush: Some(100),
@@ -174,40 +172,41 @@ mod test {
 
         let mut message_wrapper = Wrapper::new(messages.clone());
         message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await?.len(), 0);
+        assert_eq!(coalesce.transform(message_wrapper).await.unwrap().len(), 0);
 
         tokio::time::sleep(Duration::from_millis(10_u64)).await;
 
         let mut message_wrapper = Wrapper::new(messages.clone());
         message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await?.len(), 0);
+        assert_eq!(coalesce.transform(message_wrapper).await.unwrap().len(), 0);
 
         tokio::time::sleep(Duration::from_millis(100_u64)).await;
 
         let mut message_wrapper = Wrapper::new(messages.clone());
         message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await?.len(), 75);
+        assert_eq!(coalesce.transform(message_wrapper).await.unwrap().len(), 75);
 
         let mut message_wrapper = Wrapper::new(messages.clone());
         message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await?.len(), 0);
+        assert_eq!(coalesce.transform(message_wrapper).await.unwrap().len(), 0);
 
         let mut message_wrapper = Wrapper::new(messages.clone());
         message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await?.len(), 0);
+        assert_eq!(coalesce.transform(message_wrapper).await.unwrap().len(), 0);
 
         let mut message_wrapper = Wrapper::new(messages.clone());
         message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await?.len(), 0);
+        assert_eq!(coalesce.transform(message_wrapper).await.unwrap().len(), 0);
 
         let mut message_wrapper = Wrapper::new(messages.clone());
         message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await?.len(), 100);
+        assert_eq!(
+            coalesce.transform(message_wrapper).await.unwrap().len(),
+            100
+        );
 
         let mut message_wrapper = Wrapper::new(messages);
         message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await?.len(), 0);
-
-        Ok(())
+        assert_eq!(coalesce.transform(message_wrapper).await.unwrap().len(), 0);
     }
 }

--- a/shotover-proxy/src/transforms/load_balance.rs
+++ b/shotover-proxy/src/transforms/load_balance.rs
@@ -86,11 +86,10 @@ mod test {
     use crate::transforms::debug::returner::{DebugReturner, Response};
     use crate::transforms::load_balance::ConnectionBalanceAndPool;
     use crate::transforms::{Transforms, Wrapper};
-    use anyhow::Result;
     use std::sync::Arc;
 
     #[tokio::test(flavor = "multi_thread")]
-    pub async fn test_balance() -> Result<()> {
+    pub async fn test_balance() {
         let transform = Transforms::PoolConnections(ConnectionBalanceAndPool {
             active_connection: None,
             max_connections: 3,
@@ -106,11 +105,11 @@ mod test {
         let mut chain = TransformChain::new(vec![transform], "test".to_string());
 
         for _ in 0..90 {
-            let r = chain
+            chain
                 .clone()
                 .process_request(Wrapper::new(Messages::new()), "test_client".to_string())
-                .await;
-            assert!(r.is_ok());
+                .await
+                .unwrap();
         }
 
         match chain.chain.remove(0) {
@@ -123,7 +122,5 @@ mod test {
             }
             _ => panic!("whoops"),
         }
-
-        Ok(())
     }
 }


### PR DESCRIPTION
Bunch of things that were bothering me while working on other PRs.
* server.rs comments are left over from when it was copied from a tokio example.
* tests should unwrap rather than returning errors.
* `tokio::spawn` is internally just `Handle::current().spawn` 