### PR TITLE
Remove Clone from Transforms enum

### DIFF
--- a/shotover-proxy/benches/benches/chain.rs
+++ b/shotover-proxy/benches/benches/chain.rs
@@ -28,8 +28,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let chain = TransformChainBuilder::new(
             vec![TransformBuilder::Null(Null::default())],
             "bench".to_string(),
-        )
-        .build();
+        );
         let wrapper = Wrapper::new_with_chain_name(
             vec![Message::from_frame(Frame::None)],
             chain.name.clone(),
@@ -39,7 +38,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("null", |b| {
             b.to_async(&rt).iter_batched(
                 || BenchInput {
-                    chain: chain.clone(),
+                    chain: chain.clone().build(),
                     wrapper: wrapper.clone(),
                     client_details: "".into(),
                 },
@@ -58,8 +57,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 TransformBuilder::DebugReturner(DebugReturner::new(Response::Redis("a".into()))),
             ],
             "bench".to_string(),
-        )
-        .build();
+        );
         let wrapper = Wrapper::new_with_chain_name(
             vec![
                 Message::from_frame(Frame::Redis(RedisFrame::Array(vec![
@@ -79,7 +77,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("redis_filter", |b| {
             b.to_async(&rt).iter_batched(
                 || BenchInput {
-                    chain: chain.clone(),
+                    chain: chain.clone().build(),
                     wrapper: wrapper.clone(),
                     client_details: "".into(),
                 },
@@ -101,8 +99,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 ]))),
             ],
             "bench".to_string(),
-        )
-        .build();
+        );
         let wrapper_set = Wrapper::new_with_chain_name(
             vec![Message::from_frame(Frame::Redis(RedisFrame::Array(vec![
                 RedisFrame::BulkString(Bytes::from_static(b"SET")),
@@ -116,7 +113,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("redis_timestamp_tagger_untagged", |b| {
             b.to_async(&rt).iter_batched(
                 || BenchInput {
-                    chain: chain.clone(),
+                    chain: chain.clone().build(),
                     wrapper: wrapper_set.clone(),
                     client_details: "".into(),
                 },
@@ -137,7 +134,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("redis_timestamp_tagger_tagged", |b| {
             b.to_async(&rt).iter_batched(
                 || BenchInput {
-                    chain: chain.clone(),
+                    chain: chain.clone().build(),
                     wrapper: wrapper_get.clone(),
                     client_details: "".into(),
                 },
@@ -154,8 +151,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 TransformBuilder::Null(Null::default()),
             ],
             "bench".to_string(),
-        )
-        .build();
+        );
         let wrapper = Wrapper::new_with_chain_name(
             vec![Message::from_frame(Frame::Redis(RedisFrame::Array(vec![
                 RedisFrame::BulkString(Bytes::from_static(b"SET")),
@@ -169,7 +165,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("redis_cluster_ports_rewrite", |b| {
             b.to_async(&rt).iter_batched(
                 || BenchInput {
-                    chain: chain.clone(),
+                    chain: chain.clone().build(),
                     wrapper: wrapper.clone(),
                     client_details: "".into(),
                 },
@@ -193,8 +189,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 TransformBuilder::Null(Null::default()),
             ],
             "bench".to_string(),
-        )
-        .build();
+        );
         let wrapper = Wrapper::new_with_chain_name(
             vec![Message::from_bytes(
                 Bytes::from(
@@ -214,7 +209,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("cassandra_request_throttling_unparsed", |b| {
             b.to_async(&rt).iter_batched(
                 || BenchInput {
-                    chain: chain.clone(),
+                    chain: chain.clone().build(),
                     wrapper: wrapper.clone(),
                     client_details: "".into(),
                 },
@@ -231,8 +226,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 TransformBuilder::Null(Null::default()),
             ],
             "bench".into(),
-        )
-        .build();
+        );
 
         let wrapper = Wrapper::new_with_chain_name(
             vec![Message::from_bytes(
@@ -271,7 +265,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("cassandra_rewrite_peers_passthrough", |b| {
             b.to_async(&rt).iter_batched(
                 || BenchInput {
-                    chain: chain.clone(),
+                    chain: chain.clone().build(),
                     wrapper: wrapper.clone(),
                     client_details: "".into(),
                 },
@@ -305,8 +299,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 TransformBuilder::Null(Null::default()),
             ],
             "bench".into(),
-        )
-        .build();
+        );
 
         let wrapper = cassandra_parsed_query(
             "INSERT INTO test_protect_keyspace.unprotected_table (pk, cluster, col1, col2, col3) VALUES ('pk1', 'cluster', 'I am gonna get encrypted!!', 42, true);"
@@ -315,7 +308,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("cassandra_protect_unprotected", |b| {
             b.to_async(&rt).iter_batched(
                 || BenchInput {
-                    chain: chain.clone(),
+                    chain: chain.clone().build(),
                     wrapper: wrapper.clone(),
                     client_details: "".into(),
                 },
@@ -331,7 +324,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("cassandra_protect_protected", |b| {
             b.to_async(&rt).iter_batched(
                 || BenchInput {
-                    chain: chain.clone(),
+                    chain: chain.clone().build(),
                     wrapper: wrapper.clone(),
                     client_details: "".into(),
                 },

--- a/shotover-proxy/src/transforms/chain.rs
+++ b/shotover-proxy/src/transforms/chain.rs
@@ -54,7 +54,7 @@ impl BufferedChainMessages {
 /// Transform chains are defined by the user in Shotover's configuration file and are linked to sources.
 ///
 /// The transform chain is a vector of mutable references to the enum [Transforms] (which is an enum dispatch wrapper around the various transform types).
-#[derive(Clone, Derivative)]
+#[derive(Derivative)]
 #[derivative(Debug)]
 pub struct TransformChain {
     pub name: String,

--- a/shotover-proxy/src/transforms/mod.rs
+++ b/shotover-proxy/src/transforms/mod.rs
@@ -17,7 +17,7 @@ use crate::transforms::distributed::consistent_scatter::{
     ConsistentScatter, ConsistentScatterConfig,
 };
 use crate::transforms::filter::{QueryTypeFilter, QueryTypeFilterConfig};
-use crate::transforms::load_balance::ConnectionBalanceAndPool;
+use crate::transforms::load_balance::{ConnectionBalanceAndPool, ConnectionBalanceAndPoolBuilder};
 #[cfg(test)]
 use crate::transforms::loopback::Loopback;
 use crate::transforms::null::Null;
@@ -94,7 +94,7 @@ pub enum TransformBuilder {
     DebugPrinter(DebugPrinter),
     DebugForceParse(DebugForceParse),
     ParallelMap(ParallelMapBuilder),
-    PoolConnections(ConnectionBalanceAndPool),
+    PoolConnections(ConnectionBalanceAndPoolBuilder),
     Coalesce(Coalesce),
     QueryTypeFilter(QueryTypeFilter),
     QueryCounter(QueryCounter),
@@ -120,7 +120,7 @@ impl TransformBuilder {
             TransformBuilder::Null(t) => Transforms::Null(t),
             TransformBuilder::RedisSinkCluster(t) => Transforms::RedisSinkCluster(t),
             TransformBuilder::ParallelMap(t) => Transforms::ParallelMap(t.build()),
-            TransformBuilder::PoolConnections(t) => Transforms::PoolConnections(t),
+            TransformBuilder::PoolConnections(t) => Transforms::PoolConnections(t.build()),
             TransformBuilder::Coalesce(t) => Transforms::Coalesce(t),
             TransformBuilder::QueryTypeFilter(t) => Transforms::QueryTypeFilter(t),
             TransformBuilder::QueryCounter(t) => Transforms::QueryCounter(t),
@@ -206,7 +206,7 @@ impl Debug for TransformBuilder {
 /// The [`crate::transforms::Transforms`] enum is responsible for [`crate::transforms::Transform`] registration and enum dispatch
 /// in the transform chain. This is largely a performance optimisation by using enum dispatch rather
 /// than using dynamic trait objects.
-#[derive(Clone, IntoStaticStr)]
+#[derive(IntoStaticStr)]
 pub enum Transforms {
     CassandraSinkSingle(CassandraSinkSingle),
     CassandraSinkCluster(Box<CassandraSinkCluster>),

--- a/shotover-proxy/src/transforms/parallel_map.rs
+++ b/shotover-proxy/src/transforms/parallel_map.rs
@@ -21,7 +21,7 @@ pub struct ParallelMapBuilder {
     ordered: bool,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ParallelMap {
     chains: Vec<TransformChain>,
     ordered: bool,

--- a/shotover-proxy/src/transforms/redis/cache.rs
+++ b/shotover-proxy/src/transforms/redis/cache.rs
@@ -106,7 +106,6 @@ pub struct SimpleRedisCacheBuilder {
     missed_requests: Counter,
 }
 
-#[derive(Clone)]
 pub struct SimpleRedisCache {
     cache_chain: TransformChain,
     caching_schema: HashMap<FQName, TableCacheSchema>,

--- a/shotover-proxy/src/transforms/sampler.rs
+++ b/shotover-proxy/src/transforms/sampler.rs
@@ -29,7 +29,7 @@ impl Default for SamplerBuilder {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Sampler {
     numerator: u32,
     denominator: u32,


### PR DESCRIPTION
~~prereq: https://github.com/shotover/shotover-proxy/pull/960~~

Many transforms have kept their Clone implementation as they need it to act as their `build()` implementation for now.
This PR just removes Clone from the Transforms enum and then fixes any compiler issues brought about from that.