### PR TITLE
Give ShotoverProcess powerful event assertions by parsing JSON events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3150,11 +3150,12 @@ name = "test-helpers"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "nix",
  "rcgen",
  "regex",
  "serde_yaml 0.9.14",
  "subprocess",
+ "tokio",
+ "tokio-bin-process",
  "tracing",
 ]
 
@@ -3287,6 +3288,24 @@ dependencies = [
  "socket2",
  "tokio-macros",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "tokio-bin-process"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "nix",
+ "nu-ansi-term",
+ "once_cell",
+ "rcgen",
+ "serde",
+ "serde_json",
+ "subprocess",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "shotover-proxy",
     "test-helpers",
+    "tokio-bin-process",
 ]
 
 # https://deterministic.space/high-performance-rust.html

--- a/shotover-proxy/tests/runner/runner_int_tests.rs
+++ b/shotover-proxy/tests/runner/runner_int_tests.rs
@@ -1,8 +1,10 @@
+use crate::helpers::ShotoverManager;
 use serial_test::serial;
 use std::any::Any;
-
-use crate::helpers::ShotoverManager;
-use test_helpers::shotover_process::ShotoverProcess;
+use test_helpers::shotover_process::{
+    shotover_from_topology_file, shotover_from_topology_file_fail_to_startup, Count, EventMatcher,
+    Level,
+};
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
@@ -28,68 +30,108 @@ fn test_runtime_create() {
     assert!(shotover_manager.runtime.is_some());
 }
 
-#[test]
+#[tokio::test]
 #[serial]
