### PR TITLE
Topology building cleanup

### DIFF
--- a/shotover-proxy/src/runner.rs
+++ b/shotover-proxy/src/runner.rs
@@ -74,7 +74,7 @@ pub struct Runner {
 impl Runner {
     pub fn new(params: ConfigOpts) -> Result<Self> {
         let config = Config::from_file(params.config_file)?;
-        let topology = Topology::from_file(params.topology_file)?;
+        let topology = Topology::from_file(&params.topology_file)?;
 
         let tracing = TracingState::new(config.main_log_level.as_str(), params.log_format)?;
 


### PR DESCRIPTION
* `from_yaml` was used by a test but it could just as easily use the standard `from_file` so I just replaced it
* TopologyConfig and Topology have the exact same fields so there is no point in keeping the separation anymore (they used to have different fields a long time ago)