### PR TITLE
windsock: add --operations-per-second flag

### DIFF
--- a/shotover-proxy/examples/windsock/kafka.rs
+++ b/shotover-proxy/examples/windsock/kafka.rs
@@ -40,6 +40,7 @@ impl Bench for KafkaBench {
         flamegraph: bool,
         _local: bool,
         _runtime_seconds: u32,
+        _operations_per_second: Option<u64>,
         reporter: UnboundedSender<Report>,
     ) {
         let config_dir = "tests/test-configs/kafka/passthrough";

--- a/windsock/src/cli.rs
+++ b/windsock/src/cli.rs
@@ -18,6 +18,9 @@ pub struct Args {
     /// How long in seconds to run each bench for
     #[clap(long)]
     pub bench_length_seconds: Option<u32>,
+    /// Max operations per second
+    #[clap(long)]
+    pub operations_per_second: Option<u64>,
 
     /// The results of the last benchmarks run becomes the new baseline from which following benchmark runs will be compared.
     /// Baseline bench results are merged with the results of following results under a `baseline=true` tag.

--- a/windsock/src/lib.rs
+++ b/windsock/src/lib.rs
@@ -3,7 +3,7 @@ mod cli;
 mod filter;
 mod report;
 mod tables;
-pub use bench::Bench;
+pub use bench::{Bench, BenchTask};
 pub use report::Report;
 
 use anyhow::{anyhow, Result};

--- a/windsock/src/tables.rs
+++ b/windsock/src/tables.rs
@@ -126,10 +126,23 @@ fn base(reports: &[ReportArchive], table_type: &str, comparison: bool) {
             Goal::BiggerIsBetter,
         )
     }));
-    rows.push(Row::measurements(reports, "Ops Per Sec", |report| {
+    rows.push(Row::measurements(reports, "Target Ops Per Sec", |report| {
         (
-            report.ops as f64,
-            format!("{:.0}", report.ops),
+            report
+                .requested_ops
+                .map(|x| x as f64)
+                .unwrap_or(f64::INFINITY),
+            report
+                .requested_ops
+                .map(|x| x.to_string())
+                .unwrap_or("MAX".to_owned()),
+            Goal::BiggerIsBetter,
+        )
+    }));
+    rows.push(Row::measurements(reports, "Actual Ops Per Sec", |report| {
+        (
+            report.actual_ops as f64,
+            format!("{:.0}", report.actual_ops),
             Goal::BiggerIsBetter,
         )
     }));


### PR DESCRIPTION
first step towards: https://github.com/shotover/shotover-proxy/issues/1166
No matter what complete solution we end up with there, the user will still want to be able to manually set the OPS somehow.

This PR introduces the first helper to be used within a windsock bench implementation: `BenchTask`
Previously it was purely up to the user to implement required bench logic.
I think this is a good starting point but we can pull logic in and out of BenchTask as we start using it.
I think that it is important that everything in BenchTask can also be done manually because some people will have specific needs that it cant meet.

Ignore the "Ops per sec" results in the screenshots, it is broken and will be fixed by: https://github.com/shotover/shotover-proxy/pull/1174
Instead refer to the "Ops each second" results.

## --operations-per-second 100
![image](https://github.com/shotover/shotover-proxy/assets/5120858/7dec2341-20c5-4568-a336-dcc110a3eab9)


## --operations-per-second 1000
![image](https://github.com/shotover/shotover-proxy/assets/5120858/acbe8b16-90f4-4b61-9653-41778848e452)

## --operations-per-second 10000
![image](https://github.com/shotover/shotover-proxy/assets/5120858/801d6747-4e88-4833-8f1a-bb06c23f43f4)

The "Ops Each Second" instability appears to be due to the timing of these reports being sent being off due to tokio::time::sleep being best effort only:
```rust
            for _ in 0..15 {
                let second = Instant::now();
                tokio::time::sleep(Duration::from_secs(1)).await;
                reporter
                    .send(Report::SecondPassed(second.elapsed()))
                    .unwrap();
            }
```
This is an inaccuracy in the way we measure operation counting rather than an inaccuracy in the timing of running actual operations.
We could improve precision here by moving the Report::SecondPassed timestamp into `Report::QueryCompletedIn` but I'm worried about the performance implications of that. Might experiment with that approach later.

