### PR TITLE
Add ShotoverProcessBuilder::with_observability_address

### DIFF
--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -289,21 +289,21 @@ async fn cluster_multi_rack(#[case] driver: CassandraDriver) {
             "example-configs/cassandra-cluster-multi-rack/topology_rack1.yaml",
         )
         .with_log_name("Rack1")
-        .with_observability_address("127.0.0.1:9001".parse().unwrap())
+        .with_observability_port(9001)
         .start()
         .await;
         let shotover_rack2 = ShotoverProcessBuilder::new_with_topology(
             "example-configs/cassandra-cluster-multi-rack/topology_rack2.yaml",
         )
         .with_log_name("Rack2")
-        .with_observability_address("127.0.0.1:9002".parse().unwrap())
+        .with_observability_port(9002)
         .start()
         .await;
         let shotover_rack3 = ShotoverProcessBuilder::new_with_topology(
             "example-configs/cassandra-cluster-multi-rack/topology_rack3.yaml",
         )
         .with_log_name("Rack3")
-        .with_observability_address("127.0.0.1:9003".parse().unwrap())
+        .with_observability_port(9003)
         .start()
         .await;
 

--- a/test-helpers/src/shotover_process.rs
+++ b/test-helpers/src/shotover_process.rs
@@ -1,16 +1,15 @@
-use std::net::SocketAddr;
 use std::time::Duration;
+use uuid::Uuid;
 
 pub use tokio_bin_process::event::{Event, Level};
 pub use tokio_bin_process::event_matcher::{Count, EventMatcher, Events};
 pub use tokio_bin_process::BinProcess;
-use uuid::Uuid;
 
 pub struct ShotoverProcessBuilder {
     topology_path: String,
     log_name: Option<String>,
     cores: Option<String>,
-    observability_address: Option<SocketAddr>,
+    observability_port: Option<u16>,
 }
 
 impl ShotoverProcessBuilder {
@@ -19,7 +18,7 @@ impl ShotoverProcessBuilder {
             topology_path: topology_path.to_owned(),
             log_name: None,
             cores: None,
-            observability_address: None,
+            observability_port: None,
         }
     }
 
@@ -33,8 +32,8 @@ impl ShotoverProcessBuilder {
         self
     }
 
-    pub fn with_observability_address(mut self, address: SocketAddr) -> Self {
-        self.observability_address = Some(address);
+    pub fn with_observability_port(mut self, port: u16) -> Self {
+        self.observability_port = Some(port);
         self
     }
 
@@ -43,13 +42,13 @@ impl ShotoverProcessBuilder {
         if let Some(cores) = &self.cores {
             args.extend(["--core-threads", cores]);
         }
-        let config_path = if let Some(observability_address) = self.observability_address {
+        let config_path = if let Some(observability_port) = self.observability_port {
             let config_path = std::env::temp_dir().join(Uuid::new_v4().to_string());
             let config_contents = format!(
                 r#"
 ---
 main_log_level: "info,shotover_proxy=info"
-observability_interface: "{observability_address}"
+observability_interface: "127.0.0.1:{observability_port}"
 "#
             );
             std::fs::write(&config_path, config_contents).unwrap();

--- a/test-helpers/src/shotover_process.rs
+++ b/test-helpers/src/shotover_process.rs
@@ -1,13 +1,16 @@
+use std::net::SocketAddr;
 use std::time::Duration;
 
 pub use tokio_bin_process::event::{Event, Level};
 pub use tokio_bin_process::event_matcher::{Count, EventMatcher, Events};
 pub use tokio_bin_process::BinProcess;
+use uuid::Uuid;
 
 pub struct ShotoverProcessBuilder {
     topology_path: String,
     log_name: Option<String>,
     cores: Option<String>,
+    observability_address: Option<SocketAddr>,
 }
 
 impl ShotoverProcessBuilder {
@@ -16,6 +19,7 @@ impl ShotoverProcessBuilder {
             topology_path: topology_path.to_owned(),
             log_name: None,
             cores: None,
+            observability_address: None,
         }
     }
 
@@ -29,11 +33,32 @@ impl ShotoverProcessBuilder {
         self
     }
 
+    pub fn with_observability_address(mut self, address: SocketAddr) -> Self {
+        self.observability_address = Some(address);
+        self
+    }
+
     pub async fn start(&self) -> BinProcess {
         let mut args = vec!["-t", &self.topology_path, "--log-format", "json"];
         if let Some(cores) = &self.cores {
             args.extend(["--core-threads", cores]);
         }
+        let config_path = if let Some(observability_address) = self.observability_address {
+            let config_path = std::env::temp_dir().join(Uuid::new_v4().to_string());
+            let config_contents = format!(
+                r#"
+---
+main_log_level: "info,shotover_proxy=info"
+observability_interface: "{observability_address}"
+"#
+            );
+            std::fs::write(&config_path, config_contents).unwrap();
+            config_path.into_os_string().into_string().unwrap()
+        } else {
+            "config/config.yaml".to_owned()
+        };
+        args.extend(["-c", &config_path]);
+
         let mut shotover = BinProcess::start_with_args(
             "shotover-proxy",
             &args,


### PR DESCRIPTION
Allows us to correctly configure shotover in integration tests with multiple shotover instances.
Previously we had to tell BinProcess to ignore the resulting error.

Generating config for this is not ideal, but we currently dont expose this as a CLI flag, and I dont want to block this improvement on figuring out what our CLI/config.yaml split should look like.