### PR TITLE
ShotoverManager -> ShotoverProcess in cassandra_int_tests::cluster_multi_rack

### DIFF
--- a/shotover-proxy/tests/cassandra_int_tests/cluster/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cluster/mod.rs
@@ -14,7 +14,6 @@ use tokio::time::timeout;
 
 pub mod multi_rack;
 pub mod single_rack_v3;
-#[cfg(feature = "alpha-transforms")]
 pub mod single_rack_v4;
 
 pub async fn run_topology_task(ca_path: Option<&str>, port: Option<u32>) -> Vec<CassandraNode> {

--- a/test-helpers/src/shotover_process.rs
+++ b/test-helpers/src/shotover_process.rs
@@ -5,9 +5,17 @@ pub use tokio_bin_process::event_matcher::{Count, EventMatcher, Events};
 pub use tokio_bin_process::BinProcess;
 
 pub async fn shotover_from_topology_file(topology_path: &str) -> BinProcess {
+    shotover_from_topology_file_with_name(topology_path, "Shotover").await
+}
+
+pub async fn shotover_from_topology_file_with_name(
+    topology_path: &str,
+    log_name: &str,
+) -> BinProcess {
     let mut shotover = BinProcess::start_with_args(
         "shotover-proxy",
         &["-t", topology_path, "--log-format", "json"],
+        log_name,
     )
     .await;
 
@@ -33,6 +41,7 @@ pub async fn shotover_from_topology_file_fail_to_startup(
     BinProcess::start_with_args(
         "shotover-proxy",
         &["-t", topology_path, "--log-format", "json"],
+        "Shotover",
     )
     .await
     .consume_remaining_events_expect_failure(expected_errors_and_warnings)


### PR DESCRIPTION
BinProcess was adjusted to take a log_name that gets included in the log output, replacing the previously hardcoded BINPROCESS log prefix.

This means when we run:
`cargo test cluster_multi_rack --all-features -- --nocapture`
we get output like:
```
Rack3      02:13:31.963028Z  INFO connection{id=4 source="CassandraSource"}: shotover_proxy::transforms::cassandra::sink_cluster: Control connection finalized against node at: 172.16.1.4:9042
Rack1      02:13:32.053064Z  INFO connection{id=14 source="CassandraSource"}: shotover_proxy::transforms::cassandra::sink_cluster: Control connection finalized against node at: 172.16.1.2:9042
Rack2      02:13:32.097153Z  INFO connection{id=5 source="CassandraSource"}: shotover_proxy::transforms::cassandra::sink_cluster: Control connection finalized against node at: 172.16.1.3:9042
Rack1      02:13:32.098553Z  INFO connection{id=15 source="CassandraSource"}: shotover_proxy::transforms::cassandra::sink_cluster: Control connection finalized against node at: 172.16.1.2:9042
Rack3      02:13:32.098794Z  INFO connection{id=5 source="CassandraSource"}: shotover_proxy::transforms::cassandra::sink_cluster: Control connection finalized against node at: 172.16.1.4:9042
```
that gives us a way to differentiate which instance the logs are coming from.

I considered automatically generating names from an incrementing global.
But I think this way is easier to track which instance corresponds to which name and also avoids globals.