### PR TITLE
Message::set_error -> Message::to_error_response

### DIFF
--- a/shotover-proxy/src/transforms/distributed/consistent_scatter.rs
+++ b/shotover-proxy/src/transforms/distributed/consistent_scatter.rs
@@ -150,7 +150,7 @@ impl Transform for ConsistentScatter {
         Ok(if results.len() < max_required_successes as usize {
             let mut messages = message_wrapper.messages;
             for message in &mut messages {
-                message.set_error("Not enough responses".into());
+                *message = message.to_error_response("Not enough responses".into());
             }
             messages
         } else {
@@ -219,7 +219,7 @@ mod scatter_transform_tests {
 
     fn check_err_responses(mut messages: Messages, expected_err: &str) {
         let mut message = messages.pop().unwrap();
-        let expected = Frame::Redis(RedisFrame::Error(expected_err.into()));
+        let expected = Frame::Redis(RedisFrame::Error(format!("ERR {expected_err}").into()));
         assert_eq!(message.frame().unwrap(), &expected);
     }
 

--- a/shotover-proxy/src/transforms/filter.rs
+++ b/shotover-proxy/src/transforms/filter.rs
@@ -40,7 +40,12 @@ impl Transform for QueryTypeFilter {
                     None
                 }
             })
-            .map(|(i, m)| (i, m.to_filtered_reply()))
+            .map(|(i, m)| {
+                (
+                    i,
+                    m.to_error_response("Message was filtered out by shotover".to_owned()),
+                )
+            })
             .collect();
 
         for (i, _) in removed_indexes.iter().rev() {

--- a/shotover-proxy/src/transforms/null.rs
+++ b/shotover-proxy/src/transforms/null.rs
@@ -13,7 +13,7 @@ impl Transform for NullSink {
 
     async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> ChainResponse {
         for message in &mut message_wrapper.messages {
-            message.set_error("Handled by shotover null transform".to_string());
+            *message = message.to_error_response("Handled by shotover null transform".to_string());
         }
         Ok(message_wrapper.messages)
     }

--- a/shotover-proxy/src/transforms/tee.rs
+++ b/shotover-proxy/src/transforms/tee.rs
@@ -157,8 +157,8 @@ impl Transform for Tee {
 
                 if !chain_response.eq(&tee_response) {
                     for message in &mut chain_response {
-                        message.set_error(
-                            "ERR The responses from the Tee subchain and down-chain did not match and behavior is set to fail on mismatch".into())
+                        *message = message.to_error_response(
+                            "ERR The responses from the Tee subchain and down-chain did not match and behavior is set to fail on mismatch".into());
                     }
                 }
                 Ok(chain_response)

--- a/shotover-proxy/tests/transforms/tee.rs
+++ b/shotover-proxy/tests/transforms/tee.rs
@@ -83,7 +83,7 @@ async fn test_fail_with_mismatch() {
         .unwrap_err()
         .to_string();
 
-    let expected = "An error was signalled by the server: The responses from the Tee subchain and down-chain did not match and behavior is set to fail on mismatch";
+    let expected = "An error was signalled by the server: ERR The responses from the Tee subchain and down-chain did not match and behavior is set to fail on mismatch";
     assert_eq!(expected, err);
     shotover.shutdown_and_then_consume_events(&[]).await;
 }


### PR DESCRIPTION
clears out 2 TODO's from message/mod.rs

to_error_response now properly sets the redis `Error Prefix` to ERR as documented here: https://redis.io/docs/reference/protocol-spec/
We could also just not do that, but we were previously doing that only sometimes (to_filtered_reply), now we always do it. 

I think that changing the method to return a new Message instead of modifying the original Message gives us a more flexible API, with no performance loss.