### PR TITLE
CassandraSinkCluster improve get_replica_node_in_dc error type

### DIFF
--- a/shotover-proxy/src/transforms/cassandra/sink_cluster/mod.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_cluster/mod.rs
@@ -462,13 +462,13 @@ impl CassandraSinkCluster {
                         )
                         .await
                     {
-                        Ok(Some(replica_node)) => {
+                        Ok(replica_node) => {
                             replica_node
                                 .get_connection(&self.connection_factory)
                                 .await?
                                 .send(message, return_chan_tx)?;
                         }
-                        Ok(None) | Err(GetReplicaErr::NoKeyspaceMetadata) => {
+                        Err(GetReplicaErr::NoReplicasFound | GetReplicaErr::NoKeyspaceMetadata) => {
                             let node = self
                                 .pool
                                 .get_round_robin_node_in_dc_rack(&self.local_shotover_node.rack);

--- a/shotover-proxy/src/transforms/cassandra/sink_cluster/test_router.rs
+++ b/shotover-proxy/src/transforms/cassandra/sink_cluster/test_router.rs
@@ -87,7 +87,6 @@ mod test_token_aware_router {
                     &mut rng,
                 )
                 .await
-                .unwrap()
                 .unwrap();
 
             if !rack_replicas.is_empty() {


### PR DESCRIPTION
It is easier to understand the error type if we add an extra error variant instead of nesting an extra Option in there.