### PR TITLE
Another kafka fix

### DIFF
--- a/shotover-proxy/src/codec/kafka.rs
+++ b/shotover-proxy/src/codec/kafka.rs
@@ -65,10 +65,10 @@ impl KafkaDecoder {
     }
 }
 
-fn get_length_of_full_message(src: &mut BytesMut) -> Option<usize> {
+fn get_length_of_full_message(src: &BytesMut) -> Option<usize> {
     if src.len() > 4 {
         let size = u32::from_be_bytes(src[0..4].try_into().unwrap()) as usize + 4;
-        if size >= src.len() {
+        if size <= src.len() {
             Some(size)
         } else {
             None


### PR DESCRIPTION
Ooopsies we had the `>=` flipped.
It was working most of the time because most of the time `size == `src.len()`
But when we actually had an incomplete message on the buffer it panicked trying to read past the end of the buffer instead of waiting for the rest of the message to come through.