### PR TITLE
Fix connections with no messages sent during node outage

### DIFF
--- a/shotover-proxy/src/transforms/cassandra/sink_cluster/node.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_cluster/node.rs
@@ -124,7 +124,7 @@ impl ConnectionFactory {
                 })?;
             return_chan_rx.await.map_err(|e| {
                 anyhow!(e).context("Failed to initialize new connection with handshake, rx failed")
-            })?;
+            })??;
         }
 
         if let Some(use_message) = &self.use_message {
@@ -138,7 +138,7 @@ impl ConnectionFactory {
             return_chan_rx.await.map_err(|e| {
                 anyhow!(e)
                     .context("Failed to initialize new connection with use message, rx failed")
-            })?;
+            })??;
         }
 
         Ok(outbound)

--- a/shotover-proxy/src/transforms/cassandra/sink_cluster/node_pool.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_cluster/node_pool.rs
@@ -80,6 +80,15 @@ impl NodePool {
         self.token_map = TokenMap::new(self.nodes.as_slice());
     }
 
+    pub fn report_issue_with_node(&mut self, address: SocketAddr) {
+        for node in &mut self.nodes {
+            if node.address == address {
+                node.is_up = false;
+                node.outbound = None;
+            }
+        }
+    }
+
     pub async fn update_keyspaces(&mut self, keyspaces_rx: &mut KeyspaceChanRx) {
         let updated_keyspaces = keyspaces_rx.borrow_and_update().clone();
         self.keyspace_metadata = updated_keyspaces;

--- a/shotover-proxy/src/transforms/cassandra/sink_cluster/topology.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_cluster/topology.rs
@@ -204,7 +204,7 @@ async fn register_for_topology_and_status_events(
         )
         .unwrap();
 
-    if let Some(Frame::Cassandra(CassandraFrame { operation, .. })) = rx.await?.response?.frame() {
+    if let Some(Frame::Cassandra(CassandraFrame { operation, .. })) = rx.await??.frame() {
         match operation {
             CassandraOperation::Ready(_) => Ok(()),
             operation => Err(anyhow!("Expected Cassandra to respond to a Register with a Ready. Instead it responded with {:?}", operation))
@@ -259,7 +259,7 @@ mod system_keyspaces {
             tx,
         )?;
 
-        let response = rx.await?.response?;
+        let response = rx.await??;
         into_keyspaces(response, data_center)
     }
 
@@ -386,7 +386,7 @@ mod system_local {
             tx,
         )?;
 
-        into_nodes(rx.await?.response?, data_center, address)
+        into_nodes(rx.await??, data_center, address)
     }
 
     fn into_nodes(
@@ -473,7 +473,7 @@ mod system_peers {
             tx,
         )?;
 
-        let mut response = rx.await?.response?;
+        let mut response = rx.await??;
 
         if is_peers_v2_does_not_exist_error(&mut response) {
             let (tx, rx) = oneshot::channel();
@@ -492,7 +492,7 @@ mod system_peers {
                 })),
                 tx,
             )?;
-            response = rx.await?.response?;
+            response = rx.await??;
         }
 
         into_nodes(response, data_center)

--- a/shotover-proxy/tests/cassandra_int_tests/cluster/single_rack_v4.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cluster/single_rack_v4.rs
@@ -2,12 +2,12 @@ use crate::cassandra_int_tests::cluster::run_topology_task;
 use crate::helpers::cassandra::{
     assert_query_result, run_query, CassandraConnection, CassandraDriver, ResultValue,
 };
-use crate::helpers::ShotoverManager;
 use cassandra_protocol::events::ServerEvent;
 use cassandra_protocol::frame::events::{StatusChange, StatusChangeType};
 use std::net::SocketAddr;
 use std::time::Duration;
 use test_helpers::docker_compose::DockerCompose;
+use tokio::sync::broadcast;
 use tokio::time::{sleep, timeout};
 
 async fn test_rewrite_system_peers(connection: &CassandraConnection) {
@@ -275,12 +275,7 @@ pub async fn test_topology_task(ca_path: Option<&str>, cassandra_port: Option<u3
     }
 }
 
