### PR TITLE
Fix kafka intermittent failure

### DIFF
--- a/shotover/src/codec/cassandra.rs
+++ b/shotover/src/codec/cassandra.rs
@@ -1,4 +1,4 @@
-use super::Direction;
+use super::{CodecWriteError, Direction};
 use crate::codec::{CodecBuilder, CodecReadError};
 use crate::frame::cassandra::{CassandraMetadata, CassandraOperation, Tracing};
 use crate::frame::{CassandraFrame, Frame, MessageType};
@@ -636,7 +636,7 @@ impl CassandraEncoder {
 }
 
 impl Encoder<Messages> for CassandraEncoder {
-    type Error = anyhow::Error;
+    type Error = CodecWriteError;
 
     fn encode(
         &mut self,
@@ -649,7 +649,8 @@ impl Encoder<Messages> for CassandraEncoder {
 
         for m in item {
             let start = dst.len();
-            self.encode_frame(dst, m, version, compression, handshake_complete)?;
+            self.encode_frame(dst, m, version, compression, handshake_complete)
+                .map_err(CodecWriteError::Encoder)?;
             tracing::debug!(
                 "{}: outgoing cassandra message:\n{}",
                 self.direction,

--- a/shotover/src/codec/mod.rs
+++ b/shotover/src/codec/mod.rs
@@ -72,13 +72,27 @@ impl From<std::io::Error> for CodecReadError {
     }
 }
 
+#[derive(Debug)]
+pub enum CodecWriteError {
+    /// The codec failed to encode a received message
+    Encoder(anyhow::Error),
+    /// The tcp connection returned an error
+    Io(std::io::Error),
+}
+
+impl From<std::io::Error> for CodecWriteError {
+    fn from(err: std::io::Error) -> Self {
+        CodecWriteError::Io(err)
+    }
+}
+
 // TODO: Replace with trait_alias (rust-lang/rust#41517).
 pub trait DecoderHalf: Decoder<Item = Messages, Error = CodecReadError> + Send {}
 impl<T: Decoder<Item = Messages, Error = CodecReadError> + Send> DecoderHalf for T {}
 
 // TODO: Replace with trait_alias (rust-lang/rust#41517).
-pub trait EncoderHalf: Encoder<Messages, Error = anyhow::Error> + Send {}
-impl<T: Encoder<Messages, Error = anyhow::Error> + Send> EncoderHalf for T {}
+pub trait EncoderHalf: Encoder<Messages, Error = CodecWriteError> + Send {}
+impl<T: Encoder<Messages, Error = CodecWriteError> + Send> EncoderHalf for T {}
 
 pub trait CodecBuilder: Clone + Send {
     type Decoder: DecoderHalf;

--- a/shotover/src/transforms/redis/sink_single.rs
+++ b/shotover/src/transforms/redis/sink_single.rs
@@ -7,7 +7,7 @@ use crate::message::{Message, Messages};
 use crate::tcp;
 use crate::tls::{AsyncStream, TlsConnector, TlsConnectorConfig};
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use futures::{FutureExt, SinkExt, StreamExt};
 use metrics::{register_counter, Counter};
@@ -181,7 +181,7 @@ impl Transform for RedisSinkSingle {
             .outbound_tx
             .send(message_wrapper.messages)
             .await
-            .context("Failed to send messages to redis destination")?;
+            .map_err(|err| anyhow!("Failed to send messages to redis destination: {err:?}"))?;
 
         let mut result = Vec::with_capacity(messages_len);
         while result.len() < messages_len {


### PR DESCRIPTION
This fixes the kafka_int_test intermittent failure that has been plaguing us recently.
```
shotover   06:37:30.298481Z  INFO shotover::runner: Starting Shotover 0.1.10
shotover   06:37:30.298541Z  INFO shotover::runner: configuration=Config { main_log_level: "info,shotover_proxy=info", observability_interface: "0.0.0.0:9001" }
shotover   06:37:30.298574Z  INFO shotover::runner: topology=Topology { sources: {"kafka_source": Kafka(KafkaConfig { listen_addr: "127.0.0.1:9192", connection_limit: None, hard_connection_limit: None, tls: None, timeout: None })}, chain_config: {"main_chain": TransformChainConfig([DebugForceEncodeConfig { encode_requests: true, encode_responses: true }, KafkaSinkSingleConfig { address: "127.0.0.1:9092", connect_timeout_ms: 3000, read_timeout: None }])}, source_to_chain_mapping: {"kafka_source": "main_chain"} }
shotover   06:37:30.298648Z  INFO shotover::config::topology: Loaded chains ["main_chain"]
shotover   06:37:30.298683Z  INFO shotover::sources::kafka: Starting Kafka source on [127.0.0.1:9192]
shotover   06:37:30.298732Z  INFO shotover::config::topology: Loaded sources [["kafka_source"]] and linked to chains
shotover   06:37:30.298959Z  INFO shotover::server: accepting inbound connections
2023-05-01T06:37:30.300147Z ERROR librdkafka: librdkafka: FAIL [thrd:localhost:9192/bootstrap]: localhost:9192/bootstrap: Connect to ipv6#[::1]:9192 failed: Connection refused (after 0ms in state CONNECT)    
2023-05-01T06:37:30.300717Z ERROR rdkafka::client: librdkafka: Global error: BrokerTransportFailure (Local: Broker transport failure): localhost:9192/bootstrap: Connect to ipv6#[::1]:9192 failed: Connection refused (after 0ms in state CONNECT)    
2023-05-01T06:37:30.300831Z ERROR rdkafka::client: librdkafka: Global error: AllBrokersDown (Local: All broker connections are down): 1/1 brokers are down    
2023-05-01T06:37:31.300488Z ERROR librdkafka: librdkafka: FAIL [thrd:localhost:9192/bootstrap]: localhost:9192/bootstrap: Connect to ipv6#[::1]:9192 failed: Connection refused (after 0ms in state CONNECT, 1 identical error(s) suppressed)    
2023-05-01T06:37:31.300550Z ERROR rdkafka::client: librdkafka: Global error: BrokerTransportFailure (Local: Broker transport failure): localhost:9192/bootstrap: Connect to ipv6#[::1]:9192 failed: Connection refused (after 0ms in state CONNECT, 1 identical error(s) suppressed)    
shotover   06:37:37.648530Z  INFO shotover::runner: received SIGTERM
shotover   06:37:38.073244Z  INFO shotover::runner: Shotover was shutdown cleanly.
thread 'kafka_int_tests::passthrough_encode' panicked at 'Unexpected event 06:37:38.073237Z ERROR connection{id=5 source="KafkaSource"}: shotover::server: failed to send or encode message: Broken pipe (os error 32)
shotover   06:37:38.073237Z ERROR connection{id=5 source="KafkaSource"}: shotover::server: failed to send or encode message: Broken pipe (os error 32)
Any ERROR or WARN events that occur in integration tests must be explicitly allowed by adding an appropriate EventMatcher to the method call.', /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-bin-process-0.1.0/src/process.rs:248:21
stack backtrace:
   0: rust_begin_unwind
             at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/std/src/panicking.rs:579:5
   1: core::panicking::panic_fmt
             at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/core/src/panicking.rs:64:14
   2: tokio_bin_process::process::BinProcess::consume_remaining_events_inner::{{closure}}
   3: tokio_bin_process::process::BinProcess::consume_remaining_events::{{closure}}
   4: tokio_bin_process::process::BinProcess::shutdown_and_then_consume_events::{{closure}}
   5: lib::kafka_int_tests::passthrough_encode::{{closure}}::{{closure}}
   6: tokio::runtime::runtime::Runtime::block_on
   7: core::ops::function::FnOnce::call_once
   8: serial_test::serial_code_lock::local_serial_core
   9: core::ops::function::FnOnce::call_once
  10: core::ops::function::FnOnce::call_once
             at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
test kafka_int_tests::passthrough_encode ... FAILED
```

The logic fix is in `server.rs`, the rest of the changes is fiddling with types to let us bubble up the raw Io error for matching on.

The new `CodecWriteError` is the write equivalent of the existing `CodecReadError`.

The fix is just to silently close the connection when the client connection gives a BrokenPipe error.
This is a reasonable occurrence and just indicates that the client killed the connection before we could send a response back to it.