### PR TITLE
Fix invalid modifications to FindCoordinator responses

### DIFF
--- a/shotover-proxy/src/transforms/kafka/sink_single.rs
+++ b/shotover-proxy/src/transforms/kafka/sink_single.rs
@@ -123,13 +123,17 @@ impl Transform for KafkaSinkSingle {
         for response in &mut responses {
             if let Some(Frame::Kafka(KafkaFrame::Response {
                 body: ResponseBody::FindCoordinator(find_coordinator),
+                version,
                 ..
             })) = response.frame()
             {
                 let port = message_wrapper.local_addr.port() as i32;
-                find_coordinator.port = port;
-                for coordinator in &mut find_coordinator.coordinators {
-                    coordinator.port = port;
+                if *version <= 3 {
+                    find_coordinator.port = port;
+                } else {
+                    for coordinator in &mut find_coordinator.coordinators {
+                        coordinator.port = port;
+                    }
                 }
                 response.invalidate_cache();
             }


### PR DESCRIPTION
The problem was that the encoder expects protocols >= 4 to have all the removed fields set to 0 (or equivalent default value)
We were just setting all the port fields regardless of version causing the encoder to return an error when a modern protocol was used.
Now we only set the port fields that are actually available in the specific version of the message.

You can verify this fixes the issue by simultaneously running these scripts that come with kafka against `test-configs/kafka/passthrough/topology.yaml`:
```
kafka-console-producer.sh  --topic foo --bootstrap-server 127.0.0.1:9192
```
and 
```
kafka-console-consumer.sh --topic foo --bootstrap-server 127.0.0.1:9192
```
Then sending a message through the producer and observing it appear in the consumer.
Before this fix, we would hit the encode error and nothing would appear in the consumer.