### PR TITLE
windsock: Implement tag filtering

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -74,9 +74,7 @@ jobs:
       run: |
         cargo run --release --example cassandra
         cargo run --release --example windsock
-        cargo run --release --example windsock -- --flamegraph --name cassandra,OPS=unlimited,connections=128,message_type=read_bigint,shotover=standard,topology=single
-        cargo run --release --example windsock -- --flamegraph --name cassandra,OPS=unlimited,connections=128,message_type=read_bigint,shotover=standard,topology=cluster3
-        cargo run --release --example windsock -- --flamegraph --name cassandra-mocked,OPS=unlimited,connections=128,message_type=read_bigint,shotover=standard,topology=single
+        cargo run --release --example windsock -- --flamegraph "name=cassandra shotover=standard"
       if: ${{ matrix.name == 'Ubuntu 20.04 - Release' }}
     - name: Ensure that tests did not create or modify any files that arent .gitignore'd
       run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4391,6 +4391,7 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 name = "windsock"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "bincode",
  "clap 4.2.2",

--- a/windsock/Cargo.toml
+++ b/windsock/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow.workspace = true
 async-trait = "0.1.68"
 bincode.workspace = true
 clap.workspace = true

--- a/windsock/src/bench.rs
+++ b/windsock/src/bench.rs
@@ -61,6 +61,24 @@ impl Tags {
         result
     }
 
