### PR TITLE
Kafka: fix flexible version handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ dependencies = [
  "log",
  "parking_lot",
  "slog",
- "uuid 1.3.0",
+ "uuid",
 ]
 
 [[package]]
@@ -340,7 +340,7 @@ dependencies = [
  "snap",
  "thiserror",
  "time 0.3.19",
- "uuid 1.3.0",
+ "uuid",
 ]
 
 [[package]]
@@ -375,7 +375,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "uuid 1.3.0",
+ "uuid",
 ]
 
 [[package]]
@@ -605,7 +605,7 @@ dependencies = [
  "serde",
  "tree-sitter",
  "tree-sitter-cql",
- "uuid 1.3.0",
+ "uuid",
 ]
 
 [[package]]
@@ -1596,9 +1596,9 @@ dependencies = [
 
 [[package]]
 name = "kafka-protocol"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f73d62060373a9a181e2f1d927c42c1302f48fb72fb56e9493d8349bf2398af"
+checksum = "5c7fe553b72603ab9500b672e8a86dc3a1982784878e62fd77353cd35b11ca17"
 dependencies = [
  "bytes",
  "crc",
@@ -1610,7 +1610,7 @@ dependencies = [
  "paste",
  "snap",
  "string",
- "uuid 0.8.2",
+ "uuid",
 ]
 
 [[package]]
@@ -2828,7 +2828,7 @@ dependencies = [
  "tokio",
  "tokio-openssl",
  "tracing",
- "uuid 1.3.0",
+ "uuid",
 ]
 
 [[package]]
@@ -2849,7 +2849,7 @@ dependencies = [
  "snap",
  "thiserror",
  "tokio",
- "uuid 1.3.0",
+ "uuid",
 ]
 
 [[package]]
@@ -3072,7 +3072,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
- "uuid 1.3.0",
+ "uuid",
  "version-compare",
 ]
 
@@ -3275,7 +3275,7 @@ dependencies = [
  "tokio-openssl",
  "tracing",
  "tracing-subscriber",
- "uuid 1.3.0",
+ "uuid",
 ]
 
 [[package]]
@@ -3698,12 +3698,6 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
-
-[[package]]
-name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
 name = "uuid"

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -76,8 +76,8 @@ csv = "1.2.0"
 strum_macros = "0.24"
 chacha20poly1305 = { version = "0.10.0", features = ["std"] }
 generic-array = { version = "0.14", features = ["serde"] }
-kafka-protocol = "0.5.0"
 dyn-clone = "1.0.10"
+kafka-protocol = "0.6.0"
 
 [dev-dependencies]
 criterion = { git = "https://github.com/shotover/criterion.rs", branch = "0.4.0-bench_with_input_fn", features = ["async_tokio"] }


### PR DESCRIPTION
closes https://github.com/shotover/shotover-proxy/issues/1056

I managed to upstream the logic for converting an api version to a header version.
Refer to https://github.com/tychedelia/kafka-protocol-rs/pull/21 and https://github.com/tychedelia/kafka-protocol-rs/pull/22 for more info.

In order to avoid manually parsing the api_key and api_version we should one day upstream some wrappers to kafka-protocol-rs that does this for us.
For now we can land this PR as it fixes our header version issue.