### PR TITLE
Fix empty shotover_chain_latency metric

### DIFF
--- a/shotover-proxy/src/server.rs
+++ b/shotover-proxy/src/server.rs
@@ -569,7 +569,9 @@ impl<C: Codec + 'static> Handler<C> {
             );
 
             let modified_messages = if reverse_chain {
-                self.chain.process_request_rev(wrapper).await
+                self.chain
+                    .process_request_rev(wrapper, self.client_details.clone())
+                    .await
             } else {
                 self.chain
                     .process_request(wrapper, self.client_details.clone())

--- a/shotover-proxy/src/transforms/chain.rs
+++ b/shotover-proxy/src/transforms/chain.rs
@@ -189,7 +189,11 @@ impl TransformChain {
         result
     }
 
-    pub async fn process_request_rev(&mut self, mut wrapper: Wrapper<'_>) -> ChainResponse {
+    pub async fn process_request_rev(
+        &mut self,
+        mut wrapper: Wrapper<'_>,
+        client_details: String,
+    ) -> ChainResponse {
         let start = Instant::now();
         wrapper.reset_rev(&mut self.chain);
 
@@ -199,7 +203,7 @@ impl TransformChain {
             self.chain_failures.increment(1);
         }
 
-        histogram!("shotover_chain_latency", start.elapsed(),  "chain" => self.name.clone());
+        histogram!("shotover_chain_latency", start.elapsed(),  "chain" => self.name.clone(), "client_details" => client_details);
         result
     }
 }
@@ -226,7 +230,7 @@ impl TransformChainBuilder {
 
         let chain_total = register_counter!("shotover_chain_total", "chain" => name.clone());
         let chain_failures = register_counter!("shotover_chain_failures", "chain" => name.clone());
-        register_histogram!("shotover_chain_latency", "chain" => name.clone());
+        // Cant register shotover_chain_latency because a unique one is created for each client ip address
 
         TransformChainBuilder {
             name,


### PR DESCRIPTION
Because the registered shotover_chain_latency metric cant specify the client ip it ends up as a separate metric that is always `0` which is quite confusing.
e.g.
```
# TYPE shotover_chain_latency summary
shotover_chain_latency{chain="example_chain",quantile="0"} 0
shotover_chain_latency{chain="example_chain",quantile="0.5"} 0
shotover_chain_latency{chain="example_chain",quantile="0.9"} 0
shotover_chain_latency{chain="example_chain",quantile="0.95"} 0
shotover_chain_latency{chain="example_chain",quantile="0.99"} 0
shotover_chain_latency{chain="example_chain",quantile="0.999"} 0
shotover_chain_latency{chain="example_chain",quantile="1"} 0
shotover_chain_latency_sum{chain="example_chain"} 0
shotover_chain_latency_count{chain="example_chain"} 0
shotover_chain_latency{chain="example_chain",client_details="127.0.0.1",quantile="0"} 0.000205255
shotover_chain_latency{chain="example_chain",client_details="127.0.0.1",quantile="0.5"} 0.00023099834016288915
shotover_chain_latency{chain="example_chain",client_details="127.0.0.1",quantile="0.9"} 0.00023099834016288915
shotover_chain_latency{chain="example_chain",client_details="127.0.0.1",quantile="0.95"} 0.00023099834016288915
shotover_chain_latency{chain="example_chain",client_details="127.0.0.1",quantile="0.99"} 0.00023099834016288915
shotover_chain_latency{chain="example_chain",client_details="127.0.0.1",quantile="0.999"} 0.00023099834016288915
shotover_chain_latency{chain="example_chain",client_details="127.0.0.1",quantile="1"} 0.000245891
shotover_chain_latency_sum{chain="example_chain",client_details="127.0.0.1"} 0.000682139
shotover_chain_latency_count{chain="example_chain",client_details="127.0.0.1"} 3
```

So instead lets just remove the register to avoid that.

Additionally process_request_rev was failing to specify the client_details which would have also been recorded in a separate metric.

An alternate approach would be to just remove the client_details from the metric but I assume that splitting the metrics up by client is useful?