### PR TITLE
Do not clone transforms when running chain in reverse

### DIFF
--- a/shotover-proxy/src/transforms/chain.rs
+++ b/shotover-proxy/src/transforms/chain.rs
@@ -191,9 +191,7 @@ impl TransformChain {
 
     pub async fn process_request_rev(&mut self, mut wrapper: Wrapper<'_>) -> ChainResponse {
         let start = Instant::now();
-
-        let mut chain: Vec<_> = self.chain.iter().cloned().rev().collect();
-        wrapper.reset(&mut chain);
+        wrapper.reset_rev(&mut self.chain);
 
         let result = wrapper.call_next_transform_pushed().await;
         self.chain_total.increment(1);


### PR DESCRIPTION
The dangerous line is `let mut chain: Vec<_> = self.chain.iter().cloned().rev().collect();` in `transforms/chain.rs`.
This causes pushed messages to be run against a clone of the transforms so any state set when processing pushed messages is lost.
Currently I'm not aware of any bugs this has caused but its clearly dangerous.

This PR should also be a nice speedup for pushed messages as we no longer need to clone every transform for every message.
Performance for regular messages will not be affected in any meaningful way, just an extra branch per transform.