### PR TITLE
TransformBuilder::build takes &self intead of self

### DIFF
--- a/shotover-proxy/src/transforms/cassandra/sink_cluster/mod.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_cluster/mod.rs
@@ -172,25 +172,25 @@ impl CassandraSinkClusterBuilder {
         true
     }
 
-    pub fn build(self) -> Box<CassandraSinkCluster> {
+    pub fn build(&self) -> Box<CassandraSinkCluster> {
         Box::new(CassandraSinkCluster {
-            contact_points: self.contact_points,
-            shotover_peers: self.shotover_peers,
+            contact_points: self.contact_points.clone(),
+            shotover_peers: self.shotover_peers.clone(),
             control_connection: None,
             connection_factory: self.connection_factory.new_with_same_config(),
             control_connection_address: None,
             init_handshake_complete: false,
             version: None,
-            failed_requests: self.failed_requests,
+            failed_requests: self.failed_requests.clone(),
             read_timeout: self.read_timeout,
-            local_shotover_node: self.local_shotover_node,
-            pool: self.pool,
+            local_shotover_node: self.local_shotover_node.clone(),
+            pool: self.pool.clone(),
             // Because the self.nodes_rx is always copied from the original nodes_rx created before any node lists were sent,
             // once a single node list has been sent all new connections will immediately recognize it as a change.
-            nodes_rx: self.nodes_rx,
-            keyspaces_rx: self.keyspaces_rx,
+            nodes_rx: self.nodes_rx.clone(),
+            keyspaces_rx: self.keyspaces_rx.clone(),
             rng: SmallRng::from_rng(rand::thread_rng()).unwrap(),
-            task_handshake_tx: self.task_handshake_tx,
+            task_handshake_tx: self.task_handshake_tx.clone(),
         })
     }
 }

