### PR TITLE
add import_transform macro

### DIFF
--- a/custom-transforms-example/src/main.rs
+++ b/custom-transforms-example/src/main.rs
@@ -1,6 +1,7 @@
 use shotover::runner::Shotover;
 
 mod redis_get_rewrite;
+shotover::import_transform!(redis_get_rewrite::RedisGetRewriteConfig);
 
 fn main() {
     Shotover::new().run_block();

--- a/shotover/src/lib.rs
+++ b/shotover/src/lib.rs
@@ -35,3 +35,21 @@ pub mod tcp;
 pub mod tls;
 mod tracing_panic_handler;
 pub mod transforms;
+
+/// When a custom transform is defined in its own crate, typetag wont kick in unless there is some kind of `use crate_name::CustomTransformConfig`.
+/// This macro does that for you while making it clear that the `use` is a little bit magic.
+/// It also performs some type checks to ensure that you are actually importing an implementer of [`transforms::TransformConfig`].
+#[macro_export]
+macro_rules! import_transform {
+    ($ty:ty) => {
+        // import the type, this is required for typetag to pick up the type
+        use $ty;
+
+        // assert that the type actually implements TransformConfig, this prevents the easy mistake of accidentally importing the Transform instead of the TransformConfig
+        const _: fn() = || {
+            // Only callable when `$ty` implements `TransformConfig`
+            fn assert_impls_transform_config<T: ?Sized + shotover::transforms::TransformConfig>() {}
+            assert_impls_transform_config::<$ty>();
+        };
+    };
+}


### PR DESCRIPTION
The custom-transform-example works fine because the custom transform is in the same crate as the shotover binary. (directly included via `mod redis_get_rewrite`)
However it is expected for users to want to have their transforms in a separate crate, this results in needing "magic" `use`s like this: https://github.com/shotover/shotover-examples/blob/01d9a877ee563d15dee0deed0831192d754fd0b4/custom-transforms/shotover-bin/src/main.rs#L4
So I've added this macro to make things a little less magic.
Ultimately this is all a bit hacky and I would like to replace it with a solution where we actually register types to be used by typetag, but will be very complicated and likely involve forking typetag so this is a good immediate solution.

Here is what the error looks like when the imported type is not a config.
![image](https://user-images.githubusercontent.com/5120858/231029591-786ce9c3-ebfe-4dea-ab0a-cae05fc454e4.png)
