### PR TITLE
Move connection helpers into test_helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2689,8 +2689,8 @@ checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
 
 [[package]]
 name = "scylla"
-version = "0.6.1"
-source = "git+https://github.com/scylladb/scylla-rust-driver#c7ed9c9790aa44e88ff442157388ef2474d46287"
+version = "0.7.0"
+source = "git+https://github.com/scylladb/scylla-rust-driver#f145ceaa2403f4fc537a0f5c1865995d230c1bda"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2722,8 +2722,8 @@ dependencies = [
 
 [[package]]
 name = "scylla-cql"
-version = "0.0.2"
-source = "git+https://github.com/scylladb/scylla-rust-driver#c7ed9c9790aa44e88ff442157388ef2474d46287"
+version = "0.0.3"
+source = "git+https://github.com/scylladb/scylla-rust-driver#f145ceaa2403f4fc537a0f5c1865995d230c1bda"
 dependencies = [
  "async-trait",
  "bigdecimal 0.2.2",
@@ -2742,8 +2742,8 @@ dependencies = [
 
 [[package]]
 name = "scylla-macros"
-version = "0.1.1"
-source = "git+https://github.com/scylladb/scylla-rust-driver#c7ed9c9790aa44e88ff442157388ef2474d46287"
+version = "0.1.2"
+source = "git+https://github.com/scylladb/scylla-rust-driver#f145ceaa2403f4fc537a0f5c1865995d230c1bda"
 dependencies = [
  "quote",
  "syn",
@@ -2959,7 +2959,6 @@ dependencies = [
  "rstest",
  "rusoto_kms",
  "rusoto_signature",
- "scylla",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -2970,7 +2969,6 @@ dependencies = [
  "thiserror",
  "tls-parser",
  "tokio",
- "tokio-io-timeout",
  "tokio-openssl",
  "tokio-stream",
  "tokio-util",
@@ -3150,13 +3148,24 @@ name = "test-helpers"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bytes",
+ "cassandra-cpp",
+ "cassandra-protocol",
+ "cdrs-tokio",
+ "openssl",
+ "ordered-float 3.4.0",
  "rcgen",
+ "redis",
  "regex",
+ "scylla",
  "serde_yaml 0.9.14",
  "subprocess",
  "tokio",
  "tokio-bin-process",
+ "tokio-io-timeout",
+ "tokio-openssl",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -3378,9 +3387,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
  "serde",
 ]

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 [features]
 # Include WIP alpha transforms in the public API
 alpha-transforms = []
-cassandra-cpp-driver-tests = []
+cassandra-cpp-driver-tests = ["test-helpers/cassandra-cpp-driver-tests"]
 
 [dependencies]
 pretty-hex = "0.3.0"
@@ -84,16 +84,14 @@ redis = { version = "0.22.0", features = ["tokio-comp", "cluster"] }
 pcap = "1.0.0"
 pktparse = { version = "0.7.0", features = ["serde"] }
 tls-parser = "0.11.0"
-tokio-io-timeout = "1.1.1"
 serial_test = "0.9.0"
-cassandra-cpp = "1.2.0"
-test-helpers = { path = "../test-helpers" }
+cassandra-cpp = { version = "1.2.0" }
+test-helpers = { path = "../test-helpers", features = ["cassandra-cpp-driver-tests"] }
 hex-literal = "0.3.3"
 nix = "0.26.0"
 reqwest = "0.11.6"
 metrics-util = "0.14.0"
 cdrs-tokio = { git = "https://github.com/krojew/cdrs-tokio", branch = "8.0-dev" }
-scylla = { git = "https://github.com/scylladb/scylla-rust-driver", features = ["ssl"] }
 rstest = "0.16.0"
 
 [[bench]]

--- a/shotover-proxy/benches/benches/cassandra.rs
+++ b/shotover-proxy/benches/benches/cassandra.rs
@@ -1,9 +1,9 @@
-use crate::helpers::cassandra::{CassandraConnection, CassandraDriver};
 use crate::helpers::ShotoverManager;
 use cassandra_cpp::{stmt, Session, Statement};
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::collections::HashMap;
 use test_helpers::cert::generate_cassandra_test_certs;
+use test_helpers::connection::cassandra::{CassandraConnection, CassandraDriver};
 use test_helpers::docker_compose::DockerCompose;
 use test_helpers::lazy::new_lazy_shared;
 

--- a/shotover-proxy/benches/benches/redis.rs
+++ b/shotover-proxy/benches/benches/redis.rs
@@ -1,10 +1,10 @@
 use criterion::{criterion_group, Criterion};
 use redis::Cmd;
 use std::path::Path;
+use test_helpers::connection::redis_connection;
 use test_helpers::docker_compose::DockerCompose;
 use test_helpers::lazy::new_lazy_shared;
 
-use crate::helpers::redis_connection;
 use crate::helpers::ShotoverManager;
 
 struct Query {

--- a/shotover-proxy/tests/cassandra_int_tests/batch_statements.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/batch_statements.rs
@@ -1,4 +1,6 @@
-use crate::helpers::cassandra::{assert_query_result, run_query, CassandraConnection, ResultValue};
+use test_helpers::connection::cassandra::{
+    assert_query_result, run_query, CassandraConnection, ResultValue,
+};
 
 async fn use_statement(connection: &CassandraConnection) {
     {

--- a/shotover-proxy/tests/cassandra_int_tests/cache/assert.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cache/assert.rs
@@ -1,7 +1,7 @@
-use crate::helpers::cassandra::{assert_query_result, CassandraConnection, ResultValue};
 use metrics_util::debugging::{DebugValue, Snapshotter};
 use redis::Commands;
 use std::collections::HashSet;
+use test_helpers::connection::cassandra::{assert_query_result, CassandraConnection, ResultValue};
 
 /// gets the current miss count from the cache instrumentation.
 fn get_cache_miss_value(snapshotter: &Snapshotter) -> u64 {

--- a/shotover-proxy/tests/cassandra_int_tests/cache/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cache/mod.rs
@@ -1,9 +1,9 @@
 mod assert;
 
-use crate::helpers::cassandra::{run_query, CassandraConnection, ResultValue};
 use metrics_util::debugging::Snapshotter;
 use redis::Commands;
 use std::collections::HashSet;
+use test_helpers::connection::cassandra::{run_query, CassandraConnection, ResultValue};
 
 pub async fn test(
     cassandra_session: &CassandraConnection,

--- a/shotover-proxy/tests/cassandra_int_tests/cluster/multi_rack.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cluster/multi_rack.rs
@@ -1,6 +1,6 @@
 use crate::cassandra_int_tests::cluster::run_topology_task;
-use crate::helpers::cassandra::{assert_query_result, CassandraConnection, ResultValue};
 use std::net::SocketAddr;
+use test_helpers::connection::cassandra::{assert_query_result, CassandraConnection, ResultValue};
 
 async fn test_rewrite_system_peers(connection: &CassandraConnection) {
     let star_results = [

--- a/shotover-proxy/tests/cassandra_int_tests/cluster/single_rack_v3.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cluster/single_rack_v3.rs
@@ -1,6 +1,6 @@
 use crate::cassandra_int_tests::cluster::run_topology_task;
-use crate::helpers::cassandra::{assert_query_result, CassandraConnection, ResultValue};
 use std::net::SocketAddr;
+use test_helpers::connection::cassandra::{assert_query_result, CassandraConnection, ResultValue};
 
 async fn test_rewrite_system_peers_dummy_peers(connection: &CassandraConnection) {
     let star_results1 = [

--- a/shotover-proxy/tests/cassandra_int_tests/cluster/single_rack_v4.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cluster/single_rack_v4.rs
@@ -1,11 +1,11 @@
 use crate::cassandra_int_tests::cluster::run_topology_task;
-use crate::helpers::cassandra::{
-    assert_query_result, run_query, CassandraConnection, CassandraDriver, ResultValue,
-};
 use cassandra_protocol::events::ServerEvent;
 use cassandra_protocol::frame::events::{StatusChange, StatusChangeType};
 use std::net::SocketAddr;
 use std::time::Duration;
+use test_helpers::connection::cassandra::{
+    assert_query_result, run_query, CassandraConnection, CassandraDriver, ResultValue,
+};
 use test_helpers::docker_compose::DockerCompose;
 use tokio::sync::broadcast;
 use tokio::time::timeout;

--- a/shotover-proxy/tests/cassandra_int_tests/collections.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/collections.rs
@@ -1,8 +1,8 @@
-use crate::helpers::cassandra::{
-    assert_query_result, run_query, CassandraConnection, CassandraDriver, ResultValue,
-};
 use cassandra_protocol::frame::message_result::ColType;
 use itertools::Itertools;
+use test_helpers::connection::cassandra::{
+    assert_query_result, run_query, CassandraConnection, CassandraDriver, ResultValue,
+};
 
 const NATIVE_COL_TYPES: [ColType; 18] = [
     ColType::Ascii,

--- a/shotover-proxy/tests/cassandra_int_tests/functions.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/functions.rs
@@ -1,4 +1,6 @@
-use crate::helpers::cassandra::{assert_query_result, run_query, CassandraConnection, ResultValue};
+use test_helpers::connection::cassandra::{
+    assert_query_result, run_query, CassandraConnection, ResultValue,
+};
 
 async fn drop_function(session: &CassandraConnection) {
     assert_query_result(

--- a/shotover-proxy/tests/cassandra_int_tests/keyspace.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/keyspace.rs
@@ -1,4 +1,4 @@
-use crate::helpers::cassandra::{
+use test_helpers::connection::cassandra::{
     assert_query_result, assert_query_result_contains_row, run_query, CassandraConnection,
     ResultValue,
 };

--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -1,10 +1,3 @@
-use crate::helpers::cassandra::{assert_query_result, ResultValue};
-#[cfg(feature = "cassandra-cpp-driver-tests")]
-use crate::helpers::cassandra::{run_query, CassandraDriver::Datastax};
-use crate::helpers::cassandra::{
-    CassandraConnection, CassandraDriver, CassandraDriver::CdrsTokio, CassandraDriver::Scylla,
-};
-use crate::helpers::redis_connection;
 use crate::helpers::ShotoverManager;
 #[cfg(feature = "cassandra-cpp-driver-tests")]
 use cassandra_protocol::frame::message_error::{ErrorBody, ErrorType};
@@ -17,6 +10,13 @@ use futures::Future;
 use metrics_util::debugging::DebuggingRecorder;
 use rstest::rstest;
 use serial_test::serial;
+use test_helpers::connection::cassandra::{assert_query_result, ResultValue};
+#[cfg(feature = "cassandra-cpp-driver-tests")]
+use test_helpers::connection::cassandra::{run_query, CassandraDriver::Datastax};
+use test_helpers::connection::cassandra::{
+    CassandraConnection, CassandraDriver, CassandraDriver::CdrsTokio, CassandraDriver::Scylla,
+};
+use test_helpers::connection::redis_connection;
 use test_helpers::docker_compose::DockerCompose;
 use test_helpers::shotover_process::shotover_from_topology_file;
 use tokio::time::{timeout, Duration};

--- a/shotover-proxy/tests/cassandra_int_tests/native_types.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/native_types.rs
@@ -1,4 +1,6 @@
-use crate::helpers::cassandra::{assert_query_result, run_query, CassandraConnection, ResultValue};
+use test_helpers::connection::cassandra::{
+    assert_query_result, run_query, CassandraConnection, ResultValue,
+};
 
 async fn select(session: &CassandraConnection) {
     assert_query_result(

--- a/shotover-proxy/tests/cassandra_int_tests/prepared_statements_all.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/prepared_statements_all.rs
@@ -1,4 +1,6 @@
-use crate::helpers::cassandra::{assert_query_result, run_query, CassandraConnection, ResultValue};
+use test_helpers::connection::cassandra::{
+    assert_query_result, run_query, CassandraConnection, ResultValue,
+};
 
 fn values() -> Vec<ResultValue> {
     vec![

--- a/shotover-proxy/tests/cassandra_int_tests/prepared_statements_simple.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/prepared_statements_simple.rs
@@ -1,7 +1,7 @@
-use crate::helpers::cassandra::{
+use futures::Future;
+use test_helpers::connection::cassandra::{
     assert_query_result, assert_rows, run_query, CassandraConnection, ResultValue,
 };
-use futures::Future;
 
 async fn delete(session: &CassandraConnection) {
     let prepared = session

--- a/shotover-proxy/tests/cassandra_int_tests/protect.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/protect.rs
@@ -1,6 +1,8 @@
-use crate::helpers::cassandra::{assert_query_result, run_query, CassandraConnection, ResultValue};
 use chacha20poly1305::Nonce;
 use serde::Deserialize;
+use test_helpers::connection::cassandra::{
+    assert_query_result, run_query, CassandraConnection, ResultValue,
+};
 
 #[derive(Deserialize)]
 pub struct Protected {

--- a/shotover-proxy/tests/cassandra_int_tests/routing.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/routing.rs
@@ -1,7 +1,7 @@
-use crate::helpers::cassandra::{CassandraConnection, CassandraDriver};
+use test_helpers::connection::cassandra::{CassandraConnection, CassandraDriver};
 
 mod single_key {
-    use crate::helpers::cassandra::{run_query, CassandraConnection, ResultValue};
+    use test_helpers::connection::cassandra::{run_query, CassandraConnection, ResultValue};
 
     pub async fn create_keyspace(connection: &CassandraConnection) {
         let create_ks: &'static str = "CREATE KEYSPACE IF NOT EXISTS test_routing_ks WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };";
@@ -75,7 +75,7 @@ mod single_key {
 }
 
 mod compound_key {
-    use crate::helpers::cassandra::{run_query, CassandraConnection, ResultValue};
+    use test_helpers::connection::cassandra::{run_query, CassandraConnection, ResultValue};
 
     async fn create_keyspace(connection: &CassandraConnection) {
         let create_ks: &'static str = "CREATE KEYSPACE IF NOT EXISTS test_routing_ks WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };";
@@ -183,8 +183,8 @@ mod compound_key {
 }
 
 mod composite_key {
-    use crate::helpers::cassandra::{run_query, CassandraConnection, ResultValue};
     use rand::{distributions::Alphanumeric, Rng};
+    use test_helpers::connection::cassandra::{run_query, CassandraConnection, ResultValue};
 
     pub async fn test(shotover: &CassandraConnection, cassandra: &CassandraConnection) {
         simple_test(shotover, cassandra).await;

--- a/shotover-proxy/tests/cassandra_int_tests/table.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/table.rs
@@ -1,4 +1,4 @@
-use crate::helpers::cassandra::{
+use test_helpers::connection::cassandra::{
     assert_query_result, assert_query_result_contains_row, assert_query_result_not_contains_row,
     run_query, CassandraConnection, ResultValue,
 };

--- a/shotover-proxy/tests/cassandra_int_tests/timestamp.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/timestamp.rs
@@ -1,5 +1,7 @@
-use crate::helpers::cassandra::{assert_query_result, run_query, CassandraConnection, ResultValue};
 use std::time::{SystemTime, UNIX_EPOCH};
+use test_helpers::connection::cassandra::{
+    assert_query_result, run_query, CassandraConnection, ResultValue,
+};
 
 async fn flag(connection: &CassandraConnection) {
     let timestamp = get_timestamp();

--- a/shotover-proxy/tests/cassandra_int_tests/udt.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/udt.rs
@@ -1,4 +1,4 @@
-use crate::helpers::cassandra::{run_query, CassandraConnection};
+use test_helpers::connection::cassandra::{run_query, CassandraConnection};
 
 async fn test_create_udt(session: &CassandraConnection) {
     run_query(

--- a/shotover-proxy/tests/examples/mod.rs
+++ b/shotover-proxy/tests/examples/mod.rs
@@ -1,8 +1,8 @@
 #![cfg(feature = "cassandra-cpp-driver-tests")]
-use crate::helpers::cassandra::{
+use serial_test::serial;
+use test_helpers::connection::cassandra::{
     assert_query_result, CassandraConnection, CassandraDriver, ResultValue,
 };
-use serial_test::serial;
 use test_helpers::docker_compose::DockerCompose;
 
 #[tokio::test(flavor = "multi_thread")]

--- a/shotover-proxy/tests/helpers/mod.rs
+++ b/shotover-proxy/tests/helpers/mod.rs
@@ -5,9 +5,6 @@ use tokio::runtime::{Handle as RuntimeHandle, Runtime};
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 
-pub mod cassandra;
-pub mod redis_connection;
-
 #[must_use]
 pub struct ShotoverManager {
     pub runtime: Option<Runtime>,

--- a/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
+++ b/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
@@ -1,4 +1,3 @@
-use crate::helpers::redis_connection;
 use crate::redis_int_tests::assert::*;
 use futures::StreamExt;
 use rand::{thread_rng, Rng};
@@ -10,6 +9,7 @@ use shotover_proxy::tcp;
 use std::collections::{HashMap, HashSet};
 use std::thread::sleep;
 use std::time::Duration;
+use test_helpers::connection::redis_connection;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use tokio::time::timeout;

--- a/shotover-proxy/tests/redis_int_tests/mod.rs
+++ b/shotover-proxy/tests/redis_int_tests/mod.rs
@@ -1,13 +1,12 @@
-use crate::helpers::redis_connection;
 use crate::helpers::ShotoverManager;
 use basic_driver_tests::*;
 use redis::aio::Connection;
 use redis::Commands;
 use serial_test::serial;
-use shotover_proxy::tls::TlsConnectorConfig;
 use std::path::Path;
 use std::thread::sleep;
 use std::time::Duration;
+use test_helpers::connection::redis_connection;
 use test_helpers::docker_compose::DockerCompose;
 
 pub mod assert;
@@ -77,17 +76,9 @@ async fn source_tls_and_single_tls() {
     let _shotover_manager =
         ShotoverManager::from_topology_file("example-configs/redis-tls/topology.yaml");
 
-    let tls_config = TlsConnectorConfig {
-        certificate_authority_path: "example-configs/redis-tls/certs/ca.crt".into(),
-        certificate_path: Some("example-configs/redis-tls/certs/redis.crt".into()),
-        private_key_path: Some("example-configs/redis-tls/certs/redis.key".into()),
-        verify_hostname: false,
-    };
-
-    let mut connection = redis_connection::new_async_tls(6380, tls_config.clone()).await;
+    let mut connection = redis_connection::new_async_tls(6380).await;
     let mut flusher =
-        Flusher::new_single_connection(redis_connection::new_async_tls(6380, tls_config).await)
-            .await;
+        Flusher::new_single_connection(redis_connection::new_async_tls(6380).await).await;
 
     run_all(&mut connection, &mut flusher).await;
 }

--- a/shotover-proxy/tests/runner/observability_int_tests.rs
+++ b/shotover-proxy/tests/runner/observability_int_tests.rs
@@ -1,7 +1,7 @@
-use crate::helpers::redis_connection;
 use crate::helpers::ShotoverManager;
 use itertools::Itertools;
 use serial_test::serial;
+use test_helpers::connection::redis_connection;
 
 async fn http_request_metrics() -> String {
     let url = "http://localhost:9001/metrics";

--- a/shotover-proxy/tests/transforms/query_type_filter.rs
+++ b/shotover-proxy/tests/transforms/query_type_filter.rs
@@ -1,6 +1,6 @@
-use crate::helpers::redis_connection;
 use crate::helpers::ShotoverManager;
 use serial_test::serial;
+use test_helpers::connection::redis_connection;
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]

--- a/shotover-proxy/tests/transforms/tee.rs
+++ b/shotover-proxy/tests/transforms/tee.rs
@@ -1,6 +1,6 @@
-use crate::helpers::redis_connection;
 use crate::helpers::ShotoverManager;
 use serial_test::serial;
+use test_helpers::connection::redis_connection;
 use test_helpers::docker_compose::DockerCompose;
 
 #[tokio::test(flavor = "multi_thread")]

--- a/test-helpers/Cargo.toml
+++ b/test-helpers/Cargo.toml
@@ -7,6 +7,9 @@ license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+cassandra-cpp-driver-tests = ["cassandra-cpp"]
+
 [dependencies]
 tracing = "0.1.15"
 subprocess = "0.2.7"
@@ -14,5 +17,16 @@ anyhow = "1.0.42"
 rcgen = "0.10.0"
 serde_yaml = "0.9.0"
 regex = "1.7.0"
-tokio = { version = "1.21.1", features = ["full", "macros"] }
 tokio-bin-process = { path = "../tokio-bin-process" }
+cdrs-tokio = { git = "https://github.com/krojew/cdrs-tokio", branch = "8.0-dev" }
+cassandra-protocol = { git = "https://github.com/krojew/cdrs-tokio", branch = "8.0-dev" }
+cassandra-cpp = { version = "1.2.0", optional = true }
+openssl = { version = "0.10.36", features = ["vendored"] }
+bytes = "1.0.0"
+scylla = { git = "https://github.com/scylladb/scylla-rust-driver", features = ["ssl"] }
+ordered-float = { version = "3.0.0", features = ["serde"] }
+tokio = { version = "1.21.1", features = ["full", "macros"] }
+uuid = { version = "1.0.0", features = ["serde", "v4"] }
+redis = { version = "0.22.0", features = ["tokio-comp", "cluster"] }
+tokio-io-timeout = "1.1.1"
+tokio-openssl = "0.6.2"

--- a/test-helpers/src/connection/cassandra.rs
+++ b/test-helpers/src/connection/cassandra.rs
@@ -75,7 +75,6 @@ impl PreparedQuery {
     }
 }
 
-#[allow(dead_code)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub enum CassandraDriver {
     #[cfg(feature = "cassandra-cpp-driver-tests")]
@@ -107,10 +106,9 @@ pub enum CassandraConnection {
 }
 
 impl CassandraConnection {
-    #[allow(dead_code)]
     pub async fn new(contact_points: &str, port: u16, driver: CassandraDriver) -> Self {
         for contact_point in contact_points.split(',') {
-            test_helpers::wait_for_socket_to_open(contact_point, port);
+            crate::wait_for_socket_to_open(contact_point, port);
         }
 
         match driver {
@@ -193,7 +191,6 @@ impl CassandraConnection {
         }
     }
 
-    #[allow(dead_code)]
     pub fn as_cdrs(&self) -> &CdrsTokioSessionInstance {
         match self {
             Self::CdrsTokio { session, .. } => session,
@@ -201,7 +198,6 @@ impl CassandraConnection {
         }
     }
 
-    #[allow(dead_code)]
     pub fn is(&self, drivers: &[CassandraDriver]) -> bool {
         match self {
             Self::CdrsTokio { .. } => drivers.contains(&CassandraDriver::CdrsTokio),
@@ -212,7 +208,6 @@ impl CassandraConnection {
     }
 
     #[cfg(feature = "cassandra-cpp-driver-tests")]
-    #[allow(dead_code)]
     pub fn as_datastax(&self) -> &DatastaxSession {
         match self {
             Self::Datastax { session, .. } => session,
@@ -220,7 +215,6 @@ impl CassandraConnection {
         }
     }
 
-    #[allow(dead_code, unused_variables)]
     pub async fn new_tls(
         contact_points: &str,
         port: u16,
@@ -236,7 +230,7 @@ impl CassandraConnection {
                 Ssl::add_trusted_cert(&mut ssl, &ca_cert).unwrap();
 
                 for contact_point in contact_points.split(',') {
-                    test_helpers::wait_for_socket_to_open(contact_point, port);
+                    crate::wait_for_socket_to_open(contact_point, port);
                 }
 
                 let mut cluster = Cluster::default();
@@ -283,7 +277,6 @@ impl CassandraConnection {
         }
     }
 
-    #[allow(dead_code)]
     pub async fn enable_schema_awaiter(&mut self, direct_node: &str, ca_cert: Option<&str>) {
         let context = ca_cert.map(|ca_cert| {
             let mut context = SslContext::builder(SslMethod::tls()).unwrap();
@@ -321,7 +314,6 @@ impl CassandraConnection {
         }
     }
 
-    #[allow(dead_code)]
     pub async fn execute(&self, query: &str) -> Vec<Vec<ResultValue>> {
         match self.execute_fallible(query).await {
             Ok(result) => result,
@@ -329,7 +321,6 @@ impl CassandraConnection {
         }
     }
 
-    #[allow(dead_code)]
     pub async fn execute_fallible(&self, query: &str) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
         let result = match self {
             #[cfg(feature = "cassandra-cpp-driver-tests")]
@@ -354,7 +345,6 @@ impl CassandraConnection {
         result
     }
 
-    #[allow(dead_code)]
     pub async fn execute_with_timestamp(
         &self,
         query: &str,
@@ -391,7 +381,6 @@ impl CassandraConnection {
         result
     }
 
-    #[allow(dead_code)]
     pub async fn prepare(&self, query: &str) -> PreparedQuery {
         match self {
             #[cfg(feature = "cassandra-cpp-driver-tests")]
@@ -410,7 +399,6 @@ impl CassandraConnection {
         }
     }
 
-    #[allow(dead_code)]
     pub async fn execute_prepared_coordinator_node(
         &self,
         prepared_query: &PreparedQuery,
@@ -475,7 +463,6 @@ impl CassandraConnection {
         }
     }
 
-    #[allow(dead_code)]
     pub async fn execute_prepared(
         &self,
         prepared_query: &PreparedQuery,
@@ -599,7 +586,6 @@ impl CassandraConnection {
         };
     }
 
-    #[allow(dead_code)]
     pub async fn execute_batch_fallible(
         &self,
         queries: Vec<String>,
@@ -636,7 +622,6 @@ impl CassandraConnection {
         }
     }
 
-    #[allow(dead_code)]
     pub async fn execute_batch(&self, queries: Vec<String>) {
         let result = self.execute_batch_fallible(queries).await.unwrap();
         assert_eq!(result.len(), 0, "Batches should never return results");
@@ -774,7 +759,6 @@ pub enum ResultValue {
     Null,
     /// Never output by the DB
     /// Can be used by the user in assertions to allow any value.
-    #[allow(dead_code)]
     Any,
 }
 
@@ -814,7 +798,6 @@ impl PartialEq for ResultValue {
 }
 
 impl ResultValue {
-    #[allow(dead_code)]
     #[cfg(feature = "cassandra-cpp-driver-tests")]
     pub fn new_from_cpp(value: Value) -> Self {
         if value.is_null() {
@@ -1002,7 +985,6 @@ impl ResultValue {
 }
 
 /// Execute a `query` against the `session` and assert that the result rows match `expected_rows`
-#[allow(dead_code)]
 pub async fn assert_query_result(
     session: &CassandraConnection,
     query: &str,
@@ -1014,7 +996,6 @@ pub async fn assert_query_result(
 }
 
 /// Assert that the results from an integration test match the expected rows
-#[allow(dead_code)]
 pub fn assert_rows(result_rows: Vec<Vec<ResultValue>>, expected_rows: &[&[ResultValue]]) {
     let mut expected_rows: Vec<_> = expected_rows.iter().map(|x| x.to_vec()).collect();
     expected_rows.sort();
@@ -1023,7 +1004,6 @@ pub fn assert_rows(result_rows: Vec<Vec<ResultValue>>, expected_rows: &[&[Result
 }
 
 /// Execute a `query` against the `session` and assert the result rows contain `row`
-#[allow(dead_code)]
 pub async fn assert_query_result_contains_row(
     session: &CassandraConnection,
     query: &str,
@@ -1039,7 +1019,6 @@ pub async fn assert_query_result_contains_row(
 }
 
 /// Execute a `query` against the `session` and assert the result rows does not contain `row`
-#[allow(dead_code)]
 pub async fn assert_query_result_not_contains_row(
     session: &CassandraConnection,
     query: &str,
@@ -1054,7 +1033,6 @@ pub async fn assert_query_result_not_contains_row(
     }
 }
 
-#[allow(dead_code)]
 pub async fn run_query(session: &CassandraConnection, query: &str) {
     assert_query_result(session, query, &[]).await;
 }

--- a/test-helpers/src/connection/mod.rs
+++ b/test-helpers/src/connection/mod.rs
@@ -1,0 +1,3 @@
+pub mod cassandra;
+// redis_connection is named differently to the cassandra module because it contains raw functions instead of a struct with methods
+pub mod redis_connection;

--- a/test-helpers/src/lib.rs
+++ b/test-helpers/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::derive_partial_eq_without_eq)]
 
 pub mod cert;
+pub mod connection;
 pub mod docker_compose;
 pub mod lazy;
 pub mod shotover_process;


### PR DESCRIPTION
A step towards eliminating the `#[path = "../../tests/helpers/mod.rs"]` hack.

The CassandraConnection type and redis connection helper functions have been moved into a new module named: `test_helpers::connection`

The redis TLS helper relied on some shotover internals.
I've reimplemented that logic directly into the test to remove that dependency.

Some extra benefits:
* Allows removal of all the `#[allow(dead_code)]` annotations because the code is now in a regular old library crate instead of hacked in with `#[path = ".."]`
* I suspect it will allow us to work around the "dev-dependencies can not be optional" problem that is preventing us from making `cassandra-cpp` an optional dependency (but needs some extra work that I've left out of this PR)

