### PR TITLE
Initial kafka protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,7 +286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e10ca87c81aaa3a949dbbe2b5e6c2c45dbc94ba4897e45ea31ff9ec5087be3dc"
 dependencies = [
  "cached_proc_macro_types",
- "darling",
+ "darling 0.14.3",
  "proc-macro2",
  "quote",
  "syn",
@@ -310,7 +310,7 @@ dependencies = [
  "log",
  "parking_lot",
  "slog",
- "uuid",
+ "uuid 1.3.0",
 ]
 
 [[package]]
@@ -340,7 +340,7 @@ dependencies = [
  "snap",
  "thiserror",
  "time 0.3.19",
- "uuid",
+ "uuid 1.3.0",
 ]
 
 [[package]]
@@ -375,7 +375,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "uuid",
+ "uuid 1.3.0",
 ]
 
 [[package]]
@@ -604,8 +604,23 @@ dependencies = [
  "serde",
  "tree-sitter",
  "tree-sitter-cql",
- "uuid",
+ "uuid 1.3.0",
 ]
+
+[[package]]
+name = "crc"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fc9a695bca7f35f5f4c15cddc84415f66a74ea78eef08e90c5024f2b540e23"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccaeedb56da03b09f598226e25e80088cb4cd25f316e6e4df7d695f0feeb1403"
 
 [[package]]
 name = "crc16"
@@ -789,12 +804,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2c43f534ea4b0b049015d00269734195e6d3f0f6635cb692251aca6f9f8b3c"
+dependencies = [
+ "darling_core 0.12.4",
+ "darling_macro 0.12.4",
+]
+
+[[package]]
+name = "darling"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0808e1bd8671fb44a113a14e13497557533369847788fa2ae912b6ebfce9fa8"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.14.3",
+ "darling_macro 0.14.3",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e91455b86830a1c21799d94524df0845183fa55bafd9aa137b01c7d1065fa36"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
 ]
 
 [[package]]
