### PR TITLE
Optimize cassandra encoding

### DIFF
--- a/shotover-proxy/benches/benches/chain.rs
+++ b/shotover-proxy/benches/benches/chain.rs
@@ -1,7 +1,6 @@
 use bytes::Bytes;
-use cassandra_protocol::{
-    compression::Compression, consistency::Consistency, frame::Version, query::QueryParams,
-};
+use cassandra_protocol::compression::Compression;
+use cassandra_protocol::{consistency::Consistency, frame::Version, query::QueryParams};
 use criterion::{criterion_group, BatchSize, Criterion};
 use hex_literal::hex;
 use shotover_proxy::frame::cassandra::{parse_statement_single, Tracing};
@@ -252,9 +251,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         }),
                     },
                 }
-                .encode()
-                .encode_with(Compression::None)
-                .unwrap()
+                .encode(Compression::None)
                 .into(),
                 MessageType::Cassandra,
             )],

--- a/shotover-proxy/src/codec/cassandra.rs
+++ b/shotover-proxy/src/codec/cassandra.rs
@@ -16,7 +16,7 @@ use tracing::info;
 
 #[derive(Debug, Clone)]
 pub struct CassandraCodec {
-    compressor: Compression,
+    compression: Compression,
     messages: Vec<Message>,
     current_use_keyspace: Option<Identifier>,
 }
@@ -30,7 +30,7 @@ impl Default for CassandraCodec {
 impl CassandraCodec {
     pub fn new() -> CassandraCodec {
         CassandraCodec {
-            compressor: Compression::None,
+            compression: Compression::None,
             messages: vec![],
             current_use_keyspace: None,
         }
@@ -39,7 +39,7 @@ impl CassandraCodec {
 
 impl CassandraCodec {
     fn encode_raw(&mut self, item: CassandraFrame, dst: &mut BytesMut) {
-        let buffer = item.encode().encode_with(self.compressor).unwrap();
+        let buffer = item.encode(self.compression);
         if buffer.is_empty() {
             info!("trying to send 0 length frame");
         }

--- a/shotover-proxy/src/message/mod.rs
+++ b/shotover-proxy/src/message/mod.rs
@@ -682,7 +682,7 @@ impl MessageValue {
     }
 }
 
-fn serialize_with_length_prefix(
+pub(crate) fn serialize_with_length_prefix(
     cursor: &mut Cursor<&mut Vec<u8>>,
     serializer: impl FnOnce(&mut Cursor<&mut Vec<u8>>),
 ) {

--- a/shotover-proxy/src/transforms/redis/cache.rs
+++ b/shotover-proxy/src/transforms/redis/cache.rs
@@ -274,7 +274,7 @@ impl SimpleRedisCache {
                         // TODO: two performance issues here:
                         // 1. we should be able to generate the encoded bytes without cloning the entire frame
                         // 2. we should be able to directly use the raw bytes when the message has not yet been mutated
-                        let encoded = frame.clone().encode().encode_with(Compression::None)?;
+                        let encoded = frame.clone().encode(Compression::None);
 
                         return Ok(Some(Message::from_frame(Frame::Redis(RedisFrame::Array(
                             vec![


### PR DESCRIPTION
Brings the 7% time spent on decode down to 4% in the flamegraph.

The cassandra-protocol implementation of frame encoding allocates and copies all over the place: https://github.com/krojew/cdrs-tokio/blob/08814fec99190d0d79b72d1c472cb05044191946/cassandra-protocol/src/frame.rs#L237
It would be nice to upstream these improvements some time, but the cassandra-protocol implementation has a lot of complexity that we dont need, so reimplementing isnt so bad.

the TODO is a further improvement left undone on purpose to keep scope down, it causes no regression in performance or functionality.