### PR TITLE
Fix main

### DIFF
--- a/shotover-proxy/benches/benches/cassandra.rs
+++ b/shotover-proxy/benches/benches/cassandra.rs
@@ -255,6 +255,7 @@ impl BenchResources {
     }
 
     fn new_tls(shotover_topology: &str, compose_file: &str) -> Self {
+        test_helpers::cert::generate_cassandra_test_certs();
         let tokio = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()


### PR DESCRIPTION
I believe that force merging this will fix our CI failures.

The problem only manifests itself when our benchmark comparison script runs the PREVIOUS commits benchmarks.
Thats how it managed to slip past our rigorous checks that everything passes on main before merging.

As such we will need to cross our fingers and force merge this PR and see if it fixes the issue.

However I am fairly confident this is the correct fix as https://github.com/shotover/shotover-proxy/pull/1111 clearly introduced the issue and I can see that it failed to initialize the benchmark properly.