### PR TITLE
Remove error module

### DIFF
--- a/custom-transforms-example/src/redis_get_rewrite.rs
+++ b/custom-transforms-example/src/redis_get_rewrite.rs
@@ -1,9 +1,10 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use serde::Deserialize;
-use shotover::error::ChainResponse;
 use shotover::frame::{Frame, RedisFrame};
-use shotover::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
+use shotover::transforms::{
+    ChainResponse, Transform, TransformBuilder, TransformConfig, Transforms, Wrapper,
+};
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct RedisGetRewriteConfig {

--- a/custom-transforms-example/src/redis_get_rewrite.rs
+++ b/custom-transforms-example/src/redis_get_rewrite.rs
@@ -2,9 +2,8 @@ use anyhow::Result;
 use async_trait::async_trait;
 use serde::Deserialize;
 use shotover::frame::{Frame, RedisFrame};
-use shotover::transforms::{
-    ChainResponse, Transform, TransformBuilder, TransformConfig, Transforms, Wrapper,
-};
+use shotover::message::Messages;
+use shotover::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct RedisGetRewriteConfig {
@@ -44,7 +43,7 @@ pub struct RedisGetRewrite {
 
 #[async_trait]
 impl Transform for RedisGetRewrite {
-    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> ChainResponse {
+    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
         let mut get_indices = vec![];
         for (i, message) in message_wrapper.messages.iter_mut().enumerate() {
             if let Some(frame) = message.frame() {

--- a/shotover/src/error.rs
+++ b/shotover/src/error.rs
@@ -1,3 +1,0 @@
-use crate::message::Messages;
-
-pub type ChainResponse = anyhow::Result<Messages>;

--- a/shotover/src/lib.rs
+++ b/shotover/src/lib.rs
@@ -33,7 +33,6 @@
 
 pub mod codec;
 mod config;
-pub mod error;
 pub mod frame;
 pub mod message;
 pub mod message_value;

--- a/shotover/src/transforms/cassandra/peers_rewrite.rs
+++ b/shotover/src/transforms/cassandra/peers_rewrite.rs
@@ -2,10 +2,8 @@ use crate::frame::{CassandraOperation, CassandraResult, Frame};
 use crate::message::Message;
 use crate::message_value::{IntSize, MessageValue};
 use crate::transforms::cassandra::peers_rewrite::CassandraOperation::Event;
-use crate::transforms::{TransformConfig, Transforms};
-use crate::{
-    error::ChainResponse,
-    transforms::{Transform, TransformBuilder, Wrapper},
+use crate::transforms::{
+    ChainResponse, Transform, TransformBuilder, TransformConfig, Transforms, Wrapper,
 };
 use anyhow::Result;
 use async_trait::async_trait;

--- a/shotover/src/transforms/cassandra/peers_rewrite.rs
+++ b/shotover/src/transforms/cassandra/peers_rewrite.rs
@@ -1,10 +1,8 @@
 use crate::frame::{CassandraOperation, CassandraResult, Frame};
-use crate::message::Message;
+use crate::message::{Message, Messages};
 use crate::message_value::{IntSize, MessageValue};
 use crate::transforms::cassandra::peers_rewrite::CassandraOperation::Event;
-use crate::transforms::{
-    ChainResponse, Transform, TransformBuilder, TransformConfig, Transforms, Wrapper,
-};
+use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
 use cassandra_protocol::frame::events::{ServerEvent, StatusChange};
@@ -53,7 +51,7 @@ impl TransformBuilder for CassandraPeersRewrite {
 
 #[async_trait]
 impl Transform for CassandraPeersRewrite {
-    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> ChainResponse {
+    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
         // Find the indices of queries to system.peers & system.peers_v2
         // we need to know which columns in which CQL queries in which messages have system peers
         let column_names: Vec<(usize, Vec<Identifier>)> = message_wrapper
@@ -79,7 +77,10 @@ impl Transform for CassandraPeersRewrite {
         Ok(response)
     }
 
-    async fn transform_pushed<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> ChainResponse {
+    async fn transform_pushed<'a>(
+        &'a mut self,
+        mut message_wrapper: Wrapper<'a>,
+    ) -> Result<Messages> {
         for message in &mut message_wrapper.messages {
             if let Some(Frame::Cassandra(frame)) = message.frame() {
                 if let Event(ServerEvent::StatusChange(StatusChange { addr, .. })) =

--- a/shotover/src/transforms/cassandra/sink_cluster/mod.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/mod.rs
@@ -5,7 +5,6 @@ use crate::frame::{CassandraFrame, CassandraOperation, CassandraResult, Frame};
 use crate::message::{Message, Messages, Metadata};
 use crate::tls::{TlsConnector, TlsConnectorConfig};
 use crate::transforms::cassandra::connection::{CassandraConnection, Response, ResponseError};
-use crate::transforms::ChainResponse;
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -217,7 +216,7 @@ pub struct CassandraSinkCluster {
 }
 
 impl CassandraSinkCluster {
-    async fn send_message(&mut self, mut messages: Messages) -> ChainResponse {
+    async fn send_message(&mut self, mut messages: Messages) -> Result<Messages> {
         if self.version.is_none() {
             if let Some(message) = messages.first() {
                 if let Ok(Metadata::Cassandra(CassandraMetadata { version, .. })) =
@@ -701,11 +700,14 @@ fn is_use_statement_successful(response: Option<Result<Response>>) -> bool {
 
 #[async_trait]
 impl Transform for CassandraSinkCluster {
-    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> ChainResponse {
+    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
         self.send_message(message_wrapper.messages).await
     }
 
-    async fn transform_pushed<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> ChainResponse {
+    async fn transform_pushed<'a>(
+        &'a mut self,
+        mut message_wrapper: Wrapper<'a>,
+    ) -> Result<Messages> {
         message_wrapper.messages.retain_mut(|message| {
             if let Some(Frame::Cassandra(CassandraFrame {
                 operation: CassandraOperation::Event(event),

--- a/shotover/src/transforms/cassandra/sink_cluster/mod.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/mod.rs
@@ -1,11 +1,11 @@
 use self::node_pool::{get_accessible_owned_connection, NodePoolBuilder, PreparedMetadata};
 use self::rewrite::{MessageRewriter, RewriteTableTy};
-use crate::error::ChainResponse;
 use crate::frame::cassandra::{CassandraMetadata, Tracing};
 use crate::frame::{CassandraFrame, CassandraOperation, CassandraResult, Frame};
 use crate::message::{Message, Messages, Metadata};
 use crate::tls::{TlsConnector, TlsConnectorConfig};
 use crate::transforms::cassandra::connection::{CassandraConnection, Response, ResponseError};
+use crate::transforms::ChainResponse;
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;

--- a/shotover/src/transforms/cassandra/sink_single.rs
+++ b/shotover/src/transforms/cassandra/sink_single.rs
@@ -4,7 +4,6 @@ use crate::frame::cassandra::CassandraMetadata;
 use crate::message::{Messages, Metadata};
 use crate::tls::{TlsConnector, TlsConnectorConfig};
 use crate::transforms::cassandra::connection::Response;
-use crate::transforms::ChainResponse;
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -107,7 +106,7 @@ pub struct CassandraSinkSingle {
 }
 
 impl CassandraSinkSingle {
-    async fn send_message(&mut self, messages: Messages) -> ChainResponse {
+    async fn send_message(&mut self, messages: Messages) -> Result<Messages> {
         if self.version.is_none() {
             if let Some(message) = messages.first() {
                 if let Ok(Metadata::Cassandra(CassandraMetadata { version, .. })) =
@@ -162,7 +161,7 @@ impl CassandraSinkSingle {
 
 #[async_trait]
 impl Transform for CassandraSinkSingle {
-    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> ChainResponse {
+    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
         self.send_message(message_wrapper.messages).await
     }
 

--- a/shotover/src/transforms/cassandra/sink_single.rs
+++ b/shotover/src/transforms/cassandra/sink_single.rs
@@ -1,10 +1,10 @@
 use super::connection::CassandraConnection;
 use crate::codec::{cassandra::CassandraCodecBuilder, CodecBuilder, Direction};
-use crate::error::ChainResponse;
 use crate::frame::cassandra::CassandraMetadata;
 use crate::message::{Messages, Metadata};
 use crate::tls::{TlsConnector, TlsConnectorConfig};
 use crate::transforms::cassandra::connection::Response;
+use crate::transforms::ChainResponse;
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;

--- a/shotover/src/transforms/chain.rs
+++ b/shotover/src/transforms/chain.rs
@@ -1,5 +1,5 @@
-use crate::error::ChainResponse;
 use crate::message::Messages;
+use crate::transforms::ChainResponse;
 use crate::transforms::{TransformBuilder, Transforms, Wrapper};
 use anyhow::{anyhow, Result};
 use derivative::Derivative;
@@ -17,7 +17,7 @@ pub struct BufferedChainMessages {
     pub local_addr: SocketAddr,
     pub messages: Messages,
     pub flush: bool,
-    pub return_chan: Option<oneshot::Sender<crate::error::ChainResponse>>,
+    pub return_chan: Option<oneshot::Sender<crate::transforms::ChainResponse>>,
 }
 
 impl BufferedChainMessages {

--- a/shotover/src/transforms/coalesce.rs
+++ b/shotover/src/transforms/coalesce.rs
@@ -1,5 +1,4 @@
 use crate::message::Messages;
-use crate::transforms::ChainResponse;
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -64,7 +63,7 @@ impl TransformBuilder for Coalesce {
 
 #[async_trait]
 impl Transform for Coalesce {
-    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> ChainResponse {
+    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
         self.buffer.append(&mut message_wrapper.messages);
 
         let flush_buffer = message_wrapper.flush

--- a/shotover/src/transforms/coalesce.rs
+++ b/shotover/src/transforms/coalesce.rs
@@ -1,5 +1,5 @@
-use crate::error::ChainResponse;
 use crate::message::Messages;
+use crate::transforms::ChainResponse;
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;

--- a/shotover/src/transforms/debug/force_parse.rs
+++ b/shotover/src/transforms/debug/force_parse.rs
@@ -4,7 +4,7 @@
 /// The use of this transform is to allow benchmarking the performance impact of parsing messages
 /// without worrying about the performance impact of other transform logic.
 /// It could also be used to ensure that messages round trip correctly when parsed.
-use crate::error::ChainResponse;
+use crate::transforms::ChainResponse;
 #[cfg(feature = "alpha-transforms")]
 use crate::transforms::TransformConfig;
 use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};

--- a/shotover/src/transforms/debug/force_parse.rs
+++ b/shotover/src/transforms/debug/force_parse.rs
@@ -1,14 +1,13 @@
+use crate::message::Messages;
 /// This transform will by default parse requests and responses that pass through it.
 /// request and response parsing can be individually disabled if desired.
 ///
 /// The use of this transform is to allow benchmarking the performance impact of parsing messages
 /// without worrying about the performance impact of other transform logic.
 /// It could also be used to ensure that messages round trip correctly when parsed.
-use crate::transforms::ChainResponse;
 #[cfg(feature = "alpha-transforms")]
 use crate::transforms::TransformConfig;
 use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
-#[cfg(feature = "alpha-transforms")]
 use anyhow::Result;
 use async_trait::async_trait;
 use serde::Deserialize;
@@ -77,7 +76,7 @@ impl TransformBuilder for DebugForceParse {
 
 #[async_trait]
 impl Transform for DebugForceParse {
-    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> ChainResponse {
+    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
         for message in &mut message_wrapper.messages {
             if self.parse_requests {
                 message.frame();

--- a/shotover/src/transforms/debug/printer.rs
+++ b/shotover/src/transforms/debug/printer.rs
@@ -1,4 +1,4 @@
-use crate::error::ChainResponse;
+use crate::transforms::ChainResponse;
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;

--- a/shotover/src/transforms/debug/printer.rs
+++ b/shotover/src/transforms/debug/printer.rs
@@ -1,4 +1,4 @@
-use crate::transforms::ChainResponse;
+use crate::message::Messages;
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -45,7 +45,7 @@ impl TransformBuilder for DebugPrinter {
 
 #[async_trait]
 impl Transform for DebugPrinter {
-    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> ChainResponse {
+    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
         for request in &mut message_wrapper.messages {
             info!("Request: {}", request.to_high_level_string());
         }

--- a/shotover/src/transforms/debug/random_delay.rs
+++ b/shotover/src/transforms/debug/random_delay.rs
@@ -1,4 +1,4 @@
-use crate::error::ChainResponse;
+use crate::transforms::ChainResponse;
 use crate::transforms::{Transform, Wrapper};
 use async_trait::async_trait;
 use rand_distr::Distribution;

--- a/shotover/src/transforms/debug/random_delay.rs
+++ b/shotover/src/transforms/debug/random_delay.rs
@@ -1,5 +1,6 @@
-use crate::transforms::ChainResponse;
+use crate::message::Messages;
 use crate::transforms::{Transform, Wrapper};
+use anyhow::Result;
 use async_trait::async_trait;
 use rand_distr::Distribution;
 use rand_distr::Normal;
@@ -13,7 +14,7 @@ pub struct DebugRandomDelay {
 
 #[async_trait]
 impl Transform for DebugRandomDelay {
-    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> ChainResponse {
+    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
         let delay = if let Some(dist) = self.distribution {
             Duration::from_millis(dist.sample(&mut rand::thread_rng()) as u64 + self.delay)
         } else {

--- a/shotover/src/transforms/debug/returner.rs
+++ b/shotover/src/transforms/debug/returner.rs
@@ -1,8 +1,6 @@
 use crate::frame::{Frame, RedisFrame};
 use crate::message::{Message, Messages};
-use crate::transforms::{
-    ChainResponse, Transform, TransformBuilder, TransformConfig, Transforms, Wrapper,
-};
+use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use serde::Deserialize;
@@ -56,7 +54,7 @@ impl TransformBuilder for DebugReturner {
 
 #[async_trait]
 impl Transform for DebugReturner {
-    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> ChainResponse {
+    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
         match &self.response {
             Response::Message(message) => Ok(message.clone()),
             Response::Redis(string) => Ok(message_wrapper

--- a/shotover/src/transforms/distributed/tuneable_consistency_scatter.rs
+++ b/shotover/src/transforms/distributed/tuneable_consistency_scatter.rs
@@ -1,8 +1,7 @@
 use crate::config::chain::TransformChainConfig;
 use crate::frame::{Frame, RedisFrame};
-use crate::message::{Message, QueryType};
+use crate::message::{Message, Messages, QueryType};
 use crate::transforms::chain::{BufferedChain, TransformChainBuilder};
-use crate::transforms::ChainResponse;
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -183,7 +182,7 @@ enum Resolver {
 
 #[async_trait]
 impl Transform for TuneableConsistentencyScatter {
-    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> ChainResponse {
+    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
         let consistency: Vec<_> = message_wrapper
             .messages
             .iter_mut()

--- a/shotover/src/transforms/distributed/tuneable_consistency_scatter.rs
+++ b/shotover/src/transforms/distributed/tuneable_consistency_scatter.rs
@@ -1,8 +1,8 @@
 use crate::config::chain::TransformChainConfig;
-use crate::error::ChainResponse;
 use crate::frame::{Frame, RedisFrame};
 use crate::message::{Message, QueryType};
 use crate::transforms::chain::{BufferedChain, TransformChainBuilder};
+use crate::transforms::ChainResponse;
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;

--- a/shotover/src/transforms/filter.rs
+++ b/shotover/src/transforms/filter.rs
@@ -1,5 +1,5 @@
-use crate::error::ChainResponse;
 use crate::message::{Message, QueryType};
+use crate::transforms::ChainResponse;
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;

--- a/shotover/src/transforms/filter.rs
+++ b/shotover/src/transforms/filter.rs
@@ -1,5 +1,4 @@
-use crate::message::{Message, QueryType};
-use crate::transforms::ChainResponse;
+use crate::message::{Message, Messages, QueryType};
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -42,7 +41,7 @@ impl TransformBuilder for QueryTypeFilter {
 
 #[async_trait]
 impl Transform for QueryTypeFilter {
-    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> ChainResponse {
+    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
         let removed_indexes: Vec<(usize, Message)> = message_wrapper
             .messages
             .iter_mut()

--- a/shotover/src/transforms/kafka/sink_single.rs
+++ b/shotover/src/transforms/kafka/sink_single.rs
@@ -1,11 +1,11 @@
 use crate::codec::{kafka::KafkaCodecBuilder, CodecBuilder, Direction};
-use crate::error::ChainResponse;
 use crate::frame::kafka::{KafkaFrame, ResponseBody};
 use crate::frame::Frame;
 use crate::message::Messages;
 use crate::tcp;
 use crate::transforms::util::cluster_connection_pool::{spawn_read_write_tasks, Connection};
 use crate::transforms::util::{Request, Response};
+use crate::transforms::ChainResponse;
 use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;

--- a/shotover/src/transforms/kafka/sink_single.rs
+++ b/shotover/src/transforms/kafka/sink_single.rs
@@ -5,7 +5,6 @@ use crate::message::Messages;
 use crate::tcp;
 use crate::transforms::util::cluster_connection_pool::{spawn_read_write_tasks, Connection};
 use crate::transforms::util::{Request, Response};
-use crate::transforms::ChainResponse;
 use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -93,7 +92,7 @@ pub struct KafkaSinkSingle {
 
 #[async_trait]
 impl Transform for KafkaSinkSingle {
-    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> ChainResponse {
+    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
         if self.outbound.is_none() {
             let codec = KafkaCodecBuilder::new(Direction::Sink);
             let tcp_stream = tcp::tcp_stream(self.connect_timeout, &self.address).await?;

--- a/shotover/src/transforms/load_balance.rs
+++ b/shotover/src/transforms/load_balance.rs
@@ -1,7 +1,7 @@
 use super::Transforms;
 use crate::config::chain::TransformChainConfig;
-use crate::error::ChainResponse;
 use crate::transforms::chain::{BufferedChain, TransformChainBuilder};
+use crate::transforms::ChainResponse;
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;

--- a/shotover/src/transforms/load_balance.rs
+++ b/shotover/src/transforms/load_balance.rs
@@ -1,7 +1,7 @@
 use super::Transforms;
 use crate::config::chain::TransformChainConfig;
+use crate::message::Messages;
 use crate::transforms::chain::{BufferedChain, TransformChainBuilder};
-use crate::transforms::ChainResponse;
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -68,7 +68,7 @@ pub struct ConnectionBalanceAndPool {
 
 #[async_trait]
 impl Transform for ConnectionBalanceAndPool {
-    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> ChainResponse {
+    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
         if self.active_connection.is_none() {
             let mut all_connections = self.all_connections.lock().await;
             if all_connections.len() < self.max_connections {

--- a/shotover/src/transforms/loopback.rs
+++ b/shotover/src/transforms/loopback.rs
@@ -1,5 +1,6 @@
-use crate::transforms::ChainResponse;
+use crate::message::Messages;
 use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
+use anyhow::Result;
 use async_trait::async_trait;
 
 #[derive(Debug, Clone, Default)]
@@ -21,7 +22,7 @@ impl TransformBuilder for Loopback {
 
 #[async_trait]
 impl Transform for Loopback {
-    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> ChainResponse {
+    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
         Ok(message_wrapper.messages)
     }
 }

--- a/shotover/src/transforms/loopback.rs
+++ b/shotover/src/transforms/loopback.rs
@@ -1,4 +1,4 @@
-use crate::error::ChainResponse;
+use crate::transforms::ChainResponse;
 use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
 use async_trait::async_trait;
 

--- a/shotover/src/transforms/mod.rs
+++ b/shotover/src/transforms/mod.rs
@@ -1,6 +1,5 @@
 //! Various types required for defining a transform
 
-use crate::error::ChainResponse;
 use crate::message::Messages;
 use crate::transforms::cassandra::peers_rewrite::CassandraPeersRewrite;
 use crate::transforms::cassandra::sink_cluster::CassandraSinkCluster;
@@ -490,3 +489,5 @@ pub trait Transform: Send {
 }
 
 type ResponseFuture = Pin<Box<dyn Future<Output = Result<util::Response>> + Send + Sync>>;
+
+pub type ChainResponse = anyhow::Result<Messages>;

--- a/shotover/src/transforms/noop.rs
+++ b/shotover/src/transforms/noop.rs
@@ -1,4 +1,4 @@
-use crate::error::ChainResponse;
+use crate::transforms::ChainResponse;
 use crate::transforms::{Transform, Wrapper};
 use async_trait::async_trait;
 

--- a/shotover/src/transforms/noop.rs
+++ b/shotover/src/transforms/noop.rs
@@ -1,5 +1,6 @@
-use crate::transforms::ChainResponse;
+use crate::message::Messages;
 use crate::transforms::{Transform, Wrapper};
+use anyhow::Result;
 use async_trait::async_trait;
 
 #[derive(Debug, Clone)]
@@ -19,7 +20,7 @@ impl Default for NoOp {
 
 #[async_trait]
 impl Transform for NoOp {
-    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> ChainResponse {
+    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
         message_wrapper.call_next_transform().await
     }
 }

--- a/shotover/src/transforms/null.rs
+++ b/shotover/src/transforms/null.rs
@@ -1,4 +1,4 @@
-use crate::error::ChainResponse;
+use crate::transforms::ChainResponse;
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;

--- a/shotover/src/transforms/null.rs
+++ b/shotover/src/transforms/null.rs
@@ -1,4 +1,4 @@
-use crate::transforms::ChainResponse;
+use crate::message::Messages;
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -34,7 +34,7 @@ impl TransformBuilder for NullSink {
 
 #[async_trait]
 impl Transform for NullSink {
-    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> ChainResponse {
+    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
         for message in &mut message_wrapper.messages {
             *message = message.to_error_response("Handled by shotover null transform".to_string());
         }

--- a/shotover/src/transforms/parallel_map.rs
+++ b/shotover/src/transforms/parallel_map.rs
@@ -1,7 +1,6 @@
 use crate::config::chain::TransformChainConfig;
 use crate::message::Messages;
 use crate::transforms::chain::{TransformChain, TransformChainBuilder};
-use crate::transforms::ChainResponse;
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -89,7 +88,7 @@ impl TransformConfig for ParallelMapConfig {
 
 #[async_trait]
 impl Transform for ParallelMap {
-    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> ChainResponse {
+    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
         let mut results = Vec::with_capacity(message_wrapper.messages.len());
         let mut message_iter = message_wrapper.messages.into_iter();
         while message_iter.len() != 0 {

--- a/shotover/src/transforms/parallel_map.rs
+++ b/shotover/src/transforms/parallel_map.rs
@@ -1,7 +1,7 @@
 use crate::config::chain::TransformChainConfig;
-use crate::error::ChainResponse;
 use crate::message::Messages;
 use crate::transforms::chain::{TransformChain, TransformChainBuilder};
+use crate::transforms::ChainResponse;
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;

--- a/shotover/src/transforms/protect/mod.rs
+++ b/shotover/src/transforms/protect/mod.rs
@@ -1,8 +1,8 @@
 use crate::frame::{CassandraFrame, CassandraOperation, CassandraResult, Frame};
+use crate::message::Messages;
 use crate::message_value::MessageValue;
 use crate::transforms::protect::key_management::KeyManager;
 pub use crate::transforms::protect::key_management::KeyManagerConfig;
-use crate::transforms::ChainResponse;
 use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -165,7 +165,7 @@ impl Protect {
 
 #[async_trait]
 impl Transform for Protect {
-    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> ChainResponse {
+    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
         // encrypt the values included in any INSERT or UPDATE queries
         for message in message_wrapper.messages.iter_mut() {
             let mut invalidate_cache = false;

--- a/shotover/src/transforms/protect/mod.rs
+++ b/shotover/src/transforms/protect/mod.rs
@@ -1,8 +1,8 @@
-use crate::error::ChainResponse;
 use crate::frame::{CassandraFrame, CassandraOperation, CassandraResult, Frame};
 use crate::message_value::MessageValue;
 use crate::transforms::protect::key_management::KeyManager;
 pub use crate::transforms::protect::key_management::KeyManagerConfig;
+use crate::transforms::ChainResponse;
 use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;

--- a/shotover/src/transforms/query_counter.rs
+++ b/shotover/src/transforms/query_counter.rs
@@ -1,6 +1,6 @@
 use crate::frame::Frame;
 use crate::frame::RedisFrame;
-use crate::transforms::ChainResponse;
+use crate::message::Messages;
 use crate::transforms::TransformConfig;
 use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
 use anyhow::Result;
@@ -38,7 +38,7 @@ impl TransformBuilder for QueryCounter {
 
 #[async_trait]
 impl Transform for QueryCounter {
-    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> ChainResponse {
+    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
         for m in &mut message_wrapper.messages {
             match m.frame() {
                 Some(Frame::Cassandra(frame)) => {

--- a/shotover/src/transforms/query_counter.rs
+++ b/shotover/src/transforms/query_counter.rs
@@ -1,6 +1,6 @@
-use crate::error::ChainResponse;
 use crate::frame::Frame;
 use crate::frame::RedisFrame;
+use crate::transforms::ChainResponse;
 use crate::transforms::TransformConfig;
 use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
 use anyhow::Result;

--- a/shotover/src/transforms/redis/cache.rs
+++ b/shotover/src/transforms/redis/cache.rs
@@ -1,8 +1,8 @@
 use crate::config::chain::TransformChainConfig;
-use crate::error::ChainResponse;
 use crate::frame::{CassandraFrame, CassandraOperation, Frame, RedisFrame};
 use crate::message::{Message, Messages};
 use crate::transforms::chain::{TransformChain, TransformChainBuilder};
+use crate::transforms::ChainResponse;
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 use anyhow::{bail, Result};
 use async_trait::async_trait;

--- a/shotover/src/transforms/redis/cache.rs
+++ b/shotover/src/transforms/redis/cache.rs
@@ -2,7 +2,6 @@ use crate::config::chain::TransformChainConfig;
 use crate::frame::{CassandraFrame, CassandraOperation, Frame, RedisFrame};
 use crate::message::{Message, Messages};
 use crate::transforms::chain::{TransformChain, TransformChainBuilder};
-use crate::transforms::ChainResponse;
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 use anyhow::{bail, Result};
 use async_trait::async_trait;
@@ -325,7 +324,7 @@ impl SimpleRedisCache {
     async fn execute_upstream_and_write_to_cache<'a>(
         &mut self,
         mut message_wrapper: Wrapper<'a>,
-    ) -> ChainResponse {
+    ) -> Result<Messages> {
         let local_addr = message_wrapper.local_addr;
         let mut request_messages: Vec<_> = message_wrapper
             .messages
@@ -569,7 +568,7 @@ fn build_redis_key_from_cql3(
 
 #[async_trait]
 impl Transform for SimpleRedisCache {
-    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> ChainResponse {
+    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
         let cache_responses = self
             .read_from_cache(&mut message_wrapper.messages, message_wrapper.local_addr)
             .await

--- a/shotover/src/transforms/redis/cluster_ports_rewrite.rs
+++ b/shotover/src/transforms/redis/cluster_ports_rewrite.rs
@@ -1,12 +1,11 @@
+use crate::frame::Frame;
 use crate::frame::RedisFrame;
+use crate::message::Messages;
+use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 use anyhow::{anyhow, bail, Context, Result};
 use async_trait::async_trait;
 use bytes::{BufMut, Bytes, BytesMut};
 use serde::Deserialize;
-
-use crate::frame::Frame;
-use crate::transforms::ChainResponse;
-use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 
 #[derive(Deserialize, Debug)]
 pub struct RedisClusterPortsRewriteConfig {
@@ -46,7 +45,7 @@ impl RedisClusterPortsRewrite {
 
 #[async_trait]
 impl Transform for RedisClusterPortsRewrite {
-    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> ChainResponse {
+    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
         // Find the indices of cluster slot messages
         let mut cluster_slots_indices = vec![];
         let mut cluster_nodes_indices = vec![];

--- a/shotover/src/transforms/redis/cluster_ports_rewrite.rs
+++ b/shotover/src/transforms/redis/cluster_ports_rewrite.rs
@@ -4,8 +4,8 @@ use async_trait::async_trait;
 use bytes::{BufMut, Bytes, BytesMut};
 use serde::Deserialize;
 
-use crate::error::ChainResponse;
 use crate::frame::Frame;
+use crate::transforms::ChainResponse;
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 
 #[derive(Deserialize, Debug)]

--- a/shotover/src/transforms/redis/sink_cluster.rs
+++ b/shotover/src/transforms/redis/sink_cluster.rs
@@ -1,13 +1,12 @@
 use crate::codec::redis::RedisCodecBuilder;
 use crate::codec::{CodecBuilder, Direction};
 use crate::frame::{Frame, RedisFrame};
-use crate::message::Message;
+use crate::message::{Message, Messages};
 use crate::tls::TlsConnectorConfig;
 use crate::transforms::redis::RedisError;
 use crate::transforms::redis::TransformError;
 use crate::transforms::util::cluster_connection_pool::{Authenticator, ConnectionPool};
 use crate::transforms::util::{Request, Response};
-use crate::transforms::ChainResponse;
 use crate::transforms::{
     ResponseFuture, Transform, TransformBuilder, TransformConfig, Transforms, Wrapper,
     CONTEXT_CHAIN_NAME,
@@ -950,7 +949,7 @@ impl TransformBuilder for RedisSinkCluster {
 
 #[async_trait]
 impl Transform for RedisSinkCluster {
-    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> ChainResponse {
+    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
         if self.rebuild_connections {
             if let Err(err) = self.build_connections(self.token.clone()).await {
                 tracing::warn!("Error when rebuilding connections {err:?}");

--- a/shotover/src/transforms/redis/sink_cluster.rs
+++ b/shotover/src/transforms/redis/sink_cluster.rs
@@ -1,6 +1,5 @@
 use crate::codec::redis::RedisCodecBuilder;
 use crate::codec::{CodecBuilder, Direction};
-use crate::error::ChainResponse;
 use crate::frame::{Frame, RedisFrame};
 use crate::message::Message;
 use crate::tls::TlsConnectorConfig;
@@ -8,6 +7,7 @@ use crate::transforms::redis::RedisError;
 use crate::transforms::redis::TransformError;
 use crate::transforms::util::cluster_connection_pool::{Authenticator, ConnectionPool};
 use crate::transforms::util::{Request, Response};
+use crate::transforms::ChainResponse;
 use crate::transforms::{
     ResponseFuture, Transform, TransformBuilder, TransformConfig, Transforms, Wrapper,
     CONTEXT_CHAIN_NAME,

--- a/shotover/src/transforms/redis/sink_single.rs
+++ b/shotover/src/transforms/redis/sink_single.rs
@@ -6,9 +6,7 @@ use crate::frame::{Frame, RedisFrame};
 use crate::message::{Message, Messages};
 use crate::tcp;
 use crate::tls::{AsyncStream, TlsConnector, TlsConnectorConfig};
-use crate::transforms::{
-    ChainResponse, Transform, TransformBuilder, TransformConfig, Transforms, Wrapper,
-};
+use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use futures::{FutureExt, SinkExt, StreamExt};
@@ -111,7 +109,7 @@ pub struct RedisSinkSingle {
 
 #[async_trait]
 impl Transform for RedisSinkSingle {
-    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> ChainResponse {
+    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
         // Return immediately if we have no messages.
         // If we tried to send no messages we would block forever waiting for a reply that will never come.
         if message_wrapper.messages.is_empty() {

--- a/shotover/src/transforms/redis/timestamp_tagging.rs
+++ b/shotover/src/transforms/redis/timestamp_tagging.rs
@@ -1,8 +1,9 @@
-use crate::error::ChainResponse;
 use crate::frame::redis::redis_query_type;
 use crate::frame::{Frame, RedisFrame};
 use crate::message::{Message, QueryType};
-use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
+use crate::transforms::{
+    ChainResponse, Transform, TransformBuilder, TransformConfig, Transforms, Wrapper,
+};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use bytes::Bytes;

--- a/shotover/src/transforms/redis/timestamp_tagging.rs
+++ b/shotover/src/transforms/redis/timestamp_tagging.rs
@@ -1,9 +1,7 @@
 use crate::frame::redis::redis_query_type;
 use crate::frame::{Frame, RedisFrame};
-use crate::message::{Message, QueryType};
-use crate::transforms::{
-    ChainResponse, Transform, TransformBuilder, TransformConfig, Transforms, Wrapper,
-};
+use crate::message::{Message, Messages, QueryType};
+use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -183,7 +181,7 @@ fn unwrap_response(message: &mut Message) -> Result<()> {
 
 #[async_trait]
 impl Transform for RedisTimestampTagger {
-    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> ChainResponse {
+    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
         // TODO: This is wrong. We need to keep track of tagged_success per message
         let mut tagged_success = true;
         // TODO: This is wrong. We need more robust handling of transactions

--- a/shotover/src/transforms/sampler.rs
+++ b/shotover/src/transforms/sampler.rs
@@ -1,7 +1,7 @@
+use crate::message::Messages;
 use crate::transforms::chain::{TransformChain, TransformChainBuilder};
-use crate::transforms::ChainResponse;
 use crate::transforms::{Transform, Wrapper};
-
+use anyhow::Result;
 use async_trait::async_trait;
 use tokio::macros::support::thread_rng_n;
 use tracing::warn;
@@ -44,7 +44,7 @@ impl Sampler {
 
 #[async_trait]
 impl Transform for Sampler {
-    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> ChainResponse {
+    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
         let chance = thread_rng_n(self.denominator);
         if chance < self.numerator {
             let sample = message_wrapper.clone();

--- a/shotover/src/transforms/sampler.rs
+++ b/shotover/src/transforms/sampler.rs
@@ -1,5 +1,5 @@
-use crate::error::ChainResponse;
 use crate::transforms::chain::{TransformChain, TransformChainBuilder};
+use crate::transforms::ChainResponse;
 use crate::transforms::{Transform, Wrapper};
 
 use async_trait::async_trait;

--- a/shotover/src/transforms/tee.rs
+++ b/shotover/src/transforms/tee.rs
@@ -1,6 +1,6 @@
 use crate::config::chain::TransformChainConfig;
-use crate::error::ChainResponse;
 use crate::transforms::chain::{BufferedChain, TransformChainBuilder};
+use crate::transforms::ChainResponse;
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;

--- a/shotover/src/transforms/tee.rs
+++ b/shotover/src/transforms/tee.rs
@@ -1,6 +1,6 @@
 use crate::config::chain::TransformChainConfig;
+use crate::message::Messages;
 use crate::transforms::chain::{BufferedChain, TransformChainBuilder};
-use crate::transforms::ChainResponse;
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -144,7 +144,7 @@ impl TransformConfig for TeeConfig {
 
 #[async_trait]
 impl Transform for Tee {
-    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> ChainResponse {
+    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
         match &mut self.behavior {
             ConsistencyBehavior::Ignore => {
                 let (tee_result, chain_result) = tokio::join!(

--- a/shotover/src/transforms/throttling.rs
+++ b/shotover/src/transforms/throttling.rs
@@ -1,5 +1,5 @@
-use crate::message::Message;
-use crate::transforms::{ChainResponse, Transform, TransformBuilder, TransformConfig, Wrapper};
+use crate::message::{Message, Messages};
+use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
 use governor::{
@@ -62,7 +62,7 @@ impl TransformBuilder for RequestThrottling {
 
 #[async_trait]
 impl Transform for RequestThrottling {
-    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> ChainResponse {
+    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
         // extract throttled messages from the message_wrapper
         let throttled_messages: Vec<(Message, usize)> = (0..message_wrapper.messages.len())
             .rev()

--- a/shotover/src/transforms/throttling.rs
+++ b/shotover/src/transforms/throttling.rs
@@ -1,5 +1,5 @@
-use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
-use crate::{error::ChainResponse, message::Message};
+use crate::message::Message;
+use crate::transforms::{ChainResponse, Transform, TransformBuilder, TransformConfig, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
 use governor::{


### PR DESCRIPTION
I feel that `ChainResponse` is not pulling its weight as an alias so I just removed it and used `Result<Messages>` directly instead.