### PR TITLE
Fix prepared metadata sharing between connections

### DIFF
--- a/shotover-proxy/src/transforms/cassandra/sink_cluster/mod.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_cluster/mod.rs
@@ -147,7 +147,7 @@ impl Clone for CassandraSinkCluster {
             peers_v2_table: self.peers_v2_table.clone(),
             system_keyspaces: self.system_keyspaces.clone(),
             local_shotover_node: self.local_shotover_node.clone(),
-            pool: NodePool::new(vec![]),
+            pool: self.pool.clone(),
             // Because the self.nodes_rx is always copied from the original nodes_rx created before any node lists were sent,
             // once a single node list has been sent all new connections will immediately recognize it as a change.
             nodes_rx: self.nodes_rx.clone(),


### PR DESCRIPTION
Previously prepared metadata was not being shared between incoming connections.
This was because we were not cloning the `Arc<Mutex<..>>` and instead creating a new one for each connection.
This PR fixes that by cloning the NodePool that contains the mutex in CassandraSinkClusters constructor.