### PR TITLE
windsock: misc report/table improvements

### DIFF
--- a/windsock/src/report.rs
+++ b/windsock/src/report.rs
@@ -56,21 +56,21 @@ impl Percentile {
 
     pub fn name(&self) -> &'static str {
         match self {
-            Percentile::Min => "  Min   ",
-            Percentile::P1 => "    1   ",
-            Percentile::P2 => "    2   ",
-            Percentile::P5 => "    5   ",
-            Percentile::P10 => "   10   ",
-            Percentile::P25 => "   25   ",
-            Percentile::P50 => "   50   ",
-            Percentile::P75 => "   75   ",
-            Percentile::P90 => "   90   ",
-            Percentile::P95 => "   95   ",
-            Percentile::P98 => "   98   ",
-            Percentile::P99 => "   99   ",
-            Percentile::P99_9 => "   99.9 ",
-            Percentile::P99_99 => "  99.99",
-            Percentile::Max => "  Max   ",
+            Percentile::Min => "Min   ",
+            Percentile::P1 => "1   ",
+            Percentile::P2 => "2   ",
+            Percentile::P5 => "5   ",
+            Percentile::P10 => "10   ",
+            Percentile::P25 => "25   ",
+            Percentile::P50 => "50   ",
+            Percentile::P75 => "75   ",
+            Percentile::P90 => "90   ",
+            Percentile::P95 => "95   ",
+            Percentile::P98 => "98   ",
+            Percentile::P99 => "99   ",
+            Percentile::P99_9 => "99.9 ",
+            Percentile::P99_99 => "99.99",
+            Percentile::Max => "Max   ",
         }
     }
 }
@@ -95,7 +95,7 @@ impl ReportArchive {
     pub fn load(path: &str) -> Result<Self> {
         match std::fs::read(windsock_path().join(path)) {
             Ok(bytes) => bincode::deserialize(&bytes).map_err(|e|
-                anyhow!(e).context("The bench archive from the previous run is not valid archive, maybe the format changed since the last run")
+                anyhow!(e).context("The bench archive from the previous run is not a valid archive, maybe the format changed since the last run")
             ),
             Err(err) if err.kind() == ErrorKind::NotFound => Err(anyhow!("The bench {path:?} does not exist or was not run in the previous run")),
             Err(err) => Err(anyhow!("The bench {path:?} encountered a file read error {err:?}"))

--- a/windsock/src/tables.rs
+++ b/windsock/src/tables.rs
@@ -112,42 +112,53 @@ fn base(reports: &[ReportArchive], table_type: &str, comparison: bool) {
     }
     for key in nonintersecting_keys {
         rows.push(Row::ColumnNames {
-            names: reports.iter().map(|x| x.tags.0[&key].clone()).collect(),
+            names: reports
+                .iter()
+                .map(|x| x.tags.0.get(&key).cloned().unwrap_or("".to_owned()))
+                .collect(),
             legend: key,
         });
     }
 
-    rows.push(Row::Heading("Measurements".to_owned()));
+    rows.push(Row::Heading("Opns (Operations)".to_owned()));
 
-    rows.push(Row::measurements(reports, "Ops (Operations)", |report| {
+    rows.push(Row::measurements(reports, "Total Opns", |report| {
         Some((
             report.operations_total as f64,
             report.operations_total.to_string(),
             Goal::BiggerIsBetter,
         ))
     }));
-    rows.push(Row::measurements(reports, "Target Ops Per Sec", |report| {
-        Some((
-            report
-                .requested_ops
-                .map(|x| x as f64)
-                .unwrap_or(f64::INFINITY),
-            report
-                .requested_ops
-                .map(|x| x.to_string())
-                .unwrap_or("MAX".to_owned()),
-            Goal::BiggerIsBetter,
-        ))
-    }));
-    rows.push(Row::measurements(reports, "Actual Ops Per Sec", |report| {
-        Some((
-            report.actual_ops as f64,
-            format!("{:.0}", report.actual_ops),
-            Goal::BiggerIsBetter,
-        ))
-    }));
+    rows.push(Row::measurements(
+        reports,
+        "Target Opns Per Sec",
+        |report| {
+            Some((
+                report
+                    .requested_ops
+                    .map(|x| x as f64)
+                    .unwrap_or(f64::INFINITY),
+                report
+                    .requested_ops
+                    .map(|x| x.to_string())
+                    .unwrap_or("MAX".to_owned()),
+                Goal::BiggerIsBetter,
+            ))
+        },
+    ));
+    rows.push(Row::measurements(
+        reports,
+        "Actual Opns Per Sec",
+        |report| {
+            Some((
+                report.actual_ops as f64,
+                format!("{:.0}", report.actual_ops),
+                Goal::BiggerIsBetter,
+            ))
+        },
+    ));
 
-    rows.push(Row::measurements(reports, "Op Time Mean", |report| {
+    rows.push(Row::measurements(reports, "Opn Time Mean", |report| {
         Some((
             report.mean_response_time.as_secs_f64(),
             duration_ms(report.mean_response_time),
@@ -155,7 +166,7 @@ fn base(reports: &[ReportArchive], table_type: &str, comparison: bool) {
         ))
     }));
 
-    rows.push(Row::Heading("Op Time Percentiles".to_owned()));
+    rows.push(Row::Heading("Opn Time Percentiles".to_owned()));
     for (i, p) in Percentile::iter().enumerate() {
         rows.push(Row::measurements(reports, p.name(), |report| {
             Some((
@@ -166,7 +177,7 @@ fn base(reports: &[ReportArchive], table_type: &str, comparison: bool) {
         }));
     }
 
-    rows.push(Row::Heading("Ops Each Second".to_owned()));
+    rows.push(Row::Heading("Opns Each Second".to_owned()));
     for i in 0..reports
         .iter()
         .map(|x| x.operations_each_second.len())


### PR DESCRIPTION
* The Ops abbreviation was ambiguous between OPS (operations per second) and Ops (Operations), so I've changed it to Opns
* The percentile strings dont need the left padding as they are right aligned
* The column name generation changes `.map(|x| x.tags.0.get(&key).cloned().unwrap_or("".to_owned()))` fixes a panic when a bench is missing a tag of the same key that another bench has.
    + This allows us to do, `cargo run --release --example windsock; cargo run --release --example windsock -- --results-by-tags ""` to run all benches and put them all in a table. Previously this would panic.
    + In the screenshot below those cases can be seen as the empty tag value cells.
    
    

![image](https://github.com/shotover/shotover-proxy/assets/5120858/38c1d5fe-3005-4eeb-b030-44f6a8dc4ba9)
