### PR TITLE
Update to rust 1.68 🦀🦀🦀

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3047,7 +3047,6 @@ dependencies = [
  "num",
  "openssl",
  "ordered-float",
- "pin-project-lite",
  "pretty-hex",
  "rand",
  "rand_distr",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.67"
+channel = "1.68"
 components = [ "rustfmt", "clippy" ]
 targets = [ "aarch64-unknown-linux-gnu" ]

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -29,7 +29,6 @@ itertools.workspace = true
 rand = "0.8.4"
 rand_distr = "0.4.1"
 cached = "0.42"
-pin-project-lite = "0.2"
 tokio-openssl.workspace = true
 openssl.workspace = true
 async-recursion = "1.0"

--- a/shotover-proxy/src/transforms/throttling.rs
+++ b/shotover-proxy/src/transforms/throttling.rs
@@ -67,7 +67,6 @@ impl Transform for RequestThrottling {
         // extract throttled messages from the message_wrapper
         #[allow(clippy::needless_collect)]
         let throttled_messages: Vec<(Message, usize)> = (0..message_wrapper.messages.len())
-            .into_iter()
             .rev()
             .filter_map(|i| {
                 if self


### PR DESCRIPTION
1.68 adds `pin!` from pin-project-lite into the std lib.
I went to remove `pin-project-lite` and found that we werent actually making use of it anyway! :rofl: 

throttling.rs change is due to new clippy lint

Also note that you will want to configure the sparse protocol locally - https://blog.rust-lang.org/2023/03/09/Rust-1.68.0.html#cargos-sparse-protocol
We could check it into our repo level `.cargo/config` but it will be the default in a few releases anyway so lets just let developers set it themselves.