### PR TITLE
Implement FindCoordinator rewriting (fixes clients connecting directly to kafka)

### DIFF
--- a/shotover-proxy/src/transforms/kafka/sink_single.rs
+++ b/shotover-proxy/src/transforms/kafka/sink_single.rs
@@ -1,5 +1,7 @@
 use crate::codec::kafka::{Direction, KafkaCodecBuilder};
 use crate::error::ChainResponse;
+use crate::frame::kafka::{KafkaFrame, ResponseBody};
+use crate::frame::Frame;
 use crate::message::Messages;
 use crate::tcp;
 use crate::transforms::util::cluster_connection_pool::{spawn_read_write_tasks, Connection};
@@ -111,11 +113,28 @@ impl Transform for KafkaSinkSingle {
         let responses = responses?;
 
         // TODO: since kafka will never send requests out of order I wonder if it would be faster to use an mpsc instead of a oneshot or maybe just directly run the sending/receiving here?
-        if let Some(read_timeout) = self.read_timeout {
+        let mut responses = if let Some(read_timeout) = self.read_timeout {
             timeout(read_timeout, read_responses(responses)).await?
         } else {
             read_responses(responses).await
+        }?;
+
+        for response in &mut responses {
+            if let Some(Frame::Kafka(KafkaFrame::Response {
+                body: ResponseBody::FindCoordinator(find_coordinator),
+                ..
+            })) = response.frame()
+            {
+                let port = message_wrapper.local_addr.port() as i32;
+                find_coordinator.port = port;
+                for coordinator in &mut find_coordinator.coordinators {
+                    coordinator.port = port;
+                }
+                response.invalidate_cache();
+            }
         }
+
+        Ok(responses)
     }
 
     fn is_terminating(&self) -> bool {

--- a/shotover-proxy/src/transforms/kafka/sink_single.rs
+++ b/shotover-proxy/src/transforms/kafka/sink_single.rs
@@ -119,6 +119,7 @@ impl Transform for KafkaSinkSingle {
             read_responses(responses).await
         }?;
 
+        // Rewrite FindCoordinator responses messages to use shotovers port instead of kafkas port
         for response in &mut responses {
             if let Some(Frame::Kafka(KafkaFrame::Response {
                 body: ResponseBody::FindCoordinator(find_coordinator),


### PR DESCRIPTION
KafkaSinkSingle works by having a shotover instance sit on the same address as every kafka instance.
The kafka instances all use one consistent port for communication to the client and shotover uses another consistent port for communication to the client.
It is up to shotover to rewrite any messages that refer to the kafka port to instead refer to the shotover port.

FindCoordinator is one such message, it contains ip address + ports of other kafka brokers that are acting as a coordinator
So this PR introduces parsing and rewriting of these messages which fixes our issue of the client connecting directly to kafka.

You can observe more messages are now flowing through shotover by setting the `tracing::debug`s to `tracing::info` in `codec/kafka.rs`

## a secondary issue
The hardcoded header versions were too high and causing parse failures, so I lowered them.
A proper solution to these headers is tracked by https://github.com/shotover/shotover-proxy/issues/1056
These bad header versions were getting past our tests because we werent actually parsing any messages before because the produce messages were bypassing shotover and going directly to kafka.