-pub async fn test_node_going_down(
-    compose: DockerCompose,
-    shotover_manager: ShotoverManager,
-    driver: CassandraDriver,
-    kill: bool,
-) {
+pub async fn test_node_going_down(compose: &DockerCompose, driver: CassandraDriver) {
     let mut connection_shotover = CassandraConnection::new("127.0.0.1", 9042, driver).await;
     connection_shotover
         .enable_schema_awaiter("172.16.1.2:9044", None)
@@ -293,101 +288,175 @@ pub async fn test_node_going_down(
     run_query(&connection_shotover, "INSERT INTO cluster_single_rack_node_going_down.test_table (pk, col1, col2) VALUES ('pk1', 42, true);").await;
     run_query(&connection_shotover, "INSERT INTO cluster_single_rack_node_going_down.test_table (pk, col1, col2) VALUES ('pk2', 413, false);").await;
 
+    let mut event_connections = EventConnections::new().await;
+
     {
-        let event_connection_direct =
-            CassandraConnection::new("172.16.1.2", 9044, CassandraDriver::CdrsTokio).await;
-        let mut event_recv_direct = event_connection_direct.as_cdrs().create_event_receiver();
-
-        let event_connection_shotover =
-            CassandraConnection::new("127.0.0.1", 9042, CassandraDriver::CdrsTokio).await;
-        let mut event_recv_shotover = event_connection_shotover.as_cdrs().create_event_receiver();
-
-        // let the driver finish connecting to the cluster and registering for the events
-        sleep(Duration::from_secs(10)).await;
-
         // stop one of the containers to trigger a status change event.
         // event_connection_direct is connecting to cassandra-one, so make sure to instead kill caassandra-two.
-        if kill {
-            compose.kill_service("cassandra-two");
-        } else {
-            compose.stop_service("cassandra-two");
-        }
-
-        loop {
-            // The direct connection should allow all events to pass through
-            let event = timeout(Duration::from_secs(120), event_recv_direct.recv())
-                .await
-                .unwrap()
-                .unwrap();
-
-            // Sometimes we get up status events if we connect early enough.
-            // I assume these are just due to the nodes initially joining the cluster.
-            // If we hit one skip it and continue searching for our expected down status event
-            if matches!(
-                event,
-                ServerEvent::StatusChange(StatusChange {
-                    change_type: StatusChangeType::Up,
-                    ..
-                })
-            ) {
-                continue;
-            }
-
-            assert_eq!(
-                event,
-                ServerEvent::StatusChange(StatusChange {
-                    change_type: StatusChangeType::Down,
-                    addr: "172.16.1.3:9044".parse().unwrap()
-                })
-            );
-            break;
-        }
-
-        // we have already received an event directly from the cassandra instance so its reasonable to
-        // expect shotover to have processed that event within 10 seconds if it was ever going to
-        timeout(Duration::from_secs(10), event_recv_shotover.recv())
-            .await
-            .expect_err("CassandraSinkCluster must filter out this event");
+        compose.stop_service("cassandra-two");
+        assert_down_event(&mut event_connections).await;
 
         let new_connection = CassandraConnection::new("127.0.0.1", 9042, driver).await;
 
-        // test that shotover handles new connections after node goes down
+        // test that shotover handles connections created before and after node goes down
         test_connection_handles_node_down(&new_connection, driver).await;
-
-        // test that shotover handles preexisting connections after node goes down
         test_connection_handles_node_down(&connection_shotover, driver).await;
 
         compose.start_service("cassandra-two");
+        assert_up_event(&mut event_connections).await;
 
-        // The direct connection should allow all events to pass through
-        let event = timeout(Duration::from_secs(120), event_recv_direct.recv())
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            event,
-            ServerEvent::StatusChange(StatusChange {
-                change_type: StatusChangeType::Up,
-                addr: "172.16.1.3:9044".parse().unwrap()
-            })
-        );
-        // we have already received an event directly from the cassandra instance so its reasonable to
-        // expect shotover to have processed that event within 10 seconds if it was ever going to
-        timeout(Duration::from_secs(10), event_recv_shotover.recv())
-            .await
-            .expect_err("CassandraSinkCluster must filter out this event");
-
+        // test that shotover handles connections created before and after the nodes goes up
         let new_new_connection = CassandraConnection::new("127.0.0.1", 9042, driver).await;
-
         test_connection_handles_node_down(&new_new_connection, driver).await;
         test_connection_handles_node_down(&new_connection, driver).await;
         test_connection_handles_node_down(&connection_shotover, driver).await;
     }
+    {
+        // Kill the service this time instead of stopping it
+        compose.kill_service("cassandra-two");
+        assert_down_event(&mut event_connections).await;
 
-    std::mem::drop(connection_shotover);
-    // Purposefully dispose of these as we left the underlying cassandra cluster in a non-recoverable state
-    std::mem::drop(shotover_manager);
-    std::mem::drop(compose);
+        let new_connection = CassandraConnection::new("127.0.0.1", 9042, driver).await;
+
+        test_connection_handles_node_down(&new_connection, driver).await;
+        test_connection_handles_node_down(&connection_shotover, driver).await;
+
+        compose.start_service("cassandra-two");
+        assert_up_event(&mut event_connections).await;
+
+        let new_new_connection = CassandraConnection::new("127.0.0.1", 9042, driver).await;
+        test_connection_handles_node_down(&new_new_connection, driver).await;
+        test_connection_handles_node_down(&new_connection, driver).await;
+        test_connection_handles_node_down(&connection_shotover, driver).await;
+    }
+    {
+        compose.stop_service("cassandra-two");
+        assert_down_event(&mut event_connections).await;
+
+        // Test the case where connection_shotover does not receive a message while the node is down,
+        // This ensures we handle the case where the outgoing connection is dead but the per connection state never observed the node go down
+
+        compose.start_service("cassandra-two");
+        assert_up_event(&mut event_connections).await;
+
+        let new_connection = CassandraConnection::new("127.0.0.1", 9042, driver).await;
+        test_connection_handles_node_down_with_one_retry(&new_connection).await;
+        if connection_shotover.is(&[CassandraDriver::CdrsTokio, CassandraDriver::Scylla]) {
+            test_connection_handles_node_down_with_one_retry(&connection_shotover).await;
+        }
+    }
+    {
+        // Same again but with kill instead of stop
+        compose.kill_service("cassandra-two");
+        assert_down_event(&mut event_connections).await;
+
+        compose.start_service("cassandra-two");
+        assert_up_event(&mut event_connections).await;
+
+        let new_connection = CassandraConnection::new("127.0.0.1", 9042, driver).await;
+        test_connection_handles_node_down_with_one_retry(&new_connection).await;
+        if connection_shotover.is(&[CassandraDriver::CdrsTokio, CassandraDriver::Scylla]) {
+            test_connection_handles_node_down_with_one_retry(&connection_shotover).await;
+        }
+    }
+}
+
+struct EventConnections {
+    _direct: CassandraConnection,
+    recv_direct: broadcast::Receiver<ServerEvent>,
+    _shotover: CassandraConnection,
+    recv_shotover: broadcast::Receiver<ServerEvent>,
+}
+
+impl EventConnections {
+    async fn new() -> Self {
+        let direct = CassandraConnection::new("172.16.1.2", 9044, CassandraDriver::CdrsTokio).await;
+        let recv_direct = direct.as_cdrs().create_event_receiver();
+
+        let shotover =
+            CassandraConnection::new("127.0.0.1", 9042, CassandraDriver::CdrsTokio).await;
+        let recv_shotover = shotover.as_cdrs().create_event_receiver();
+
+        // let the driver finish connecting to the cluster and registering for the events
+        sleep(Duration::from_secs(10)).await;
+
+        EventConnections {
+            _direct: direct,
+            recv_direct,
+            _shotover: shotover,
+            recv_shotover,
+        }
+    }
+}
+
+async fn assert_down_event(event_connections: &mut EventConnections) {
+    loop {
+        // The direct connection should allow all events to pass through
+        let event = timeout(
+            Duration::from_secs(120),
+            event_connections.recv_direct.recv(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        // Sometimes we get up status events if we connect early enough.
+        // I assume these are just due to the nodes initially joining the cluster.
+        // If we hit one skip it and continue searching for our expected down status event
+        if matches!(
+            event,
+            ServerEvent::StatusChange(StatusChange {
+                change_type: StatusChangeType::Up,
+                ..
+            })
+        ) {
+            continue;
+        }
+
+        assert_eq!(
+            event,
+            ServerEvent::StatusChange(StatusChange {
+                change_type: StatusChangeType::Down,
+                addr: "172.16.1.3:9044".parse().unwrap()
+            })
+        );
+        break;
+    }
+
+    // we have already received an event directly from the cassandra instance so its reasonable to
+    // expect shotover to have processed that event within 10 seconds if it was ever going to
+    timeout(
+        Duration::from_secs(10),
+        event_connections.recv_shotover.recv(),
+    )
+    .await
+    .expect_err("CassandraSinkCluster must filter out this event");
+}
+
+async fn assert_up_event(event_connections: &mut EventConnections) {
+    // The direct connection should allow all events to pass through
+    let event = timeout(
+        Duration::from_secs(120),
+        event_connections.recv_direct.recv(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert_eq!(
+        event,
+        ServerEvent::StatusChange(StatusChange {
+            change_type: StatusChangeType::Up,
+            addr: "172.16.1.3:9044".parse().unwrap()
+        })
+    );
+    // we have already received an event directly from the cassandra instance so its reasonable to
+    // expect shotover to have processed that event within 10 seconds if it was ever going to
+    timeout(
+        Duration::from_secs(10),
+        event_connections.recv_shotover.recv(),
+    )
+    .await
+    .expect_err("CassandraSinkCluster must filter out this event");
 }
 
 async fn test_connection_handles_node_down(
@@ -417,4 +486,24 @@ async fn test_connection_handles_node_down(
         )
         .await;
     }
+}
+
+async fn test_connection_handles_node_down_with_one_retry(connection: &CassandraConnection) {
+    // run this a few times to make sure we arent getting lucky with the routing
+    let mut fail_count = 0;
+    for _ in 0..50 {
+        if connection
+            .execute_fallible(
+                "SELECT pk, col1, col2 FROM cluster_single_rack_node_going_down.test_table;",
+            )
+            .await
+            .is_err()
+        {
+            fail_count += 1;
+        }
+    }
+    assert!(
+        fail_count == 0 || fail_count == 1,
+        "must never fail or fail only once. The case where it fails once indicates that the connection to cassandra-two was dead but recreated allowing the next query to succeed"
+    )
 }

--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -191,6 +191,8 @@ async fn cluster_single_rack_v4(#[case] driver: CassandraDriver) {
             .enable_schema_awaiter("172.16.1.2:9044", None)
             .await;
         native_types::test(&connection2).await;
+
+        cluster::single_rack_v4::test_node_going_down(&compose, driver).await;
     }
 
     {
@@ -202,25 +204,6 @@ async fn cluster_single_rack_v4(#[case] driver: CassandraDriver) {
     }
 
     cluster::single_rack_v4::test_topology_task(None, Some(9044)).await;
-
-    let shotover_manager =
-        ShotoverManager::from_topology_file("example-configs/cassandra-cluster-v4/topology.yaml");
-    cluster::single_rack_v4::test_node_going_down(compose, shotover_manager, driver, false).await;
-}
-
-#[cfg(feature = "alpha-transforms")]
-#[cfg(feature = "cassandra-cpp-driver-tests")]
-#[rstest]
-//#[case::cdrs(CdrsTokio)]
-#[cfg_attr(feature = "cassandra-cpp-driver-tests", case::datastax(Datastax))]
-#[tokio::test(flavor = "multi_thread")]
-#[serial]
-async fn cluster_single_rack_node_lost(#[case] driver: CassandraDriver) {
-    let compose = DockerCompose::new("example-configs/cassandra-cluster-v4/docker-compose.yaml");
-
-    let shotover_manager =
-        ShotoverManager::from_topology_file("example-configs/cassandra-cluster-v4/topology.yaml");
-    cluster::single_rack_v4::test_node_going_down(compose, shotover_manager, driver, true).await;
 }
 
 #[rstest]


### PR DESCRIPTION
Changes:
* prereq PR - https://github.com/shotover/shotover-proxy/pull/943
* cassandra errors that are generated in response to internal shotover errors are now `Overloaded` errors instead of `Server` errors. This is needed because the cassandra_cpp drivers will terminate the connection on `Server` errors but will allow the user to retry a failed message when `Overloaded` occurs.
* The cassandra connection abstraction is refactored to allow for error handling:
    + Internal errors are now returned as a ResponseError instead of silently being converted to a cassandra error message.
    + The ResponseError contains the connections destination allowing the transform to recreated dead connections
    + The stream_id is only required in the case of errors allowing us to replace the Response struct with a simple type alias of `Result<Message, ResponseError>`
* test_node_going_down is completely refactored to make adding unique test cases easy
    + The test logic is now split up across multiple functions that can be optionally called for each case.
    + cluster_single_rack_node_lost is removed because test_node_going_down now tests every case within a single call.
    + The refactor enabled me to add 2 new test cases to reproduce the problem this PR fixes
    

I'm opening this up for review despite the unmerged prereq, the changes in `helpers/cassandra.rs` can be just ignored as they are a subset of those in https://github.com/shotover/shotover-proxy/pull/943