### PR TITLE
Move NodePool custom clone into a NodePoolBuilder

### DIFF
--- a/shotover-proxy/src/transforms/cassandra/sink_cluster/mod.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_cluster/mod.rs
@@ -1,4 +1,4 @@
-use self::node_pool::PreparedMetadata;
+use self::node_pool::{NodePoolBuilder, PreparedMetadata};
 use crate::error::ChainResponse;
 use crate::frame::cassandra::{parse_statement_single, CassandraMetadata, Tracing};
 use crate::frame::{CassandraFrame, CassandraOperation, CassandraResult, Frame};
@@ -119,7 +119,7 @@ pub struct CassandraSinkClusterBuilder {
     nodes_rx: watch::Receiver<Vec<CassandraNode>>,
     keyspaces_rx: KeyspaceChanRx,
     task_handshake_tx: mpsc::Sender<TaskConnectionInfo>,
-    pool: NodePool,
+    pool: NodePoolBuilder,
 }
 
 impl CassandraSinkClusterBuilder {
@@ -160,7 +160,7 @@ impl CassandraSinkClusterBuilder {
             nodes_rx: local_nodes_rx,
             keyspaces_rx,
             task_handshake_tx,
-            pool: NodePool::new(vec![]),
+            pool: NodePoolBuilder::new(),
         }
     }
 
@@ -184,7 +184,7 @@ impl CassandraSinkClusterBuilder {
             failed_requests: self.failed_requests.clone(),
             read_timeout: self.read_timeout,
             local_shotover_node: self.local_shotover_node.clone(),
-            pool: self.pool.clone(),
+            pool: self.pool.build(),
             // Because the self.nodes_rx is always copied from the original nodes_rx created before any node lists were sent,
             // once a single node list has been sent all new connections will immediately recognize it as a change.
             nodes_rx: self.nodes_rx.clone(),

--- a/shotover-proxy/src/transforms/cassandra/sink_cluster/test_router.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_cluster/test_router.rs
@@ -1,9 +1,11 @@
 #[cfg(test)]
 mod test_token_aware_router {
-    use super::super::node_pool::{KeyspaceMetadata, NodePool};
+    use super::super::node_pool::KeyspaceMetadata;
     use super::super::routing_key::calculate_routing_key;
     use crate::transforms::cassandra::sink_cluster::node::CassandraNode;
-    use crate::transforms::cassandra::sink_cluster::node_pool::PreparedMetadata;
+    use crate::transforms::cassandra::sink_cluster::node_pool::{
+        NodePoolBuilder, PreparedMetadata,
+    };
     use crate::transforms::cassandra::sink_cluster::{KeyspaceChanRx, KeyspaceChanTx};
     use cassandra_protocol::consistency::Consistency::One;
     use cassandra_protocol::frame::message_execute::BodyReqExecuteOwned;
@@ -23,7 +25,10 @@ mod test_token_aware_router {
     async fn test_router() {
         let mut rng = SmallRng::from_rng(rand::thread_rng()).unwrap();
 
-        let mut router = NodePool::new(prepare_nodes());
+        let nodes = prepare_nodes();
+        let mut router = NodePoolBuilder::new().build();
+        let (_nodes_tx, mut nodes_rx) = watch::channel(nodes);
+        router.update_nodes(&mut nodes_rx);
 
         let id = CBytesShort::new(vec![
             11, 241, 38, 11, 140, 72, 217, 34, 214, 128, 175, 241, 151, 73, 197, 227,


### PR DESCRIPTION
NodePoolBuilder matches the abstractions and naming used by CassandraSinkClusterBuilder. We no longer have a custom clone impl responsible for deciding which values are shared between transform instances.

unit tests no longer rely on a unit test specific code path (`NodePath::new` with a prepopulated vec), they now follow the same path to set the node list as the real code does (`NodePath::update_nodes`)