### PR TITLE
windsock: add `--disable-release-safety-check`

### DIFF
--- a/windsock/src/bench.rs
+++ b/windsock/src/bench.rs
@@ -17,11 +17,11 @@ impl BenchState {
         BenchState { bench, tags }
     }
 
-    pub async fn run(&mut self, args: &Args) {
+    pub async fn run(&mut self, args: &Args, running_in_release: bool) {
         println!("Running {:?}", self.tags.get_name());
 
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-        let process = tokio::spawn(report_builder(self.tags.clone(), rx));
+        let process = tokio::spawn(report_builder(self.tags.clone(), rx, running_in_release));
         self.bench.run(args.flamegraph, true, tx).await;
         let report = process.await.unwrap();
         crate::tables::display_results_table(&[report]);

--- a/windsock/src/cli.rs
+++ b/windsock/src/cli.rs
@@ -50,4 +50,8 @@ pub struct Args {
     /// --results-by-tags "db=kafka OPS=10000"
     #[clap(long)]
     pub results_by_tags: Option<String>,
+
+    /// Prevent release mode safety check from triggering to allow running in debug mode
+    #[clap(long)]
+    pub disable_release_safety_check: bool,
 }

--- a/windsock/src/report.rs
+++ b/windsock/src/report.rs
@@ -76,6 +76,7 @@ impl Percentile {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct ReportArchive {
+    pub(crate) running_in_release: bool,
     pub(crate) tags: Tags,
     pub(crate) operations_total: u64,
     pub(crate) ops: f32,
@@ -149,7 +150,11 @@ pub fn windsock_path() -> PathBuf {
     PathBuf::from("windsock_data")
 }
 
-pub(crate) async fn report_builder(tags: Tags, mut rx: UnboundedReceiver<Report>) -> ReportArchive {
+pub(crate) async fn report_builder(
+    tags: Tags,
+    mut rx: UnboundedReceiver<Report>,
+    running_in_release: bool,
+) -> ReportArchive {
     let mut operations_total = 0;
     let mut response_times = vec![];
     let mut total_response_time = Duration::from_secs(0);
@@ -202,6 +207,7 @@ pub(crate) async fn report_builder(tags: Tags, mut rx: UnboundedReceiver<Report>
     }
 
     let archive = ReportArchive {
+        running_in_release,
         tags,
         ops,
         operations_total,

--- a/windsock/src/tables.rs
+++ b/windsock/src/tables.rs
@@ -278,6 +278,16 @@ fn base(reports: &[ReportArchive], table_type: &str, comparison: bool) {
             }
         }
     }
+
+    for report in reports {
+        if !report.running_in_release {
+            let error = format!(
+                "Bench results invalid! Bench compiled with non-release profile: {}",
+                report.tags.get_name()
+            );
+            println!("{}", style(error).red().bold());
+        }
+    }
 }
 
 fn duration_ms(duration: Duration) -> String {


### PR DESCRIPTION
This provides an escape hatch for running windsock in debug mode.
An additional warning is provided in red text that a bench result came from a binary compiled in a non-release profile.

The motivation is faster compile times and better stacktraces while developing the benches and windsock itself

example output:
![image](https://github.com/shotover/shotover-proxy/assets/5120858/7d8e4b8e-dd67-4c30-86fb-ca5d15fd1310)