### PR TITLE
Options rewrite

### DIFF
--- a/shotover-proxy/src/transforms/cassandra/mod.rs
+++ b/shotover-proxy/src/transforms/cassandra/mod.rs
@@ -1,4 +1,5 @@
 mod connection;
+pub mod options_rewrite;
 pub mod peers_rewrite;
 pub mod sink_cluster;
 pub mod sink_single;

--- a/shotover-proxy/src/transforms/cassandra/options_rewrite.rs
+++ b/shotover-proxy/src/transforms/cassandra/options_rewrite.rs
@@ -1,0 +1,64 @@
+use crate::frame::{CassandraOperation, Frame};
+use crate::{
+    error::ChainResponse,
+    transforms::{Transform, TransformBuilder, Wrapper},
+};
+use anyhow::Result;
+use async_trait::async_trait;
+use cassandra_protocol::frame::message_supported::BodyResSupported;
+use serde::Deserialize;
+use std::collections::HashMap;
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct CassandraOptionsRewriteConfig {
+    pub map: HashMap<String, Vec<String>>,
+}
+
+impl CassandraOptionsRewriteConfig {
+    pub async fn get_transform(&self) -> Result<TransformBuilder> {
+        Ok(TransformBuilder::CassandraOptionsRewrite(
+            CassandraOptionsRewrite::new(self.map.clone()),
+        ))
+    }
+}
+
+#[derive(Clone)]
+pub struct CassandraOptionsRewrite {
+    map: HashMap<String, Vec<String>>,
+}
+
+impl CassandraOptionsRewrite {
+    pub fn new(map: HashMap<String, Vec<String>>) -> Self {
+        CassandraOptionsRewrite { map }
+    }
+}
+
+#[async_trait]
+impl Transform for CassandraOptionsRewrite {
+    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> ChainResponse {
+        let mut response = message_wrapper.call_next_transform().await?;
+        for message in &mut response {
+            let mut invalidate = false;
+            if let Some(Frame::Cassandra(frame)) = message.frame() {
+                if let CassandraOperation::Supported(BodyResSupported { data }) =
+                    &mut frame.operation
+                {
+                    for key in self.map.keys() {
+                        data.insert(key.clone(), self.map.get(key).unwrap().clone());
+                    }
+                    invalidate = true;
+                }
+            }
+            if invalidate {
+                message.invalidate_cache();
+            }
+        }
+
+        Ok(response)
+    }
+
+    async fn transform_pushed<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> ChainResponse {
+        let response = message_wrapper.call_next_transform_pushed().await?;
+        Ok(response)
+    }
+}

--- a/shotover-proxy/tests/cassandra_int_tests/cluster/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cluster/mod.rs
@@ -1,3 +1,4 @@
+use cassandra_protocol::frame::message_startup::BodyReqStartup;
 use cassandra_protocol::frame::Version;
 use shotover_proxy::frame::{cassandra::Tracing, CassandraFrame, CassandraOperation, Frame};
 use shotover_proxy::message::Message;
