### PR TITLE
Implement error handling for to_error_response

### DIFF
--- a/shotover/src/server.rs
+++ b/shotover/src/server.rs
@@ -602,7 +602,13 @@ impl<C: CodecBuilder + 'static> Handler<C> {
                         //     + they might not know to check the shotover logs
                         //     + they may not be able to correlate which error in the shotover logs corresponds to their failed message
                         for m in &mut error_report_messages {
-                            *m = m.to_error_response(format!("Internal shotover (or custom transform) bug: {err:?}"));
+                            #[allow(clippy::single_match)]
+                            match m.to_error_response(format!("Internal shotover (or custom transform) bug: {err:?}")) {
+                                Ok(new_m) => *m = new_m,
+                                Err(_) => {
+                                    // If we cant produce an error then nothing we can do, just continue on and close the connection.
+                                }
+                            }
                         }
                         out_tx.send(error_report_messages)?;
                         return Err(err);

--- a/shotover/src/transforms/cassandra/sink_cluster/rewrite.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/rewrite.rs
@@ -255,7 +255,8 @@ impl MessageRewriter {
                                 Ok(x) => x,
                                 Err(MessageParseError::CassandraError(err)) => {
                                     *client_peers_response = client_peers_response
-                                        .to_error_response(format!("{:?}", err.context("Shotover failed to generate system.peers, an error occured when an internal system.peers query was run.")));
+                                        .to_error_response(format!("{:?}", err.context("Shotover failed to generate system.peers, an error occured when an internal system.peers query was run.")))
+                                        .expect("This must succeed because it is a cassandra message and we already know it to be parseable");
                                     return Ok(());
                                 }
                                 Err(MessageParseError::ParseFailure(err)) => return Err(err),
@@ -264,7 +265,8 @@ impl MessageRewriter {
                                 Ok(x) => nodes.extend(x),
                                 Err(MessageParseError::CassandraError(err)) => {
                                     *client_peers_response = client_peers_response
-                                        .to_error_response(format!("{:?}", err.context("Shotover failed to generate system.peers, an error occured when an internal system.local query was run.")));
+                                        .to_error_response(format!("{:?}", err.context("Shotover failed to generate system.peers, an error occured when an internal system.local query was run.")))
+                                        .expect("This must succeed because it is a cassandra message and we already know it to be parseable");
                                     return Ok(());
                                 }
                                 Err(MessageParseError::ParseFailure(err)) => return Err(err),
@@ -505,7 +507,8 @@ impl MessageRewriter {
         let mut peers = match parse_system_nodes(peers_response) {
             Ok(x) => x,
             Err(MessageParseError::CassandraError(err)) => {
-                *local_response = local_response.to_error_response(format!("{:?}", err.context("Shotover failed to generate system.local, an error occured when an internal system.peers query was run.")));
+                *local_response = local_response.to_error_response(format!("{:?}", err.context("Shotover failed to generate system.local, an error occured when an internal system.peers query was run.")))
+                    .expect("This must succeed because it is a cassandra message and we already know it to be parseable");
                 return Ok(());
             }
             Err(MessageParseError::ParseFailure(err)) => return Err(err),

--- a/shotover/src/transforms/distributed/tuneable_consistency_scatter.rs
+++ b/shotover/src/transforms/distributed/tuneable_consistency_scatter.rs
@@ -237,7 +237,7 @@ impl Transform for TuneableConsistentencyScatter {
         Ok(if results.len() < max_required_successes as usize {
             let mut messages = message_wrapper.messages;
             for message in &mut messages {
-                *message = message.to_error_response("Not enough responses".into());
+                *message = message.to_error_response("Not enough responses".into())?
             }
             messages
         } else {

--- a/shotover/src/transforms/null.rs
+++ b/shotover/src/transforms/null.rs
@@ -36,7 +36,8 @@ impl TransformBuilder for NullSink {
 impl Transform for NullSink {
     async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
         for message in &mut message_wrapper.messages {
-            *message = message.to_error_response("Handled by shotover null transform".to_string());
+            *message =
+                message.to_error_response("Handled by shotover null transform".to_string())?;
         }
         Ok(message_wrapper.messages)
     }

--- a/shotover/src/transforms/tee.rs
+++ b/shotover/src/transforms/tee.rs
@@ -170,7 +170,7 @@ impl Transform for Tee {
                 if !chain_response.eq(&tee_response) {
                     for message in &mut chain_response {
                         *message = message.to_error_response(
-                            "ERR The responses from the Tee subchain and down-chain did not match and behavior is set to fail on mismatch".into());
+                            "ERR The responses from the Tee subchain and down-chain did not match and behavior is set to fail on mismatch".into())?;
                     }
                 }
                 Ok(chain_response)


### PR DESCRIPTION
There were two error cases in to_error_response that previously caused panics.
* Failing to parse metadata - this only affects cassandra but meant that an invalid cassandra message could cause shotover to panic, better to handle this as an Error.
* attempting to produce an error from a kafka message - previously this was just unimplemented, but in attempting to implement it I found it to be incredibly complex, and even when overcoming the complexity, the kafka driver we use didnt get any benefit from knowing about the error. So I just wrote up my findings in a comment and consider kafka error generation unsupported.

Both these cases now return an Error.

This was either causing noise or hiding actual errors when an internal error was returned from a kafka transform.