### PR TITLE
CassandraConnectionBuilder

### DIFF
--- a/shotover-proxy/benches/benches/cassandra.rs
+++ b/shotover-proxy/benches/benches/cassandra.rs
@@ -2,7 +2,9 @@ use cassandra_cpp::{stmt, Session, Statement};
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::collections::HashMap;
 use test_helpers::cert::generate_cassandra_test_certs;
-use test_helpers::connection::cassandra::{CassandraConnection, CassandraDriver};
+use test_helpers::connection::cassandra::{
+    CassandraConnection, CassandraConnectionBuilder, CassandraDriver,
+};
 use test_helpers::docker_compose::DockerCompose;
 use test_helpers::lazy::new_lazy_shared;
 use test_helpers::shotover_process::{BinProcess, ShotoverProcessBuilder};
@@ -286,7 +288,8 @@ impl BenchResources {
             tokio.block_on(ShotoverProcessBuilder::new_with_topology(shotover_topology).start()),
         );
 
-        let connection = tokio.block_on(CassandraConnection::new("127.0.0.1", 9042, DRIVER));
+        let connection =
+            tokio.block_on(CassandraConnectionBuilder::new("127.0.0.1", 9042, DRIVER).build());
 
         let mut bench_resources = Self {
             _compose: compose,
@@ -316,12 +319,11 @@ impl BenchResources {
 
         let ca_cert = "example-configs/docker-images/cassandra-tls-4.0.6/certs/localhost_CA.crt";
 
-        let connection = tokio.block_on(CassandraConnection::new_tls(
-            "127.0.0.1",
-            9042,
-            ca_cert,
-            DRIVER,
-        ));
+        let connection = tokio.block_on(
+            CassandraConnectionBuilder::new("127.0.0.1", 9042, DRIVER)
+                .with_tls(ca_cert)
+                .build(),
+        );
 
         let mut bench_resources = Self {
             _compose: compose,

--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -10,8 +10,8 @@ use serial_test::serial;
 use test_helpers::connection::cassandra::CassandraDriver::Datastax;
 use test_helpers::connection::cassandra::Compression;
 use test_helpers::connection::cassandra::{
-    assert_query_result, run_query, CassandraConnection, CassandraDriver,
-    CassandraDriver::CdrsTokio, CassandraDriver::Scylla, ResultValue,
+    assert_query_result, run_query, CassandraConnection, CassandraConnectionBuilder,
+    CassandraDriver, CassandraDriver::CdrsTokio, CassandraDriver::Scylla, ResultValue,
 };
 use test_helpers::connection::redis_connection;
 use test_helpers::docker_compose::DockerCompose;
@@ -67,7 +67,7 @@ async fn passthrough_standard(#[case] driver: CassandraDriver) {
     .start()
     .await;
 
-    let connection = || CassandraConnection::new("127.0.0.1", 9042, driver);
+    let connection = || CassandraConnectionBuilder::new("127.0.0.1", 9042, driver).build();
 
     standard_test_suite(&connection, driver).await;
 
@@ -89,7 +89,7 @@ async fn passthrough_encode(#[case] driver: CassandraDriver) {
     .start()
     .await;
 
-    let connection = || CassandraConnection::new("127.0.0.1", 9042, driver);
+    let connection = || CassandraConnectionBuilder::new("127.0.0.1", 9042, driver).build();
 
     standard_test_suite(&connection, driver).await;
 
@@ -115,8 +115,10 @@ async fn source_tls_and_single_tls(#[case] driver: CassandraDriver) {
 
     {
         // Run a quick test straight to Cassandra to check our assumptions that Shotover and Cassandra TLS are behaving exactly the same
-        let direct_connection =
-            CassandraConnection::new_tls("127.0.0.1", 9042, ca_cert, driver).await;
+        let direct_connection = CassandraConnectionBuilder::new("127.0.0.1", 9042, driver)
+            .with_tls(ca_cert)
+            .build()
+            .await;
         assert_query_result(
             &direct_connection,
             "SELECT bootstrapped FROM system.local",
@@ -125,7 +127,11 @@ async fn source_tls_and_single_tls(#[case] driver: CassandraDriver) {
         .await;
     }
 
-    let connection = || CassandraConnection::new_tls("127.0.0.1", 9043, ca_cert, driver);
+    let connection = || {
+        CassandraConnectionBuilder::new("127.0.0.1", 9043, driver)
+            .with_tls(ca_cert)
+            .build()
+    };
 
     standard_test_suite(&connection, driver).await;
 
@@ -149,7 +155,9 @@ async fn cluster_single_rack_v3(#[case] driver: CassandraDriver) {
         .await;
 
         let connection = || async {
-            let mut connection = CassandraConnection::new("127.0.0.1", 9042, driver).await;
+            let mut connection = CassandraConnectionBuilder::new("127.0.0.1", 9042, driver)
+                .build()
+                .await;
             connection
                 .enable_schema_awaiter("172.16.1.2:9042", None)
                 .await;
@@ -179,7 +187,9 @@ async fn cluster_single_rack_v4(#[case] driver: CassandraDriver) {
     let compose = DockerCompose::new("example-configs/cassandra-cluster-v4/docker-compose.yaml");
 
     let connection = || async {
-        let mut connection = CassandraConnection::new("127.0.0.1", 9042, driver).await;
+        let mut connection = CassandraConnectionBuilder::new("127.0.0.1", 9042, driver)
+            .build()
+            .await;
         connection
             .enable_schema_awaiter("172.16.1.2:9044", None)
             .await;
@@ -198,7 +208,9 @@ async fn cluster_single_rack_v4(#[case] driver: CassandraDriver) {
         routing::test("127.0.0.1", 9042, "172.16.1.2", 9044, driver).await;
 
         //Check for bugs in cross connection state
-        let mut connection2 = CassandraConnection::new("127.0.0.1", 9042, driver).await;
+        let mut connection2 = CassandraConnectionBuilder::new("127.0.0.1", 9042, driver)
+            .build()
+            .await;
         connection2
             .enable_schema_awaiter("172.16.1.2:9044", None)
             .await;
@@ -293,7 +305,9 @@ async fn cluster_multi_rack(#[case] driver: CassandraDriver) {
         .await;
 
         let connection = || async {
-            let mut connection = CassandraConnection::new("127.0.0.1", 9042, driver).await;
+            let mut connection = CassandraConnectionBuilder::new("127.0.0.1", 9042, driver)
+                .build()
+                .await;
             connection
                 .enable_schema_awaiter("172.16.1.2:9042", None)
                 .await;
@@ -345,8 +359,10 @@ async fn source_tls_and_cluster_tls(#[case] driver: CassandraDriver) {
 
         {
             // Run a quick test straight to Cassandra to check our assumptions that Shotover and Cassandra TLS are behaving exactly the same
-            let direct_connection =
-                CassandraConnection::new_tls("172.16.1.2", 9042, ca_cert, driver).await;
+            let direct_connection = CassandraConnectionBuilder::new("172.16.1.2", 9042, driver)
+                .with_tls(ca_cert)
+                .build()
+                .await;
             assert_query_result(
                 &direct_connection,
                 "SELECT bootstrapped FROM system.local",
@@ -356,8 +372,10 @@ async fn source_tls_and_cluster_tls(#[case] driver: CassandraDriver) {
         }
 
         let connection = || async {
-            let mut connection =
-                CassandraConnection::new_tls("127.0.0.1", 9042, ca_cert, driver).await;
+            let mut connection = CassandraConnectionBuilder::new("127.0.0.1", 9042, driver)
+                .with_tls(ca_cert)
+                .build()
+                .await;
             connection
                 .enable_schema_awaiter("172.16.1.2:9042", Some(ca_cert))
                 .await;
@@ -389,7 +407,7 @@ async fn cassandra_redis_cache(#[case] driver: CassandraDriver) {
     .await;
 
     let mut redis_connection = redis_connection::new(6379);
-    let connection_creator = || CassandraConnection::new("127.0.0.1", 9042, driver);
+    let connection_creator = || CassandraConnectionBuilder::new("127.0.0.1", 9042, driver).build();
     let connection = connection_creator().await;
 
     keyspace::test(&connection).await;
@@ -420,8 +438,10 @@ async fn protect_transform_local(#[case] driver: CassandraDriver) {
     .start()
     .await;
 
-    let shotover_connection = || CassandraConnection::new("127.0.0.1", 9042, driver);
-    let direct_connection = CassandraConnection::new("127.0.0.1", 9043, driver).await;
+    let shotover_connection = || CassandraConnectionBuilder::new("127.0.0.1", 9042, driver).build();
+    let direct_connection = CassandraConnectionBuilder::new("127.0.0.1", 9043, driver)
+        .build()
+        .await;
 
     standard_test_suite(shotover_connection, driver).await;
     protect::test(&shotover_connection().await, &direct_connection).await;
@@ -445,8 +465,10 @@ async fn protect_transform_aws(#[case] driver: CassandraDriver) {
     .start()
     .await;
 
-    let shotover_connection = || CassandraConnection::new("127.0.0.1", 9042, driver);
-    let direct_connection = CassandraConnection::new("127.0.0.1", 9043, driver).await;
+    let shotover_connection = || CassandraConnectionBuilder::new("127.0.0.1", 9042, driver).build();
+    let direct_connection = CassandraConnectionBuilder::new("127.0.0.1", 9043, driver)
+        .build()
+        .await;
 
     standard_test_suite(shotover_connection, driver).await;
     protect::test(&shotover_connection().await, &direct_connection).await;
@@ -471,8 +493,12 @@ async fn peers_rewrite_v4(#[case] driver: CassandraDriver) {
     .start()
     .await;
 
-    let normal_connection = CassandraConnection::new("127.0.0.1", 9043, driver).await;
-    let rewrite_port_connection = CassandraConnection::new("127.0.0.1", 9044, driver).await;
+    let normal_connection = CassandraConnectionBuilder::new("127.0.0.1", 9043, driver)
+        .build()
+        .await;
+    let rewrite_port_connection = CassandraConnectionBuilder::new("127.0.0.1", 9044, driver)
+        .build()
+        .await;
 
     // run some basic tests to confirm it works as normal
     table::test(&normal_connection).await;
@@ -569,7 +595,9 @@ async fn peers_rewrite_v3(#[case] driver: CassandraDriver) {
     .start()
     .await;
 
-    let connection = CassandraConnection::new("127.0.0.1", 9044, driver).await;
+    let connection = CassandraConnectionBuilder::new("127.0.0.1", 9044, driver)
+        .build()
+        .await;
     // run some basic tests to confirm it works as normal
     table::test(&connection).await;
 
@@ -604,9 +632,13 @@ async fn request_throttling(#[case] driver: CassandraDriver) {
     .start()
     .await;
 
-    let connection = CassandraConnection::new("127.0.0.1", 9042, driver).await;
+    let connection = CassandraConnectionBuilder::new("127.0.0.1", 9042, driver)
+        .build()
+        .await;
     std::thread::sleep(std::time::Duration::from_secs(1)); // sleep to reset the window and not trigger the rate limiter with client's startup reqeusts
-    let connection_2 = CassandraConnection::new("127.0.0.1", 9042, driver).await;
+    let connection_2 = CassandraConnectionBuilder::new("127.0.0.1", 9042, driver)
+        .build()
+        .await;
     std::thread::sleep(std::time::Duration::from_secs(1)); // sleep to reset the window again
 
     let statement = "SELECT * FROM system.peers";
@@ -704,8 +736,11 @@ async fn compression_single(#[case] driver: CassandraDriver) {
         let shotover = ShotoverProcessBuilder::new_with_topology(topology_path)
             .start()
             .await;
-        let connection =
-            || CassandraConnection::new_with_compression("127.0.0.1", 9042, driver, compression);
+        let connection = || {
+            CassandraConnectionBuilder::new("127.0.0.1", 9042, driver)
+                .with_compression(compression)
+                .build()
+        };
 
         standard_test_suite(connection, driver).await;
 
@@ -735,9 +770,10 @@ async fn compression_cluster(#[case] driver: CassandraDriver) {
             .start()
             .await;
         let connection = || async {
-            let mut connection =
-                CassandraConnection::new_with_compression("127.0.0.1", 9042, driver, compression)
-                    .await;
+            let mut connection = CassandraConnectionBuilder::new("127.0.0.1", 9042, driver)
+                .with_compression(compression)
+                .build()
+                .await;
             connection
                 .enable_schema_awaiter("172.16.1.2:9044", None)
                 .await;
@@ -771,7 +807,9 @@ async fn events_keyspace(#[case] driver: CassandraDriver) {
     .start()
     .await;
 
-    let connection = CassandraConnection::new("127.0.0.1", 9042, driver).await;
+    let connection = CassandraConnectionBuilder::new("127.0.0.1", 9042, driver)
+        .build()
+        .await;
 
     let mut event_recv = connection.as_cdrs().create_event_receiver();
 

--- a/shotover-proxy/tests/cassandra_int_tests/routing.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/routing.rs
@@ -1,4 +1,4 @@
-use test_helpers::connection::cassandra::{CassandraConnection, CassandraDriver};
+use test_helpers::connection::cassandra::{CassandraConnectionBuilder, CassandraDriver};
 
 mod single_key {
     use test_helpers::connection::cassandra::{run_query, CassandraConnection, ResultValue};
@@ -401,7 +401,9 @@ pub async fn test(
 
     if run {
         let mut shotover =
-            CassandraConnection::new(shotover_contact_point, shotover_port, driver).await;
+            CassandraConnectionBuilder::new(shotover_contact_point, shotover_port, driver)
+                .build()
+                .await;
         shotover
             .enable_schema_awaiter(
                 &format!("{}:{}", cassandra_contact_point, cassandra_port),
@@ -409,7 +411,9 @@ pub async fn test(
             )
             .await;
         let cassandra =
-            CassandraConnection::new(cassandra_contact_point, cassandra_port, driver).await;
+            CassandraConnectionBuilder::new(cassandra_contact_point, cassandra_port, driver)
+                .build()
+                .await;
 
         single_key::test(&shotover, &cassandra).await;
         composite_key::test(&shotover, &cassandra).await;

--- a/shotover-proxy/tests/examples/mod.rs
+++ b/shotover-proxy/tests/examples/mod.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "cassandra-cpp-driver-tests")]
 use serial_test::serial;
 use test_helpers::connection::cassandra::{
-    assert_query_result, CassandraConnection, CassandraDriver, ResultValue,
+    assert_query_result, CassandraConnectionBuilder, CassandraDriver, ResultValue,
 };
 use test_helpers::docker_compose::DockerCompose;
 
@@ -11,7 +11,9 @@ async fn test_cassandra_rewrite_peers_example() {
     let _docker_compose =
         DockerCompose::new("example-configs-docker/cassandra-peers-rewrite/docker-compose.yaml");
 
-    let connection = CassandraConnection::new("172.16.1.2", 9043, CassandraDriver::Datastax).await;
+    let connection = CassandraConnectionBuilder::new("172.16.1.2", 9043, CassandraDriver::Datastax)
+        .build()
+        .await;
 
     assert_query_result(
         &connection,

--- a/test-helpers/src/connection/cassandra.rs
+++ b/test-helpers/src/connection/cassandra.rs
@@ -43,6 +43,79 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::timeout;
 
+pub struct CassandraConnectionBuilder {
+    contact_points: String,
+    port: u16,
+    driver: CassandraDriver,
+    ca_cert_path: Option<String>,
+    compression: Option<Compression>,
+    protocol_version: ProtocolVersion,
+}
+
+impl CassandraConnectionBuilder {
+    pub fn new(contact_points: &str, port: u16, driver: CassandraDriver) -> Self {
+        Self {
+            contact_points: contact_points.into(),
+            port,
+            driver,
+            ca_cert_path: None,
+            compression: None,
+            protocol_version: ProtocolVersion::V4,
+        }
+    }
+
+    pub fn with_tls(mut self, ca_cert_path: &str) -> Self {
+        self.ca_cert_path = Some(ca_cert_path.into());
+        self
+    }
+
+    pub fn with_compression(mut self, compression: Compression) -> Self {
+        self.compression = Some(compression);
+        self
+    }
+
+    pub fn with_protocol_version(mut self, protocol_version: ProtocolVersion) -> Self {
+        self.protocol_version = protocol_version;
+        self
+    }
+
+    pub async fn build(self) -> CassandraConnection {
+        let tls = if let Some(ca_cert_path) = self.ca_cert_path {
+            match self.driver {
+                #[cfg(feature = "cassandra-cpp-driver-tests")]
+                CassandraDriver::Datastax => {
+                    let ca_cert = read_to_string(ca_cert_path).unwrap();
+                    let mut ssl = Ssl::default();
+                    Ssl::add_trusted_cert(&mut ssl, &ca_cert).unwrap();
+
+                    Some(Tls::Datastax(ssl))
+                }
+                // TODO actually implement TLS for cdrs-tokio
+                CassandraDriver::CdrsTokio => todo!(),
+                CassandraDriver::Scylla => {
+                    let mut context = SslContext::builder(SslMethod::tls()).unwrap();
+                    context.set_ca_file(ca_cert_path).unwrap();
+                    let ssl_context = context.build();
+
+                    Some(Tls::Scylla(ssl_context))
+                }
+            }
+        } else {
+            None
+        };
+
+        CassandraConnection::new(
+            &self.contact_points,
+            self.port,
+            self.driver,
+            self.compression,
+            tls,
+            self.protocol_version,
+        )
+        .await
+    }
+}
+
 #[derive(Debug)]
 pub enum PreparedQuery {
     #[cfg(feature = "cassandra-cpp-driver-tests")]
@@ -81,7 +154,14 @@ pub enum Compression {
     Lz4,
 }
 
-enum Tls {
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub enum ProtocolVersion {
+    V3,
+    V4,
+    V5,
+}
+
+pub enum Tls {
     #[cfg(feature = "cassandra-cpp-driver-tests")]
     Datastax(Ssl),
     Scylla(SslContext),
@@ -118,66 +198,13 @@ pub enum CassandraConnection {
 }
 
 impl CassandraConnection {
-    pub async fn new(contact_points: &str, port: u16, driver: CassandraDriver) -> Self {
-        CassandraConnection::new_inner(contact_points, port, driver, None, None).await
-    }
-
-    pub async fn new_tls(
-        contact_points: &str,
-        port: u16,
-        ca_cert_path: &str,
-        driver: CassandraDriver,
-    ) -> Self {
-        match driver {
-            #[cfg(feature = "cassandra-cpp-driver-tests")]
-            CassandraDriver::Datastax => {
-                let ca_cert = read_to_string(ca_cert_path).unwrap();
-                let mut ssl = Ssl::default();
-                Ssl::add_trusted_cert(&mut ssl, &ca_cert).unwrap();
-
-                CassandraConnection::new_inner(
-                    contact_points,
-                    port,
-                    driver,
-                    None,
-                    Some(Tls::Datastax(ssl)),
-                )
-                .await
-            }
-            // TODO actually implement TLS for cdrs-tokio
-            CassandraDriver::CdrsTokio => todo!(),
-            CassandraDriver::Scylla => {
-                let mut context = SslContext::builder(SslMethod::tls()).unwrap();
-                context.set_ca_file(ca_cert_path).unwrap();
-                let ssl_context = context.build();
-
-                CassandraConnection::new_inner(
-                    contact_points,
-                    port,
-                    driver,
-                    None,
-                    Some(Tls::Scylla(ssl_context)),
-                )
-                .await
-            }
-        }
-    }
-
-    pub async fn new_with_compression(
-        contact_points: &str,
-        port: u16,
-        driver: CassandraDriver,
-        compression: Compression,
-    ) -> Self {
-        CassandraConnection::new_inner(contact_points, port, driver, Some(compression), None).await
-    }
-
-    async fn new_inner(
+    pub async fn new(
         contact_points: &str,
         port: u16,
         driver: CassandraDriver,
         compression: Option<Compression>,
         tls: Option<Tls>,
+        protocol: ProtocolVersion,
     ) -> Self {
         for contact_point in contact_points.split(',') {
             crate::wait_for_socket_to_open(contact_point, port);
@@ -192,6 +219,17 @@ impl CassandraConnection {
                 cluster.set_credentials("cassandra", "cassandra").unwrap();
                 cluster.set_port(port).unwrap();
                 cluster.set_load_balance_round_robin();
+                cluster
+                    .set_protocol_version(match protocol {
+                        ProtocolVersion::V3 => 3,
+                        ProtocolVersion::V4 => 4,
+                        ProtocolVersion::V5 => 5,
+                    })
+                    .unwrap();
+
+                if compression.is_some() {
+                    panic!("Cannot set compression with Datastax driver");
+                }
 
                 if let Some(Tls::Datastax(mut ssl)) = tls {
                     cluster.set_ssl(&mut ssl);
@@ -223,6 +261,11 @@ impl CassandraConnection {
                     NodeTcpConfigBuilder::new()
                         .with_contact_points(node_addresses)
                         .with_authenticator_provider(Arc::new(auth))
+                        .with_version(match protocol {
+                            ProtocolVersion::V3 => Version::V3,
+                            ProtocolVersion::V4 => Version::V4,
+                            ProtocolVersion::V5 => Version::V5,
+                        })
                         .build(),
                 )
                 .await


### PR DESCRIPTION
Now that we have a bunch of different config options for the `CassandraConnection` helper it makes sense to use the builder pattern. This will make testing different combinations of protocol versions, compression and TLS easier.