### PR TITLE
Timestamp tests

### DIFF
--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -35,6 +35,7 @@ mod protect;
 #[cfg(not(feature = "cassandra-cpp-driver-tests"))]
 mod routing;
 mod table;
+mod timestamp;
 mod udt;
 
 async fn standard_test_suite<Fut>(connection_creator: impl Fn() -> Fut, driver: CassandraDriver)
@@ -53,6 +54,7 @@ where
     prepared_statements_simple::test(&connection, connection_creator).await;
     prepared_statements_all::test(&connection).await;
     batch_statements::test(&connection).await;
+    timestamp::test(&connection).await;
 }
 
 #[rstest]

--- a/shotover-proxy/tests/cassandra_int_tests/timestamp.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/timestamp.rs
@@ -1,0 +1,93 @@
+use crate::helpers::cassandra::{assert_query_result, run_query, CassandraConnection, ResultValue};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+async fn flag(connection: &CassandraConnection) {
+    let timestamp = setup(connection).await;
+
+    let _r = connection
+        .execute_with_timestamp(
+            "UPDATE test_timestamps.test_table SET a = 'a1-modified-1' WHERE id = 0;",
+            timestamp,
+        )
+        .await;
+
+    assert_query_result(
+        connection,
+        "SELECT WRITETIME(a) FROM test_timestamps.test_table WHERE id = 0;",
+        &[&[ResultValue::BigInt(timestamp)]],
+    )
+    .await;
+}
+
+async fn query(connection: &CassandraConnection) {
+    let timestamp = setup(connection).await;
+
+    run_query(
+        connection,
+        &format!(
+            "UPDATE test_timestamps.test_table USING TIMESTAMP {} SET a = 'a1-modified-1' WHERE id = 0;",
+            timestamp
+        ),
+    )
+    .await;
+
+    assert_query_result(
+        connection,
+        "SELECT WRITETIME(a) FROM test_timestamps.test_table WHERE id = 0;",
+        &[&[ResultValue::BigInt(timestamp)]],
+    )
+    .await;
+}
+
+async fn setup(connection: &CassandraConnection) -> i64 {
+    run_query(
+        connection,
+        "UPDATE test_timestamps.test_table SET a = 'a1-modified' WHERE id = 0;",
+    )
+    .await;
+
+    let cassandra_timestamp = if let ResultValue::BigInt(v) = connection
+        .execute("SELECT WRITETIME(a) FROM test_timestamps.test_table WHERE id = 0;")
+        .await[0][0]
+    {
+        v
+    } else {
+        panic!("Expected a ResultValue::BigInt");
+    };
+
+    let timestamp: i64 = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_micros()
+        .try_into()
+        .unwrap();
+
+    assert!(cassandra_timestamp < timestamp);
+
+    timestamp
+}
+
+pub async fn test(connection: &CassandraConnection) {
+    run_query(connection, "CREATE KEYSPACE test_timestamps WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1  };").await;
+    run_query(
+        connection,
+        "CREATE TABLE test_timestamps.test_table (id int PRIMARY KEY, a text);",
+    )
+    .await;
+
+    assert_query_result(
+        connection,
+        "INSERT INTO test_timestamps.test_table (id, a) VALUES (0, 'a1');",
+        &[],
+    )
+    .await;
+    assert_query_result(
+        connection,
+        "INSERT INTO test_timestamps.test_table (id, a) VALUES (1, 'a2');",
+        &[],
+    )
+    .await;
+
+    query(connection).await;
+    flag(connection).await;
+}

