### PR TITLE
Avoid creating extra TransformBuilder instance

### DIFF
--- a/shotover-proxy/tests/test-configs/invalid_subchains.yaml
+++ b/shotover-proxy/tests/test-configs/invalid_subchains.yaml
@@ -1,6 +1,9 @@
 ---
 sources:
-  redis_prod:
+  redis1:
+    Redis:
+      listen_addr: "127.0.0.1:6379"
+  redis2:
     Redis:
       listen_addr: "127.0.0.1:6379"
 chain_config:
@@ -31,4 +34,5 @@ chain_config:
                     - NullSink
                     - NullSink
 source_to_chain_mapping:
-  redis_prod: redis_chain
+  redis1: a_first_chain
+  redis2: b_second_chain

--- a/shotover/src/server.rs
+++ b/shotover/src/server.rs
@@ -23,7 +23,7 @@ use tracing::Instrument;
 use tracing::{debug, error, info, warn};
 
 pub struct TcpCodecListener<C: CodecBuilder> {
-    chain: TransformChainBuilder,
+    chain_builder: TransformChainBuilder,
     source_name: String,
 
     /// TCP listener supplied by the `run` caller.
@@ -69,7 +69,7 @@ pub struct TcpCodecListener<C: CodecBuilder> {
 impl<C: CodecBuilder + 'static> TcpCodecListener<C> {
     #![allow(clippy::too_many_arguments)]
     pub async fn new(
-        chain: TransformChainBuilder,
+        chain_builder: TransformChainBuilder,
         source_name: String,
         listen_addr: String,
         hard_connection_limit: bool,
@@ -86,7 +86,7 @@ impl<C: CodecBuilder + 'static> TcpCodecListener<C> {
         let listener = Some(create_listener(&listen_addr).await?);
 
         Ok(TcpCodecListener {
-            chain,
+            chain_builder,
             source_name,
             listener,
             listen_addr,
@@ -188,7 +188,9 @@ impl<C: CodecBuilder + 'static> TcpCodecListener<C> {
                     tokio::sync::mpsc::unbounded_channel::<Messages>();
 
                 let mut handler = Handler {
-                    chain: self.chain.build_with_pushed_messages(pushed_messages_tx),
+                    chain: self
+                        .chain_builder
+                        .build_with_pushed_messages(pushed_messages_tx),
                     client_details: peer,
                     conn_details: conn_string,
                     source_details: self.source_name.clone(),

--- a/shotover/src/sources/cassandra.rs
+++ b/shotover/src/sources/cassandra.rs
@@ -23,12 +23,12 @@ pub struct CassandraConfig {
 impl CassandraConfig {
     pub async fn get_source(
         &self,
-        chain: &TransformChainBuilder,
+        chain_builder: TransformChainBuilder,
         trigger_shutdown_rx: watch::Receiver<bool>,
     ) -> Result<Vec<Sources>> {
         Ok(vec![Sources::Cassandra(
             CassandraSource::new(
-                chain,
+                chain_builder,
                 self.listen_addr.clone(),
                 trigger_shutdown_rx,
                 self.connection_limit,
@@ -50,7 +50,7 @@ pub struct CassandraSource {
 
 impl CassandraSource {
     pub async fn new(
-        chain: &TransformChainBuilder,
+        chain_builder: TransformChainBuilder,
         listen_addr: String,
         mut trigger_shutdown_rx: watch::Receiver<bool>,
         connection_limit: Option<usize>,
@@ -63,7 +63,7 @@ impl CassandraSource {
         info!("Starting Cassandra source on [{}]", listen_addr);
 
         let mut listener = TcpCodecListener::new(
-            chain.clone(),
+            chain_builder,
             name.to_string(),
             listen_addr.clone(),
             hard_connection_limit.unwrap_or(false),

--- a/shotover/src/sources/kafka.rs
+++ b/shotover/src/sources/kafka.rs
@@ -22,12 +22,12 @@ pub struct KafkaConfig {
 impl KafkaConfig {
     pub async fn get_source(
         &self,
-        chain: &TransformChainBuilder,
+        chain_builder: TransformChainBuilder,
         trigger_shutdown_rx: watch::Receiver<bool>,
     ) -> Result<Vec<Sources>> {
         Ok(vec![Sources::Kafka(
             KafkaSource::new(
-                chain,
+                chain_builder,
                 self.listen_addr.clone(),
                 trigger_shutdown_rx,
                 self.connection_limit,
@@ -49,7 +49,7 @@ pub struct KafkaSource {
 
 impl KafkaSource {
     pub async fn new(
-        chain: &TransformChainBuilder,
+        chain_builder: TransformChainBuilder,
         listen_addr: String,
         mut trigger_shutdown_rx: watch::Receiver<bool>,
         connection_limit: Option<usize>,
@@ -62,7 +62,7 @@ impl KafkaSource {
         info!("Starting Kafka source on [{}]", listen_addr);
 
         let mut listener = TcpCodecListener::new(
-            chain.clone(),
+            chain_builder,
             name.to_string(),
             listen_addr.clone(),
             hard_connection_limit.unwrap_or(false),

--- a/shotover/src/sources/mod.rs
+++ b/shotover/src/sources/mod.rs
@@ -38,13 +38,13 @@ pub enum SourcesConfig {
 impl SourcesConfig {
     pub(crate) async fn get_source(
         &self,
-        chain: &TransformChainBuilder,
+        chain_builder: TransformChainBuilder,
         trigger_shutdown_rx: watch::Receiver<bool>,
     ) -> Result<Vec<Sources>> {
         match self {
-            SourcesConfig::Cassandra(c) => c.get_source(chain, trigger_shutdown_rx).await,
-            SourcesConfig::Redis(r) => r.get_source(chain, trigger_shutdown_rx).await,
-            SourcesConfig::Kafka(r) => r.get_source(chain, trigger_shutdown_rx).await,
+            SourcesConfig::Cassandra(c) => c.get_source(chain_builder, trigger_shutdown_rx).await,
+            SourcesConfig::Redis(r) => r.get_source(chain_builder, trigger_shutdown_rx).await,
+            SourcesConfig::Kafka(r) => r.get_source(chain_builder, trigger_shutdown_rx).await,
         }
     }
 }

--- a/shotover/src/sources/redis.rs
+++ b/shotover/src/sources/redis.rs
@@ -22,11 +22,11 @@ pub struct RedisConfig {
 impl RedisConfig {
     pub async fn get_source(
         &self,
-        chain: &TransformChainBuilder,
+        chain_builder: TransformChainBuilder,
         trigger_shutdown_rx: watch::Receiver<bool>,
     ) -> Result<Vec<Sources>> {
         RedisSource::new(
-            chain,
+            chain_builder,
             self.listen_addr.clone(),
             trigger_shutdown_rx,
             self.connection_limit,
@@ -48,7 +48,7 @@ pub struct RedisSource {
 
 impl RedisSource {
     pub async fn new(
-        chain: &TransformChainBuilder,
+        chain_builder: TransformChainBuilder,
         listen_addr: String,
         mut trigger_shutdown_rx: watch::Receiver<bool>,
         connection_limit: Option<usize>,
@@ -60,7 +60,7 @@ impl RedisSource {
         let name = "RedisSource";
 
         let mut listener = TcpCodecListener::new(
-            chain.clone(),
+            chain_builder,
             name.to_string(),
             listen_addr.clone(),
             hard_connection_limit.unwrap_or(false),


### PR DESCRIPTION
Cloning from a base TransformBuilder means that we duplicate any resources held behind TransformBuilder.
Currently this doesnt cause any issues for internal transforms, but custom transform users have reported issues due to using the builder as a point to introduce external resource construction/destruction.

So instead this PR changes it to construct a new builder for each source instead of cloning.

I had to change `shotover-proxy/tests/test-configs/invalid_subchains.yaml` to actually make use of each chain so that the validation is triggered.
This isnt ideal but there isnt a way around that.

The variables named chain were always ChainBuilder's I've just properly named them now.