### PR TITLE
Add benchmarks for kafka

### DIFF
--- a/shotover-proxy/examples/kafka_bench.rs
+++ b/shotover-proxy/examples/kafka_bench.rs
@@ -1,0 +1,27 @@
+use test_helpers::docker_compose::DockerCompose;
+use test_helpers::kafka_producer_perf_test::run_producer_bench;
+use test_helpers::shotover_process::ShotoverProcessBuilder;
+
+#[tokio::main]
+async fn main() {
+    test_helpers::bench::init();
+
+    let config_dir = "tests/test-configs/kafka/passthrough";
+    {
+        let _compose = DockerCompose::new(&format!("{}/docker-compose.yaml", config_dir));
+        let shotover =
+            ShotoverProcessBuilder::new_with_topology(&format!("{}/topology.yaml", config_dir))
+                .start()
+                .await;
+
+        println!("Benching Shotover ...");
+        run_producer_bench("[localhost]:9192");
+
+        shotover.shutdown_and_then_consume_events(&[]).await;
+    }
+
+    // restart the docker container to avoid running out of disk space
+    let _compose = DockerCompose::new(&format!("{}/docker-compose.yaml", config_dir));
+    println!("\nBenching Direct Kafka ...");
+    run_producer_bench("[localhost]:9092");
+}

--- a/shotover-proxy/examples/kafka_flamegraph.rs
+++ b/shotover-proxy/examples/kafka_flamegraph.rs
@@ -1,0 +1,32 @@
+use test_helpers::docker_compose::DockerCompose;
+use test_helpers::flamegraph::Perf;
+use test_helpers::kafka_producer_perf_test::run_producer_bench;
+use test_helpers::shotover_process::ShotoverProcessBuilder;
+
+// To get useful results you will need to modify the Cargo.toml like:
+// [profile.release]
+// #lto = "fat"
+// codegen-units = 1
+// debug = true
+
+#[tokio::main]
+async fn main() {
+    test_helpers::bench::init();
+    let config_dir = "tests/test-configs/kafka/passthrough";
+    {
+        let _compose = DockerCompose::new(&format!("{}/docker-compose.yaml", config_dir));
+
+        let shotover =
+            ShotoverProcessBuilder::new_with_topology(&format!("{}/topology.yaml", config_dir))
+                .start()
+                .await;
+
+        let perf = Perf::new(shotover.child.as_ref().unwrap().id().unwrap());
+
+        println!("Benching Shotover ...");
+        run_producer_bench("[localhost]:9192");
+
+        shotover.shutdown_and_then_consume_events(&[]).await;
+        perf.flamegraph();
+    }
+}

--- a/test-helpers/src/kafka_producer_perf_test.rs
+++ b/test-helpers/src/kafka_producer_perf_test.rs
@@ -1,0 +1,19 @@
+use crate::run_command_to_stdout;
+
+pub fn run_producer_bench(address_bench: &str) {
+    run_command_to_stdout(
+        "kafka-producer-perf-test.sh",
+        &[
+            "--producer-props",
+            &format!("bootstrap.servers={address_bench}"),
+            "--record-size",
+            "1000",
+            "--throughput",
+            "-1",
+            "--num-records",
+            "5000000",
+            "--topic",
+            "foo",
+        ],
+    );
+}

--- a/test-helpers/src/latte.rs
+++ b/test-helpers/src/latte.rs
@@ -1,3 +1,5 @@
+use crate::run_command_to_stdout;
+
 // TODO: Shelling out directly like this is just for experimenting.
 // Either:
 // * get access to latte as a crate
@@ -84,16 +86,4 @@ impl Latte {
     pub fn compare(&self, file_a: &str, file_b: &str) {
         run_command_to_stdout("latte", &["show", file_b, "-b", file_a]);
     }
-}
-
-/// unlike crate::docker_compose::run_command stdout of the command is sent to the stdout of the application
-fn run_command_to_stdout(command: &str, args: &[&str]) {
-    assert!(
-        std::process::Command::new(command)
-            .args(args)
-            .status()
-            .unwrap()
-            .success(),
-        "Failed to run: {command} {args:?}"
-    );
 }

--- a/test-helpers/src/lib.rs
+++ b/test-helpers/src/lib.rs
@@ -3,6 +3,7 @@ pub mod cert;
 pub mod connection;
 pub mod docker_compose;
 pub mod flamegraph;
+pub mod kafka_producer_perf_test;
 pub mod latte;
 pub mod lazy;
 pub mod metrics;
@@ -25,4 +26,15 @@ pub fn try_wait_for_socket_to_open(address: &str, port: u16) -> Result<()> {
         tries += 1;
     }
     Ok(())
+}
+
+fn run_command_to_stdout(command: &str, args: &[&str]) {
+    assert!(
+        std::process::Command::new(command)
+            .args(args)
+            .status()
+            .unwrap()
+            .success(),
+        "Failed to run: {command} {args:?}"
+    );
 }


