### PR TITLE
Make TransformBuilder a trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,6 +972,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3024,6 +3030,7 @@ dependencies = [
  "criterion",
  "csv",
  "derivative",
+ "dyn-clone",
  "futures",
  "generic-array",
  "governor",

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -77,6 +77,7 @@ strum_macros = "0.24"
 chacha20poly1305 = { version = "0.10.0", features = ["std"] }
 generic-array = { version = "0.14", features = ["serde"] }
 kafka-protocol = "0.5.0"
+dyn-clone = "1.0.10"
 
 [dev-dependencies]
 criterion = { git = "https://github.com/shotover/criterion.rs", branch = "0.4.0-bench_with_input_fn", features = ["async_tokio"] }

--- a/shotover-proxy/benches/benches/chain.rs
+++ b/shotover-proxy/benches/benches/chain.rs
@@ -16,7 +16,7 @@ use shotover_proxy::transforms::protect::{KeyManagerConfig, ProtectConfig};
 use shotover_proxy::transforms::redis::cluster_ports_rewrite::RedisClusterPortsRewrite;
 use shotover_proxy::transforms::redis::timestamp_tagging::RedisTimestampTagger;
 use shotover_proxy::transforms::throttling::RequestThrottlingConfig;
-use shotover_proxy::transforms::{TransformBuilder, Wrapper};
+use shotover_proxy::transforms::Wrapper;
 
 fn criterion_benchmark(c: &mut Criterion) {
     let rt = tokio::runtime::Runtime::new().unwrap();
@@ -24,10 +24,8 @@ fn criterion_benchmark(c: &mut Criterion) {
     group.noise_threshold(0.2);
 
     {
-        let chain = TransformChainBuilder::new(
-            vec![TransformBuilder::NullSink(NullSink::default())],
-            "bench".to_string(),
-        );
+        let chain =
+            TransformChainBuilder::new(vec![Box::<NullSink>::default()], "bench".to_string());
         let wrapper = Wrapper::new_with_chain_name(
             vec![Message::from_frame(Frame::Redis(RedisFrame::Null))],
             chain.name.clone(),
@@ -50,10 +48,10 @@ fn criterion_benchmark(c: &mut Criterion) {
     {
         let chain = TransformChainBuilder::new(
             vec![
-                TransformBuilder::QueryTypeFilter(QueryTypeFilter {
+                Box::new(QueryTypeFilter {
                     filter: QueryType::Read,
                 }),
-                TransformBuilder::DebugReturner(DebugReturner::new(Response::Redis("a".into()))),
+                Box::new(DebugReturner::new(Response::Redis("a".into()))),
             ],
             "bench".to_string(),
         );
@@ -89,8 +87,8 @@ fn criterion_benchmark(c: &mut Criterion) {
     {
         let chain = TransformChainBuilder::new(
             vec![
-                TransformBuilder::RedisTimestampTagger(RedisTimestampTagger::new()),
-                TransformBuilder::DebugReturner(DebugReturner::new(Response::Message(vec![
+                Box::new(RedisTimestampTagger::new()),
+                Box::new(DebugReturner::new(Response::Message(vec![
                     Message::from_frame(Frame::Redis(RedisFrame::Array(vec![
                         RedisFrame::BulkString(Bytes::from_static(b"1")), // real frame
                         RedisFrame::BulkString(Bytes::from_static(b"1")), // timestamp
@@ -146,8 +144,8 @@ fn criterion_benchmark(c: &mut Criterion) {
     {
         let chain = TransformChainBuilder::new(
             vec![
-                TransformBuilder::RedisClusterPortsRewrite(RedisClusterPortsRewrite::new(2004)),
-                TransformBuilder::NullSink(NullSink::default()),
+                Box::new(RedisClusterPortsRewrite::new(2004)),
+                Box::<NullSink>::default(),
             ],
             "bench".to_string(),
         );
@@ -177,15 +175,13 @@ fn criterion_benchmark(c: &mut Criterion) {
     {
         let chain = TransformChainBuilder::new(
             vec![
-                rt.block_on(
-                    RequestThrottlingConfig {
-                        // an absurdly large value is given so that all messages will pass through
-                        max_requests_per_second: std::num::NonZeroU32::new(100_000_000).unwrap(),
-                    }
-                    .get_builder(),
-                )
+                RequestThrottlingConfig {
+                    // an absurdly large value is given so that all messages will pass through
+                    max_requests_per_second: std::num::NonZeroU32::new(100_000_000).unwrap(),
+                }
+                .get_builder()
                 .unwrap(),
-                TransformBuilder::NullSink(NullSink::default()),
+                Box::<NullSink>::default(),
             ],
             "bench".to_string(),
         );
@@ -223,8 +219,8 @@ fn criterion_benchmark(c: &mut Criterion) {
     {
         let chain = TransformChainBuilder::new(
             vec![
-                TransformBuilder::CassandraPeersRewrite(CassandraPeersRewrite::new(9042)),
-                TransformBuilder::NullSink(NullSink::default()),
+                Box::new(CassandraPeersRewrite::new(9042)),
+                Box::<NullSink>::default(),
             ],
             "bench".into(),
         );
@@ -297,7 +293,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     .get_builder(),
                 )
                 .unwrap(),
-                TransformBuilder::NullSink(NullSink::default()),
+                Box::<NullSink>::default(),
             ],
             "bench".into(),
         );

--- a/shotover-proxy/src/config/topology.rs
+++ b/shotover-proxy/src/config/topology.rs
@@ -120,8 +120,7 @@ impl Topology {
 
 #[cfg(test)]
 mod topology_tests {
-    use tokio::sync::watch;
-
+    use crate::config::topology::{Topology, TopologyConfig};
     use crate::transforms::coalesce::CoalesceConfig;
     use crate::{
         sources::{redis_source::RedisConfig, Sources, SourcesConfig},
@@ -132,8 +131,7 @@ mod topology_tests {
         },
     };
     use std::{collections::HashMap, fs};
-
-    use super::{Topology, TopologyConfig};
+    use tokio::sync::watch;
 
     async fn run_test_topology(chain: Vec<TransformsConfig>) -> anyhow::Result<Vec<Sources>> {
         let mut chain_config = HashMap::new();
@@ -355,7 +353,7 @@ redis_chain:
     async fn test_validate_chain_invalid_subchain_redis_cache() {
         let expected = r#"Topology errors
 redis_chain:
-  SimpleRedisCache:
+  RedisCache:
     cache_chain:
       Terminating transform "NullSink" is not last in chain. Terminating transform must be last in chain.
 "#;

--- a/shotover-proxy/src/transforms/cassandra/peers_rewrite.rs
+++ b/shotover-proxy/src/transforms/cassandra/peers_rewrite.rs
@@ -2,6 +2,7 @@ use crate::frame::{CassandraOperation, CassandraResult, Frame};
 use crate::message::Message;
 use crate::message_value::{IntSize, MessageValue};
 use crate::transforms::cassandra::peers_rewrite::CassandraOperation::Event;
+use crate::transforms::Transforms;
 use crate::{
     error::ChainResponse,
     transforms::{Transform, TransformBuilder, Wrapper},
@@ -20,10 +21,8 @@ pub struct CassandraPeersRewriteConfig {
 }
 
 impl CassandraPeersRewriteConfig {
-    pub async fn get_builder(&self) -> Result<TransformBuilder> {
-        Ok(TransformBuilder::CassandraPeersRewrite(
-            CassandraPeersRewrite::new(self.port),
-        ))
+    pub async fn get_builder(&self) -> Result<Box<dyn TransformBuilder>> {
+        Ok(Box::new(CassandraPeersRewrite::new(self.port)))
     }
 }
 
@@ -39,6 +38,16 @@ impl CassandraPeersRewrite {
             port,
             peer_table: FQName::new("system", "peers_v2"),
         }
+    }
+}
+
+impl TransformBuilder for CassandraPeersRewrite {
+    fn build(&self) -> Transforms {
+        Transforms::CassandraPeersRewrite(self.clone())
+    }
+
+    fn get_name(&self) -> &'static str {
+        "CassandraPeersRewrite"
     }
 }
 

--- a/shotover-proxy/src/transforms/cassandra/sink_cluster/mod.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_cluster/mod.rs
@@ -6,7 +6,7 @@ use crate::message::{Message, Messages, Metadata};
 use crate::message_value::{IntSize, MessageValue};
 use crate::tls::{TlsConnector, TlsConnectorConfig};
 use crate::transforms::cassandra::connection::{CassandraConnection, Response};
-use crate::transforms::{Transform, TransformBuilder, Wrapper};
+use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use cassandra_protocol::events::ServerEvent;
@@ -80,7 +80,7 @@ pub struct CassandraSinkClusterConfig {
 }
 
 impl CassandraSinkClusterConfig {
-    pub async fn get_builder(&self, chain_name: String) -> Result<TransformBuilder> {
+    pub async fn get_builder(&self, chain_name: String) -> Result<Box<dyn TransformBuilder>> {
         let tls = self.tls.clone().map(TlsConnector::new).transpose()?;
         let mut shotover_nodes = self.shotover_nodes.clone();
         let index = self
@@ -95,16 +95,14 @@ impl CassandraSinkClusterConfig {
             })?;
         let local_node = shotover_nodes.remove(index);
 
-        Ok(TransformBuilder::CassandraSinkCluster(Box::new(
-            CassandraSinkClusterBuilder::new(
-                self.first_contact_points.clone(),
-                shotover_nodes,
-                chain_name,
-                local_node,
-                tls,
-                self.connect_timeout_ms,
-                self.read_timeout,
-            ),
+        Ok(Box::new(CassandraSinkClusterBuilder::new(
+            self.first_contact_points.clone(),
+            shotover_nodes,
+            chain_name,
+            local_node,
+            tls,
+            self.connect_timeout_ms,
+            self.read_timeout,
         )))
     }
 }
@@ -164,17 +162,11 @@ impl CassandraSinkClusterBuilder {
             pool: NodePoolBuilder::new(chain_name),
         }
     }
+}
 
-    pub fn validate(&self) -> Vec<String> {
-        vec![]
-    }
-
-    pub fn is_terminating(&self) -> bool {
-        true
-    }
-
-    pub fn build(&self) -> Box<CassandraSinkCluster> {
-        Box::new(CassandraSinkCluster {
+impl TransformBuilder for CassandraSinkClusterBuilder {
+    fn build(&self) -> crate::transforms::Transforms {
+        Transforms::CassandraSinkCluster(Box::new(CassandraSinkCluster {
             contact_points: self.contact_points.clone(),
             shotover_peers: self.shotover_peers.clone(),
             control_connection: None,
@@ -192,7 +184,15 @@ impl CassandraSinkClusterBuilder {
             keyspaces_rx: self.keyspaces_rx.clone(),
             rng: SmallRng::from_rng(rand::thread_rng()).unwrap(),
             task_handshake_tx: self.task_handshake_tx.clone(),
-        })
+        }))
+    }
+
+    fn get_name(&self) -> &'static str {
+        "CassandraSinkCluster"
+    }
+
+    fn is_terminating(&self) -> bool {
+        true
     }
 }
 

--- a/shotover-proxy/src/transforms/chain.rs
+++ b/shotover-proxy/src/transforms/chain.rs
@@ -201,7 +201,7 @@ impl TransformChain {
 #[derivative(Debug, Clone)]
 pub struct TransformChainBuilder {
     pub name: String,
-    pub chain: Vec<TransformBuilder>,
+    pub chain: Vec<Box<dyn TransformBuilder>>,
 
     #[derivative(Debug = "ignore")]
     chain_total: Counter,
@@ -210,7 +210,7 @@ pub struct TransformChainBuilder {
 }
 
 impl TransformChainBuilder {
-    pub fn new(chain: Vec<TransformBuilder>, name: String) -> Self {
+    pub fn new(chain: Vec<Box<dyn TransformBuilder>>, name: String) -> Self {
         for transform in &chain {
             register_counter!("shotover_transform_total", "transform" => transform.get_name());
             register_counter!("shotover_transform_failures", "transform" => transform.get_name());
@@ -381,7 +381,6 @@ mod chain_tests {
     use crate::transforms::chain::TransformChainBuilder;
     use crate::transforms::debug::printer::DebugPrinter;
     use crate::transforms::null::NullSink;
-    use crate::transforms::TransformBuilder;
 
     #[tokio::test]
     async fn test_validate_invalid_chain() {
@@ -396,9 +395,9 @@ mod chain_tests {
     async fn test_validate_valid_chain() {
         let chain = TransformChainBuilder::new(
             vec![
-                TransformBuilder::DebugPrinter(DebugPrinter::new()),
-                TransformBuilder::DebugPrinter(DebugPrinter::new()),
-                TransformBuilder::NullSink(NullSink::default()),
+                Box::<DebugPrinter>::default(),
+                Box::<DebugPrinter>::default(),
+                Box::<NullSink>::default(),
             ],
             "test-chain".to_string(),
         );

--- a/shotover-proxy/src/transforms/debug/force_parse.rs
+++ b/shotover-proxy/src/transforms/debug/force_parse.rs
@@ -5,7 +5,7 @@
 /// without worrying about the performance impact of other transform logic.
 /// It could also be used to ensure that messages round trip correctly when parsed.
 use crate::error::ChainResponse;
-use crate::transforms::{Transform, TransformBuilder, Wrapper};
+use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
 use serde::Deserialize;
@@ -19,8 +19,8 @@ pub struct DebugForceParseConfig {
 }
 
 impl DebugForceParseConfig {
-    pub async fn get_builder(&self) -> Result<TransformBuilder> {
-        Ok(TransformBuilder::DebugForceParse(DebugForceParse {
+    pub async fn get_builder(&self) -> Result<Box<dyn TransformBuilder>> {
+        Ok(Box::new(DebugForceParse {
             parse_requests: self.parse_requests,
             parse_responses: self.parse_responses,
             encode_requests: false,
@@ -38,8 +38,8 @@ pub struct DebugForceEncodeConfig {
 }
 
 impl DebugForceEncodeConfig {
-    pub async fn get_builder(&self) -> Result<TransformBuilder> {
-        Ok(TransformBuilder::DebugForceParse(DebugForceParse {
+    pub async fn get_builder(&self) -> Result<Box<dyn TransformBuilder>> {
+        Ok(Box::new(DebugForceParse {
             parse_requests: self.encode_requests,
             parse_responses: self.encode_responses,
             encode_requests: self.encode_requests,
@@ -54,6 +54,16 @@ pub struct DebugForceParse {
     parse_responses: bool,
     encode_requests: bool,
     encode_responses: bool,
+}
+
+impl TransformBuilder for DebugForceParse {
+    fn build(&self) -> Transforms {
+        Transforms::DebugForceParse(self.clone())
+    }
+
+    fn get_name(&self) -> &'static str {
+        "DebugForceParse"
+    }
 }
 
 #[async_trait]

--- a/shotover-proxy/src/transforms/debug/printer.rs
+++ b/shotover-proxy/src/transforms/debug/printer.rs
@@ -1,7 +1,7 @@
 use tracing::info;
 
 use crate::error::ChainResponse;
-use crate::transforms::{Transform, Wrapper};
+use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
 use async_trait::async_trait;
 
 #[derive(Debug, Clone)]
@@ -18,6 +18,16 @@ impl Default for DebugPrinter {
 impl DebugPrinter {
     pub fn new() -> DebugPrinter {
         DebugPrinter { counter: 0 }
+    }
+}
+
+impl TransformBuilder for DebugPrinter {
+    fn build(&self) -> Transforms {
+        Transforms::DebugPrinter(self.clone())
+    }
+
+    fn get_name(&self) -> &'static str {
+        "DebugPrinter"
     }
 }
 

--- a/shotover-proxy/src/transforms/filter.rs
+++ b/shotover-proxy/src/transforms/filter.rs
@@ -6,6 +6,8 @@ use async_trait::async_trait;
 use serde::Deserialize;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use super::Transforms;
+
 static SHOWN_ERROR: AtomicBool = AtomicBool::new(false);
 
 #[derive(Debug, Clone)]
@@ -19,10 +21,20 @@ pub struct QueryTypeFilterConfig {
 }
 
 impl QueryTypeFilterConfig {
-    pub async fn get_builder(&self) -> Result<TransformBuilder> {
-        Ok(TransformBuilder::QueryTypeFilter(QueryTypeFilter {
+    pub async fn get_builder(&self) -> Result<Box<dyn TransformBuilder>> {
+        Ok(Box::new(QueryTypeFilter {
             filter: self.filter.clone(),
         }))
+    }
+}
+
+impl TransformBuilder for QueryTypeFilter {
+    fn build(&self) -> Transforms {
+        Transforms::QueryTypeFilter(self.clone())
+    }
+
+    fn get_name(&self) -> &'static str {
+        "QueryTypeFilter"
     }
 }
 

--- a/shotover-proxy/src/transforms/loopback.rs
+++ b/shotover-proxy/src/transforms/loopback.rs
@@ -1,17 +1,27 @@
 use crate::error::ChainResponse;
-use crate::transforms::{Transform, Wrapper};
+use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
 use async_trait::async_trait;
 
 #[derive(Debug, Clone, Default)]
 pub struct Loopback {}
 
-#[async_trait]
-impl Transform for Loopback {
-    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> ChainResponse {
-        Ok(message_wrapper.messages)
+impl TransformBuilder for Loopback {
+    fn build(&self) -> Transforms {
+        Transforms::Loopback(self.clone())
+    }
+
+    fn get_name(&self) -> &'static str {
+        "Loopback"
     }
 
     fn is_terminating(&self) -> bool {
         true
+    }
+}
+
+#[async_trait]
+impl Transform for Loopback {
+    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> ChainResponse {
+        Ok(message_wrapper.messages)
     }
 }

--- a/shotover-proxy/src/transforms/mod.rs
+++ b/shotover-proxy/src/transforms/mod.rs
@@ -4,11 +4,9 @@ use crate::transforms::cassandra::peers_rewrite::{
     CassandraPeersRewrite, CassandraPeersRewriteConfig,
 };
 use crate::transforms::cassandra::sink_cluster::{
-    CassandraSinkCluster, CassandraSinkClusterBuilder, CassandraSinkClusterConfig,
+    CassandraSinkCluster, CassandraSinkClusterConfig,
 };
-use crate::transforms::cassandra::sink_single::{
-    CassandraSinkSingle, CassandraSinkSingleBuilder, CassandraSinkSingleConfig,
-};
+use crate::transforms::cassandra::sink_single::{CassandraSinkSingle, CassandraSinkSingleConfig};
 use crate::transforms::chain::TransformChainBuilder;
 use crate::transforms::coalesce::{Coalesce, CoalesceConfig};
 use crate::transforms::debug::force_parse::DebugForceParse;
@@ -18,36 +16,34 @@ use crate::transforms::debug::printer::DebugPrinter;
 use crate::transforms::debug::random_delay::DebugRandomDelay;
 use crate::transforms::debug::returner::{DebugReturner, DebugReturnerConfig};
 use crate::transforms::distributed::consistent_scatter::{
-    ConsistentScatter, ConsistentScatterBuilder, ConsistentScatterConfig,
+    ConsistentScatter, ConsistentScatterConfig,
 };
 use crate::transforms::filter::{QueryTypeFilter, QueryTypeFilterConfig};
+use crate::transforms::kafka::sink_single::KafkaSinkSingle;
 #[cfg(feature = "alpha-transforms")]
 use crate::transforms::kafka::sink_single::KafkaSinkSingleConfig;
-use crate::transforms::kafka::sink_single::{KafkaSinkSingle, KafkaSinkSingleBuilder};
-use crate::transforms::load_balance::{ConnectionBalanceAndPool, ConnectionBalanceAndPoolBuilder};
-#[cfg(test)]
+use crate::transforms::load_balance::ConnectionBalanceAndPool;
 use crate::transforms::loopback::Loopback;
 use crate::transforms::null::NullSink;
-use crate::transforms::parallel_map::{ParallelMap, ParallelMapBuilder, ParallelMapConfig};
+use crate::transforms::parallel_map::{ParallelMap, ParallelMapConfig};
 use crate::transforms::protect::Protect;
 #[cfg(feature = "alpha-transforms")]
 use crate::transforms::protect::ProtectConfig;
 use crate::transforms::query_counter::{QueryCounter, QueryCounterConfig};
-use crate::transforms::redis::cache::{RedisConfig, SimpleRedisCache, SimpleRedisCacheBuilder};
+use crate::transforms::redis::cache::{RedisConfig, SimpleRedisCache};
 use crate::transforms::redis::cluster_ports_rewrite::{
     RedisClusterPortsRewrite, RedisClusterPortsRewriteConfig,
 };
 use crate::transforms::redis::sink_cluster::{RedisSinkCluster, RedisSinkClusterConfig};
-use crate::transforms::redis::sink_single::{
-    RedisSinkSingle, RedisSinkSingleBuilder, RedisSinkSingleConfig,
-};
+use crate::transforms::redis::sink_single::{RedisSinkSingle, RedisSinkSingleConfig};
 use crate::transforms::redis::timestamp_tagging::RedisTimestampTagger;
-use crate::transforms::tee::{Tee, TeeBuilder, TeeConfig};
+use crate::transforms::tee::{Tee, TeeConfig};
 use crate::transforms::throttling::{RequestThrottling, RequestThrottlingConfig};
 use anyhow::{anyhow, Result};
 use async_recursion::async_recursion;
 use async_trait::async_trait;
 use core::fmt;
+use dyn_clone::DynClone;
 use futures::Future;
 use metrics::{counter, histogram};
 use serde::Deserialize;
@@ -83,140 +79,22 @@ pub mod util;
 // TODO: probably better, semantically, to have this not Clone.
 //       Fixing that is left to a followup PR though.
 //       It would also affect whether sources pointing into the same chain share state, which will require careful consideration
-#[derive(Clone, IntoStaticStr)]
-pub enum TransformBuilder {
-    KafkaSinkSingle(KafkaSinkSingleBuilder),
-    CassandraSinkSingle(CassandraSinkSingleBuilder),
-    CassandraSinkCluster(Box<CassandraSinkClusterBuilder>),
-    RedisSinkSingle(RedisSinkSingleBuilder),
-    CassandraPeersRewrite(CassandraPeersRewrite),
-    RedisCache(SimpleRedisCacheBuilder),
-    Tee(TeeBuilder),
-    NullSink(NullSink),
-    #[cfg(test)]
-    Loopback(Loopback),
-    Protect(Box<Protect>),
-    ConsistentScatter(ConsistentScatterBuilder),
-    RedisTimestampTagger(RedisTimestampTagger),
-    RedisSinkCluster(RedisSinkCluster),
-    RedisClusterPortsRewrite(RedisClusterPortsRewrite),
-    DebugReturner(DebugReturner),
-    DebugRandomDelay(DebugRandomDelay),
-    DebugPrinter(DebugPrinter),
-    DebugForceParse(DebugForceParse),
-    ParallelMap(ParallelMapBuilder),
-    PoolConnections(ConnectionBalanceAndPoolBuilder),
-    Coalesce(Coalesce),
-    QueryTypeFilter(QueryTypeFilter),
-    QueryCounter(QueryCounter),
-    RequestThrottling(RequestThrottling),
-}
+pub trait TransformBuilder: DynClone + Send {
+    fn build(&self) -> Transforms;
 
-impl TransformBuilder {
-    pub fn build(&self) -> Transforms {
-        match self {
-            TransformBuilder::KafkaSinkSingle(t) => Transforms::KafkaSinkSingle(t.build()),
-            TransformBuilder::CassandraSinkSingle(t) => Transforms::CassandraSinkSingle(t.build()),
-            TransformBuilder::CassandraSinkCluster(t) => {
-                Transforms::CassandraSinkCluster(t.build())
-            }
-            TransformBuilder::CassandraPeersRewrite(t) => {
-                Transforms::CassandraPeersRewrite(t.clone())
-            }
-            TransformBuilder::RedisCache(t) => Transforms::RedisCache(t.build()),
-            TransformBuilder::Tee(t) => Transforms::Tee(t.build()),
-            TransformBuilder::RedisSinkSingle(t) => Transforms::RedisSinkSingle(t.build()),
-            TransformBuilder::ConsistentScatter(t) => Transforms::ConsistentScatter(t.build()),
-            TransformBuilder::RedisTimestampTagger(t) => {
-                Transforms::RedisTimestampTagger(t.clone())
-            }
-            TransformBuilder::RedisClusterPortsRewrite(t) => {
-                Transforms::RedisClusterPortsRewrite(t.clone())
-            }
-            TransformBuilder::DebugPrinter(t) => Transforms::DebugPrinter(t.clone()),
-            TransformBuilder::DebugForceParse(t) => Transforms::DebugForceParse(t.clone()),
-            TransformBuilder::NullSink(t) => Transforms::NullSink(t.clone()),
-            TransformBuilder::RedisSinkCluster(t) => Transforms::RedisSinkCluster(t.clone()),
-            TransformBuilder::ParallelMap(t) => Transforms::ParallelMap(t.build()),
-            TransformBuilder::PoolConnections(t) => Transforms::PoolConnections(t.build()),
-            TransformBuilder::Coalesce(t) => Transforms::Coalesce(t.clone()),
-            TransformBuilder::QueryTypeFilter(t) => Transforms::QueryTypeFilter(t.clone()),
-            TransformBuilder::QueryCounter(t) => Transforms::QueryCounter(t.clone()),
-            #[cfg(test)]
-            TransformBuilder::Loopback(t) => Transforms::Loopback(t.clone()),
-            TransformBuilder::Protect(t) => Transforms::Protect(t.clone()),
-            TransformBuilder::DebugReturner(t) => Transforms::DebugReturner(t.clone()),
-            TransformBuilder::DebugRandomDelay(t) => Transforms::DebugRandomDelay(t.clone()),
-            TransformBuilder::RequestThrottling(t) => Transforms::RequestThrottling(t.clone()),
-        }
-    }
-
-    fn get_name(&self) -> &'static str {
-        self.into()
-    }
+    fn get_name(&self) -> &'static str;
 
     fn validate(&self) -> Vec<String> {
-        match self {
-            TransformBuilder::KafkaSinkSingle(c) => c.validate(),
-            TransformBuilder::CassandraSinkSingle(c) => c.validate(),
-            TransformBuilder::CassandraSinkCluster(c) => c.validate(),
-            TransformBuilder::CassandraPeersRewrite(c) => c.validate(),
-            TransformBuilder::RedisCache(r) => r.validate(),
-            TransformBuilder::Tee(t) => t.validate(),
-            TransformBuilder::RedisSinkSingle(r) => r.validate(),
-            TransformBuilder::ConsistentScatter(c) => c.validate(),
-            TransformBuilder::RedisTimestampTagger(r) => r.validate(),
-            TransformBuilder::RedisClusterPortsRewrite(r) => r.validate(),
-            TransformBuilder::DebugPrinter(p) => p.validate(),
-            TransformBuilder::DebugForceParse(p) => p.validate(),
-            TransformBuilder::NullSink(n) => n.validate(),
-            TransformBuilder::RedisSinkCluster(r) => r.validate(),
-            TransformBuilder::ParallelMap(s) => s.validate(),
-            TransformBuilder::PoolConnections(s) => s.validate(),
-            TransformBuilder::Coalesce(s) => s.validate(),
-            TransformBuilder::QueryTypeFilter(s) => s.validate(),
-            TransformBuilder::QueryCounter(s) => s.validate(),
-            #[cfg(test)]
-            TransformBuilder::Loopback(l) => l.validate(),
-            TransformBuilder::Protect(p) => p.validate(),
-            TransformBuilder::DebugReturner(d) => d.validate(),
-            TransformBuilder::DebugRandomDelay(d) => d.validate(),
-            TransformBuilder::RequestThrottling(d) => d.validate(),
-        }
+        vec![]
     }
 
     fn is_terminating(&self) -> bool {
-        match self {
-            TransformBuilder::KafkaSinkSingle(c) => c.is_terminating(),
-            TransformBuilder::CassandraSinkSingle(c) => c.is_terminating(),
-            TransformBuilder::CassandraSinkCluster(c) => c.is_terminating(),
-            TransformBuilder::CassandraPeersRewrite(c) => c.is_terminating(),
-            TransformBuilder::RedisCache(r) => r.is_terminating(),
-            TransformBuilder::Tee(t) => t.is_terminating(),
-            TransformBuilder::RedisSinkSingle(r) => r.is_terminating(),
-            TransformBuilder::ConsistentScatter(c) => c.is_terminating(),
-            TransformBuilder::RedisTimestampTagger(r) => r.is_terminating(),
-            TransformBuilder::RedisClusterPortsRewrite(r) => r.is_terminating(),
-            TransformBuilder::DebugPrinter(p) => p.is_terminating(),
-            TransformBuilder::DebugForceParse(p) => p.is_terminating(),
-            TransformBuilder::NullSink(n) => n.is_terminating(),
-            TransformBuilder::RedisSinkCluster(r) => r.is_terminating(),
-            TransformBuilder::ParallelMap(s) => s.is_terminating(),
-            TransformBuilder::PoolConnections(s) => s.is_terminating(),
-            TransformBuilder::Coalesce(s) => s.is_terminating(),
-            TransformBuilder::QueryTypeFilter(s) => s.is_terminating(),
-            TransformBuilder::QueryCounter(s) => s.is_terminating(),
-            #[cfg(test)]
-            TransformBuilder::Loopback(l) => l.is_terminating(),
-            TransformBuilder::Protect(p) => p.is_terminating(),
-            TransformBuilder::DebugReturner(d) => d.is_terminating(),
-            TransformBuilder::DebugRandomDelay(d) => d.is_terminating(),
-            TransformBuilder::RequestThrottling(d) => d.is_terminating(),
-        }
+        false
     }
 }
+dyn_clone::clone_trait_object!(TransformBuilder);
 
-impl Debug for TransformBuilder {
+impl Debug for dyn TransformBuilder {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "Transform: {}", self.get_name())
     }
@@ -236,7 +114,6 @@ pub enum Transforms {
     RedisCache(SimpleRedisCache),
     Tee(Tee),
     NullSink(NullSink),
-    #[cfg(test)]
     Loopback(Loopback),
     Protect(Box<Protect>),
     ConsistentScatter(ConsistentScatter),
@@ -273,7 +150,6 @@ impl Transforms {
             Transforms::DebugPrinter(p) => p.transform(message_wrapper).await,
             Transforms::DebugForceParse(p) => p.transform(message_wrapper).await,
             Transforms::NullSink(n) => n.transform(message_wrapper).await,
-            #[cfg(test)]
             Transforms::Loopback(n) => n.transform(message_wrapper).await,
             Transforms::Protect(p) => p.transform(message_wrapper).await,
             Transforms::DebugReturner(p) => p.transform(message_wrapper).await,
@@ -303,7 +179,6 @@ impl Transforms {
             Transforms::DebugPrinter(p) => p.transform_pushed(message_wrapper).await,
             Transforms::DebugForceParse(p) => p.transform_pushed(message_wrapper).await,
             Transforms::NullSink(n) => n.transform_pushed(message_wrapper).await,
-            #[cfg(test)]
             Transforms::Loopback(n) => n.transform_pushed(message_wrapper).await,
             Transforms::Protect(p) => p.transform_pushed(message_wrapper).await,
             Transforms::DebugReturner(p) => p.transform_pushed(message_wrapper).await,
@@ -347,7 +222,6 @@ impl Transforms {
             Transforms::Coalesce(s) => s.set_pushed_messages_tx(pushed_messages_tx),
             Transforms::QueryTypeFilter(s) => s.set_pushed_messages_tx(pushed_messages_tx),
             Transforms::QueryCounter(s) => s.set_pushed_messages_tx(pushed_messages_tx),
-            #[cfg(test)]
             Transforms::Loopback(l) => l.set_pushed_messages_tx(pushed_messages_tx),
             Transforms::Protect(p) => p.set_pushed_messages_tx(pushed_messages_tx),
             Transforms::DebugReturner(d) => d.set_pushed_messages_tx(pushed_messages_tx),
@@ -394,7 +268,7 @@ pub enum TransformsConfig {
 
 impl TransformsConfig {
     #[async_recursion]
-    pub async fn get_builder(&self, chain_name: String) -> Result<TransformBuilder> {
+    pub async fn get_builder(&self, chain_name: String) -> Result<Box<dyn TransformBuilder>> {
         match self {
             #[cfg(feature = "alpha-transforms")]
             TransformsConfig::KafkaSinkSingle(c) => c.get_builder(chain_name).await,
@@ -405,17 +279,21 @@ impl TransformsConfig {
             TransformsConfig::Tee(t) => t.get_builder().await,
             TransformsConfig::RedisSinkSingle(r) => r.get_builder(chain_name).await,
             TransformsConfig::ConsistentScatter(c) => c.get_builder().await,
-            TransformsConfig::RedisTimestampTagger => Ok(TransformBuilder::RedisTimestampTagger(
-                RedisTimestampTagger::new(),
-            )),
+            TransformsConfig::RedisTimestampTagger => {
+                Ok(Box::new(RedisTimestampTagger::new()) as Box<dyn TransformBuilder>)
+            }
             TransformsConfig::RedisClusterPortsRewrite(r) => r.get_builder().await,
             TransformsConfig::DebugPrinter => {
-                Ok(TransformBuilder::DebugPrinter(DebugPrinter::new()))
+                Ok(Box::new(DebugPrinter::new()) as Box<dyn TransformBuilder>)
             }
             TransformsConfig::DebugReturner(d) => d.get_builder().await,
-            TransformsConfig::NullSink => Ok(TransformBuilder::NullSink(NullSink::default())),
+            TransformsConfig::NullSink => {
+                Ok(Box::<NullSink>::default() as Box<dyn TransformBuilder>)
+            }
             #[cfg(test)]
-            TransformsConfig::Loopback => Ok(TransformBuilder::Loopback(Loopback::default())),
+            TransformsConfig::Loopback => {
+                Ok(Box::<Loopback>::default() as Box<dyn TransformBuilder>)
+            }
             #[cfg(feature = "alpha-transforms")]
             TransformsConfig::Protect(p) => p.get_builder().await,
             #[cfg(feature = "alpha-transforms")]
@@ -424,11 +302,11 @@ impl TransformsConfig {
             TransformsConfig::DebugForceEncode(d) => d.get_builder().await,
             TransformsConfig::RedisSinkCluster(r) => r.get_builder(chain_name).await,
             TransformsConfig::ParallelMap(s) => s.get_builder().await,
-            //TransformsConfig::PoolConnections(s) => s.get_builder().await,
+            // TransformsConfig::PoolConnections(s) => s.get_builder().await,
             TransformsConfig::Coalesce(s) => s.get_builder().await,
             TransformsConfig::QueryTypeFilter(s) => s.get_builder().await,
             TransformsConfig::QueryCounter(s) => s.get_builder().await,
-            TransformsConfig::RequestThrottling(s) => s.get_builder().await,
+            TransformsConfig::RequestThrottling(s) => s.get_builder(),
         }
     }
 }
@@ -437,7 +315,7 @@ pub async fn build_chain_from_config(
     name: String,
     transform_configs: &[TransformsConfig],
 ) -> Result<TransformChainBuilder> {
-    let mut transforms: Vec<TransformBuilder> = Vec::new();
+    let mut transforms: Vec<Box<dyn TransformBuilder>> = Vec::new();
     for tc in transform_configs {
         transforms.push(tc.get_builder(name.clone()).await?)
     }
@@ -698,14 +576,6 @@ pub trait Transform: Send {
     async fn transform_pushed<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> ChainResponse {
         let response = message_wrapper.call_next_transform_pushed().await?;
         Ok(response)
-    }
-
-    fn is_terminating(&self) -> bool {
-        false
-    }
-
-    fn validate(&self) -> Vec<String> {
-        vec![]
     }
 
     fn set_pushed_messages_tx(&mut self, _pushed_messages_tx: mpsc::UnboundedSender<Messages>) {}

--- a/shotover-proxy/src/transforms/null.rs
+++ b/shotover-proxy/src/transforms/null.rs
@@ -2,15 +2,27 @@ use crate::error::ChainResponse;
 use crate::transforms::{Transform, Wrapper};
 use async_trait::async_trait;
 
+use super::{TransformBuilder, Transforms};
+
 #[derive(Debug, Clone, Default)]
 pub struct NullSink {}
 
-#[async_trait]
-impl Transform for NullSink {
+impl TransformBuilder for NullSink {
+    fn build(&self) -> super::Transforms {
+        Transforms::NullSink(self.clone())
+    }
+
+    fn get_name(&self) -> &'static str {
+        "NullSink"
+    }
+
     fn is_terminating(&self) -> bool {
         true
     }
+}
 
+#[async_trait]
+impl Transform for NullSink {
     async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> ChainResponse {
         for message in &mut message_wrapper.messages {
             *message = message.to_error_response("Handled by shotover null transform".to_string());

--- a/shotover-proxy/src/transforms/protect/mod.rs
+++ b/shotover-proxy/src/transforms/protect/mod.rs
@@ -3,7 +3,7 @@ use crate::frame::{CassandraFrame, CassandraOperation, CassandraResult, Frame};
 use crate::message_value::MessageValue;
 use crate::transforms::protect::key_management::KeyManager;
 pub use crate::transforms::protect::key_management::KeyManagerConfig;
-use crate::transforms::{Transform, TransformBuilder, Wrapper};
+use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
 use cql3_parser::cassandra_statement::CassandraStatement;
@@ -26,8 +26,8 @@ pub struct ProtectConfig {
 }
 
 impl ProtectConfig {
-    pub async fn get_builder(&self) -> Result<TransformBuilder> {
-        Ok(TransformBuilder::Protect(Box::new(Protect {
+    pub async fn get_builder(&self) -> Result<Box<dyn TransformBuilder>> {
+        Ok(Box::new(Protect {
             keyspace_table_columns: self
                 .keyspace_table_columns
                 .iter()
@@ -47,7 +47,7 @@ impl ProtectConfig {
                 .collect(),
             key_source: self.key_manager.build()?,
             key_id: "XXXXXXX".to_string(),
-        })))
+        }))
     }
 }
 
@@ -59,6 +59,16 @@ pub struct Protect {
     // TODO this should be a function to create key_ids based on "something", e.g. primary key
     // for the moment this is just a string
     key_id: String,
+}
+
+impl TransformBuilder for Protect {
+    fn build(&self) -> Transforms {
+        Transforms::Protect(Box::new(self.clone()))
+    }
+
+    fn get_name(&self) -> &'static str {
+        "Protect"
+    }
 }
 
 impl Protect {

--- a/shotover-proxy/src/transforms/redis/cluster_ports_rewrite.rs
+++ b/shotover-proxy/src/transforms/redis/cluster_ports_rewrite.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 
 use crate::error::ChainResponse;
 use crate::frame::Frame;
-use crate::transforms::{Transform, TransformBuilder, Wrapper};
+use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct RedisClusterPortsRewriteConfig {
@@ -14,12 +14,20 @@ pub struct RedisClusterPortsRewriteConfig {
 }
 
 impl RedisClusterPortsRewriteConfig {
-    pub async fn get_builder(&self) -> Result<TransformBuilder> {
-        Ok(TransformBuilder::RedisClusterPortsRewrite(
-            RedisClusterPortsRewrite {
-                new_port: self.new_port,
-            },
-        ))
+    pub async fn get_builder(&self) -> Result<Box<dyn TransformBuilder>> {
+        Ok(Box::new(RedisClusterPortsRewrite {
+            new_port: self.new_port,
+        }))
+    }
+}
+
+impl TransformBuilder for RedisClusterPortsRewrite {
+    fn build(&self) -> Transforms {
+        Transforms::RedisClusterPortsRewrite(self.clone())
+    }
+
+    fn get_name(&self) -> &'static str {
+        "RedisClusterPortsRewrite"
     }
 }
 

--- a/shotover-proxy/src/transforms/redis/timestamp_tagging.rs
+++ b/shotover-proxy/src/transforms/redis/timestamp_tagging.rs
@@ -2,7 +2,7 @@ use crate::error::ChainResponse;
 use crate::frame::redis::redis_query_type;
 use crate::frame::{Frame, RedisFrame};
 use crate::message::{Message, QueryType};
-use crate::transforms::{Transform, Wrapper};
+use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -17,6 +17,16 @@ pub struct RedisTimestampTagger {}
 impl RedisTimestampTagger {
     pub fn new() -> Self {
         RedisTimestampTagger {}
+    }
+}
+
+impl TransformBuilder for RedisTimestampTagger {
+    fn build(&self) -> Transforms {
+        Transforms::RedisTimestampTagger(self.clone())
+    }
+
+    fn get_name(&self) -> &'static str {
+        "RedisTimestampTagger"
     }
 }
 


### PR DESCRIPTION
closes: https://github.com/shotover/shotover-proxy/issues/951

There are 3 stages to a transform: config, builder and transform
Currently we use seperate enums to represent all 3, I am experimenting with changing all of these enums into traits so that we can provide shotover as a library for purposes of users implementing their own transforms.

In this PR I have changed just TransformBuilder into a trait.

I skipped the other enums for now because:
* The transforms themselves are performance sensitive so I wanted to be careful changing them to dynamic dispatch.
* The configs are complicated to make into a trait due to needing to be deserialized via serde.

So this left TransformBuilder as a good, non-controversial, first step because:
It lacks the previously mentioned downsides and making TransformBuilder into a trait gives us:
* Less central configuration of transforms in transform.rs
* Cleans up the duplication of `fn validate` and `fn is_terminating()` across both the builder and transform.

dyn-clone dependency was added to allow us to clone the TransformBuilder trait.
We were previously cloning the TransformBuilder enum and its possible we could avoid doing that in the future, but thats out of scope of this PR.

Previously we were using IntoStaticStr to get the name of the TransformBuilder enum variant as the transform name.
That is no longer possible with it as a trait, but I think its reasonable to just have the user define it instead. We could possibly work out some macro solution for this in the future.