### PR TITLE
Fix CI (bitnami/kafka had a breaking change)

### DIFF
--- a/shotover-proxy/tests/test-configs/kafka/passthrough/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/passthrough/docker-compose.yaml
@@ -1,18 +1,12 @@
 version: "3"
 services:
   kafka:
-    image: 'bitnami/kafka:3.3.2'
+    image: 'bitnami/kafka:3.4.0-debian-11-r22'
     ports:
       - '9092:9092'
     environment:
-      - KAFKA_ENABLE_KRAFT=yes
-      - KAFKA_CFG_PROCESS_ROLES=broker,controller
-      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
       - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
-      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
-      - KAFKA_BROKER_ID=1
       - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://127.0.0.1:9092
-      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=1@127.0.0.1:9093
       - ALLOW_PLAINTEXT_LISTENER=yes
     volumes:
       - type: tmpfs

--- a/test-helpers/src/docker_compose.rs
+++ b/test-helpers/src/docker_compose.rs
@@ -66,7 +66,7 @@ fn get_image_waiters() -> &'static [Image] {
             log_regex_to_wait_for: r"Startup complete",
         },
         Image {
-            name: "bitnami/kafka:3.3.2",
+            name: "bitnami/kafka:3.4.0-debian-11-r22",
             log_regex_to_wait_for: r"Kafka Server started",
         },
     ]


### PR DESCRIPTION
This PR fixes a CI failure on main:
![image](https://user-images.githubusercontent.com/5120858/233513685-b4bb31fa-3519-4d9a-84d9-7c73576ce00b.png)

kraft is now enabled by default on the kafka images and I think the breakage was related to that, so I updated to latest and simplified our config and now it works again.

It was still working locally for me at first because the container was cached, but when I cleared the image docker pulled in a new one that reproduced the issue.

I've made our kafka image name more specific to avoid this issue in the future.