### PR TITLE
Update to cassandra-cpp 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,9 +300,9 @@ checksum = "3a4f925191b4367301851c6d99b09890311d74b0d43f274c0b34c86d308a3663"
 
 [[package]]
 name = "cassandra-cpp"
-version = "1.2.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac225f80bd80702ff216407c16691ab15c47ae91de8539efe01dc9d60ded34d"
+checksum = "877b9c602f5337bea76f4868f4555a0bf450b8431920d624fc3770a18f7f2247"
 dependencies = [
  "cassandra-cpp-sys",
  "error-chain",

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -82,7 +82,7 @@ kafka-protocol = "0.6.0"
 criterion = { git = "https://github.com/shotover/criterion.rs", branch = "0.4.0-bench_with_input_fn", features = ["async_tokio"] }
 redis.workspace = true
 serial_test = "1.0.0"
-cassandra-cpp = { version = "1.2.0" }
+cassandra-cpp = { version = "2.0.0" }
 test-helpers = { path = "../test-helpers", features = ["cassandra-cpp-driver-tests"] }
 hex-literal = "0.3.3"
 nix.workspace = true

--- a/test-helpers/Cargo.toml
+++ b/test-helpers/Cargo.toml
@@ -17,7 +17,7 @@ regex = "1.7.0"
 tokio-bin-process = { path = "../tokio-bin-process" }
 cdrs-tokio.workspace = true
 cassandra-protocol.workspace = true
-cassandra-cpp = { version = "1.2.0", optional = true }
+cassandra-cpp = { version = "2.0.0", optional = true }
 scylla = { version = "0.7.0", features = ["ssl"] }
 openssl.workspace = true
 bytes.workspace = true


### PR DESCRIPTION
changelog: https://github.com/Metaswitch/cassandra-rs#new-session-api-version-20

We only use this library for integration tests so as long as the tests still pass we should be good.

The main things for us are the removal of `stmt!` and removal of legacy non-async APIs.
This ended up needing fairly invasive changes for our cassandra benches as they were storing `Statement`s for reuse which is no longer possible.
This should have minimal affect on benchmark results as recreating the statements each round of the bench only introduces one extra allocation per round. (which is nothing compared to the entirety of shotover+cassandra on the other side)