+    /// Does not handle invalid names, only use on internally generated names
+    pub fn from_name(name: &str) -> Self {
+        let mut map = HashMap::new();
+        for tag in name.split(',') {
+            if tag.contains('=') {
+                let mut pair = tag.split('=');
+                let key = pair.next().unwrap().to_owned();
+                let value = pair.next().unwrap().to_owned();
+                map.insert(key, value);
+            } else if map.contains_key("name") {
+                panic!("The name tag was already set and a tag without an '=' was found")
+            } else {
+                map.insert("name".to_owned(), tag.to_owned());
+            }
+        }
+        Tags(map)
+    }
+
     /// returns the set wise intersection of two `Tags`s
     pub(crate) fn intersection(&self, other: &Tags) -> Self {
         let mut intersection = HashMap::new();

--- a/windsock/src/cli.rs
+++ b/windsock/src/cli.rs
@@ -3,8 +3,8 @@ use clap::Parser;
 #[derive(Parser, Clone)]
 #[clap()]
 pub struct Args {
-    // TODO: parse `filter` from `tag_name=tag_value tag_name2=bar`
     /// Run all benches that match the specified tag key/values
+    /// `tag_key=tag_value foo=bar`
     pub filter: Option<String>,
     /// List the name of every bench
     #[clap(long)]

--- a/windsock/src/filter.rs
+++ b/windsock/src/filter.rs
@@ -1,0 +1,45 @@
+use crate::bench::Tags;
+use anyhow::{anyhow, Result};
+
+pub(crate) struct Filter {
+    filter: Vec<[String; 2]>,
+}
+
+impl Filter {
+    pub(crate) fn from_query(query: &str) -> Result<Filter> {
+        let mut filter = vec![];
+        for pair in query.split_whitespace() {
+            let mut iter = pair.split('=');
+            let key = iter.next().unwrap();
+            let value = match iter.next() {
+                Some(value) => value,
+                None => {
+                    return Err(anyhow!(
+                        "Expected exactly one '=' but found no '=' in tag {pair:?}"
+                    ))
+                }
+            };
+            if iter.next().is_some() {
+                return Err(anyhow!(
+                    "Expected exactly one '=' but found multiple '=' in tag {pair:?}"
+                ));
+            }
+            filter.push([key.to_owned(), value.to_owned()])
+        }
+        Ok(Filter { filter })
+    }
+
+    pub(crate) fn matches(&self, tags: &Tags) -> bool {
+        for [key, value] in &self.filter {
+            match tags.0.get(key) {
+                Some(other_value) => {
+                    if value != other_value {
+                        return false;
+                    }
+                }
+                None => return false,
+            }
+        }
+        true
+    }
+}

--- a/windsock/src/lib.rs
+++ b/windsock/src/lib.rs
@@ -1,13 +1,17 @@
 mod bench;
 mod cli;
+mod filter;
 mod report;
 mod tables;
 pub use bench::Bench;
 pub use report::Report;
 
+use anyhow::{anyhow, Result};
 use bench::BenchState;
 use clap::Parser;
 use cli::Args;
+use filter::Filter;
+use report::ReportArchive;
 use std::process::exit;
 use tokio::runtime::Runtime;
 
@@ -36,38 +40,68 @@ impl Windsock {
 
     // Hands control of the process over to windsock, this method will never return
     // Windsock processes CLI arguments and then runs benchmarks as instructed by the user.
-    pub fn run(mut self) -> ! {
+    pub fn run(self) -> ! {
+        match self.run_inner() {
+            Ok(()) => exit(0),
+            Err(err) => {
+                eprintln!("{:?}", err);
+                exit(1);
+            }
+        }
+    }
+
+    fn run_inner(mut self) -> Result<()> {
         let args = cli::Args::parse();
-        // TODO: maybe we should create a new runtime per bench for consistency reasons
         if let Some(compare_by_name) = &args.compare_by_name {
-            tables::compare_by_name(compare_by_name);
+            tables::compare_by_name(compare_by_name)?;
         } else if let Some(compare_by_name) = &args.results_by_name {
-            tables::results_by_name(compare_by_name);
+            tables::results_by_name(compare_by_name)?;
         } else if let Some(compare_by_tags) = &args.compare_by_tags {
-            todo!("compare_by_tags: {compare_by_tags}")
+            tables::compare_by_tags(compare_by_tags)?;
         } else if let Some(results_by_tags) = &args.results_by_tags {
-            todo!("results_by_tags: {results_by_tags}")
+            tables::results_by_tags(results_by_tags)?;
         } else if args.list {
             println!("Benches:");
             for bench in &self.benches {
                 println!("{}", bench.tags.get_name());
             }
         } else if let Some(name) = &args.name {
+            ReportArchive::clear_last_run();
             match self.benches.iter_mut().find(|x| &x.tags.get_name() == name) {
                 Some(bench) => run_bench(bench, &args),
                 None => {
-                    eprintln!("Specified bench {name:?} does not exist.");
-                    exit(1)
+                    return Err(anyhow!("Specified bench {name:?} does not exist."));
                 }
             }
         } else {
+            ReportArchive::clear_last_run();
+            let filter = match args
+                .filter
+                .as_ref()
+                .map(|x| Filter::from_query(x.as_ref()))
+                .transpose()
+            {
+                Ok(filter) => filter,
+                Err(err) => {
+                    return Err(anyhow!(
+                        "Failed to parse FILTER {:?}\n{}",
+                        args.filter.unwrap(),
+                        err
+                    ))
+                }
+            };
             for bench in &mut self.benches {
-                if filter(&args, bench) {
+                if filter
+                    .as_ref()
+                    .map(|x| x.matches(&bench.tags))
+                    .unwrap_or(true)
+                {
                     run_bench(bench, &args)
                 }
             }
         }
-        exit(0)
+
+        Ok(())
     }
 }
 fn run_bench(bench: &mut BenchState, args: &Args) {
@@ -75,14 +109,6 @@ fn run_bench(bench: &mut BenchState, args: &Args) {
     runtime.block_on(async {
         bench.run(args).await;
     });
-}
-
-fn filter(args: &cli::Args, _bench: &BenchState) -> bool {
-    if args.filter.is_some() {
-        todo!("Filter not yet implemented");
-    }
-
-    true
 }
 
 fn create_runtime(worker_threads: Option<usize>) -> Runtime {


### PR DESCRIPTION
closes https://github.com/shotover/shotover-proxy/issues/1153

This PR implements tag filtering for running benches (`[FILTER]`) and for displaying results (`--results-by-tag` and `--compare-by-tag`).

This PR provides the most common filter we need (a simple key/value match) and hooks it up to various locations that need a filter.
We can improve on the exact features we provide in our filtering later on but I do intend to keep it lean, maybe just a key level match that ignores the value?

This PR also improves some general error handling that was left in a poor state from the initial windsock PR.

The cli flags should be properly documented in `cargo run --release --example windsock -- --help`

## Some expected workflows
```shell
cargo run --release --example windsock # run all benches
cargo run --release --example windsock -- --results-by-tags name=cassandra # show a table of all cassandra benches
cargo run --release --example windsock -- --compare-by-tags "cassandra,OPS=unlimited,connections=128,message_type=read_bigint,shotover=standard,topology=single name=cassandra shotover=standard" # show a comparison of one cassandra bench against some others
```

```shell
cargo run --release --example windsock name=kafka # run all kafka benches
cargo run --release --example windsock -- --results-by-tags name=kafka # show all the benches we just ran
```