### PR DESCRIPTION
Adds benchmarks for kafka using the `kafka-producer-perf-test.sh` script that comes with kafka.
The results of `kafka_bench.rs` is that shotover has the same throughput as a direct connection:
```
shotover-proxy〉cargo run --release --example kafka_bench
   Compiling test-helpers v0.1.0 (/home/rukai2/Projects/Crates/shotover/shotover-proxy/test-helpers)
   Compiling shotover-proxy v0.1.9 (/home/rukai2/Projects/Crates/shotover/shotover-proxy/shotover-proxy)
    Finished release [optimized] target(s) in 22.04s
     Running `target/release/examples/kafka_bench`
shotover   01:21:27.856420Z  INFO shotover_proxy::runner: Starting Shotover 0.1.9
shotover   01:21:27.856442Z  INFO shotover_proxy::runner: configuration=Config { main_log_level: "info,shotover_proxy=info", observability_interface: "0.0.0.0:9001" }
shotover   01:21:27.856449Z  INFO shotover_proxy::runner: topology=Topology { sources: {"kafka_source": Kafka(KafkaConfig { listen_addr: "127.0.0.1:9192", connection_limit: None, hard_connection_limit: None, tls: None, timeout: None })}, chain_config: {"main_chain": [KafkaSinkSingle(KafkaSinkSingleConfig { address: "127.0.0.1:9092", connect_timeout_ms: 3000, read_timeout: None })]}, source_to_chain_mapping: {"kafka_source": "main_chain"} }
shotover   01:21:27.856471Z  INFO shotover_proxy::config::topology: Loaded chains ["main_chain"]
shotover   01:21:27.856483Z  INFO shotover_proxy::sources::kafka: Starting Kafka source on [127.0.0.1:9192]
shotover   01:21:27.856509Z  INFO shotover_proxy::config::topology: Loaded sources [["kafka_source"]] and linked to chains
shotover   01:21:27.856527Z  INFO shotover_proxy::server: accepting inbound connections
Benching Shotover ...
[2023-03-16 12:21:28,611] WARN [Producer clientId=perf-producer-client] Error while fetching metadata with correlation id 1 : {foo=UNKNOWN_TOPIC_OR_PARTITION} (org.apache.kafka.clients.NetworkClient)
643164 records sent, 128632.8 records/sec (122.67 MB/sec), 105.4 ms avg latency, 587.0 ms max latency.
877718 records sent, 175543.6 records/sec (167.41 MB/sec), 0.6 ms avg latency, 11.0 ms max latency.
882304 records sent, 176460.8 records/sec (168.29 MB/sec), 0.4 ms avg latency, 5.0 ms max latency.
897520 records sent, 179504.0 records/sec (171.19 MB/sec), 0.4 ms avg latency, 3.0 ms max latency.
874635 records sent, 174927.0 records/sec (166.82 MB/sec), 0.4 ms avg latency, 3.0 ms max latency.
5000000 records sent, 168361.505825 records/sec (160.56 MB/sec), 13.95 ms avg latency, 587.00 ms max latency, 0 ms 50th, 14 ms 95th, 402 ms 99th, 561 ms 99.9th.
shotover   01:21:58.470692Z  INFO shotover_proxy::runner: received SIGTERM
shotover   01:21:58.470766Z  INFO shotover_proxy::runner: Shotover was shutdown cleanly.

Benching Direct Kafka ...
[2023-03-16 12:22:04,936] WARN [Producer clientId=perf-producer-client] Error while fetching metadata with correlation id 1 : {foo=UNKNOWN_TOPIC_OR_PARTITION} (org.apache.kafka.clients.NetworkClient)
652616 records sent, 130523.2 records/sec (124.48 MB/sec), 96.1 ms avg latency, 538.0 ms max latency.
868250 records sent, 173650.0 records/sec (165.61 MB/sec), 0.4 ms avg latency, 7.0 ms max latency.
872695 records sent, 174539.0 records/sec (166.45 MB/sec), 0.4 ms avg latency, 4.0 ms max latency.
889070 records sent, 177814.0 records/sec (169.58 MB/sec), 0.5 ms avg latency, 7.0 ms max latency.
894402 records sent, 178880.4 records/sec (170.59 MB/sec), 0.5 ms avg latency, 3.0 ms max latency.
5000000 records sent, 168953.166182 records/sec (161.13 MB/sec), 12.95 ms avg latency, 538.00 ms max latency, 0 ms 50th, 5 ms 95th, 381 ms 99th, 510 ms 99.9th.
```

However I do not really trust these results, I suspect the bencher is only single threaded and therefore isnt putting a proper load on shotover or kafka.
We can further investigate a better benchmarker but for now lets land these benches as they are a useful starting point.

The benchmarks also do not measure encoding/decoding time as a simple shotover setup does not trigger encoding/decoding.