--- a/shotover-proxy/tests/cassandra_int_tests/timestamp.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/timestamp.rs
@@ -2,7 +2,7 @@ use crate::helpers::cassandra::{assert_query_result, run_query, CassandraConnect
 use std::time::{SystemTime, UNIX_EPOCH};
 
 async fn flag(connection: &CassandraConnection) {
-    let timestamp = setup(connection).await;
+    let timestamp = get_timestamp(connection).await;
 
     let _r = connection
         .execute_with_timestamp(
@@ -20,7 +20,7 @@ async fn flag(connection: &CassandraConnection) {
 }
 
 async fn query(connection: &CassandraConnection) {
-    let timestamp = setup(connection).await;
+    let timestamp = get_timestamp(connection).await;
 
     run_query(
         connection,
@@ -39,7 +39,10 @@ async fn query(connection: &CassandraConnection) {
     .await;
 }
 
-async fn setup(connection: &CassandraConnection) -> i64 {
+// We have to use a current timestamp from Cassandra
+// because if we send one with an earlier timestamp than Cassandra
+// has as the last write (the insert in `fn test`) it will be ignored.
+async fn get_timestamp(connection: &CassandraConnection) -> i64 {
     run_query(
         connection,
         "UPDATE test_timestamps.test_table SET a = 'a1-modified' WHERE id = 0;",

--- a/shotover-proxy/tests/helpers/cassandra.rs
+++ b/shotover-proxy/tests/helpers/cassandra.rs
@@ -14,7 +14,7 @@ use cassandra_protocol::{
     types::cassandra_type::{wrapper_fn, CassandraType},
 };
 use cdrs_tokio::query::{QueryParams, QueryParamsBuilder};
-use cdrs_tokio::statement::StatementParams;
+use cdrs_tokio::statement::{StatementParams, StatementParamsBuilder};
 use cdrs_tokio::{
     authenticators::StaticPasswordAuthenticatorProvider,
     cluster::session::{Session as CdrsTokioSession, SessionBuilder, TcpSessionBuilder},
@@ -35,6 +35,7 @@ use scylla::frame::response::result::CqlValue;
 use scylla::frame::types::Consistency;
 use scylla::frame::value::Value as ScyllaValue;
 use scylla::prepared_statement::PreparedStatement as PreparedStatementScylla;
+use scylla::statement::query::Query as ScyllaQuery;
 use scylla::{Session as SessionScylla, SessionBuilder as SessionBuilderScylla};
 #[cfg(feature = "cassandra-cpp-driver-tests")]
 use std::fs::read_to_string;
@@ -315,6 +316,64 @@ impl CassandraConnection {
                 Self::process_cdrs_response(response)
             }
             Self::Scylla { session, .. } => {
+                let rows = session.query(query, ()).await.unwrap().rows;
+                match rows {
+                    Some(rows) => rows
+                        .into_iter()
+                        .map(|x| {
+                            x.columns
+                                .into_iter()
+                                .map(ResultValue::new_from_scylla)
+                                .collect()
+                        })
+                        .collect(),
+                    None => vec![],
+                }
+            }
+        };
+
+        let query = query.to_uppercase();
+        let query = query.trim();
+        if query.starts_with("CREATE") || query.starts_with("ALTER") || query.starts_with("DROP") {
+            self.await_schema_agreement().await;
+        }
+
+        result
+    }
+
+    #[allow(dead_code)]
+    pub async fn execute_with_timestamp(
+        &self,
+        query: &str,
+        timestamp: i64,
+    ) -> Vec<Vec<ResultValue>> {
+        let result = match self {
+            #[cfg(feature = "cassandra-cpp-driver-tests")]
+            Self::Datastax { session, .. } => {
+                let mut statement = stmt!(query);
+                statement.set_timestamp(timestamp).unwrap();
+                match session.execute(&statement).await {
+                    Ok(result) => result
+                        .into_iter()
+                        .map(|x| x.into_iter().map(ResultValue::new_from_cpp).collect())
+                        .collect(),
+                    Err(Error(err, _)) => panic!("The CQL query: {query}\nFailed with: {err}"),
+                }
+            }
+            Self::CdrsTokio { session, .. } => {
+                let statement_params = StatementParamsBuilder::new()
+                    .with_timestamp(timestamp)
+                    .build();
+
+                let response = session
+                    .query_with_params(query, statement_params)
+                    .await
+                    .unwrap();
+                Self::process_cdrs_response(response)
+            }
+            Self::Scylla { session, .. } => {
+                let mut query = ScyllaQuery::new(query);
+                query.set_timestamp(Some(timestamp));
                 let rows = session.query(query, ()).await.unwrap().rows;
                 match rows {
                     Some(rows) => rows


### PR DESCRIPTION
Timestamps in Cassandra can be included in the query parameters or inside the CQL. We test that they are supported in Shotover by sending a query with a timestamp included and test that this matches the last written timestamp on the row's column. 