### PR TITLE
emit startup failures through tracing

### DIFF
--- a/shotover-proxy/src/config/mod.rs
+++ b/shotover-proxy/src/config/mod.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use serde::Deserialize;
 
 pub mod topology;
@@ -14,6 +14,6 @@ impl Config {
         let file = std::fs::File::open(&filepath).map_err(|err| {
             anyhow!(err).context(format!("Couldn't open the config file {}", &filepath))
         })?;
-        Ok(serde_yaml::from_reader(file)?)
+        serde_yaml::from_reader(file).context(format!("Failed to parse config file {}", &filepath))
     }
 }

--- a/shotover-proxy/src/config/topology.rs
+++ b/shotover-proxy/src/config/topology.rs
@@ -1,7 +1,7 @@
 use crate::sources::{Sources, SourcesConfig};
 use crate::transforms::chain::TransformChainBuilder;
 use crate::transforms::{build_chain_from_config, TransformsConfig};
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use itertools::Itertools;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -37,7 +37,7 @@ impl Topology {
         let deserializer = serde_yaml::Deserializer::from_reader(file);
         let config: TopologyConfig =
             serde_yaml::with::singleton_map_recursive::deserialize(deserializer)
-                .map_err(|e| anyhow!(e))?;
+                .context(format!("Failed to parse topology file {}", &filepath))?;
 
         Ok(Topology::topology_from_config(config))
     }

--- a/shotover-proxy/src/main.rs
+++ b/shotover-proxy/src/main.rs
@@ -1,13 +1,33 @@
 #![warn(rust_2018_idioms)]
 #![recursion_limit = "256"]
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Parser;
-
-use shotover_proxy::runner::{ConfigOpts, Runner};
+use shotover_proxy::runner::{ConfigOpts, Runner, TracingState};
+use tokio::runtime::Runtime;
 
 fn main() -> Result<()> {
-    Runner::new(ConfigOpts::parse())?
+    let opts = ConfigOpts::parse();
+    let log_format = opts.log_format.clone();
+    match run(opts) {
+        Ok(()) => Ok(()),
+        Err(err) => {
+            let rt = Runtime::new()
+                .context("Failed to create runtime while trying to report {err:?}")
+                .unwrap();
+            let _guard = rt.enter();
+            let _tracing_state = TracingState::new("error", log_format)
+                .context("Failed to create TracingState while trying to report {err:?}")
+                .unwrap();
+
+            tracing::error!("{:?}", err.context("Failed to start shotover"));
+            std::process::exit(1);
+        }
+    }
+}
+
+fn run(opts: ConfigOpts) -> Result<()> {
+    Runner::new(opts)?
         .with_observability_interface()?
         .run_block()
 }

--- a/shotover-proxy/src/runner.rs
+++ b/shotover-proxy/src/runner.rs
@@ -142,7 +142,7 @@ impl Runner {
     }
 }
 
-struct TracingState {
+pub struct TracingState {
     /// Once this is dropped tracing logs are ignored
     _guard: WorkerGuard,
     handle: ReloadHandle,
@@ -170,7 +170,7 @@ fn try_parse_log_directives(directives: &[Option<&str>]) -> Result<EnvFilter> {
 }
 
 impl TracingState {
-    fn new(log_level: &str, format: LogFormat) -> Result<Self> {
+    pub fn new(log_level: &str, format: LogFormat) -> Result<Self> {
         let (non_blocking, guard) = tracing_appender::non_blocking(std::io::stdout());
 
         // Load log directives from shotover config and then from the RUST_LOG env var, with the latter taking priority.

--- a/shotover-proxy/tests/runner/runner_int_tests.rs
+++ b/shotover-proxy/tests/runner/runner_int_tests.rs
@@ -56,7 +56,15 @@ async fn test_shotover_shutdown_when_invalid_topology_non_terminating_last() {
     ShotoverProcessBuilder::new_with_topology(
         "tests/test-configs/invalid_non_terminating_last.yaml",
     )
-    .assert_fails_to_start(&[])
+    .assert_fails_to_start(&[EventMatcher::new()
+        .with_level(Level::Error)
+        .with_target("shotover_proxy::runner")
+        .with_message(
+            "Topology errors
+redis_chain:
+  Non-terminating transform \"DebugPrinter\" is last in chain. Last transform must be terminating.
+",
+        )])
     .await;
 }
 
@@ -66,7 +74,13 @@ async fn test_shotover_shutdown_when_invalid_topology_terminating_not_last() {
     ShotoverProcessBuilder::new_with_topology(
         "tests/test-configs/invalid_terminating_not_last.yaml",
     )
-    .assert_fails_to_start(&[])
+    .assert_fails_to_start(&[EventMatcher::new()
+        .with_level(Level::Error)
+        .with_target("shotover_proxy::runner")
+        .with_message("Topology errors
+redis_chain:
+  Terminating transform \"NullSink\" is not last in chain. Terminating transform must be last in chain.
+")])
     .await;
 }
 

--- a/shotover-proxy/tests/test-configs/invalid_non_terminating_last.yaml
+++ b/shotover-proxy/tests/test-configs/invalid_non_terminating_last.yaml
@@ -5,7 +5,6 @@ sources:
       listen_addr: "127.0.0.1:6379"
 chain_config:
   redis_chain:
-    - NullSink
-    - Printer
+    - DebugPrinter
 source_to_chain_mapping:
   redis_prod: redis_chain

--- a/shotover-proxy/tests/test-configs/invalid_terminating_not_last.yaml
+++ b/shotover-proxy/tests/test-configs/invalid_terminating_not_last.yaml
@@ -6,7 +6,7 @@ sources:
 chain_config:
   redis_chain:
     - NullSink
-    - Printer
+    - DebugPrinter
     - NullSink
 source_to_chain_mapping:
   redis_prod: redis_chain


### PR DESCRIPTION
closes https://github.com/shotover/shotover-proxy/issues/993

In order to get tracing at this point we just spin up our own runtime and tracing logger.
Technically these functions are fallible but they shouldnt ever fail and if they do somehow fail we still output the issue to stdout in some form which isnt any worse than before.

This resolves the problem described in the issue and gives consistency of error messages to `--log-format human` users and gives parseable output to `--log-format json` users.

`std::process::exit(1);` may seem dodgy but:
* clap already does it internally when the user gives invalid cli args
* and there is no other way to return a nonzero exit code without also outputting to stdout