### PR TITLE
Improve docker-compose.yaml validation with this one small trick

### DIFF
--- a/test-helpers/src/docker_compose.rs
+++ b/test-helpers/src/docker_compose.rs
@@ -76,11 +76,13 @@ impl DockerCompose {
             panic!("Could not find docker-compose. Have you installed it?");
         }
 
+        // It is critical that clean_up is run before everything else as the internal `docker-compose` commands act as validation
+        // for the docker-compose.yaml file that we later manually parse with poor error handling
+        DockerCompose::clean_up(file_path).unwrap();
+
         let service_to_image = DockerCompose::get_service_to_image(file_path);
 
         DockerCompose::build_images(&service_to_image);
-
-        DockerCompose::clean_up(file_path).unwrap();
 
         run_command("docker-compose", &["-f", file_path, "up", "-d"]).unwrap();
 


### PR DESCRIPTION
Fixes a small regression introduced by https://github.com/shotover/shotover-proxy/pull/1070
Before 1070 we were running docker-compose against the docker-compose.yaml before we ran `DockerCompose::get_service_to_image`.
This ensured that we ran all of docker-compose's validation against the docker-compose.yaml, ensuring that we had a valid docker-compose.yaml for when our parser with poor error handling attempts to read it .

This PR restores a similar logic by moving `clean_up` before `get_service_to_image`.
You can verify the effect of this PR by breaking a docker-compose.yaml file and then running its test.