@@ -57,13 +58,15 @@ pub async fn run_topology_task(ca_path: Option<&str>, port: Option<u32>) -> Vec<
 }
 
 fn create_handshake() -> Vec<Message> {
+    let mut startup_body: HashMap<String, String> = HashMap::new();
+    startup_body.insert("CQL_VERSION".into(), "3.0.0".into());
     vec![
         Message::from_frame(Frame::Cassandra(CassandraFrame {
             version: Version::V4,
             stream_id: 64,
             tracing: Tracing::Request(false),
             warnings: vec![],
-            operation: CassandraOperation::Startup(b"\0\x01\0\x0bCQL_VERSION\0\x053.0.0".to_vec()),
+            operation: CassandraOperation::Startup(BodyReqStartup { map: startup_body }),
         })),
         Message::from_frame(Frame::Cassandra(CassandraFrame {
             version: Version::V4,

--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -8,8 +8,10 @@ use futures::Future;
 use metrics_util::debugging::DebuggingRecorder;
 use rstest::rstest;
 use serial_test::serial;
+use test_helpers::connection::cassandra::run_query;
 #[cfg(feature = "cassandra-cpp-driver-tests")]
 use test_helpers::connection::cassandra::CassandraDriver::Datastax;
+use test_helpers::connection::cassandra::{assert_query_result, ResultValue};
 use test_helpers::connection::cassandra::{
     assert_query_result, run_query, CassandraConnection, CassandraDriver,
     CassandraDriver::CdrsTokio, CassandraDriver::Scylla, ResultValue,
@@ -308,6 +310,7 @@ async fn cluster_multi_rack(#[case] driver: CassandraDriver) {
 }
 
 #[cfg(feature = "alpha-transforms")]
+//#[cfg(feature = "cassandra-cpp-driver-tests")]
 #[rstest]
 #[case::scylla(Scylla)]
 //#[case::cdrs(CdrsTokio)] // TODO
@@ -542,6 +545,7 @@ async fn peers_rewrite_v4(#[case] driver: CassandraDriver) {
     shotover.shutdown_and_then_consume_events(&[]).await;
 }
 
+//#[cfg(feature = "cassandra-cpp-driver-tests")]
 #[rstest]
 //#[case::cdrs(CdrsTokio)] // Disabled due to intermittent failure that only occurs on v3
 #[case::scylla(Scylla)]
@@ -576,6 +580,7 @@ async fn peers_rewrite_v3(#[case] driver: CassandraDriver) {
     shotover.shutdown_and_then_consume_events(&[]).await;
 }
 
+//#[cfg(feature = "cassandra-cpp-driver-tests")]
 #[rstest]
 //#[case::cdrs(CdrsTokio)] // TODO: cdrs-tokio seems to be sending extra messages triggering the rate limiter
 #[case::scylla(Scylla)]

--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -1,8 +1,14 @@
 use crate::helpers::ShotoverManager;
 use cassandra_protocol::frame::message_error::{ErrorBody, ErrorType};
+use cdrs_tokio::cluster::send_envelope::send_envelope;
 use cdrs_tokio::frame::events::{
     SchemaChange, SchemaChangeOptions, SchemaChangeTarget, SchemaChangeType, ServerEvent,
 };
+use cdrs_tokio::frame::message_response::ResponseBody;
+use cdrs_tokio::frame::message_supported::BodyResSupported;
+use cdrs_tokio::frame::Envelope;
+use cdrs_tokio::frame::Version;
+use cdrs_tokio::retry::DefaultRetrySession;
 use futures::future::join_all;
 use futures::Future;
 use metrics_util::debugging::DebuggingRecorder;
@@ -310,7 +316,6 @@ async fn cluster_multi_rack(#[case] driver: CassandraDriver) {
 }
 
 #[cfg(feature = "alpha-transforms")]
-//#[cfg(feature = "cassandra-cpp-driver-tests")]
 #[rstest]
 #[case::scylla(Scylla)]
 //#[case::cdrs(CdrsTokio)] // TODO
@@ -545,7 +550,6 @@ async fn peers_rewrite_v4(#[case] driver: CassandraDriver) {
     shotover.shutdown_and_then_consume_events(&[]).await;
 }
 
-//#[cfg(feature = "cassandra-cpp-driver-tests")]
 #[rstest]
 //#[case::cdrs(CdrsTokio)] // Disabled due to intermittent failure that only occurs on v3
 #[case::scylla(Scylla)]
@@ -580,7 +584,59 @@ async fn peers_rewrite_v3(#[case] driver: CassandraDriver) {
     shotover.shutdown_and_then_consume_events(&[]).await;
 }
 
-//#[cfg(feature = "cassandra-cpp-driver-tests")]
+#[rstest]
+#[case::cdrs(CdrsTokio)]
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn test_options_rewrite(#[case] driver: CassandraDriver) {
+    let _docker_compose =
+        DockerCompose::new("tests/test-configs/cassandra-options-rewrite/docker-compose.yaml");
+
+    let _shotover_manager = ShotoverManager::from_topology_file(
+        "tests/test-configs/cassandra-options-rewrite/topology.yaml",
+    );
+
+    let envelope = Envelope::new_req_options(Version::V4);
+
+    let normal_connection = CassandraConnection::new("127.0.0.1", 9043, driver).await;
+    let normal_query_plan = normal_connection.as_cdrs().query_plan(None);
+    let normal_result = send_envelope(
+        normal_query_plan.into_iter(),
+        &envelope,
+        false,
+        Box::<DefaultRetrySession>::default(),
+    )
+    .await
+    .unwrap()
+    .unwrap()
+    .response_body()
+    .unwrap();
+    if let ResponseBody::Supported(BodyResSupported { data }) = normal_result {
+        assert_eq!(*data.get("CQL_VERSION").unwrap(), vec!["3.4.5".to_string()]);
+    }
+
+    let options_rewrite_connection = CassandraConnection::new("127.0.0.1", 9044, driver).await;
+    let options_rewrite_query_plan = options_rewrite_connection.as_cdrs().query_plan(None);
+    let options_rewrite_result = send_envelope(
+        options_rewrite_query_plan.into_iter(),
+        &envelope,
+        false,
+        Box::<DefaultRetrySession>::default(),
+    )
+    .await
+    .unwrap()
+    .unwrap()
+    .response_body()
+    .unwrap();
+
+    if let ResponseBody::Supported(BodyResSupported { data }) = options_rewrite_result {
+        assert_eq!(
+            *data.get("CQL_VERSION").unwrap(),
+            vec!["changed".to_string()]
+        );
+    }
+}
+
 #[rstest]
 //#[case::cdrs(CdrsTokio)] // TODO: cdrs-tokio seems to be sending extra messages triggering the rate limiter
 #[case::scylla(Scylla)]

--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -14,10 +14,8 @@ use futures::Future;
 use metrics_util::debugging::DebuggingRecorder;
 use rstest::rstest;
 use serial_test::serial;
-use test_helpers::connection::cassandra::run_query;
 #[cfg(feature = "cassandra-cpp-driver-tests")]
 use test_helpers::connection::cassandra::CassandraDriver::Datastax;
-use test_helpers::connection::cassandra::{assert_query_result, ResultValue};
 use test_helpers::connection::cassandra::{
     assert_query_result, run_query, CassandraConnection, CassandraDriver,
     CassandraDriver::CdrsTokio, CassandraDriver::Scylla, ResultValue,

--- a/shotover-proxy/tests/test-configs/cassandra-options-rewrite/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra-options-rewrite/docker-compose.yaml
@@ -1,0 +1,14 @@
+version: "3.3"
+services:
+  cassandra-one:
+    image: shotover-int-tests/cassandra:4.0.6
+    ports:
+      - "9042:9042"
+    environment:
+      MAX_HEAP_SIZE: "400M"
+      MIN_HEAP_SIZE: "400M"
+      HEAP_NEWSIZE: "48M"
+    volumes:
+      - type: tmpfs
+        target: /var/lib/cassandra
+    command: cassandra -f -Dcassandra.skip_wait_for_gossip_to_settle=0 -Dcassandra.initial_token=0

--- a/shotover-proxy/tests/test-configs/cassandra-options-rewrite/topology.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra-options-rewrite/topology.yaml
@@ -1,0 +1,24 @@
+---
+sources:
+  cassandra_prod_1:
+    Cassandra:
+      listen_addr: "127.0.0.1:9043"
+  cassandra_prod_2:
+    Cassandra:
+      listen_addr: "127.0.0.1:9044"
+
+chain_config:
+  main_chain:
+    - CassandraSinkSingle:
+        remote_address: "127.0.0.1:9042"
+        connect_timeout_ms: 3000
+  options_rewrite:
+    - CassandraOptionsRewrite:
+        map:
+          CQL_VERSION: ["changed"]
+    - CassandraSinkSingle:
+        remote_address: "127.0.0.1:9042"
+        connect_timeout_ms: 3000
+source_to_chain_mapping:
+  cassandra_prod_1: main_chain
+  cassandra_prod_2: options_rewrite


### PR DESCRIPTION
Shotover does not support compression in Cassandra yet.  Changes in this PR:

- Reject STARTUP messages if they attempt to use compression.
-  Add a transform for rewriting the SUPPORTED response to OPTIONS requests so users can disable compression