### PR TITLE
a few dep fixes

### DIFF
--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -26,7 +26,7 @@ async-trait = "0.1.30"
 clap = { version = "4.0.4", features = ["cargo", "derive"] }
 derivative = "2.1.1"
 itertools.workspace = true
-rand = "0.8.4"
+rand = { version = "0.8.4", features = ["small_rng"] }
 rand_distr = "0.4.1"
 cached = "0.42"
 tokio-openssl.workspace = true
@@ -88,10 +88,8 @@ hex-literal = "0.3.3"
 nix.workspace = true
 cdrs-tokio.workspace = true
 rstest = "0.16.0"
-rand = { version = "0.8.4", features = ["small_rng"] }
 rdkafka = { version = "0.29", features = ["cmake-build"] }
 
 [[bench]]
 name = "benches"
 harness = false
-required-features = ["cassandra-cpp-driver-tests"]

--- a/shotover-proxy/benches/benches/cassandra.rs
+++ b/shotover-proxy/benches/benches/cassandra.rs
@@ -1,5 +1,5 @@
 use cassandra_cpp::{PreparedStatement, Session, Statement};
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, Criterion};
 use test_helpers::cert::generate_cassandra_test_certs;
 use test_helpers::connection::cassandra::{
     CassandraConnection, CassandraConnectionBuilder, CassandraDriver,
@@ -206,7 +206,6 @@ fn cassandra(c: &mut Criterion) {
 }
 
 criterion_group!(benches, cassandra);
-criterion_main!(benches);
 
 pub struct BenchResources {
     connection: CassandraConnection,

--- a/shotover-proxy/benches/benches/main.rs
+++ b/shotover-proxy/benches/benches/main.rs
@@ -1,6 +1,14 @@
 use criterion::criterion_main;
 
+#[cfg(feature = "cassandra-cpp-driver-tests")]
 mod cassandra;
+#[cfg(not(feature = "cassandra-cpp-driver-tests"))]
+mod cassandra {
+    use criterion::{criterion_group, Criterion};
+    fn cassandra(_: &mut Criterion) {}
+    criterion_group!(benches, cassandra);
+}
+
 mod chain;
 mod codec;
 mod redis;


### PR DESCRIPTION
* The rand `small_rng` feature is needed by shotover itself so we move that from dev-dependencies into a regular dependency
    + Previously this was working because the features are supposed to be additive so the dev-dep enabling the feature meant that cargo could just use the same feature set for shotover itself as well.
* Previously we entirely disabled benchmarks if cassandra-cpp was disabled, this has been changed to now only disable cassandra benchmarks if cassandra-cpp is disabled.