### PR TITLE
Make TransformConfig into a trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,6 +766,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "cxx"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,6 +1031,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "erased-serde"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2b0c2380453a92ea8b6c8e5f64ecaafccddde8ceab55ff7a8ac1029f894569"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1230,6 +1249,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "ghost"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e0cd8a998937e25c6ba7cc276b96ec5cc3f4dc4ab5de9ede4fb152bdd5c5eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1547,6 +1577,16 @@ name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
+name = "inventory"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498ae1c9c329c7972b917506239b557a60386839192f1cf0ca034f345b65db99"
+dependencies = [
+ "ctor",
+ "ghost",
+]
 
 [[package]]
 name = "io-lifetimes"
@@ -3078,6 +3118,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "typetag",
  "uuid",
  "version-compare",
 ]
@@ -3648,6 +3689,30 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "typetag"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69bf9bd14fed1815295233a0eee76a963283b53ebcbd674d463f697d3bfcae0c"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf9f5f225956dc2254c6c27500deac9390a066b2e8a1a571300627a7c4400a33"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,7 +772,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1259,7 +1259,7 @@ checksum = "69e0cd8a998937e25c6ba7cc276b96ec5cc3f4dc4ab5de9ede4fb152bdd5c5eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3711,7 +3711,7 @@ checksum = "bf9f5f225956dc2254c6c27500deac9390a066b2e8a1a571300627a7c4400a33"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -77,6 +77,7 @@ chacha20poly1305 = { version = "0.10.0", features = ["std"] }
 generic-array = { version = "0.14", features = ["serde"] }
 dyn-clone = "1.0.10"
 kafka-protocol = "0.6.0"
+typetag = "0.2.5"
 
 [dev-dependencies]
 criterion = { git = "https://github.com/shotover/criterion.rs", branch = "0.4.0-bench_with_input_fn", features = ["async_tokio"] }

--- a/shotover-proxy/src/config/chain.rs
+++ b/shotover-proxy/src/config/chain.rs
@@ -1,0 +1,89 @@
+use crate::transforms::chain::TransformChainBuilder;
+use crate::transforms::{TransformBuilder, TransformConfig};
+use anyhow::Result;
+use serde::de::{DeserializeSeed, Deserializer, MapAccess, SeqAccess, Visitor};
+use serde::Deserialize;
+use std::fmt::{self, Debug};
+use std::iter;
+
+#[derive(Deserialize, Debug)]
+pub struct TransformChainConfig(
+    #[serde(rename = "TransformChain", deserialize_with = "vec_transform_config")]
+    pub  Vec<Box<dyn TransformConfig>>,
+);
+
+impl TransformChainConfig {
+    pub async fn get_builder(&self, name: String) -> Result<TransformChainBuilder> {
+        let mut transforms: Vec<Box<dyn TransformBuilder>> = Vec::new();
+        for tc in &self.0 {
+            transforms.push(tc.get_builder(name.clone()).await?)
+        }
+        Ok(TransformChainBuilder::new(transforms, name))
+    }
+}
+
+fn vec_transform_config<'de, D>(deserializer: D) -> Result<Vec<Box<dyn TransformConfig>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct VecTransformConfigVisitor;
+
+    impl<'de> Visitor<'de> for VecTransformConfigVisitor {
+        type Value = Vec<Box<dyn TransformConfig>>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("list of TransformConfig")
+        }
+
+        fn visit_seq<S>(self, mut seq: S) -> Result<Self::Value, S::Error>
+        where
+            S: SeqAccess<'de>,
+        {
+            let mut vec = Vec::new();
+            while let Some(item) = seq.next_element_seed(TransformConfigVisitor)? {
+                vec.push(item);
+            }
+            Ok(vec)
+        }
+    }
+
+    struct TransformConfigVisitor;
+
+    impl<'de> Visitor<'de> for TransformConfigVisitor {
+        type Value = Box<dyn TransformConfig>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("TransformConfig")
+        }
+
+        fn visit_map<M>(self, map: M) -> Result<Self::Value, M::Error>
+        where
+            M: MapAccess<'de>,
+        {
+            let de = serde::de::value::MapAccessDeserializer::new(map);
+            Deserialize::deserialize(de)
+        }
+
+        fn visit_str<E>(self, string: &str) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            let singleton_map = iter::once((string, ()));
+            let de = serde::de::value::MapDeserializer::new(singleton_map);
+            Deserialize::deserialize(de)
+        }
+    }
+
+    impl<'de> DeserializeSeed<'de> for TransformConfigVisitor {
+        type Value = Box<dyn TransformConfig>;
+
+        fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            deserializer.deserialize_any(self)
+        }
+    }
+
+    deserializer.deserialize_seq(VecTransformConfigVisitor)
+}

