### PR TITLE
Shutdown cassandra mock on handle drop

### DIFF
--- a/shotover-proxy/examples/windsock/cassandra.rs
+++ b/shotover-proxy/examples/windsock/cassandra.rs
@@ -3,12 +3,12 @@ use scylla::SessionBuilder;
 use std::{
     collections::HashMap,
     sync::Arc,
-    thread::JoinHandle,
     time::{Duration, Instant},
 };
 use test_helpers::{
     docker_compose::{docker_compose, DockerCompose},
     flamegraph::Perf,
+    mock_cassandra::MockHandle,
     shotover_process::ShotoverProcessBuilder,
 };
 use tokio::sync::mpsc::UnboundedSender;
@@ -21,7 +21,7 @@ pub enum CassandraDb {
 
 enum CassandraDbInstance {
     Compose(DockerCompose),
-    Mocked(JoinHandle<()>),
+    Mocked(MockHandle),
 }
 
 pub enum Topology {


### PR DESCRIPTION
Now that we are running cassandra mock within windsock we need to be more careful about cleanly shutting it down.
Currently we work around this in windsock by running cassandra mock benches last but that is hardly ideal.

It is impossible to kill a thread, instead we need to instruct the thread to finish processing by sending a shutdown message. (or in this case just setting a bool to true)