### PR TITLE
Remove clone from TransformBuilder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1101,12 +1101,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dyn-clone"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
-
-[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3298,7 +3292,6 @@ dependencies = [
  "crc16",
  "csv",
  "derivative",
- "dyn-clone",
  "futures",
  "generic-array",
  "governor",

--- a/shotover-proxy/benches/benches/chain.rs
+++ b/shotover-proxy/benches/benches/chain.rs
@@ -36,7 +36,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("NullSink", |b| {
             b.to_async(&rt).iter_batched(
                 || BenchInput {
-                    chain: chain.clone().build(),
+                    chain: chain.build(),
                     wrapper: wrapper.clone(),
                     client_details: "".into(),
                 },
@@ -75,7 +75,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("redis_filter", |b| {
             b.to_async(&rt).iter_batched(
                 || BenchInput {
-                    chain: chain.clone().build(),
+                    chain: chain.build(),
                     wrapper: wrapper.clone(),
                     client_details: "".into(),
                 },
@@ -111,7 +111,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("redis_timestamp_tagger_untagged", |b| {
             b.to_async(&rt).iter_batched(
                 || BenchInput {
-                    chain: chain.clone().build(),
+                    chain: chain.build(),
                     wrapper: wrapper_set.clone(),
                     client_details: "".into(),
                 },
@@ -132,7 +132,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("redis_timestamp_tagger_tagged", |b| {
             b.to_async(&rt).iter_batched(
                 || BenchInput {
-                    chain: chain.clone().build(),
+                    chain: chain.build(),
                     wrapper: wrapper_get.clone(),
                     client_details: "".into(),
                 },
@@ -163,7 +163,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("redis_cluster_ports_rewrite", |b| {
             b.to_async(&rt).iter_batched(
                 || BenchInput {
-                    chain: chain.clone().build(),
+                    chain: chain.build(),
                     wrapper: wrapper.clone(),
                     client_details: "".into(),
                 },
@@ -209,7 +209,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("cassandra_request_throttling_unparsed", |b| {
             b.to_async(&rt).iter_batched(
                 || BenchInput {
-                    chain: chain.clone().build(),
+                    chain: chain.build(),
                     wrapper: wrapper.clone(),
                     client_details: "".into(),
                 },
@@ -265,7 +265,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("cassandra_rewrite_peers_passthrough", |b| {
             b.to_async(&rt).iter_batched(
                 || BenchInput {
-                    chain: chain.clone().build(),
+                    chain: chain.build(),
                     wrapper: wrapper.clone(),
                     client_details: "".into(),
                 },
@@ -309,7 +309,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("cassandra_protect_unprotected", |b| {
             b.to_async(&rt).iter_batched(
                 || BenchInput {
-                    chain: chain.clone().build(),
+                    chain: chain.build(),
                     wrapper: wrapper.clone(),
                     client_details: "".into(),
                 },
@@ -325,7 +325,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("cassandra_protect_protected", |b| {
             b.to_async(&rt).iter_batched(
                 || BenchInput {
-                    chain: chain.clone().build(),
+                    chain: chain.build(),
                     wrapper: wrapper.clone(),
                     client_details: "".into(),
                 },

--- a/shotover/Cargo.toml
+++ b/shotover/Cargo.toml
@@ -80,7 +80,6 @@ rusoto_signature = "0.48.0"
 strum_macros = "0.24"
 chacha20poly1305 = { version = "0.10.0", features = ["std"] }
 generic-array = { version = "0.14", features = ["serde"] }
-dyn-clone = "1.0.10"
 kafka-protocol = "0.6.0"
 # dangerous_configuration is used to implement equivalent functionality to openssl `verify_hostname(false)`
 #

--- a/shotover/src/transforms/chain.rs
+++ b/shotover/src/transforms/chain.rs
@@ -197,7 +197,7 @@ impl TransformChain {
 }
 
 #[derive(Derivative)]
-#[derivative(Debug, Clone)]
+#[derivative(Debug)]
 pub struct TransformChainBuilder {
     pub name: String,
     pub chain: Vec<Box<dyn TransformBuilder>>,

--- a/shotover/src/transforms/distributed/tuneable_consistency_scatter.rs
+++ b/shotover/src/transforms/distributed/tuneable_consistency_scatter.rs
@@ -38,7 +38,6 @@ impl TransformConfig for TuneableConsistencyScatterConfig {
     }
 }
 
-#[derive(Clone)]
 pub struct TuneableConsistencyScatterBuilder {
     route_map: Vec<TransformChainBuilder>,
     write_consistency: i32,

--- a/shotover/src/transforms/mod.rs
+++ b/shotover/src/transforms/mod.rs
@@ -28,7 +28,6 @@ use crate::transforms::throttling::RequestThrottling;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use core::fmt;
-use dyn_clone::DynClone;
 use futures::Future;
 use metrics::{counter, histogram};
 use std::fmt::{Debug, Formatter};
@@ -60,10 +59,7 @@ pub mod tee;
 pub mod throttling;
 pub mod util;
 
-// TODO: probably better, semantically, to have this not Clone.
-//       Fixing that is left to a followup PR though.
-//       It would also affect whether sources pointing into the same chain share state, which will require careful consideration
-pub trait TransformBuilder: DynClone + Send {
+pub trait TransformBuilder: Send + Sync {
     fn build(&self) -> Transforms;
 
     fn get_name(&self) -> &'static str;
@@ -76,7 +72,6 @@ pub trait TransformBuilder: DynClone + Send {
         false
     }
 }
-dyn_clone::clone_trait_object!(TransformBuilder);
 
 impl Debug for dyn TransformBuilder {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {

--- a/shotover/src/transforms/redis/cache.rs
+++ b/shotover/src/transforms/redis/cache.rs
@@ -99,7 +99,6 @@ impl TransformConfig for RedisConfig {
     }
 }
 
-#[derive(Clone)]
 pub struct SimpleRedisCacheBuilder {
     cache_chain: TransformChainBuilder,
     caching_schema: HashMap<FQName, TableCacheSchema>,

--- a/shotover/src/transforms/sampler.rs
+++ b/shotover/src/transforms/sampler.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use tokio::macros::support::thread_rng_n;
 use tracing::warn;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct SamplerBuilder {
     pub numerator: u32,
     pub denominator: u32,

--- a/shotover/src/transforms/tee.rs
+++ b/shotover/src/transforms/tee.rs
@@ -8,7 +8,6 @@ use metrics::{register_counter, Counter};
 use serde::Deserialize;
 use tracing::trace;
 
-#[derive(Clone)]
 pub struct TeeBuilder {
     pub tx: TransformChainBuilder,
     pub buffer_size: usize,
@@ -17,7 +16,6 @@ pub struct TeeBuilder {
     dropped_messages: Counter,
 }
 
-#[derive(Clone)]
 pub enum ConsistencyBehaviorBuilder {
     Ignore,
     FailOnMismatch,


### PR DESCRIPTION
When implementing a TransformBuilder its not clear what the semantics of your clone implementation should be.
This is even more problematic now since TransformBuilder is part of our custom transforms API.

The few remaining locations that rely on TransformBuilder having Clone can be quite easily adjusted to either separately create the builders from the config or share one builder via an Arc.
So lets just remove the clone requirement.