### PR TITLE
remove Frame::None

### DIFF
--- a/shotover-proxy/benches/benches/chain.rs
+++ b/shotover-proxy/benches/benches/chain.rs
@@ -29,7 +29,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             "bench".to_string(),
         );
         let wrapper = Wrapper::new_with_chain_name(
-            vec![Message::from_frame(Frame::None)],
+            vec![Message::from_frame(Frame::Redis(RedisFrame::Null))],
             chain.name.clone(),
             "127.0.0.1:6379".parse().unwrap(),
         );

--- a/shotover-proxy/src/frame/mod.rs
+++ b/shotover-proxy/src/frame/mod.rs
@@ -11,14 +11,12 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 pub enum MessageType {
     Redis,
     Cassandra,
-    None,
 }
 
 #[derive(PartialEq, Debug, Clone)]
 pub enum Frame {
     Cassandra(CassandraFrame),
     Redis(RedisFrame),
-    None,
 }
 
 impl Frame {
@@ -28,7 +26,6 @@ impl Frame {
             MessageType::Redis => redis_protocol::resp2::decode::decode(&bytes)
                 .map(|x| Frame::Redis(x.unwrap().0))
                 .map_err(|e| anyhow!("{e:?}")),
-            MessageType::None => Ok(Frame::None),
         }
     }
 
@@ -36,7 +33,6 @@ impl Frame {
         match self {
             Frame::Redis(_) => "Redis",
             Frame::Cassandra(_) => "Cassandra",
-            Frame::None => "None",
         }
     }
 
@@ -44,7 +40,6 @@ impl Frame {
         match self {
             Frame::Cassandra(_) => MessageType::Cassandra,
             Frame::Redis(_) => MessageType::Redis,
-            Frame::None => MessageType::None,
         }
     }
 
@@ -61,7 +56,6 @@ impl Frame {
     pub fn into_redis(self) -> Result<RedisFrame> {
         match self {
             Frame::Redis(frame) => Ok(frame),
-            Frame::None => Ok(RedisFrame::Null),
             frame => Err(anyhow!(
                 "Expected redis frame but received {} frame",
                 frame.name()
@@ -85,7 +79,6 @@ impl Display for Frame {
         match self {
             Frame::Cassandra(frame) => write!(f, "Cassandra {}", frame),
             Frame::Redis(frame) => write!(f, "Redis {:?})", frame),
-            Frame::None => write!(f, "None"),
         }
     }
 }

--- a/shotover-proxy/src/message/mod.rs
+++ b/shotover-proxy/src/message/mod.rs
@@ -36,7 +36,6 @@ use uuid::Uuid;
 pub enum Metadata {
     Cassandra(CassandraMetadata),
     Redis,
-    None,
 }
 
 pub type Messages = Vec<Message>;
@@ -184,13 +183,11 @@ impl Message {
                 message_type,
             } => match message_type {
                 MessageType::Redis => nonzero!(1u32),
-                MessageType::None => nonzero!(1u32),
                 MessageType::Cassandra => cassandra::raw_frame::cell_count(bytes)?,
             },
             MessageInner::Modified { frame } | MessageInner::Parsed { frame, .. } => match frame {
                 Frame::Cassandra(frame) => frame.cell_count()?,
                 Frame::Redis(_) => nonzero!(1u32),
-                Frame::None => nonzero!(1u32),
             },
         })
     }
@@ -224,7 +221,6 @@ impl Message {
                 tracing: frame.tracing,
                 warnings: vec![],
             }),
-            Frame::None => Frame::None,
         })
     }
 
@@ -232,7 +228,6 @@ impl Message {
         match self.frame() {
             Some(Frame::Cassandra(cassandra)) => cassandra.get_query_type(),
             Some(Frame::Redis(redis)) => redis_query_type(redis), // free-standing function as we cant define methods on RedisFrame
-            Some(Frame::None) => QueryType::ReadWrite,
             None => QueryType::ReadWrite,
         }
     }
@@ -253,7 +248,6 @@ impl Message {
                 tracing: Tracing::Response(None),
                 warnings: vec![],
             }),
-            Metadata::None => Frame::None,
         });
         self.invalidate_cache();
     }
@@ -269,12 +263,10 @@ impl Message {
                     Ok(Metadata::Cassandra(cassandra::raw_frame::metadata(bytes)?))
                 }
                 MessageType::Redis => Ok(Metadata::Redis),