--- a/shotover-proxy/src/config/chain.rs
+++ b/shotover-proxy/src/config/chain.rs
@@ -22,6 +22,25 @@ impl TransformChainConfig {
     }
 }
 
+/// This function is a custom deserializer that works around a mismatch in the way yaml and typetag represent things,
+/// resulting in typetagged structs with no fields failing to deserialize from a single line yaml entry.
+/// e.g. with typetag + yaml + the default serializer:
+/// this would fail to deserialize:
+/// ```yaml
+/// chain_config:
+///   redis_chain:
+///     - NullSink
+/// ```
+///
+/// but this would work fine:
+/// ```yaml
+/// chain_config:
+///   redis_chain:
+///     - NullSink: {}
+/// ```
+///
+/// With the use of this custom deserializer both cases now deserialize correctly.
+/// The implementation was a suggestion from dtolnay: https://github.com/dtolnay/typetag/pull/40#issuecomment-1454961686
 fn vec_transform_config<'de, D>(deserializer: D) -> Result<Vec<Box<dyn TransformConfig>>, D::Error>
 where
     D: Deserializer<'de>,

--- a/shotover-proxy/src/config/mod.rs
+++ b/shotover-proxy/src/config/mod.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Context, Result};
 use serde::Deserialize;
 
+pub mod chain;
 pub mod topology;
 
 #[derive(Deserialize, Debug, Clone)]

--- a/shotover-proxy/src/lib.rs
+++ b/shotover-proxy/src/lib.rs
@@ -6,7 +6,7 @@
 //! the [`transforms::Transforms`] enum.
 //!
 //! To allow your [`transforms::Transform`] to be configurable in Shotover config files you will need to create
-//! a serializable config struct and register it in the [`transforms::TransformsConfig`] enum (note plural Transform**s**).
+//! a serializable config struct and implement [`transforms::TransformConfig`] trait.
 //!
 //! ## Messages
 //! * [`message::Message`], the main struct that carries database queries/frames around in Shotover.
@@ -15,7 +15,7 @@
 //! * [`transforms::Wrapper`], used to wrap messages as they traverse the [`transforms::Transform`] chain.
 //! * [`transforms::Transform`], the main extension trait for adding your own behaviour to Shotover.
 //! * [`transforms::Transforms`], the enum to register with (add a variant) for enabling your own transform.
-//! * [`transforms::TransformsConfig`], the enum to register with (add a variant) for configuring your own transform.
+//! * [`transforms::TransformConfig`], the trait to implement for configuring your own transform.
 
 // Accidentally printing would break json log output
 #![deny(clippy::print_stdout)]

--- a/shotover-proxy/src/transforms/cassandra/peers_rewrite.rs
+++ b/shotover-proxy/src/transforms/cassandra/peers_rewrite.rs
@@ -2,7 +2,7 @@ use crate::frame::{CassandraOperation, CassandraResult, Frame};
 use crate::message::Message;
 use crate::message_value::{IntSize, MessageValue};
 use crate::transforms::cassandra::peers_rewrite::CassandraOperation::Event;
