### PR TITLE
Optimize cassandra metadata

### DIFF
--- a/shotover-proxy/src/message/mod.rs
+++ b/shotover-proxy/src/message/mod.rs
@@ -1,4 +1,5 @@
 use crate::codec::redis::redis_query_type;
+use crate::frame::cassandra::Tracing;
 use crate::frame::{
     cassandra,
     cassandra::{to_cassandra_type, CassandraMetadata, CassandraOperation},
@@ -249,7 +250,7 @@ impl Message {
                     message: error,
                     ty: ErrorType::Server,
                 }),
-                tracing: frame.tracing,
+                tracing: Tracing::Response(None),
                 warnings: vec![],
             }),
             Metadata::None => Frame::None,
@@ -292,7 +293,7 @@ impl Message {
                 Frame::Cassandra(CassandraFrame {
                     version: metadata.version,
                     stream_id: metadata.stream_id,
-                    tracing: metadata.tracing,
+                    tracing: Tracing::Response(None),
                     warnings: vec![],
                     operation: body,
                 })

--- a/shotover-proxy/src/transforms/cassandra/sink_cluster/mod.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_cluster/mod.rs
@@ -1081,7 +1081,6 @@ fn get_execute_message(message: &mut Message) -> Option<(&BodyReqExecuteOwned, C
         operation: CassandraOperation::Execute(execute_body),
         version,
         stream_id,
-        tracing,
         ..
     })) = message.frame()
     {
@@ -1090,7 +1089,6 @@ fn get_execute_message(message: &mut Message) -> Option<(&BodyReqExecuteOwned, C
             CassandraMetadata {
                 version: *version,
                 stream_id: *stream_id,
-                tracing: *tracing,
                 opcode: Opcode::Execute,
             },
         ));


### PR DESCRIPTION
`RawCassandraFrame` copies the entire body into a newly allocated vec.
We dont use that at all in metadata so we can get a nice win by just reading the bytes we need directly off the buffer.
Before this change, metadata shows up as taking 0.8% on the flamegraph afterwards its just 0.1%

Previously we included tracing in our metadata however:
* All the use cases of it were actually incorrect, if a client requests tracing and we return an error then the best we can do is just return no tracing.
* tracing is part of the body which can be compressed, so implementing reading of tracing robustly would be very costly.

So I removed it