### PR TITLE
Avoid cloning prepared metadata fields

### DIFF
--- a/shotover-proxy/src/transforms/cassandra/sink_cluster/node_pool.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_cluster/node_pool.rs
@@ -4,7 +4,6 @@ use super::token_map::TokenMap;
 use super::KeyspaceChanRx;
 use anyhow::{anyhow, Error, Result};
 use cassandra_protocol::frame::message_execute::BodyReqExecuteOwned;
-use cassandra_protocol::frame::message_result::PreparedMetadata;
 use cassandra_protocol::frame::Version;
 use cassandra_protocol::token::Murmur3Token;
 use cassandra_protocol::types::CBytesShort;
@@ -13,6 +12,12 @@ use split_iter::Splittable;
 use std::sync::Arc;
 use std::{collections::HashMap, net::SocketAddr};
 use tokio::sync::{watch, RwLock};
+
+#[derive(Debug, Clone)]
+pub struct PreparedMetadata {
+    pub pk_indexes: Vec<i16>,
+    pub keyspace: Option<String>,
+}
 
 #[derive(Debug)]
 pub enum GetReplicaErr {
@@ -157,11 +162,10 @@ impl NodePool {
         let keyspace = self
             .keyspace_metadata
             .get(
-                &metadata
-                    .global_table_spec
+                metadata
+                    .keyspace
                     .as_ref()
-                    .ok_or(GetReplicaErr::NoKeyspaceMetadata)?
-                    .ks_name,
+                    .ok_or(GetReplicaErr::NoKeyspaceMetadata)?,
             )
             .ok_or(GetReplicaErr::NoKeyspaceMetadata)?;
 

--- a/shotover-proxy/src/transforms/cassandra/sink_cluster/test_router.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_cluster/test_router.rs
@@ -3,13 +3,10 @@ mod test_token_aware_router {
     use super::super::node_pool::{KeyspaceMetadata, NodePool};
     use super::super::routing_key::calculate_routing_key;
     use crate::transforms::cassandra::sink_cluster::node::CassandraNode;
+    use crate::transforms::cassandra::sink_cluster::node_pool::PreparedMetadata;
     use crate::transforms::cassandra::sink_cluster::{KeyspaceChanRx, KeyspaceChanTx};
     use cassandra_protocol::consistency::Consistency::One;
     use cassandra_protocol::frame::message_execute::BodyReqExecuteOwned;
-    use cassandra_protocol::frame::message_result::PreparedMetadata;
-    use cassandra_protocol::frame::message_result::{
-        ColSpec, ColType::Varchar, ColTypeOption, TableSpec,
-    };
     use cassandra_protocol::frame::Version;
     use cassandra_protocol::query::QueryParams;
     use cassandra_protocol::query::QueryValues::SimpleValues;
@@ -50,7 +47,7 @@ mod test_token_aware_router {
         router.update_keyspaces(&mut keyspaces_rx).await;
 
         router
-            .add_prepared_result(id.clone(), prepared_metadata().clone())
+            .add_prepared_result(id.clone(), prepared_metadata())
             .await;
 
         for (pk, test_token, rack_replicas, dc_replicas) in test_data() {
@@ -149,18 +146,7 @@ mod test_token_aware_router {
     fn prepared_metadata() -> PreparedMetadata {
         PreparedMetadata {
             pk_indexes: vec![0],
-            global_table_spec: Some(TableSpec {
-                ks_name: "demo_ks".into(),
-                table_name: "books_by_author".into(),
-            }),
-            col_specs: vec![ColSpec {
-                table_spec: None,
-                name: "author".into(),
-                col_type: ColTypeOption {
-                    id: Varchar,
-                    value: None,
-                },
-            }],
+            keyspace: Some("demo_ks".into()),
         }
     }
 


### PR DESCRIPTION
PreparedMetadata contains a bunch of allocating fields we dont actually use like `col_specs` and `global_table_spec.table_name`.
So I created a cut down version of PreparedMetadata to save 2 clones of these unused allocations.
This saves ~0.5% in the flamegraph but this would have an even larger affect when the col_specs field has more complicated values in it.