@@ -813,11 +852,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
+dependencies = [
+ "darling_core 0.12.4",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b36230598a2d5de7ec1c6f51f72d8a99a9208daff41de2084d06e3fd3ea56685"
 dependencies = [
- "darling_core",
+ "darling_core 0.14.3",
  "quote",
  "syn",
 ]
@@ -843,6 +893,37 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d13202debe11181040ae9063d739fa32cfcaaebe2275fe387703460ae2365b30"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e616858f6187ed828df7c64a6d71720d83767a7f19740b2d1b6fe6327b36e5"
+dependencies = [
+ "darling 0.12.4",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58a94ace95092c5acb1e97a7e846b310cfbd499652f72297da7493f618a98d73"
+dependencies = [
+ "derive_builder_core",
  "syn",
 ]
 
@@ -906,6 +987,19 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "env_logger"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
@@ -951,6 +1045,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1292,6 +1396,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1389,7 +1499,7 @@ dependencies = [
  "crossbeam-channel",
  "crossbeam-utils",
  "dashmap",
- "env_logger",
+ "env_logger 0.10.0",
  "indexmap",
  "is-terminal",
  "itoa",
@@ -1475,6 +1585,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kafka-protocol"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f73d62060373a9a181e2f1d927c42c1302f48fb72fb56e9493d8349bf2398af"
+dependencies = [
+ "bytes",
+ "crc",
+ "derive_builder",
+ "env_logger 0.8.4",
+ "flate2",
+ "indexmap",
+ "log",
+ "paste",
+ "snap",
+ "string",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -2025,6 +2154,12 @@ dependencies = [
  "smallvec",
  "windows-sys 0.45.0",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
 
 [[package]]
 name = "pem"
@@ -2686,7 +2821,7 @@ dependencies = [
  "tokio",
  "tokio-openssl",
  "tracing",
- "uuid",
+ "uuid 1.3.0",
 ]
 
 [[package]]
@@ -2707,7 +2842,7 @@ dependencies = [
  "snap",
  "thiserror",
  "tokio",
- "uuid",
+ "uuid 1.3.0",
 ]
 
 [[package]]
@@ -2896,6 +3031,7 @@ dependencies = [
  "hex-literal",
  "hyper",
  "itertools",
+ "kafka-protocol",
  "metrics",
  "metrics-exporter-prometheus",
  "nix",
@@ -2928,7 +3064,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
- "uuid",
+ "uuid 1.3.0",
  "version-compare",
 ]
 
@@ -3007,6 +3143,15 @@ name = "str_stack"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
+
+[[package]]
+name = "string"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a984fb878618df5d8df7a476085310472dfd6eee03c5e4b35feb689066b1c1e6"
+dependencies = [
+ "bytes",
+]
 
 [[package]]
 name = "strsim"
@@ -3122,7 +3267,7 @@ dependencies = [
  "tokio-openssl",
  "tracing",
  "tracing-subscriber",
- "uuid",
+ "uuid 1.3.0",
 ]
 
 [[package]]
@@ -3545,6 +3690,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
 name = "uuid"

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -77,6 +77,7 @@ csv = "1.2.0"
 strum_macros = "0.24"
 chacha20poly1305 = { version = "0.10.0", features = ["std"] }
 generic-array = { version = "0.14", features = ["serde"] }
+kafka-protocol = "0.5.0"
 
 [dev-dependencies]
 criterion = { git = "https://github.com/shotover/criterion.rs", branch = "0.4.0-bench_with_input_fn", features = ["async_tokio"] }

--- a/shotover-proxy/src/codec/cassandra.rs
+++ b/shotover-proxy/src/codec/cassandra.rs
@@ -271,7 +271,7 @@ impl Encoder<Messages> for CassandraEncoder {
     ) -> std::result::Result<(), Self::Error> {
         for m in item {
             let start = dst.len();
-            let compression = m.codec_state.as_compression();
+            let compression = m.codec_state.as_cassandra();
 
             // TODO: always check if cassandra message
             match m.into_encodable(MessageType::Cassandra)? {

--- a/shotover-proxy/src/codec/mod.rs
+++ b/shotover-proxy/src/codec/mod.rs
@@ -1,5 +1,6 @@
 use crate::message::Messages;
 use cassandra_protocol::compression::Compression;
+use kafka::RequestHeader;
 use tokio_util::codec::{Decoder, Encoder};
 
 pub mod cassandra;
@@ -8,17 +9,30 @@ pub mod redis;
 
 #[derive(Debug, Clone, PartialEq, Copy)]
 pub enum CodecState {
-    Cassandra { compression: Compression },
+    Cassandra {
+        compression: Compression,
+    },
     Redis,
-    Kafka,
+    Kafka {
+        request_header: Option<RequestHeader>,
+    },
 }
 
 impl CodecState {
-    pub fn as_compression(&self) -> Compression {
+    pub fn as_cassandra(&self) -> Compression {
         match self {
             CodecState::Cassandra { compression } => *compression,
             _ => {
                 panic!("This is a {self:?}, expected CodecState::Cassandra")
+            }
+        }
+    }
+
+    pub fn as_kafka(&self) -> Option<RequestHeader> {
+        match self {
+            CodecState::Kafka { request_header } => *request_header,
+            _ => {
+                panic!("This is a {self:?}, expected CodecState::Kafka")
             }
         }
     }

--- a/shotover-proxy/src/frame/kafka.rs
+++ b/shotover-proxy/src/frame/kafka.rs
@@ -1,0 +1,129 @@
+use crate::codec::kafka::RequestHeader as CodecRequestHeader;
+use anyhow::{anyhow, Context, Result};
+use bytes::{BufMut, Bytes, BytesMut};
+use kafka_protocol::messages::{
+    ApiKey, ProduceRequest, ProduceResponse, RequestHeader, ResponseHeader,
+};
+use kafka_protocol::protocol::{Decodable, Encodable};
+
+// No way to know which version to use, just have to guess
+const REQUEST_HEADER_VERSION: i16 = 2;
+const RESPONSE_HEADER_VERSION: i16 = 1;
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum KafkaFrame {
+    Request {
+        header: RequestHeader,
+        body: RequestBody,
+    },
+    Response {
+        version: i16,
+        header: ResponseHeader,
+        body: ResponseBody,
+    },
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum RequestBody {
+    Produce(ProduceRequest),
+    Unknown { api_key: ApiKey, message: Bytes },
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum ResponseBody {
+    Produce(ProduceResponse),
+    Unknown { api_key: ApiKey, message: Bytes },
+}
+
+impl KafkaFrame {
+    pub fn from_bytes(
+        mut bytes: Bytes,
+        request_header: Option<CodecRequestHeader>,
+    ) -> Result<Self> {
+        // remove length header
+        let _ = bytes.split_to(4);
+
+        match request_header {
+            Some(request_header) => KafkaFrame::parse_response(bytes, request_header),
+            None => KafkaFrame::parse_request(bytes),
+        }
+    }
+
+    fn parse_request(mut bytes: Bytes) -> Result<Self> {
+        let header = RequestHeader::decode(&mut bytes, REQUEST_HEADER_VERSION)
+            .context("Failed to decode request header")?;
+
+        let api_key = ApiKey::try_from(header.request_api_key)
+            .map_err(|_| anyhow!("unknown api key {}", header.request_api_key))?;
+        let body = match api_key {
+            ApiKey::ProduceKey => RequestBody::Produce(
+                ProduceRequest::decode(&mut bytes, header.request_api_version)
+                    .context("Failed to decode request body")?,
+            ),
+            api_key => RequestBody::Unknown {
+                api_key,
+                message: bytes,
+            },
+        };
+
+        Ok(KafkaFrame::Request { header, body })
+    }
+
+    fn parse_response(mut bytes: Bytes, request_header: CodecRequestHeader) -> Result<Self> {
+        let header = ResponseHeader::decode(&mut bytes, RESPONSE_HEADER_VERSION)
+            .context("Failed to decode response header")?;
+
+        let body = match request_header.api_key {
+            ApiKey::ProduceKey => ResponseBody::Produce(
+                ProduceResponse::decode(&mut bytes, request_header.version)
+                    .context("Failed to decode response body")?,
+            ),
+            api_key => ResponseBody::Unknown {
+                api_key,
+                message: bytes,
+            },
+        };
+
+        Ok(KafkaFrame::Response {
+            version: request_header.version,
+            header,
+            body,
+        })
+    }
+
+    pub fn encode(self, bytes: &mut BytesMut) -> Result<()> {
+        // write dummy length
+        let length_start = bytes.len();
+        let bytes_start = length_start + 4;
+        bytes.put_i32(0);
+
+        // write message
+        match self {
+            KafkaFrame::Request { header, body } => {
+                header.encode(bytes, REQUEST_HEADER_VERSION)?;
+                let version = header.request_api_version;
+                match body {
+                    RequestBody::Produce(x) => x.encode(bytes, version)?,
+                    RequestBody::Unknown { message, .. } => bytes.extend_from_slice(&message),
+                }
+            }
+            KafkaFrame::Response {
+                version,
+                header,
+                body,
+            } => {
+                header.encode(bytes, RESPONSE_HEADER_VERSION)?;
+                match body {
+                    ResponseBody::Produce(x) => x.encode(bytes, version)?,
+                    ResponseBody::Unknown { message, .. } => bytes.extend_from_slice(&message),
+                }
+            }
+        }
+
+        // overwrite dummy length with actual length of serialized bytes
+        let bytes_len = bytes.len() - bytes_start;
+        bytes[length_start..bytes_start].copy_from_slice(&(bytes_len as i32).to_be_bytes());
+
+        Ok(())
+    }
+}

--- a/shotover-proxy/src/frame/mod.rs
+++ b/shotover-proxy/src/frame/mod.rs
@@ -130,7 +130,7 @@ impl Display for Frame {
         match self {
             Frame::Cassandra(frame) => write!(f, "Cassandra {}", frame),
             Frame::Redis(frame) => write!(f, "Redis {:?})", frame),
-            Frame::Kafka(frame) => write!(f, "Redis {:?})", frame),
+            Frame::Kafka(frame) => write!(f, "Kafka {:?})", frame),
         }
     }
 }

--- a/shotover-proxy/src/frame/mod.rs
+++ b/shotover-proxy/src/frame/mod.rs
@@ -3,10 +3,12 @@ use anyhow::{anyhow, Result};
 use bytes::Bytes;
 pub use cassandra::{CassandraFrame, CassandraOperation, CassandraResult};
 use cassandra_protocol::compression::Compression;
+use kafka::KafkaFrame;
 pub use redis_protocol::resp2::types::Frame as RedisFrame;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 pub mod cassandra;
+pub mod kafka;
 pub mod redis;
 
 #[derive(PartialEq, Debug, Clone, Copy)]
@@ -21,7 +23,7 @@ impl From<&ProtocolType> for MessageType {
         match value {
             ProtocolType::Cassandra { .. } => Self::Cassandra,
             ProtocolType::Redis => Self::Redis,
-            ProtocolType::Kafka => Self::Kafka,
+            ProtocolType::Kafka { .. } => Self::Kafka,
         }
     }
 }
@@ -33,6 +35,9 @@ impl Frame {
                 compression: Compression::None,
             },
             Frame::Redis(_) => CodecState::Redis,
+            Frame::Kafka(_) => CodecState::Kafka {
+                request_header: None,
+            },
         }
     }
 }
@@ -41,6 +46,7 @@ impl Frame {
 pub enum Frame {
     Cassandra(CassandraFrame),
     Redis(RedisFrame),
+    Kafka(KafkaFrame),
 }
 
 impl Frame {
@@ -51,13 +57,14 @@ impl Frame {
     ) -> Result<Self> {
         match message_type {
             MessageType::Cassandra => {
-                CassandraFrame::from_bytes(bytes, codec_state.as_compression())
-                    .map(Frame::Cassandra)
+                CassandraFrame::from_bytes(bytes, codec_state.as_cassandra()).map(Frame::Cassandra)
             }
             MessageType::Redis => redis_protocol::resp2::decode::decode(&bytes)
                 .map(|x| Frame::Redis(x.unwrap().0))
                 .map_err(|e| anyhow!("{e:?}")),
-            MessageType::Kafka => todo!(),
+            MessageType::Kafka => {
+                KafkaFrame::from_bytes(bytes, codec_state.as_kafka()).map(Frame::Kafka)
+            }
         }
     }
 
@@ -65,6 +72,7 @@ impl Frame {
         match self {
             Frame::Redis(_) => "Redis",
             Frame::Cassandra(_) => "Cassandra",
+            Frame::Kafka(_) => "Kafka",
         }
     }
 
@@ -72,6 +80,7 @@ impl Frame {
         match self {
             Frame::Cassandra(_) => MessageType::Cassandra,
             Frame::Redis(_) => MessageType::Redis,
+            Frame::Kafka(_) => MessageType::Kafka,
         }
     }
 
@@ -80,6 +89,16 @@ impl Frame {
             Frame::Redis(frame) => Ok(frame),
             frame => Err(anyhow!(
                 "Expected redis frame but received {} frame",
+                frame.name()
+            )),
+        }
+    }
+
+    pub fn into_kafka(self) -> Result<KafkaFrame> {
+        match self {
+            Frame::Kafka(frame) => Ok(frame),
+            frame => Err(anyhow!(
+                "Expected kafka frame but received {} frame",
                 frame.name()
             )),
         }
@@ -111,6 +130,7 @@ impl Display for Frame {
         match self {
             Frame::Cassandra(frame) => write!(f, "Cassandra {}", frame),
             Frame::Redis(frame) => write!(f, "Redis {:?})", frame),
+            Frame::Kafka(frame) => write!(f, "Redis {:?})", frame),
         }
     }
 }

--- a/shotover-proxy/src/sources/kafka.rs
+++ b/shotover-proxy/src/sources/kafka.rs
@@ -1,4 +1,4 @@
-use crate::codec::kafka::KafkaCodecBuilder;
+use crate::codec::kafka::{Direction, KafkaCodecBuilder};
 use crate::server::TcpCodecListener;
 use crate::sources::Sources;
 use crate::tls::{TlsAcceptor, TlsAcceptorConfig};
@@ -67,7 +67,7 @@ impl KafkaSource {
             name.to_string(),
             listen_addr.clone(),
             hard_connection_limit.unwrap_or(false),
-            KafkaCodecBuilder::new(),
+            KafkaCodecBuilder::new(Direction::Source),
             Arc::new(Semaphore::new(connection_limit.unwrap_or(512))),
             trigger_shutdown_rx.clone(),
             tls.map(TlsAcceptor::new).transpose()?,

--- a/shotover-proxy/src/transforms/kafka/sink_single.rs
+++ b/shotover-proxy/src/transforms/kafka/sink_single.rs
@@ -1,4 +1,4 @@
-use crate::codec::kafka::KafkaCodecBuilder;
+use crate::codec::kafka::{Direction, KafkaCodecBuilder};
 use crate::error::ChainResponse;
 use crate::message::Messages;
 use crate::tcp;
@@ -87,7 +87,7 @@ pub struct KafkaSinkSingle {
 impl Transform for KafkaSinkSingle {
     async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> ChainResponse {
         if self.outbound.is_none() {
-            let codec = KafkaCodecBuilder::new();
+            let codec = KafkaCodecBuilder::new(Direction::Sink);
             let tcp_stream = tcp::tcp_stream(self.connect_timeout, &self.address).await?;
             let (rx, tx) = tcp_stream.into_split();
             self.outbound = Some(spawn_read_write_tasks(&codec, rx, tx));

--- a/shotover-proxy/src/transforms/query_counter.rs
+++ b/shotover-proxy/src/transforms/query_counter.rs
@@ -42,6 +42,9 @@ impl Transform for QueryCounter {
                         counter!("query_count", 1, "name" => self.counter_name.clone(), "query" => "unknown", "type" => "redis");
                     }
                 }
+                Some(Frame::Kafka(_)) => {
+                    counter!("query_count", 1, "name" => self.counter_name.clone(), "query" => "unknown", "type" => "kafka");
+                }
                 None => {
                     counter!("query_count", 1, "name" => self.counter_name.clone(), "query" => "unknown", "type" => "none")
                 }
@@ -51,6 +54,7 @@ impl Transform for QueryCounter {
         message_wrapper.call_next_transform().await
     }
 }
+
 fn get_redis_query_type(frame: &RedisFrame) -> Option<String> {
     if let RedisFrame::Array(array) = frame {
         if let Some(RedisFrame::BulkString(v)) = array.get(0) {

--- a/shotover-proxy/tests/kafka_int_tests/mod.rs
+++ b/shotover-proxy/tests/kafka_int_tests/mod.rs
@@ -18,3 +18,19 @@ async fn passthrough() {
 
     shotover.shutdown_and_then_consume_events(&[]).await;
 }
+
+#[tokio::test]
+#[serial]
+async fn passthrough_encode() {
+    let _docker_compose =
+        DockerCompose::new("tests/test-configs/kafka/passthrough/docker-compose.yaml");
+    let shotover = ShotoverProcessBuilder::new_with_topology(
+        "tests/test-configs/kafka/passthrough/topology-encode.yaml",
+    )
+    .start()
+    .await;
+
+    test_cases::basic().await;
+
+    shotover.shutdown_and_then_consume_events(&[]).await;
+}

--- a/shotover-proxy/tests/test-configs/kafka/passthrough/topology-encode.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/passthrough/topology-encode.yaml
@@ -1,0 +1,15 @@
+---
+sources:
+  kafka_source:
+    Kafka:
+      listen_addr: "127.0.0.1:9192"
+chain_config:
+  main_chain:
+    - DebugForceEncode:
+        encode_requests: true
+        encode_responses: true
+    - KafkaSinkSingle:
+        remote_address: "127.0.0.1:9092"
+        connect_timeout_ms: 3000
+source_to_chain_mapping:
+  kafka_source: main_chain


### PR DESCRIPTION
as per my [writeup](https://github.com/shotover/shotover-proxy/issues/1006#issuecomment-1437669604), this PR gives an initial protocol implementation that we can start with.
I have no idea what the performance is like internally in the `kafka-protocol` crate but the code in the PR itself tries to be performant.

## kafka message overview

The spec does not give a good overview, so I'll give a quick one.
Every kafka message consists of: `size header` -> `message header` -> `message body`

* size header: every message starts with this simple header https://kafka.apache.org/protocol.html#protocol_common
* message header: A different header is used depending on if its a request or response - https://kafka.apache.org/protocol.html#protocol_messages
* message body: A different format is used depending on if its a request or response and on the api_key in the message_header: e.g. https://kafka.apache.org/protocol.html#The_Messages_Produce

## choices

unlike requests, kafka responses do not contain the message api_key or version.
So in order to get api_key+version for parsing a response you need to match it up with its corresponding request.
This is easily done because kafka does not support out of order messaging, so we just rely on matching up the order of messages.
To perform this matching up in shotover I've setup the codec to send the api_key+version from encoder to the decoder when its used as a sink. (when its a sink the encoder always has the requests and the decoder always has the responses)
Then the decoder includes the api_key+version in the messages codec state field so it can be used by the `.frame()` parser later on.

I've kept the logic for stripping the message size in the frame because every other protocol deals with that in the frame, but the kafka protocol would uniquely allow for us to actually handle that at the codec stage if we wanted to.
It doesn't particularly matter either way though.

api_keys that we havent hooked up parsing for yet will just get stored as a `RequestBody::Unknown` / `ResponseBody::Unknown`, allowing them to silently and correctly pass through shotover.

## weird bits

I'm not sure whats up with those header versions, we basically have to assume everyone is using the latest version, there's no way to detect what header versions are in use (the version in the header is for the body not the header itself), seems like a bug in the spec.

There is some duplication in state between the RequestHeader and the RequestBody: the `request_api_key` and the RequestBody variant.
But I've chosen to leave that for now because this protocol implementation is likely to need vast changes in the future in order to get the performance we need.

## Future work

In the next PR I'll add parsing for receive messages, I havent added them in this PR because they'll need integration test changes.