### PR TITLE
Make ShotoverProcess API a bit more similar to ShotoverManager

### DIFF
--- a/shotover-proxy/examples/cassandra_bench.rs
+++ b/shotover-proxy/examples/cassandra_bench.rs
@@ -33,7 +33,8 @@ fn main() {
         let _compose = DockerCompose::new(&format!("{}/docker-compose.yaml", args.config_dir));
 
         // Uses ShotoverProcess instead of ShotoverManager for a more accurate benchmark
-        let shotover_manager = ShotoverProcess::new(&format!("{}/topology.yaml", args.config_dir));
+        let shotover_manager =
+            ShotoverProcess::from_topology_file(&format!("{}/topology.yaml", args.config_dir));
 
         println!("Benching Shotover ...");
         bench_read(&latte, "localhost:9043", "localhost:9042");

--- a/shotover-proxy/tests/runner/runner_int_tests.rs
+++ b/shotover-proxy/tests/runner/runner_int_tests.rs
@@ -39,7 +39,8 @@ fn test_early_shutdown_cassandra_source() {
 #[test]
 #[serial]
 fn test_shotover_responds_sigterm() {
-    let shotover_process = ShotoverProcess::new("example-configs/null-redis/topology.yaml");
+    let shotover_process =
+        ShotoverProcess::from_topology_file("example-configs/null-redis/topology.yaml");
     shotover_process.signal(nix::sys::signal::Signal::SIGTERM);
 
     let wait_output = shotover_process.wait();
@@ -55,7 +56,8 @@ fn test_shotover_responds_sigterm() {
 #[test]
 #[serial]
 fn test_shotover_responds_sigint() {
-    let shotover_process = ShotoverProcess::new("example-configs/null-redis/topology.yaml");
+    let shotover_process =
+        ShotoverProcess::from_topology_file("example-configs/null-redis/topology.yaml");
     shotover_process.signal(nix::sys::signal::Signal::SIGINT);
 
     let wait_output = shotover_process.wait();

--- a/test-helpers/src/shotover_process.rs
+++ b/test-helpers/src/shotover_process.rs
@@ -26,7 +26,7 @@ impl Drop for ShotoverProcess {
 
 impl ShotoverProcess {
     #[allow(dead_code)]
-    pub fn new(topology_path: &str) -> ShotoverProcess {
+    pub fn from_topology_file(topology_path: &str) -> ShotoverProcess {
         // First ensure shotover is fully built so that the potentially lengthy build time is not included in the wait_for_socket_to_open timeout
         // PROFILE is set in build.rs from PROFILE listed in https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts
         let all_args = if env!("PROFILE") == "release" {
@@ -42,12 +42,20 @@ impl ShotoverProcess {
                 "run",
                 "--all-features",
                 "--release",
+                "--quiet",
                 "--",
                 "-t",
                 topology_path,
             ]
         } else {
-            vec!["run", "--all-features", "--", "-t", topology_path]
+            vec![
+                "run",
+                "--all-features",
+                "--quiet",
+                "--",
+                "-t",
+                topology_path,
+            ]
         };
         let child = Some(
             Command::new(env!("CARGO"))


### PR DESCRIPTION
The constructor name now matches and adding `--quiet` hides the fact that the cargo is used to run the executable.
i.e. The test logs are no longer spammed with:
```
   Finished dev [unoptimized + debuginfo] target(s) in 0.13s
     Running `/home/rukai2/Projects/Crates/shotover/shotover-proxy/target/debug/shotover-proxy -t example-configs/cassandra-passthrough/topology.yaml`
```