### PR TITLE
Avoid allocating for table name comparisons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,8 +576,7 @@ dependencies = [
 [[package]]
 name = "cql3-parser"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da32ab68b2179b3a25f91f83701b6d3ba1b82bdad6c1bafa9e6c44de7e83588"
+source = "git+https://github.com/rukai/rust-cql3-parser?branch=identifier_ref#fbb0563950a101e4178a8bf38ea92be2666864b8"
 dependencies = [
  "bigdecimal 0.3.0",
  "bytes",

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -44,7 +44,8 @@ anyhow = "1.0.31"
 backtrace = "0.3.66"
 
 # Parsers
-cql3-parser = "0.3.1"
+#cql3-parser = "0.3.1"
+cql3-parser =  { version = "0.3.1", git = "https://github.com/rukai/rust-cql3-parser", branch = "identifier_ref" }
 serde = { version = "1.0.111", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.8.21"


### PR DESCRIPTION
prereq: https://github.com/shotover/rust-cql3-parser/pull/36

Makes use of the soon to be added `IdentifierRef` and `FQNameRef` types to avoid allocating when creating a value just for comparison purposes.

I also changed every `Unquoted` to a `Quoted` because that will avoid an allocation within the `partial_eq` implementation.
