### PR TITLE
Cassandra test speed

### DIFF
--- a/test-helpers/src/connection/cassandra.rs
+++ b/test-helpers/src/connection/cassandra.rs
@@ -729,6 +729,15 @@ impl CassandraConnection {
             Err(err) => panic!("Unexpected cdrs-tokio error: {err:?}"),
         }
     }
+
+    pub fn name(&self) -> &str {
+        match self {
+            CassandraConnection::CdrsTokio { .. } => "CDRS",
+            #[cfg(feature = "cassandra-cpp-driver-tests")]
+            CassandraConnection::Datastax { .. } => "DATASTAX",
+            CassandraConnection::Scylla { .. } => "SCYLLA",
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialOrd, Eq, Ord)]


### PR DESCRIPTION
An idea for Cassandra test speedup. 

- Add a suffix to our test keyspaces with the name of the driver
- Create the `DockerCompose` once and run all of each driver's tests against it
- Involves moving away from `rstest` because their `#[once]` fixture does not drop values so the containers would hang

This also gives us the ability to potentially run the driver test suites concurrently.

We lose the convenience of `rstest` telling us which driver failed what test. If we improve the logging we could fix this but it does mean when a driver fails a test that entire test stops.