--- a/shotover-proxy/src/transforms/chain.rs
+++ b/shotover-proxy/src/transforms/chain.rs
@@ -354,7 +354,7 @@ impl TransformChainBuilder {
 
     /// Clone the chain while adding a producer for the pushed messages channel
     pub fn build(&self) -> TransformChain {
-        let chain = self.chain.iter().cloned().map(|x| x.build()).collect();
+        let chain = self.chain.iter().map(|x| x.build()).collect();
 
         TransformChain {
             name: self.name.clone(),
@@ -373,7 +373,7 @@ impl TransformChainBuilder {
             .chain
             .iter()
             .map(|x| {
-                let mut transform = x.clone().build();
+                let mut transform = x.build();
                 transform.set_pushed_messages_tx(pushed_messages_tx.clone());
                 transform
             })

--- a/shotover-proxy/src/transforms/load_balance.rs
+++ b/shotover-proxy/src/transforms/load_balance.rs
@@ -38,12 +38,12 @@ pub struct ConnectionBalanceAndPoolBuilder {
 }
 
 impl ConnectionBalanceAndPoolBuilder {
-    pub fn build(self) -> ConnectionBalanceAndPool {
+    pub fn build(&self) -> ConnectionBalanceAndPool {
         ConnectionBalanceAndPool {
             active_connection: None,
             max_connections: self.max_connections,
-            all_connections: self.all_connections,
-            chain_to_clone: self.chain_to_clone,
+            all_connections: self.all_connections.clone(),
+            chain_to_clone: self.chain_to_clone.clone(),
         }
     }
 

--- a/shotover-proxy/src/transforms/mod.rs
+++ b/shotover-proxy/src/transforms/mod.rs
@@ -104,36 +104,40 @@ pub enum TransformBuilder {
 }
 
 impl TransformBuilder {
-    pub fn build(self) -> Transforms {
+    pub fn build(&self) -> Transforms {
         match self {
-            TransformBuilder::CassandraSinkSingle(t) => Transforms::CassandraSinkSingle(t),
+            TransformBuilder::CassandraSinkSingle(t) => Transforms::CassandraSinkSingle(t.clone()),
             TransformBuilder::CassandraSinkCluster(t) => {
                 Transforms::CassandraSinkCluster(t.build())
             }
-            TransformBuilder::CassandraPeersRewrite(t) => Transforms::CassandraPeersRewrite(t),
-            TransformBuilder::RedisCache(t) => Transforms::RedisCache(t.build()),
-            TransformBuilder::Tee(t) => Transforms::Tee(t),
-            TransformBuilder::RedisSinkSingle(t) => Transforms::RedisSinkSingle(t),
-            TransformBuilder::ConsistentScatter(t) => Transforms::ConsistentScatter(t),
-            TransformBuilder::RedisTimestampTagger(t) => Transforms::RedisTimestampTagger(t),
-            TransformBuilder::RedisClusterPortsRewrite(t) => {
-                Transforms::RedisClusterPortsRewrite(t)
+            TransformBuilder::CassandraPeersRewrite(t) => {
+                Transforms::CassandraPeersRewrite(t.clone())
             }
-            TransformBuilder::DebugPrinter(t) => Transforms::DebugPrinter(t),
-            TransformBuilder::DebugForceParse(t) => Transforms::DebugForceParse(t),
-            TransformBuilder::NullSink(t) => Transforms::NullSink(t),
-            TransformBuilder::RedisSinkCluster(t) => Transforms::RedisSinkCluster(t),
+            TransformBuilder::RedisCache(t) => Transforms::RedisCache(t.build()),
+            TransformBuilder::Tee(t) => Transforms::Tee(t.clone()),
+            TransformBuilder::RedisSinkSingle(t) => Transforms::RedisSinkSingle(t.clone()),
+            TransformBuilder::ConsistentScatter(t) => Transforms::ConsistentScatter(t.clone()),
+            TransformBuilder::RedisTimestampTagger(t) => {
+                Transforms::RedisTimestampTagger(t.clone())
+            }
+            TransformBuilder::RedisClusterPortsRewrite(t) => {
+                Transforms::RedisClusterPortsRewrite(t.clone())
+            }
+            TransformBuilder::DebugPrinter(t) => Transforms::DebugPrinter(t.clone()),
+            TransformBuilder::DebugForceParse(t) => Transforms::DebugForceParse(t.clone()),
+            TransformBuilder::NullSink(t) => Transforms::NullSink(t.clone()),
+            TransformBuilder::RedisSinkCluster(t) => Transforms::RedisSinkCluster(t.clone()),
             TransformBuilder::ParallelMap(t) => Transforms::ParallelMap(t.build()),
             TransformBuilder::PoolConnections(t) => Transforms::PoolConnections(t.build()),
-            TransformBuilder::Coalesce(t) => Transforms::Coalesce(t),
-            TransformBuilder::QueryTypeFilter(t) => Transforms::QueryTypeFilter(t),
-            TransformBuilder::QueryCounter(t) => Transforms::QueryCounter(t),
+            TransformBuilder::Coalesce(t) => Transforms::Coalesce(t.clone()),
+            TransformBuilder::QueryTypeFilter(t) => Transforms::QueryTypeFilter(t.clone()),
+            TransformBuilder::QueryCounter(t) => Transforms::QueryCounter(t.clone()),
             #[cfg(test)]
-            TransformBuilder::Loopback(t) => Transforms::Loopback(t),
-            TransformBuilder::Protect(t) => Transforms::Protect(t),
-            TransformBuilder::DebugReturner(t) => Transforms::DebugReturner(t),
-            TransformBuilder::DebugRandomDelay(t) => Transforms::DebugRandomDelay(t),
-            TransformBuilder::RequestThrottling(t) => Transforms::RequestThrottling(t),
+            TransformBuilder::Loopback(t) => Transforms::Loopback(t.clone()),
+            TransformBuilder::Protect(t) => Transforms::Protect(t.clone()),
+            TransformBuilder::DebugReturner(t) => Transforms::DebugReturner(t.clone()),
+            TransformBuilder::DebugRandomDelay(t) => Transforms::DebugRandomDelay(t.clone()),
+            TransformBuilder::RequestThrottling(t) => Transforms::RequestThrottling(t.clone()),
         }
     }
 

--- a/shotover-proxy/src/transforms/parallel_map.rs
+++ b/shotover-proxy/src/transforms/parallel_map.rs
@@ -122,9 +122,9 @@ impl Transform for ParallelMap {
 }
 
 impl ParallelMapBuilder {
-    pub fn build(self) -> ParallelMap {
+    pub fn build(&self) -> ParallelMap {
         ParallelMap {
-            chains: self.chains.into_iter().map(|x| x.build()).collect(),
+            chains: self.chains.iter().map(|x| x.build()).collect(),
             ordered: self.ordered,
         }
     }

--- a/shotover-proxy/src/transforms/redis/cache.rs
+++ b/shotover-proxy/src/transforms/redis/cache.rs
@@ -566,11 +566,11 @@ impl Transform for SimpleRedisCache {
     }
 }
 impl SimpleRedisCacheBuilder {
-    pub fn build(self) -> SimpleRedisCache {
+    pub fn build(&self) -> SimpleRedisCache {
         SimpleRedisCache {
             cache_chain: self.cache_chain.build(),
-            caching_schema: self.caching_schema,
-            missed_requests: self.missed_requests,
+            caching_schema: self.caching_schema.clone(),
+            missed_requests: self.missed_requests.clone(),
         }
     }
 


### PR DESCRIPTION
I think that semantically it makes a bit more sense to have a single build method that generates a transform, rather than cloning the builder and then building a transform by destroying the builder.

There should also be some performance improvements:
* Avoids having the two step process of clone -> build, this results in a bunch of extra copying on the stack which I doubt the compiler can optimize away because the structures are so deeply nested. (copies on the heap are unchanged because they only get copied during the clone)
* There are cases where we call `TransformChainBuilder::build(&self)` in a transform builder which results in needless internal clones due to taking an `&self`
