### PR TITLE
CassandraConnection::send returns rx channel

### DIFF
--- a/shotover-proxy/src/transforms/cassandra/sink_cluster/node.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_cluster/node.rs
@@ -11,7 +11,7 @@ use derivative::Derivative;
 use std::net::SocketAddr;
 use std::time::Duration;
 use tokio::net::ToSocketAddrs;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::mpsc;
 use uuid::Uuid;
 
 #[derive(Clone, Derivative)]
@@ -116,30 +116,31 @@ impl ConnectionFactory {
         .map_err(|e| e.context("Failed to create new connection"))?;
 
         for handshake_message in &self.init_handshake {
-            let (return_chan_tx, return_chan_rx) = oneshot::channel();
             outbound
-                .send(handshake_message.clone(), return_chan_tx)
+                .send(handshake_message.clone())
                 .map_err(|e| {
                     anyhow!(e)
                         .context("Failed to initialize new connection with handshake, tx failed")
-                })?;
-            return_chan_rx.await.map_err(|e| {
-                anyhow!(e).context("Failed to initialize new connection with handshake, rx failed")
-            })??;
+                })?
+                .await
+                .map_err(|e| {
+                    anyhow!(e)
+                        .context("Failed to initialize new connection with handshake, rx failed")
+                })??;
         }
 
         if let Some(use_message) = &self.use_message {
-            let (return_chan_tx, return_chan_rx) = oneshot::channel();
             outbound
-                .send(use_message.clone(), return_chan_tx)
+                .send(use_message.clone())
                 .map_err(|e| {
                     anyhow!(e)
                         .context("Failed to initialize new connection with use message, tx failed")
-                })?;
-            return_chan_rx.await.map_err(|e| {
-                anyhow!(e)
-                    .context("Failed to initialize new connection with use message, rx failed")
-            })??;
+                })?
+                .await
+                .map_err(|e| {
+                    anyhow!(e)
+                        .context("Failed to initialize new connection with use message, rx failed")
+                })??;
         }
 
         Ok(outbound)

--- a/shotover-proxy/src/transforms/cassandra/sink_single.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_single.rs
@@ -141,15 +141,8 @@ impl CassandraSinkSingle {
         trace!("sending frame upstream");
 
         let outbound = self.outbound.as_mut().unwrap();
-        let responses_future: Result<FuturesOrdered<oneshot::Receiver<Response>>> = messages
-            .into_iter()
-            .map(|m| {
-                let (return_chan_tx, return_chan_rx) = oneshot::channel();
-                outbound.send(m, return_chan_tx)?;
-
-                Ok(return_chan_rx)
-            })
-            .collect();
+        let responses_future: Result<FuturesOrdered<oneshot::Receiver<Response>>> =
+            messages.into_iter().map(|m| outbound.send(m)).collect();
 
         super::connection::receive(self.read_timeout, &self.failed_requests, responses_future?)
             .await

--- a/shotover-proxy/tests/cassandra_int_tests/cluster/single_rack_v4.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cluster/single_rack_v4.rs
@@ -295,7 +295,7 @@ pub async fn test_node_going_down(compose: &DockerCompose, driver: CassandraDriv
 
     {
         // stop one of the containers to trigger a status change event.
-        // event_connection_direct is connecting to cassandra-one, so make sure to instead kill caassandra-two.
+        // event_connections.direct is connecting to cassandra-one, so make sure to instead kill caassandra-two.
         compose.stop_service("cassandra-two");
         assert_down_event(&mut event_connections).await;
 


### PR DESCRIPTION
By making the `CassandraConnection::send` return the rx rather than take the tx, the API becomes much more ergonomic to work with.

There is value in having abstractions that take the tx or rx for more flexibility.
But in practice we always create a new tx/rx pair just before sending, so we dont get any value from that flexibility.