-use crate::transforms::Transforms;
+use crate::transforms::{TransformConfig, Transforms};
 use crate::{
     error::ChainResponse,
     transforms::{Transform, TransformBuilder, Wrapper},
@@ -20,8 +20,10 @@ pub struct CassandraPeersRewriteConfig {
     pub port: u16,
 }
 
-impl CassandraPeersRewriteConfig {
-    pub async fn get_builder(&self) -> Result<Box<dyn TransformBuilder>> {
+#[typetag::deserialize(name = "CassandraPeersRewrite")]
+#[async_trait(?Send)]
+impl TransformConfig for CassandraPeersRewriteConfig {
+    async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(CassandraPeersRewrite::new(self.port)))
     }
 }

--- a/shotover-proxy/src/transforms/cassandra/sink_cluster/mod.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_cluster/mod.rs
@@ -6,7 +6,7 @@ use crate::message::{Message, Messages, Metadata};
 use crate::message_value::{IntSize, MessageValue};
 use crate::tls::{TlsConnector, TlsConnectorConfig};
 use crate::transforms::cassandra::connection::{CassandraConnection, Response};
-use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
+use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use cassandra_protocol::events::ServerEvent;
@@ -79,8 +79,10 @@ pub struct CassandraSinkClusterConfig {
     pub read_timeout: Option<u64>,
 }
 
-impl CassandraSinkClusterConfig {
-    pub async fn get_builder(&self, chain_name: String) -> Result<Box<dyn TransformBuilder>> {
+#[typetag::deserialize(name = "CassandraSinkCluster")]
+#[async_trait(?Send)]
+impl TransformConfig for CassandraSinkClusterConfig {
+    async fn get_builder(&self, chain_name: String) -> Result<Box<dyn TransformBuilder>> {
         let tls = self.tls.clone().map(TlsConnector::new).transpose()?;
         let mut shotover_nodes = self.shotover_nodes.clone();
         let index = self

--- a/shotover-proxy/src/transforms/cassandra/sink_single.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_single.rs
@@ -5,7 +5,7 @@ use crate::frame::cassandra::CassandraMetadata;
 use crate::message::{Messages, Metadata};
 use crate::tls::{TlsConnector, TlsConnectorConfig};
 use crate::transforms::cassandra::connection::Response;
-use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
+use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use cassandra_protocol::frame::Version;
@@ -25,8 +25,10 @@ pub struct CassandraSinkSingleConfig {
     pub read_timeout: Option<u64>,
 }
 
-impl CassandraSinkSingleConfig {
-    pub async fn get_builder(&self, chain_name: String) -> Result<Box<dyn TransformBuilder>> {
+#[typetag::deserialize(name = "CassandraSinkSingle")]
+#[async_trait(?Send)]
+impl TransformConfig for CassandraSinkSingleConfig {
+    async fn get_builder(&self, chain_name: String) -> Result<Box<dyn TransformBuilder>> {
         let tls = self.tls.clone().map(TlsConnector::new).transpose()?;
         Ok(Box::new(CassandraSinkSingleBuilder::new(
             self.address.clone(),

--- a/shotover-proxy/src/transforms/coalesce.rs
+++ b/shotover-proxy/src/transforms/coalesce.rs
@@ -1,7 +1,6 @@
-use super::Transforms;
 use crate::error::ChainResponse;
 use crate::message::Messages;
-use crate::transforms::{Transform, TransformBuilder, Wrapper};
+use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
 use serde::Deserialize;
@@ -21,8 +20,10 @@ pub struct CoalesceConfig {
     pub flush_when_millis_since_last_flush: Option<u128>,
 }
 
-impl CoalesceConfig {
-    pub async fn get_builder(&self) -> Result<Box<dyn TransformBuilder>> {
+#[typetag::deserialize(name = "Coalesce")]
+#[async_trait(?Send)]
+impl TransformConfig for CoalesceConfig {
+    async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(Coalesce {
             buffer: Vec::with_capacity(self.flush_when_buffered_message_count.unwrap_or(0)),
             flush_when_buffered_message_count: self.flush_when_buffered_message_count,

--- a/shotover-proxy/src/transforms/debug/force_parse.rs
+++ b/shotover-proxy/src/transforms/debug/force_parse.rs
@@ -6,20 +6,27 @@
 /// It could also be used to ensure that messages round trip correctly when parsed.
 use crate::error::ChainResponse;
 use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
-use anyhow::Result;
 use async_trait::async_trait;
 use serde::Deserialize;
+
+#[cfg(feature = "alpha-transforms")]
+use crate::transforms::TransformConfig;
+#[cfg(feature = "alpha-transforms")]
+use anyhow::Result;
 
 /// Messages that pass through this transform will be parsed.
 /// Must be individually enabled at the request or response level.
 #[derive(Deserialize, Debug)]
 pub struct DebugForceParseConfig {
-    parse_requests: bool,
-    parse_responses: bool,
+    pub parse_requests: bool,
+    pub parse_responses: bool,
 }
 
-impl DebugForceParseConfig {
-    pub async fn get_builder(&self) -> Result<Box<dyn TransformBuilder>> {
+#[cfg(feature = "alpha-transforms")]
+#[typetag::deserialize(name = "DebugForceParse")]
+#[async_trait(?Send)]
+impl TransformConfig for DebugForceParseConfig {
+    async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(DebugForceParse {
             parse_requests: self.parse_requests,
             parse_responses: self.parse_responses,
@@ -33,12 +40,15 @@ impl DebugForceParseConfig {
 /// Must be individually enabled at the request or response level.
 #[derive(Deserialize, Debug)]
 pub struct DebugForceEncodeConfig {
-    encode_requests: bool,
-    encode_responses: bool,
+    pub encode_requests: bool,
+    pub encode_responses: bool,
 }
 
-impl DebugForceEncodeConfig {
-    pub async fn get_builder(&self) -> Result<Box<dyn TransformBuilder>> {
+#[cfg(feature = "alpha-transforms")]
+#[typetag::deserialize(name = "DebugForceEncode")]
+#[async_trait(?Send)]
+impl TransformConfig for DebugForceEncodeConfig {
+    async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(DebugForceParse {
             parse_requests: self.encode_requests,
             parse_responses: self.encode_responses,

--- a/shotover-proxy/src/transforms/debug/force_parse.rs
+++ b/shotover-proxy/src/transforms/debug/force_parse.rs
@@ -5,14 +5,13 @@
 /// without worrying about the performance impact of other transform logic.
 /// It could also be used to ensure that messages round trip correctly when parsed.
 use crate::error::ChainResponse;
-use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
-use async_trait::async_trait;
-use serde::Deserialize;
-
 #[cfg(feature = "alpha-transforms")]
 use crate::transforms::TransformConfig;
+use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
 #[cfg(feature = "alpha-transforms")]
 use anyhow::Result;
+use async_trait::async_trait;
+use serde::Deserialize;
 
 /// Messages that pass through this transform will be parsed.
 /// Must be individually enabled at the request or response level.

--- a/shotover-proxy/src/transforms/debug/printer.rs
+++ b/shotover-proxy/src/transforms/debug/printer.rs
@@ -1,8 +1,20 @@
+use crate::error::ChainResponse;
+use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::Deserialize;
 use tracing::info;
 
-use crate::error::ChainResponse;
-use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
-use async_trait::async_trait;
+#[derive(Deserialize, Debug)]
+pub struct DebugPrinterConfig;
+
+#[typetag::deserialize(name = "DebugPrinter")]
+#[async_trait(?Send)]
+impl TransformConfig for DebugPrinterConfig {
+    async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
+        Ok(Box::new(DebugPrinter::new()))
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct DebugPrinter {

--- a/shotover-proxy/src/transforms/debug/returner.rs
+++ b/shotover-proxy/src/transforms/debug/returner.rs
@@ -1,6 +1,8 @@
 use crate::frame::{Frame, RedisFrame};
 use crate::message::{Message, Messages};
-use crate::transforms::{ChainResponse, Transform, TransformBuilder, Transforms, Wrapper};
+use crate::transforms::{
+    ChainResponse, Transform, TransformBuilder, TransformConfig, Transforms, Wrapper,
+};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use serde::Deserialize;
@@ -11,8 +13,10 @@ pub struct DebugReturnerConfig {
     response: Response,
 }
 
-impl DebugReturnerConfig {
-    pub async fn get_builder(&self) -> Result<Box<dyn TransformBuilder>> {
+#[typetag::deserialize(name = "DebugReturner")]
+#[async_trait(?Send)]
+impl TransformConfig for DebugReturnerConfig {
+    async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(DebugReturner::new(self.response.clone())))
     }
 }

--- a/shotover-proxy/src/transforms/distributed/tuneable_consistency_scatter.rs
+++ b/shotover-proxy/src/transforms/distributed/tuneable_consistency_scatter.rs
@@ -1,10 +1,9 @@
+use crate::config::chain::TransformChainConfig;
 use crate::error::ChainResponse;
 use crate::frame::{Frame, RedisFrame};
 use crate::message::{Message, QueryType};
 use crate::transforms::chain::{BufferedChain, TransformChainBuilder};
-use crate::transforms::{
-    build_chain_from_config, Transform, TransformBuilder, Transforms, TransformsConfig, Wrapper,
-};
+use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
 use futures::stream::FuturesUnordered;
@@ -15,18 +14,20 @@ use tracing::{error, warn};
 
 #[derive(Deserialize, Debug)]
 pub struct TuneableConsistencyScatterConfig {
-    pub route_map: HashMap<String, Vec<TransformsConfig>>,
+    pub route_map: HashMap<String, TransformChainConfig>,
     pub write_consistency: i32,
     pub read_consistency: i32,
 }
 
-impl TuneableConsistencyScatterConfig {
-    pub async fn get_builder(&self) -> Result<Box<dyn TransformBuilder>> {
+#[typetag::deserialize(name = "TuneableConsistencyScatter")]
+#[async_trait(?Send)]
+impl TransformConfig for TuneableConsistencyScatterConfig {
+    async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
         let mut route_map = Vec::with_capacity(self.route_map.len());
         warn!("Using this transform is considered unstable - Does not work with REDIS pipelines");
 
         for (key, value) in &self.route_map {
-            route_map.push(build_chain_from_config(key.clone(), value).await?);
+            route_map.push(value.get_builder(key.clone()).await?);
         }
         route_map.sort_by_key(|x| x.name.clone());
 

--- a/shotover-proxy/src/transforms/filter.rs
+++ b/shotover-proxy/src/transforms/filter.rs
@@ -1,6 +1,6 @@
 use crate::error::ChainResponse;
 use crate::message::{Message, QueryType};
-use crate::transforms::{Transform, TransformBuilder, Wrapper};
+use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
 use serde::Deserialize;
@@ -20,8 +20,10 @@ pub struct QueryTypeFilterConfig {
     pub filter: QueryType,
 }
 
-impl QueryTypeFilterConfig {
-    pub async fn get_builder(&self) -> Result<Box<dyn TransformBuilder>> {
+#[typetag::deserialize(name = "QueryTypeFilter")]
+#[async_trait(?Send)]
+impl TransformConfig for QueryTypeFilterConfig {
+    async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(QueryTypeFilter {
             filter: self.filter.clone(),
         }))

--- a/shotover-proxy/src/transforms/kafka/sink_single.rs
+++ b/shotover-proxy/src/transforms/kafka/sink_single.rs
@@ -22,8 +22,14 @@ pub struct KafkaSinkSingleConfig {
     pub read_timeout: Option<u64>,
 }
 
-impl KafkaSinkSingleConfig {
-    pub async fn get_builder(&self, chain_name: String) -> Result<Box<dyn TransformBuilder>> {
+#[cfg(feature = "alpha-transforms")]
+use crate::transforms::TransformConfig;
+
+#[cfg(feature = "alpha-transforms")]
+#[typetag::deserialize(name = "KafkaSinkSingle")]
+#[async_trait(?Send)]
+impl TransformConfig for KafkaSinkSingleConfig {
+    async fn get_builder(&self, chain_name: String) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(KafkaSinkSingleBuilder::new(
             self.address.clone(),
             chain_name,

--- a/shotover-proxy/src/transforms/null.rs
+++ b/shotover-proxy/src/transforms/null.rs
@@ -1,8 +1,19 @@
 use crate::error::ChainResponse;
-use crate::transforms::{Transform, Wrapper};
+use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
+use anyhow::Result;
 use async_trait::async_trait;
+use serde::Deserialize;
 
-use super::{TransformBuilder, Transforms};
+#[derive(Deserialize, Debug)]
+pub struct NullSinkConfig;
+
+#[typetag::deserialize(name = "NullSink")]
+#[async_trait(?Send)]
+impl TransformConfig for NullSinkConfig {
+    async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
+        Ok(Box::new(NullSink {}))
+    }
+}
 
 #[derive(Debug, Clone, Default)]
 pub struct NullSink {}

--- a/shotover-proxy/src/transforms/protect/mod.rs
+++ b/shotover-proxy/src/transforms/protect/mod.rs
@@ -25,8 +25,14 @@ pub struct ProtectConfig {
     pub key_manager: KeyManagerConfig,
 }
 
-impl ProtectConfig {
-    pub async fn get_builder(&self) -> Result<Box<dyn TransformBuilder>> {
+#[cfg(feature = "alpha-transforms")]
+use crate::transforms::TransformConfig;
+
+#[cfg(feature = "alpha-transforms")]
+#[typetag::deserialize(name = "Protect")]
+#[async_trait(?Send)]
+impl TransformConfig for ProtectConfig {
+    async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(Protect {
             keyspace_table_columns: self
                 .keyspace_table_columns

--- a/shotover-proxy/src/transforms/query_counter.rs
+++ b/shotover-proxy/src/transforms/query_counter.rs
@@ -1,6 +1,7 @@
 use crate::error::ChainResponse;
 use crate::frame::Frame;
 use crate::frame::RedisFrame;
+use crate::transforms::TransformConfig;
 use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -85,8 +86,10 @@ fn get_redis_query_type(frame: &RedisFrame) -> Option<String> {
     None
 }
 
-impl QueryCounterConfig {
-    pub async fn get_builder(&self) -> Result<Box<dyn TransformBuilder>> {
+#[typetag::deserialize(name = "QueryCounter")]
+#[async_trait(?Send)]
+impl TransformConfig for QueryCounterConfig {
+    async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(QueryCounter::new(self.name.clone())))
     }
 }

--- a/shotover-proxy/src/transforms/redis/cluster_ports_rewrite.rs
+++ b/shotover-proxy/src/transforms/redis/cluster_ports_rewrite.rs
@@ -6,15 +6,17 @@ use serde::Deserialize;
 
 use crate::error::ChainResponse;
 use crate::frame::Frame;
-use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
+use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 
 #[derive(Deserialize, Debug)]
 pub struct RedisClusterPortsRewriteConfig {
     pub new_port: u16,
 }
 
-impl RedisClusterPortsRewriteConfig {
-    pub async fn get_builder(&self) -> Result<Box<dyn TransformBuilder>> {
+#[typetag::deserialize(name = "RedisClusterPortsRewrite")]
+#[async_trait(?Send)]
+impl TransformConfig for RedisClusterPortsRewriteConfig {
+    async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(RedisClusterPortsRewrite {
             new_port: self.new_port,
         }))

--- a/shotover-proxy/src/transforms/redis/sink_cluster.rs
+++ b/shotover-proxy/src/transforms/redis/sink_cluster.rs
@@ -9,7 +9,8 @@ use crate::transforms::redis::TransformError;
 use crate::transforms::util::cluster_connection_pool::{Authenticator, ConnectionPool};
 use crate::transforms::util::{Request, Response};
 use crate::transforms::{
-    ResponseFuture, Transform, TransformBuilder, Transforms, Wrapper, CONTEXT_CHAIN_NAME,
+    ResponseFuture, Transform, TransformBuilder, TransformConfig, Transforms, Wrapper,
+    CONTEXT_CHAIN_NAME,
 };
 use anyhow::{anyhow, bail, ensure, Context, Result};
 use async_trait::async_trait;
@@ -45,8 +46,10 @@ pub struct RedisSinkClusterConfig {
     pub connect_timeout_ms: u64,
 }
 
-impl RedisSinkClusterConfig {
-    pub async fn get_builder(&self, chain_name: String) -> Result<Box<dyn TransformBuilder>> {
+#[typetag::deserialize(name = "RedisSinkCluster")]
+#[async_trait(?Send)]
+impl TransformConfig for RedisSinkClusterConfig {
+    async fn get_builder(&self, chain_name: String) -> Result<Box<dyn TransformBuilder>> {
         let mut cluster = RedisSinkCluster::new(
             self.first_contact_points.clone(),
             self.direct_destination.clone(),

--- a/shotover-proxy/src/transforms/redis/sink_single.rs
+++ b/shotover-proxy/src/transforms/redis/sink_single.rs
@@ -6,8 +6,9 @@ use crate::frame::{Frame, RedisFrame};
 use crate::message::{Message, Messages};
 use crate::tcp;
 use crate::tls::{AsyncStream, TlsConnector, TlsConnectorConfig};
-use crate::transforms::ChainResponse;
-use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
+use crate::transforms::{
+    ChainResponse, Transform, TransformBuilder, TransformConfig, Transforms, Wrapper,
+};
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use futures::{FutureExt, SinkExt, StreamExt};
@@ -29,8 +30,10 @@ pub struct RedisSinkSingleConfig {
     pub connect_timeout_ms: u64,
 }
 
-impl RedisSinkSingleConfig {
-    pub async fn get_builder(&self, chain_name: String) -> Result<Box<dyn TransformBuilder>> {
+#[typetag::deserialize(name = "RedisSinkSingle")]
+#[async_trait(?Send)]
+impl TransformConfig for RedisSinkSingleConfig {
+    async fn get_builder(&self, chain_name: String) -> Result<Box<dyn TransformBuilder>> {
         let tls = self.tls.clone().map(TlsConnector::new).transpose()?;
         Ok(Box::new(RedisSinkSingleBuilder::new(
             self.address.clone(),

--- a/shotover-proxy/src/transforms/redis/timestamp_tagging.rs
+++ b/shotover-proxy/src/transforms/redis/timestamp_tagging.rs
@@ -2,14 +2,26 @@ use crate::error::ChainResponse;
 use crate::frame::redis::redis_query_type;
 use crate::frame::{Frame, RedisFrame};
 use crate::message::{Message, QueryType};
-use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
+use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
 use itertools::Itertools;
+use serde::Deserialize;
 use std::fmt::Write;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::{debug, trace};
+
+#[derive(Deserialize, Debug)]
+pub struct RedisTimestampTaggerConfig;
+
+#[typetag::deserialize(name = "RedisTimestampTagger")]
+#[async_trait(?Send)]
+impl TransformConfig for RedisTimestampTaggerConfig {
+    async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
+        Ok(Box::new(RedisTimestampTagger {}))
+    }
+}
 
 #[derive(Clone, Default)]
 pub struct RedisTimestampTagger {}

--- a/shotover-proxy/src/transforms/throttling.rs
+++ b/shotover-proxy/src/transforms/throttling.rs
@@ -1,8 +1,5 @@
-use crate::{
-    error::ChainResponse,
-    message::Message,
-    transforms::{Transform, TransformBuilder, Wrapper},
-};
+use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
+use crate::{error::ChainResponse, message::Message};
 use anyhow::Result;
 use async_trait::async_trait;
 use governor::{
@@ -23,8 +20,10 @@ pub struct RequestThrottlingConfig {
     pub max_requests_per_second: NonZeroU32,
 }
 
-impl RequestThrottlingConfig {
-    pub fn get_builder(&self) -> Result<Box<dyn TransformBuilder>> {
+#[typetag::deserialize(name = "RequestThrottling")]
+#[async_trait(?Send)]
+impl TransformConfig for RequestThrottlingConfig {
+    async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(RequestThrottling {
             limiter: Arc::new(RateLimiter::direct(Quota::per_second(
                 self.max_requests_per_second,


### PR DESCRIPTION
To achieve this, we sprinkle in some dtolnay magic crates: 
* typetag - we will always need this to magically hook up our traits to serde
* async_trait - the rust team seem pretty intent on landing some form of async traits one day so we should eventually be able to remove this

And finally we need a custom deserialize implementation for our chain config.
The problem was that typetagged structs with no fields would not deserialize from a yaml string.
e.g.
this would fail to deserialize:
```
chain_config:
  redis_chain:
    - NullSink
```

but this would work fine:
```
chain_config:
  redis_chain:
    - NullSink: {}
```

I do not really understand what the `vec_transform_config` custom deserializer is doing, but it clearly does fix the issue, allowing us to write our config as `NullSink` instead of `NullSink: {}`.
I can do a thorough investigation to better understand it if needed.
The implementation was a suggestion from dtolnay: https://github.com/dtolnay/typetag/pull/40#issuecomment-1454961686
This solution does add a bunch of complexity but it is at least hidden away in its own module and doesn't affect users of the API.