### PR TITLE
CassandraSinkCluster: make prepared results handling robust

### DIFF
--- a/shotover-proxy/src/transforms/cassandra/sink_cluster/mod.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_cluster/mod.rs
@@ -698,7 +698,9 @@ impl CassandraSinkCluster {
                                 .pool
                                 .nodes()
                                 .iter()
-                                .filter(|node| node.is_up)
+                                .filter(|node| {
+                                    node.is_up && node.rack == self.local_shotover_node.rack
+                                })
                                 .map(|node| node.host_id)
                                 .collect(),
                         },


### PR DESCRIPTION
## High level goal

We currently have two methods of sending extra messages needed by the CassandraSinkCluster transform:
1. the TableToRewrite system - messages are inserted into the main list and kept track of via a list of `TableToRewrite`s
2. sending to a unique FuturesOrdered - a unique FuturesOrdered is created for every set of messages that need to be send and then processed seperately from the main list

Currently the 2nd approach is never implemented correctly, we only have a single FuturesOrdered for each type of message that needs one, so for example all prepared messages end up in the same FuturesOrdered despite needing to be processed seperately.

The 1st system is more powerful in that it allows the original message that spawned the extra messages to be modified.
Currently this is used to implement system.local and system.peers rewriting but we could also use it to do things like:
* add warnings to certain queries we dont support.
* When multiple queries are sent across multiple connections, prefer either responses that succeeded or responses that failed

As such I think we should move over all cases to use the 1st approach.
It makes it easier to reason about our code when we only use one approach and we need the power of the 1st approach in certain cases.

## This PR

So this PR makes a step towards this by converting prepare message handling to use the 1st approach instead of the 2nd.

In doing so, this PR fixes the following issues:
* Fixes a bug where prepared statements within the same batch would result in an error log
* cassandra errors instead of cassandra Prepared is handled, previously we ignored errors
* prepared statements no longer introduce a delay in asynchronous processing of messages, previously we only processed prepare messages after we have received a response from all other messages
* Only send prepare message to nodes that are is_up
* Ensure we always return a successful message when at least one response was succesful.
* Include cassandra warnings in the response messages when errors occur

Working with the 2nd approach can be tricky when it comes to obeying the invariants required for such long lived indices.
I needed to add a `TableToRewrite.outgoing_index` field to lookup the TableToRewrite of a specific message.
But explicitly naming incoming_index and outgoing_index ended up making the trickiness more evident which is nice.
But I wonder if we could or should swap it out for some kind of generational vector. (A vec that gives out keys rather then indexes)
Something like these: https://docs.rs/gen_value/latest/gen_value/ https://github.com/fitzgen/generational-arena
But we would need a way to efficiently convert back to a Vec.