### PR TITLE
fallback to no compression if compressed len is longer

### DIFF
--- a/shotover/src/codec/cassandra.rs
+++ b/shotover/src/codec/cassandra.rs
@@ -765,6 +765,7 @@ impl CassandraEncoder {
         dst.resize(payload_start + get_maximum_output_size(uncompressed_len), 0);
         let mut compressed_len = compress_into(&bytes, &mut dst[payload_start..])?;
 
+        // fallback to uncompressed data if its more efficient
         if compressed_len > uncompressed_len {
             dst[payload_start..(payload_start + uncompressed_len)]
                 .copy_from_slice(&bytes[..uncompressed_len]);


### PR DESCRIPTION
Lz4 compression replaces repeated occurrences of data with references to a single copy of that data existing earlier in the input - https://en.wikipedia.org/wiki/LZ77_and_LZ78#LZ77. The compressed size can be larger than the uncompressed in cases where there is random text without any repeating sequences. We should fallback to no compression when this occurs. This is how the java driver behaves: https://github.com/datastax/native-protocol/blob/78e62fd7c93afb2500c7db103f4bf7c9dfd6662d/src/main/java/com/datastax/oss/protocol/internal/SegmentCodec.java#L54