### PR TITLE
Return error message to client when chain fails to send/receive

### DIFF
--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -227,7 +227,7 @@ async fn cluster_single_rack_v4(#[case] driver: CassandraDriver) {
                         r#"connection was unexpectedly terminated
 
 Caused by:
-    0: chain failed to send and/or receive messages
+    0: Chain failed to send and/or receive messages, the connection will now be closed.
     1: CassandraSinkCluster transform failed
     2: Failed to create new connection
     3: destination 172.16.1.3:9044 did not respond to connection attempt within 3s"#,
@@ -240,7 +240,7 @@ Caused by:
                         r#"connection was unexpectedly terminated
 
 Caused by:
-    0: chain failed to send and/or receive messages
+    0: Chain failed to send and/or receive messages, the connection will now be closed.
     1: CassandraSinkCluster transform failed
     2: system.local returned unexpected cassandra operation: Error(ErrorBody { message: "Internal shotover error: Broken pipe (os error 32)", ty: Server })"#,
                     )

--- a/shotover-proxy/tests/redis_int_tests/mod.rs
+++ b/shotover-proxy/tests/redis_int_tests/mod.rs
@@ -68,7 +68,7 @@ async fn passthrough_redis_down() {
                     r#"connection was unexpectedly terminated
 
 Caused by:
-    0: chain failed to send and/or receive messages
+    0: Chain failed to send and/or receive messages, the connection will now be closed.
     1: RedisSinkSingle transform failed
     2: Failed to connect to destination "127.0.0.1:1111"
     3: Connection refused (os error 111)"#,


### PR DESCRIPTION
I think this is useful for the reasons I wrote about in the code comment.

However it does come at a performance cost - there is now one extra allocation per incoming message batch. (just for the vec, the `Message`s themselves do not allocate)

I still think its worth it though.

An easy way to test this new handling is to run a shotover config without a database running at the destination address.
