### PR TITLE
make certificate_authority_path field optional in source TLS config

### DIFF
--- a/docs/src/source-types.md
+++ b/docs/src/source-types.md
@@ -23,12 +23,13 @@ Cassandra:
   # When this field is provided TLS is used when the client connects to Shotover.
   # Removing this field will disable TLS.
   #tls:
-  #  # Path to the certificate authority file, typically named with a .crt extension.
-  #  certificate_authority_path: "tls/localhost_CA.crt"
   #  # Path to the certificate file, typically named with a .crt extension.
   #  certificate_path: "tls/localhost.crt"
   #  # Path to the private key file, typically named with a .key extension.
   #  private_key_path: "tls/localhost.key"
+  #  # Path to the certificate authority file, typically named with a .crt extension.
+  #  # When this field is provided client authentication will be enabled.
+  #  #certificate_authority_path: "tls/localhost_CA.crt"
  
   # Timeout in seconds after which to terminate an idle connection. This field is optional, if not provided, idle connections will never be terminated.
   # timeout: 60
@@ -57,7 +58,8 @@ Redis:
   #  # Path to the private key file, typically named with a .key extension.
   #  private_key_path: "tls/redis.key"
   #  # Path to the certificate authority file typically named ca.crt.
-  #  certificate_authority_path: "tls/ca.crt"
+  #  # When this field is provided client authentication will be enabled.
+  #  #certificate_authority_path: "tls/ca.crt"
     
   # Timeout in seconds after which to terminate an idle connection. This field is optional, if not provided, idle connections will never be terminated.
   # timeout: 60

--- a/shotover-proxy/example-configs/cassandra-cluster-tls/topology.yaml
+++ b/shotover-proxy/example-configs/cassandra-cluster-tls/topology.yaml
@@ -4,7 +4,6 @@ sources:
     Cassandra:
       listen_addr: "127.0.0.1:9042"
       tls:
-        certificate_authority_path: "example-configs/docker-images/cassandra-tls-4.0.6/certs/localhost_CA.crt"
         certificate_path: "example-configs/docker-images/cassandra-tls-4.0.6/certs/localhost.crt"
         private_key_path: "example-configs/docker-images/cassandra-tls-4.0.6/certs/localhost.key"
 chain_config:

--- a/shotover-proxy/example-configs/cassandra-tls/topology-with-key.yaml
+++ b/shotover-proxy/example-configs/cassandra-tls/topology-with-key.yaml
@@ -4,7 +4,6 @@ sources:
     Cassandra:
       listen_addr: "127.0.0.1:9043"
       tls:
-        certificate_authority_path: "example-configs/docker-images/cassandra-tls-4.0.6/certs/localhost_CA.crt"
         certificate_path: "example-configs/docker-images/cassandra-tls-4.0.6/certs/localhost.crt"
         private_key_path: "example-configs/docker-images/cassandra-tls-4.0.6/certs/localhost.key"
 chain_config:

--- a/shotover-proxy/example-configs/cassandra-tls/topology.yaml
+++ b/shotover-proxy/example-configs/cassandra-tls/topology.yaml
@@ -4,7 +4,6 @@ sources:
     Cassandra:
       listen_addr: "127.0.0.1:9043"
       tls:
-        certificate_authority_path: "example-configs/docker-images/cassandra-tls-4.0.6/certs/localhost_CA.crt"
         certificate_path: "example-configs/docker-images/cassandra-tls-4.0.6/certs/localhost.crt"
         private_key_path: "example-configs/docker-images/cassandra-tls-4.0.6/certs/localhost.key"
 chain_config:

--- a/shotover-proxy/example-configs/redis-tls/topology.yaml
+++ b/shotover-proxy/example-configs/redis-tls/topology.yaml
@@ -7,7 +7,6 @@ sources:
     Redis:
       listen_addr: "127.0.0.1:6380"
       tls:
-        certificate_authority_path: "example-configs/redis-tls/certs/localhost_CA.crt"
         certificate_path: "example-configs/redis-tls/certs/localhost.crt"
         private_key_path: "example-configs/redis-tls/certs/localhost.key"
 chain_config:


### PR DESCRIPTION
Turns out we never needed the CA when creating a TLS acceptor, the CA would only be used by an acceptor when we have enabled client auth (Usually just the client verifies who the server is, but with "client auth" the server also verifies who the client is)

I only noticed this because rustls API does not accept a CA for its TLS acceptor unless you explicitly enable client auth. (yay type safety :tada: )

I havent enabled client auth in this PR because I couldnt easily figure out how to do that in openssl but that will arrive in https://github.com/shotover/shotover-proxy/pull/1108