-                MessageType::None => Ok(Metadata::None),
             },
             MessageInner::Parsed { frame, .. } | MessageInner::Modified { frame } => match frame {
                 Frame::Cassandra(frame) => Ok(Metadata::Cassandra(frame.metadata())),
                 Frame::Redis(_) => Ok(Metadata::Redis),
-                Frame::None => Ok(Metadata::None),
             },
         }
     }
@@ -301,7 +293,6 @@ impl Message {
             Metadata::Redis => {
                 unimplemented!()
             }
-            Metadata::None => Frame::None,
         });
 
         Ok(())
@@ -329,7 +320,6 @@ impl Message {
                 match frame {
                     Frame::Cassandra(cassandra) => Some(cassandra.stream_id),
                     Frame::Redis(_) => None,
-                    Frame::None => None,
                 }
             }
             None => None,

--- a/shotover-proxy/src/transforms/coalesce.rs
+++ b/shotover-proxy/src/transforms/coalesce.rs
@@ -79,7 +79,7 @@ impl Transform for Coalesce {
 
 #[cfg(test)]
 mod test {
-    use crate::frame::Frame;
+    use crate::frame::{Frame, RedisFrame};
     use crate::message::Message;
     use crate::transforms::coalesce::Coalesce;
     use crate::transforms::loopback::Loopback;
@@ -97,7 +97,9 @@ mod test {
 
         let mut chain = vec![Transforms::Loopback(Loopback::default())];
 
-        let messages: Vec<_> = (0..25).map(|_| Message::from_frame(Frame::None)).collect();
+        let messages: Vec<_> = (0..25)
+            .map(|_| Message::from_frame(Frame::Redis(RedisFrame::Null)))
+            .collect();
 
         let mut message_wrapper = Wrapper::new(messages.clone());
         message_wrapper.reset(&mut chain);
@@ -134,7 +136,9 @@ mod test {
 
         let mut chain = vec![Transforms::Loopback(Loopback::default())];
 
-        let messages: Vec<_> = (0..25).map(|_| Message::from_frame(Frame::None)).collect();
+        let messages: Vec<_> = (0..25)
+            .map(|_| Message::from_frame(Frame::Redis(RedisFrame::Null)))
+            .collect();
 
         let mut message_wrapper = Wrapper::new(messages.clone());
         message_wrapper.reset(&mut chain);
@@ -168,7 +172,9 @@ mod test {
 
         let mut chain = vec![Transforms::Loopback(Loopback::default())];
 
-        let messages: Vec<_> = (0..25).map(|_| Message::from_frame(Frame::None)).collect();
+        let messages: Vec<_> = (0..25)
+            .map(|_| Message::from_frame(Frame::Redis(RedisFrame::Null)))
+            .collect();
 
         let mut message_wrapper = Wrapper::new(messages.clone());
         message_wrapper.reset(&mut chain);

--- a/shotover-proxy/src/transforms/query_counter.rs
+++ b/shotover-proxy/src/transforms/query_counter.rs
@@ -42,7 +42,7 @@ impl Transform for QueryCounter {
                         counter!("query_count", 1, "name" => self.counter_name.clone(), "query" => "unknown", "type" => "redis");
                     }
                 }
-                Some(Frame::None) | None => {
+                None => {
                     counter!("query_count", 1, "name" => self.counter_name.clone(), "query" => "unknown", "type" => "none")
                 }
             }

--- a/shotover-proxy/src/transforms/redis/sink_cluster.rs
+++ b/shotover-proxy/src/transforms/redis/sink_cluster.rs
@@ -915,7 +915,7 @@ fn short_circuit(frame: RedisFrame) -> Result<ResponseFuture> {
 
     one_tx
         .send(Response {
-            original: Message::from_frame(Frame::None),
+            original: Message::from_frame(Frame::Redis(RedisFrame::Null)),
             response: Ok(Message::from_frame(Frame::Redis(frame))),
         })
         .map_err(|_| anyhow!("Failed to send short circuited redis frame"))?;
@@ -954,7 +954,7 @@ impl Transform for RedisSinkCluster {
             trace!("Got resp {:?}", s);
             let Response { original, response } = s.or_else(|e| -> Result<Response> {
                 Ok(Response {
-                    original: Message::from_frame(Frame::None),
+                    original: Message::from_frame(Frame::Redis(RedisFrame::Null)),
                     response: Ok(Message::from_frame(Frame::Redis(RedisFrame::Error(
                         format!("ERR Could not route request - {e}").into(),
                     )))),


### PR DESCRIPTION
 I think this was originally intended to mean "null" of redis frame but it's prevalence has gone beyond the scope of that. We can just use `RedisFrame::Null`.