-fn test_early_shutdown_cassandra_source() {
-    std::mem::drop(ShotoverManager::from_topology_file(
-        "example-configs/null-cassandra/topology.yaml",
-    ));
+async fn test_early_shutdown_cassandra_source() {
+    shotover_from_topology_file("example-configs/null-cassandra/topology.yaml")
+        .await
+        .shutdown_and_then_consume_events(&[])
+        .await;
 }
 
-#[test]
+#[tokio::test]
 #[serial]
-fn test_shotover_responds_sigterm() {
-    let shotover_process =
-        ShotoverProcess::from_topology_file("example-configs/null-redis/topology.yaml");
-    shotover_process.signal(nix::sys::signal::Signal::SIGTERM);
+async fn test_shotover_responds_sigterm() {
+    // Ensure it isnt reliant on timing
+    for _ in 0..1000 {
+        let shotover_process =
+            shotover_from_topology_file("example-configs/null-redis/topology.yaml").await;
+        shotover_process.signal(nix::sys::signal::Signal::SIGTERM);
 
-    let wait_output = shotover_process.wait();
-    assert_eq!(wait_output.exit_code, 0);
-    if !wait_output.stdout.contains("received SIGTERM") {
-        panic!(
-            "stdout does not contain 'received SIGTERM'. Instead was: {}",
-            wait_output.stdout
+        let events = shotover_process.consume_remaining_events(&[]).await;
+        events.contains(
+            &EventMatcher::new()
+                .with_level(Level::Info)
+                .with_target("shotover_proxy::runner")
+                .with_message("received SIGTERM"),
         );
     }
 }
 
-#[test]
+#[tokio::test]
 #[serial]
-fn test_shotover_responds_sigint() {
+async fn test_shotover_responds_sigint() {
     let shotover_process =
-        ShotoverProcess::from_topology_file("example-configs/null-redis/topology.yaml");
+        shotover_from_topology_file("example-configs/null-redis/topology.yaml").await;
     shotover_process.signal(nix::sys::signal::Signal::SIGINT);
 
-    let wait_output = shotover_process.wait();
-    assert_eq!(wait_output.exit_code, 0);
-    if !wait_output.stdout.contains("received SIGINT") {
-        panic!(
-            "stdout does not contain 'received SIGINT'. Instead was: {}",
-            wait_output.stdout
-        );
-    }
+    let events = shotover_process.consume_remaining_events(&[]).await;
+    events.contains(
+        &EventMatcher::new()
+            .with_level(Level::Info)
+            .with_target("shotover_proxy::runner")
+            .with_message("received SIGINT"),
+    );
 }
 
-#[test]
-#[should_panic]
+#[tokio::test]
 #[serial]
-fn test_shotover_shutdown_when_invalid_topology_non_terminating_last() {
-    let _shotover_manager =
-        ShotoverManager::from_topology_file("tests/test-configs/invalid_non_terminating_last.yaml");
+async fn test_shotover_shutdown_when_invalid_topology_non_terminating_last() {
+    shotover_from_topology_file_fail_to_startup(
+        "tests/test-configs/invalid_non_terminating_last.yaml",
+        &[],
+    )
+    .await;
 }
 
-#[test]
-#[should_panic]
+#[tokio::test]
 #[serial]
-fn test_shotover_shutdown_when_invalid_topology_terminating_not_last() {
-    let _shotover_manager =
-        ShotoverManager::from_topology_file("tests/test-configs/invalid_terminating_not_last.yaml");
+async fn test_shotover_shutdown_when_invalid_topology_terminating_not_last() {
+    shotover_from_topology_file_fail_to_startup(
+        "tests/test-configs/invalid_terminating_not_last.yaml",
+        &[],
+    )
+    .await;
 }
 
-#[test]
-#[should_panic]
+#[tokio::test]
 #[serial]
-fn test_shotover_shutdown_when_topology_invalid_topology_subchains() {
-    let _shotover_manager =
-        ShotoverManager::from_topology_file("tests/test-configs/invalid_subchains.yaml");
+async fn test_shotover_shutdown_when_topology_invalid_topology_subchains() {
+    shotover_from_topology_file_fail_to_startup(
+        "tests/test-configs/invalid_subchains.yaml",
+        &[
+            EventMatcher::new().with_level(Level::Error)
+                .with_target("shotover_proxy::runner")
+                .with_message(r#"Topology errors
+a_first_chain:
+  Terminating transform "Null" is not last in chain. Terminating transform must be last in chain.
+  Terminating transform "Null" is not last in chain. Terminating transform must be last in chain.
+  Non-terminating transform "DebugPrinter" is last in chain. Last transform must be terminating.
+b_second_chain:
+  ConsistentScatter:
+    a_chain_1:
+      Terminating transform "Null" is not last in chain. Terminating transform must be last in chain.
+      Non-terminating transform "DebugPrinter" is last in chain. Last transform must be terminating.
+    b_chain_2:
+      Terminating transform "Null" is not last in chain. Terminating transform must be last in chain.
+    c_chain_3:
+      ConsistentScatter:
+        sub_chain_2:
+          Terminating transform "Null" is not last in chain. Terminating transform must be last in chain.
+"#),
+            EventMatcher::new().with_level(Level::Warn)
+                .with_target("shotover_proxy::transforms::distributed::consistent_scatter")
+                .with_message("Using this transform is considered unstable - Does not work with REDIS pipelines")
+                .with_count(Count::Times(2)),
+            // TODO: Investigate these
+            EventMatcher::new().with_level(Level::Error)
+                .with_message("failed response Couldn't send message to wrapped chain SendError(BufferedChainMessages { local_addr: 127.0.0.1:10000, messages: [], flush: true, return_chan: Some(Sender { inner: Some(Inner { state: State { is_complete: false, is_closed: false, is_rx_task_set: false, is_tx_task_set: false } }) }) })")
+                .with_count(Count::Any),
+            EventMatcher::new().with_level(Level::Error)
+                .with_target("shotover_proxy::transforms::distributed::consistent_scatter")
+                .with_message("failed response channel closed")
+                .with_count(Count::Any),
+        ],
+    )
+    .await;
 }

--- a/test-helpers/src/lib.rs
+++ b/test-helpers/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::derive_partial_eq_without_eq)]
+
 pub mod cert;
 pub mod docker_compose;
 pub mod lazy;

--- a/test-helpers/src/shotover_process.rs
+++ b/test-helpers/src/shotover_process.rs
@@ -1,127 +1,40 @@
-use crate::docker_compose::run_command;
-use nix::sys::signal::Signal;
-use nix::unistd::Pid;
-use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+use tokio_bin_process::BinProcess;
 
-pub struct ShotoverProcess {
-    /// Always Some while ShotoverProcess is owned
-    pub child: Option<Child>,
+pub use tokio_bin_process::event::{Event, Level};
+pub use tokio_bin_process::event_matcher::{Count, EventMatcher, Events};
+
+pub async fn shotover_from_topology_file(topology_path: &str) -> BinProcess {
+    let mut shotover = BinProcess::start_with_args(
+        "shotover-proxy",
+        &["-t", topology_path, "--log-format", "json"],
+    )
+    .await;
+
+    tokio::time::timeout(
+        Duration::from_secs(30),
+        shotover.wait_for(
+            &EventMatcher::new()
+                .with_level(Level::Info)
+                .with_target("shotover_proxy::server")
+                .with_message("accepting inbound connections"),
+        ),
+    )
+    .await
+    .unwrap();
+
+    shotover
 }
 
-impl Drop for ShotoverProcess {
-    fn drop(&mut self) {
-        if let Some(child) = self.child.take() {
-            if let Err(err) =
-                nix::sys::signal::kill(Pid::from_raw(child.id() as i32), Signal::SIGKILL)
-            {
-                println!("Failed to shutdown ShotoverProcess {err}");
-            }
-
-            if !std::thread::panicking() {
-                panic!("Need to call either wait or shutdown_and_assert_success method on ShotoverProcess before dropping it ");
-            }
-        }
-    }
-}
-
-impl ShotoverProcess {
-    #[allow(dead_code)]
-    pub fn from_topology_file(topology_path: &str) -> ShotoverProcess {
-        // First ensure shotover is fully built so that the potentially lengthy build time is not included in the wait_for_socket_to_open timeout
-        // PROFILE is set in build.rs from PROFILE listed in https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts
-        let all_args = if env!("PROFILE") == "release" {
-            vec!["build", "--all-features", "--release"]
-        } else {
-            vec!["build", "--all-features"]
-        };
-        run_command(env!("CARGO"), &all_args).unwrap();
-
-        // Now actually run shotover and keep hold of the child process
-        let all_args = if env!("PROFILE") == "release" {
-            vec![
-                "run",
-                "--all-features",
-                "--release",
-                "--quiet",
-                "--",
-                "-t",
-                topology_path,
-            ]
-        } else {
-            vec![
-                "run",
-                "--all-features",
-                "--quiet",
-                "--",
-                "-t",
-                topology_path,
-            ]
-        };
-        let child = Some(
-            Command::new(env!("CARGO"))
-                .args(&all_args)
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .spawn()
-                .unwrap(),
-        );
-
-        // Wait for observability metrics port to open
-        if let Err(err) = crate::try_wait_for_socket_to_open("127.0.0.1", 9001) {
-            // Shutdown shotover and panic if shotover hit any kind of failure.
-            // Panicking here is good because any errors here are more important then reporting the timeout
-            ShotoverProcess { child }.shutdown_and_assert_success();
-
-            // If shotover shutdown fine then just panic with a generic error. Good luck developer.
-            panic!("Shotover succesfully started up and shutdown, but the metrics port was never opened: {}", err);
-        }
-
-        ShotoverProcess { child }
-    }
-
-    #[allow(dead_code)]
-    fn pid(&self) -> Pid {
-        Pid::from_raw(self.child.as_ref().unwrap().id() as i32)
-    }
-
-    #[allow(dead_code)]
-    pub fn signal(&self, signal: Signal) {
-        nix::sys::signal::kill(self.pid(), signal).unwrap();
-    }
-
-    #[allow(dead_code)]
-    pub fn wait(mut self) -> WaitOutput {
-        let output = self.child.take().unwrap().wait_with_output().unwrap();
-
-        let stdout = String::from_utf8(output.stdout).expect("stdout was not valid utf8");
-        let stderr = String::from_utf8(output.stderr).expect("stderr was not valid utf8");
-
-        WaitOutput {
-            exit_code: output
-                .status
-                .code()
-                .expect("Couldnt get exit code, the process was killed by something like SIGKILL"),
-            stdout,
-            stderr,
-        }
-    }
-
-    #[allow(dead_code)]
-    pub fn shutdown_and_assert_success(self) {
-        self.signal(nix::sys::signal::Signal::SIGTERM);
-        let result = self.wait();
-
-        if result.exit_code != 0 {
-            panic!(
-                "Shotover exited with {} but expected 0 exit code (Success).\nstdout:\n{}\nstderr:\n{}",
-                result.exit_code, result.stdout, result.stderr
-            );
-        }
-    }
-}
-
-pub struct WaitOutput {
-    pub stdout: String,
-    pub stderr: String,
-    pub exit_code: i32,
+pub async fn shotover_from_topology_file_fail_to_startup(
+    topology_path: &str,
+    expected_errors_and_warnings: &[EventMatcher],
+) -> Events {
+    BinProcess::start_with_args(
+        "shotover-proxy",
+        &["-t", topology_path, "--log-format", "json"],
+    )
+    .await
+    .consume_remaining_events_expect_failure(expected_errors_and_warnings)
+    .await
 }

--- a/tokio-bin-process/Cargo.toml
+++ b/tokio-bin-process/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "test-helpers"
+name = "tokio-bin-process"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.56"
@@ -9,10 +9,14 @@ license = "Apache-2.0"
 
 [dependencies]
 tracing = "0.1.15"
+tracing-subscriber = { version = "0.3.1", features = ["env-filter", "json"] }
 subprocess = "0.2.7"
 anyhow = "1.0.42"
+nix = "0.26.0"
 rcgen = "0.10.0"
-serde_yaml = "0.9.0"
-regex = "1.7.0"
 tokio = { version = "1.21.1", features = ["full", "macros"] }
-tokio-bin-process = { path = "../tokio-bin-process" }
+serde = { version = "1.0.111", features = ["derive"] }
+serde_json = "1.0.89"
+nu-ansi-term = "0.46.0"
+itertools = "0.10.1"
+once_cell = "1.16.0"

--- a/tokio-bin-process/build.rs
+++ b/tokio-bin-process/build.rs
@@ -1,0 +1,6 @@
+use std::env;
+
+fn main() {
+    let profile = env::var("PROFILE").unwrap();
+    println!("cargo:rustc-env=PROFILE={profile}");
+}

--- a/tokio-bin-process/src/event.rs
+++ b/tokio-bin-process/src/event.rs
@@ -1,0 +1,173 @@
+use anyhow::Context;
+use anyhow::Result;
+use itertools::Itertools;
+use nu_ansi_term::Color;
+use serde_json::Value as JsonValue;
+use std::collections::HashMap;
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
+#[derive(serde::Deserialize, Debug, Clone, PartialEq)]
+pub struct Event {
+    pub timestamp: String,
+    pub level: Level,
+    pub target: String,
+    pub fields: Fields,
+    #[serde(default)]
+    pub span: HashMap<String, JsonValue>,
+    #[serde(default)]
+    pub spans: Vec<HashMap<String, JsonValue>>,
+}
+
+impl Event {
+    pub fn new(level: Level, target: &str, message: &str) -> Event {
+        Event {
+            timestamp: "".to_owned(),
+            level,
+            target: target.to_owned(),
+            fields: Fields {
+                message: message.to_owned(),
+                fields: HashMap::new(),
+            },
+            span: HashMap::new(),
+            spans: vec![],
+        }
+    }
+}
+
+#[derive(serde::Deserialize, Debug, Clone, PartialEq)]
+pub enum Level {
+    #[serde(rename = "ERROR")]
+    Error,
+    #[serde(rename = "WARN")]
+    Warn,
+    #[serde(rename = "INFO")]
+    Info,
+    #[serde(rename = "DEBUG")]
+    Debug,
+    #[serde(rename = "TRACE")]
+    Trace,
+}
+
+impl Display for Level {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Level::Error => write!(f, "{}", Color::Red.paint("ERROR")),
+            Level::Warn => write!(f, " {}", Color::Yellow.paint("WARN")),
+            Level::Info => write!(f, " {}", Color::Green.paint("INFO")),
+            Level::Debug => write!(f, " {}", Color::Blue.paint("DEBUG")),
+            Level::Trace => write!(f, " {}", Color::Purple.paint("TRACE")),
+        }
+    }
+}
+
+#[derive(serde::Deserialize, Debug, Clone, PartialEq)]
+pub struct Fields {
+    #[serde(default)]
+    pub message: String,
+    #[serde(flatten)]
+    pub fields: HashMap<String, JsonValue>,
+}
+
+impl Display for Event {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(
+            f,
+            "{}",
+            // Strip the date from the datetime.
+            // The date portion isnt useful in integration tests
+            Color::Default.dimmed().paint(&self.timestamp[11..])
+        )?;
+
+        if let Some(backtrace) = self.fields.fields.get("panic.backtrace") {
+            // Special case panics.
+            // Panics usually get reasonable formatting locally and we dont want to regress on that just because we had to stuff them through tracing
+            writeln!(
+                f,
+                " {} {}",
+                Color::Red.reverse().paint("PANIC"),
+                self.fields.message,
+            )?;
+            match backtrace {
+                JsonValue::String(backtrace) => {
+                    for line in backtrace.lines() {
+                        // we can have a little color as a treat
+                        if line.trim().starts_with("at ") {
+                            writeln!(f, "{}", Color::Default.dimmed().paint(line))?;
+                        } else {
+                            writeln!(f, "{}", line)?;
+                        }
+                    }
+                }
+                backtrace => write!(f, "{backtrace}")?,
+            }
+        } else {
+            // Regular old formatting, matches the formatting used by the default tracing subscriber
+            write!(f, " {} ", self.level)?;
+            if !self.spans.is_empty() {
+                for span in &self.spans {
+                    let name = span.get("name").unwrap().as_str().unwrap();
+                    write!(f, "{}", Color::Default.bold().paint(name))?;
+                    write!(f, "{}", Color::Default.bold().paint("{"))?;
+                    let mut first = true;
+                    for (key, value) in span.iter().sorted_by_key(|(key, _)| <&String>::clone(key))
+                    {
+                        if key != "name" {
+                            if !first {
+                                write!(f, " ")?;
+                            }
+                            first = false;
+
+                            write!(f, "{}", key)?;
+                            write!(f, "{}", Color::Default.dimmed().paint("="))?;
+                            write!(f, "{}", value)?;
+                        }
+                    }
+                    write!(f, "{}", Color::Default.bold().paint("}"))?;
+                    write!(f, "{}", Color::Default.dimmed().paint(":"))?;
+                }
+                write!(f, " ")?;
+            }
+
+            write!(
+                f,
+                "{}{}",
+                Color::Default.dimmed().paint(&self.target),
+                Color::Default.dimmed().paint(":"),
+            )?;
+
+            if !self.fields.message.is_empty() {
+                write!(f, " {}", self.fields.message)?;
+            }
+
+            for (key, value) in self
+                .fields
+                .fields
+                .iter()
+                .sorted_by_key(|(key, _)| <&String>::clone(key))
+            {
+                write!(f, " {}", Color::Default.italic().paint(key))?;
+                write!(f, "{}", Color::Default.dimmed().paint("="))?;
+                write!(f, "{}", QuotelessDisplay(value))?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+struct QuotelessDisplay<'a>(&'a JsonValue);
+
+impl<'a> Display for QuotelessDisplay<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            QuotelessDisplay(JsonValue::String(str)) => write!(f, "{str}"),
+            QuotelessDisplay(value) => write!(f, "{value}"),
+        }
+    }
+}
+
+impl Event {
+    pub fn from_json_str(s: &str) -> Result<Self> {
+        serde_json::from_str(s).context(format!("Failed to parse json: {s}"))
+    }
+}

--- a/tokio-bin-process/src/event_matcher.rs
+++ b/tokio-bin-process/src/event_matcher.rs
@@ -1,0 +1,97 @@
+use crate::event::{Event, Level};
+use itertools::Itertools;
+
+#[derive(Debug)]
+pub struct Events {
+    pub events: Vec<Event>,
+}
+
+impl Events {
+    pub fn contains(&self, matcher: &EventMatcher) {
+        if !self.events.iter().any(|e| matcher.matches(e)) {
+            panic!(
+                "An event with {matcher:?} was not found in the list of events:\n{}",
+                self.events.iter().join("\n")
+            )
+        }
+    }
+
+    pub fn contains_in_order(&self, _matchers: &[EventMatcher]) {
+        todo!()
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct EventMatcher {
+    pub level: Matcher<Level>,
+    pub message: Matcher<String>,
+    pub target: Matcher<String>,
+    pub count: Count,
+}
+
+impl EventMatcher {
+    pub fn new() -> EventMatcher {
+        EventMatcher::default()
+    }
+
+    pub fn with_level(mut self, level: Level) -> EventMatcher {
+        self.level = Matcher::Matches(level);
+        self
+    }
+
+    pub fn with_target(mut self, target: &str) -> EventMatcher {
+        self.target = Matcher::Matches(target.to_owned());
+        self
+    }
+
+    pub fn with_message(mut self, message: &str) -> EventMatcher {
+        self.message = Matcher::Matches(message.to_owned());
+        self
+    }
+
+    /// This is not used internally i.e. it has no effect on EventMatcher::matches
+    /// Instead its used by higher level matching logic
+    pub fn with_count(mut self, count: Count) -> EventMatcher {
+        self.count = count;
+        self
+    }
+
+    pub fn matches(&self, event: &Event) -> bool {
+        self.level.matches(&event.level)
+            && self.message.matches(&event.fields.message)
+            && self.target.matches(&event.target)
+    }
+}
+
+#[derive(Debug)]
+pub enum Count {
+    Times(usize),
+    Any,
+}
+
+impl Default for Count {
+    fn default() -> Self {
+        Count::Times(1)
+    }
+}
+
+#[derive(Debug)]
+pub enum Matcher<T: PartialEq> {
+    Matches(T),
+    Any,
+}
+
+impl<T: PartialEq> Default for Matcher<T> {
+    fn default() -> Self {
+        Matcher::Any
+    }
+}
+
+impl<T: PartialEq> Matcher<T> {
+    fn matches(&self, value: &T) -> bool {
+        match self {
+            Matcher::Matches(x) => value == x,
+            Matcher::Any => true,
+        }
+    }
+}

--- a/tokio-bin-process/src/lib.rs
+++ b/tokio-bin-process/src/lib.rs
@@ -1,0 +1,7 @@
+#![allow(clippy::derive_partial_eq_without_eq)]
+
+pub mod event;
+pub mod event_matcher;
+pub mod process;
+
+pub use process::BinProcess;

--- a/tokio-bin-process/src/process.rs
+++ b/tokio-bin-process/src/process.rs
@@ -1,0 +1,304 @@
+use crate::event::{Event, Fields, Level};
+use crate::event_matcher::{Count, EventMatcher, Events};
+use anyhow::{anyhow, Context, Result};
+use nix::sys::signal::Signal;
+use nix::unistd::Pid;
+use nu_ansi_term::Color;
+use once_cell::sync::Lazy;
+use std::collections::HashSet;
+use std::env;
+use std::path::Path;
+use std::process::Stdio;
+use std::sync::Mutex;
+use subprocess::{Exec, Redirection};
+use tokio::sync::mpsc;
+use tokio::{
+    io::{AsyncBufReadExt, BufReader},
+    process::{Child, ChildStdout, Command},
+};
+use tracing_subscriber::fmt::TestWriter;
+
+// It is actually quite expensive to invoke `cargo build` even when there is nothing to build.
+// On my machine, on a specific project, it takes 170ms.
+// To avoid this cost for every call to start_with_args we use this global to keep track of which packages have been built by a BinProcess for the lifetime of the test run.
+//
+// Unfortunately this doesnt work when running each test in its own process. e.g. when using nextest
+// But worst case it just unnecessarily reruns `cargo build`.
+static BUILT_PACKAGES: Lazy<Mutex<HashSet<String>>> = Lazy::new(|| Mutex::new(HashSet::new()));
+
+pub struct BinProcess {
+    /// Always Some while BinProcess is owned
+    pub child: Option<Child>,
+    event_rx: mpsc::UnboundedReceiver<Event>,
+}
+
+impl Drop for BinProcess {
+    fn drop(&mut self) {
+        if self.child.is_some() && !std::thread::panicking() {
+            panic!("Need to call either wait or shutdown_and_assert_success method on BinProcess before dropping it.");
+        }
+    }
+}
+
+fn setup_tracing_subscriber_for_test_logic() {
+    tracing_subscriber::fmt()
+        .with_writer(TestWriter::new())
+        .with_env_filter("warn")
+        .try_init()
+        .ok();
+}
+
+impl BinProcess {
+    /// Starts the crates binary in a process and returns a BinProcess which can be used to interact with the process.
+    /// The binary will be internally compiled by cargo if its not already, it will be compiled in a release/debug mode that matches the release/debug mode of the integration test.
+    ///
+    /// The `user_args` will be used as the args to the binary.
+    /// The args should give the desired setup for the given integration test and should also enable the tracing json logger to stdout if that is not the default.
+    /// All tracing events emitted by your binary in json over stdout will be processed by BinProcess and then emitted to the tests stdout in the default human readable tracing format.
+    /// To ensure any WARN/ERROR's from your test logic are visible, BinProcess will setup its own subscriber that outputs to the tests stdout in the default human readable format.
+    /// If you set your own subscriber before calling `BinProcess::start_with_args` that will take preference instead.
+    ///
+    /// Dropping the BinProcess will trigger a panic unless shutdown_and_then_consume_events or consume_remaining_events has been called.
+    /// This is done to avoid missing important assertions run by those methods.
+    pub async fn start_with_args(cargo_package_name: &str, binary_args: &[&str]) -> BinProcess {
+        setup_tracing_subscriber_for_test_logic();
+
+        // PROFILE is set in build.rs from PROFILE listed in https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts
+        let release = env!("PROFILE") == "release";
+
+        // First build the binary if its not yet built
+        let mut built_packages = BUILT_PACKAGES.lock().unwrap();
+        if !built_packages.contains(cargo_package_name) {
+            let all_args = if release {
+                vec!["build", "--all-features", "--release"]
+            } else {
+                vec!["build", "--all-features"]
+            };
+            run_command(env!("CARGO"), &all_args).unwrap();
+            built_packages.insert(cargo_package_name.to_owned());
+        }
+
+        let project_root = Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap())
+            .ancestors()
+            .nth(1)
+            .unwrap()
+            .to_path_buf();
+
+        // Now actually run the binary and keep hold of the child process
+        let bin_path = project_root
+            .join("target")
+            .join(if release { "release" } else { "debug" })
+            .join(cargo_package_name);
+        let mut child = Some(
+            Command::new(&bin_path)
+                .args(binary_args)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .kill_on_drop(true)
+                .spawn()
+                .context(format!("Failed to run {bin_path:?}"))
+                .unwrap(),
+        )
+        .unwrap();
+
+        let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel();
+        let reader = BufReader::new(child.stdout.take().unwrap()).lines();
+        tokio::spawn(async move {
+            if let Err(err) = process_stdout_events(reader, &event_tx).await {
+                // Because we are in a task, panicking is likely to be ignored.
+                // Instead we generate a fake error event, which is possibly a bit confusing for the user but will at least cause the test to fail.
+                event_tx
+                    .send(Event {
+                        timestamp: "".to_owned(),
+                        level: Level::Error,
+                        target: "tokio-bin-process".to_owned(),
+                        fields: Fields {
+                            message: err.to_string(),
+                            fields: Default::default(),
+                        },
+                        span: Default::default(),
+                        spans: Default::default(),
+                    })
+                    .ok();
+            }
+        });
+
+        BinProcess {
+            child: Some(child),
+            event_rx,
+        }
+    }
+
+    fn pid(&self) -> Pid {
+        Pid::from_raw(self.child.as_ref().unwrap().id().unwrap() as i32)
+    }
+
+    pub fn signal(&self, signal: Signal) {
+        nix::sys::signal::kill(self.pid(), signal).unwrap();
+    }
+
+    /// Waits for the `ready` EventMatcher to match on an incoming event.
+    /// All events that were encountered while waiting are returned.
+    pub async fn wait_for(&mut self, ready: &EventMatcher) -> Events {
+        let mut events = vec![];
+        while let Some(event) = self.event_rx.recv().await {
+            let ready_match = ready.matches(&event);
+            events.push(event);
+            if ready_match {
+                return Events { events };
+            }
+        }
+        panic!("bin process shutdown before an event was found matching {ready:?}")
+    }
+
+    /// TODO: I can imagine lots of scenarios where a method like this would be really useful for integration testing.
+    ///       I havent implemented it yet because I dont yet have anywhere to use it.
+    ///
+    /// Await `event_count` messages to be emitted from the process.
+    pub async fn consume_events(
+        &self,
+        _event_count: usize,
+        _expected_errors_and_warnings: &[EventMatcher],
+    ) -> Events {
+        todo!()
+    }
+
+    /// Issues sigterm to the process and then awaits its shutdown.
+    /// All remaining events will be returned.
+    pub async fn shutdown_and_then_consume_events(
+        self,
+        expected_errors_and_warnings: &[EventMatcher],
+    ) -> Events {
+        self.signal(nix::sys::signal::Signal::SIGTERM);
+        self.consume_remaining_events(expected_errors_and_warnings)
+            .await
+    }
+
+    /// prefer shutdown_and_then_consume_events.
+    /// This method will not return until the process has terminated.
+    /// It is useful when you need to test a shutdown method other than SIGTERM.
+    pub async fn consume_remaining_events(
+        mut self,
+        expected_errors_and_warnings: &[EventMatcher],
+    ) -> Events {
+        let (events, status) = self
+            .consume_remaining_events_inner(expected_errors_and_warnings)
+            .await;
+
+        if status != 0 {
+            let events: String = events.events.iter().map(|x| format!("\n{x}")).collect();
+            panic!("The bin process exited with {status} but expected 0 exit code (Success).\nevents:{events}");
+        }
+
+        events
+    }
+
+    /// Identical to consume_remaining_events but asserts that the process exited with failure code instead of success
+    pub async fn consume_remaining_events_expect_failure(
+        mut self,
+        expected_errors_and_warnings: &[EventMatcher],
+    ) -> Events {
+        let (events, status) = self
+            .consume_remaining_events_inner(expected_errors_and_warnings)
+            .await;
+
+        if status == 0 {
+            let events: String = events.events.iter().map(|x| format!("\n{x}")).collect();
+            panic!("The bin process exited with {status} but expected non 0 exit code (Failure).\nevents:{events}");
+        }
+
+        events
+    }
+
+    async fn consume_remaining_events_inner(
+        &mut self,
+        expected_errors_and_warnings: &[EventMatcher],
+    ) -> (Events, i32) {
+        let mut events = vec![];
+        while let Some(event) = self.event_rx.recv().await {
+            events.push(event);
+        }
+
+        let mut error_count = vec![0; expected_errors_and_warnings.len()];
+        for event in &events {
+            if let Level::Error | Level::Warn = event.level {
+                let mut matched = false;
+                for (matcher, count) in expected_errors_and_warnings
+                    .iter()
+                    .zip(error_count.iter_mut())
+                {
+                    if matcher.matches(event) {
+                        *count += 1;
+                        matched = true;
+                    }
+                }
+                if !matched {
+                    panic!("Unexpected event {event}\nAny ERROR or WARN events that occur in integration tests must be explicitly allowed by adding an appropriate EventMatcher to the method call.")
+                }
+            }
+        }
+
+        // TODO: move into Events::contains
+        for (matcher, count) in expected_errors_and_warnings.iter().zip(error_count.iter()) {
+            match matcher.count {
+                Count::Any => {}
+                Count::Times(matcher_count) => {
+                    if matcher_count != *count {
+                        panic!("Expected to find matches for {matcher:?}, {matcher_count} times but actually matched {count} times")
+                    }
+                }
+            }
+        }
+
+        use std::os::unix::process::ExitStatusExt;
+        let output = self.child.take().unwrap().wait_with_output().await.unwrap();
+        let status = output.status.code().unwrap_or_else(|| {
+            panic!(
+                "Failed to get exit status, usually this indicates a SIGKILL was issued but it could also be a failure of the application to return an exit value. The actual signal that killed the process was {:?}",
+                output.status.signal()
+            )
+        });
+
+        (Events { events }, status)
+    }
+}
+
+async fn process_stdout_events(
+    mut reader: tokio::io::Lines<BufReader<ChildStdout>>,
+    event_tx: &mpsc::UnboundedSender<Event>,
+) -> Result<()> {
+    while let Some(line) = reader.next_line().await.context("An IO error occured while reading stdout from the application, I'm not actually sure when this happens?")? {
+        let event = Event::from_json_str(&line).context(format!(
+            "The application emitted a line that was not a valid event encoded in json: {}",
+            line
+        ))?;
+        println!("{} {event}", Color::Default.dimmed().paint("BINPROCESS"));
+        if event_tx.send(event).is_err() {
+            // BinProcess is no longer interested in events
+            return Ok(());
+        }
+    }
+    Ok(())
+}
+
+/// Runs a command and returns the output as a string.
+/// Both stderr and stdout are returned in the result.
+fn run_command(command: &str, args: &[&str]) -> Result<String> {
+    let data = Exec::cmd(command)
+        .args(args)
+        .stdout(Redirection::Pipe)
+        .stderr(Redirection::Merge)
+        .capture()?;
+
+    if data.exit_status.success() {
+        Ok(data.stdout_str())
+    } else {
+        Err(anyhow!(
+            "command {} {:?} exited with {:?} and output:\n{}",
+            command,
+            args,
+            data.exit_status,
+            data.stdout_str()
+        ))
+    }
+}


### PR DESCRIPTION
## Goal

The goal of this PR is to allow making assertions on what tracing events occur during integration tests.
At first I wanted to do this with ShotoverManager by routing tracing events directly into a Vec.
However after thinking about it I realized there were a lot of advantages to instead using ShotoverProcess for this.

### Advantages to replacing ShotoverManager with ShotoverProcess
* events are isolated within each shotover instance so we can e.g. assert that each shotover instance logs the same error once.
* more accurate shotover usage:
    * Shotover is gauranteed to shutdown when ShotoverProcess is dropped. Currently ShotoverManager still leaves tasks and resources alive after it is dropped.
    * No risk of cross contamination of state (e.g. global values) between running shotover instances and test logic
    * No API hacks, particularly at startup time, we only get access to APIs that are included in an actual binary.
         + The one exception is the alpha-transforms feature which will remain enabled in tests but not released binaries.
    * The binary that we test is closer to the real final binary that we ship. Its possible for optimizations/codegen to occur differently when called within a test binary.
* possibly better iterative buildtimes
     + we can change just shotover or just the tests without having to recompile both into a single binary.
     + this wont take affect until we completely remove ShotoverManager though
* Can remove a bunch of `#[cfg(feature = "alpha-transforms")]` because the binary is always compiled with --all-features
* Due to the removal of a circular dependency, we no longer need #[path ...] hacks in order to import tests/helpers from test and bench binaries.
     + Instead tests/helpers can live properly in the test-helpers crate
* We only need to maintain a single shotover helper, just ShotoverProcess instead of both ShotoverManager and ShotoverProcess
* Logs are kept hidden unless the test is run with `--show-output`

The only disadvantage I can think of is losing the strong typing in the boundary between tests and shotover i.e. we go from calling rust code to executing a binary

### Advantages to implementing event assertions on ShotoverProcess instead of ShotoverManager:
* Our integration tests can process and format events however it likes, without having to worry about the formatting being usable for users.
    + Currently I am taking advantage of this by putting some basic coloring on our stack traces.
* Our assertion that no panics occurred in shotover can be nicely treated as yet another case of our event assertions. 
    + Panics are sent as error events in json logging mode, so we just get this for free.
* Better support for concurrent tests, we wouldn't be able to run tests concurrently with the ShotoverManager approach due to tracing's global state - cant make use of it without huge refactors elsewhere though
* Implementing it via ShotoverManager is just really complicated and there werent any good examples on how to do it, so it was hard to justify figuring it out when we should really replace ShotoverManager with ShotoverProcess anyway.

The only disadvantage I can think of is that we cant assert on logs from the test logic, but tbh thats acceptable because most of the time we want to assert on Shotovers events not the tests.

## Approach

I renamed ShotoverProcess to BinProcess and moved it into a new crate tokio-bin-process.
The goal is to have it as a reusable crate that other projects can take advantage of.
To that end I have kept anything shotover specific out of that crate, and then made some small shotover specific wrappers in `test-helpers/shotover_process.rs`
Once we are happy with tokio-bin-process for our own usage we should move it into its own repo, for now keeping it in shotover-proxy helps us move quickly.

test_shotover_shutdown_when_topology_invalid_topology_subchains is a good example of what it looks like when we have some warnings/errors to allow.

A BinProcess enforces that it is properly shutdown in its drop implementation.
To properly shutdown a BinProcess the users calls a shutdown method such as `shutdown_and_then_consume_events`.
When this occurs BinProcess asserts that no error or warning events occurred.
If the user specifically desires that a warning or error occurs then they can provide EventMatcher's to `shutdown_and_then_consume_events` to describe which events they want to allow.
It is quite flexible but we will want developers to be as specific as possible when writing EventMatcher's

I would just review all the tokio-bin-process code from scratch as it has changed so drastically from the original ShotoverProcess code.

## Future work

Future work can be split up into the following PRs:
* replace ShotoverManager with ShotoverProcess in cassandra_int_tests (Remove unneeded `#[cfg(feature = "alpha-transforms")]` )
* replace ShotoverManager with ShotoverProcess in redis_int_tests
* Remove ShotoverProcess and remove all `#[path ...]` hacks in tests and benchmarks.