### PR TITLE
Release shotover 0.1.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3167,7 +3167,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "shotover"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3233,7 +3233,7 @@ dependencies = [
 
 [[package]]
 name = "shotover-proxy"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "bincode",

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shotover-proxy"
-version = "0.1.9"
+version = "0.1.10"
 authors = ["Ben <ben@instaclustr.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/shotover/Cargo.toml
+++ b/shotover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shotover"
-version = "0.1.9"
+version = "0.1.10"
 authors = ["Ben <ben@instaclustr.com>"]
 edition = "2021"
 rust-version = "1.56"


### PR DESCRIPTION
waiting on:
https://github.com/shotover/shotover-proxy/pull/1125
https://github.com/shotover/shotover-proxy/pull/1124
https://github.com/shotover/shotover-proxy/pull/1130