### PR TITLE
Fix cassandra ResponseError formatting

### DIFF
--- a/shotover-proxy/src/transforms/cassandra/connection.rs
+++ b/shotover-proxy/src/transforms/cassandra/connection.rs
@@ -31,7 +31,7 @@ struct Request {
 pub type Response = Result<Message, ResponseError>;
 
 #[derive(Debug, thiserror::Error)]
-#[error("Connection to destination cassandra node {destination} was closed: {cause}")]
+#[error("Connection to destination cassandra node {destination} was closed: {cause:?}")]
 pub struct ResponseError {
     #[source]
     pub cause: anyhow::Error,
@@ -44,7 +44,7 @@ impl ResponseError {
         Message::from_frame(Frame::Cassandra(CassandraFrame::shotover_error(
             self.stream_id,
             version,
-            &format!("{:#}", self.cause),
+            &format!("{}", self),
         )))
     }
 }


### PR DESCRIPTION
We now generate the message from `self` instead of `self.cause`, using `self.cause` was skipping the error formatting specified by `#[error("Connection to destination cassandra node {destination} was closed: {cause:?}")]`

Additionally:
* we just use `{}` instead of `{:#}` because thiserror includes everything on the default formatter.
* we use `{cause:?}` instead of `{cause}` because anyhow needs the Debug formatter to include everything.