### PR TITLE
windsock: allow empty rows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,3 +6,6 @@ rustflags = [
 
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"
+
+[alias]
+windsock = "run --release --example windsock --"

--- a/windsock/src/tables.rs
+++ b/windsock/src/tables.rs
@@ -120,14 +120,14 @@ fn base(reports: &[ReportArchive], table_type: &str, comparison: bool) {
     rows.push(Row::Heading("Measurements".to_owned()));
 
     rows.push(Row::measurements(reports, "Ops (Operations)", |report| {
-        (
+        Some((
             report.operations_total as f64,
             report.operations_total.to_string(),
             Goal::BiggerIsBetter,
-        )
+        ))
     }));
     rows.push(Row::measurements(reports, "Target Ops Per Sec", |report| {
-        (
+        Some((
             report
                 .requested_ops
                 .map(|x| x as f64)
@@ -137,32 +137,32 @@ fn base(reports: &[ReportArchive], table_type: &str, comparison: bool) {
                 .map(|x| x.to_string())
                 .unwrap_or("MAX".to_owned()),
             Goal::BiggerIsBetter,
-        )
+        ))
     }));
     rows.push(Row::measurements(reports, "Actual Ops Per Sec", |report| {
-        (
+        Some((
             report.actual_ops as f64,
             format!("{:.0}", report.actual_ops),
             Goal::BiggerIsBetter,
-        )
+        ))
     }));
 
     rows.push(Row::measurements(reports, "Op Time Mean", |report| {
-        (
+        Some((
             report.mean_response_time.as_secs_f64(),
             duration_ms(report.mean_response_time),
             Goal::SmallerIsBetter,
-        )
+        ))
     }));
 
     rows.push(Row::Heading("Op Time Percentiles".to_owned()));
     for (i, p) in Percentile::iter().enumerate() {
         rows.push(Row::measurements(reports, p.name(), |report| {
-            (
+            Some((
                 report.response_time_percentiles[i].as_secs_f64(),
                 duration_ms(report.response_time_percentiles[i]),
                 Goal::SmallerIsBetter,
-            )
+            ))
         }));
     }
 
@@ -174,11 +174,10 @@ fn base(reports: &[ReportArchive], table_type: &str, comparison: bool) {
         .unwrap()
     {
         rows.push(Row::measurements(reports, &i.to_string(), |report| {
-            if let Some(value) = report.operations_each_second.get(i) {
-                (*value as f64, value.to_string(), Goal::BiggerIsBetter)
-            } else {
-                (0.0, "".to_owned(), Goal::BiggerIsBetter)
-            }
+            report
+                .operations_each_second
+                .get(i)
+                .map(|value| (*value as f64, value.to_string(), Goal::BiggerIsBetter))
         }));
     }
 
@@ -351,7 +350,7 @@ enum Color {
 }
 
 impl Row {
-    fn measurements<F: Fn(&ReportArchive) -> (f64, String, Goal)>(
+    fn measurements<F: Fn(&ReportArchive) -> Option<(f64, String, Goal)>>(
         reports: &[ReportArchive],
         legend: &str,
         f: F,
@@ -361,14 +360,23 @@ impl Row {
         let measurements = reports
             .iter()
             .map(|x| {
-                let (compare, value, goal) = f(x);
-                let (comparison, comparison_raw) = if let Some(base) = base {
-                    let comparison_raw = (compare - base) / base * 100.0;
-                    (format!("{:+.1}%", comparison_raw), comparison_raw)
-                } else {
-                    base = Some(compare);
-                    ("".to_owned(), 0.0)
-                };
+                let (value, comparison, comparison_raw, goal) =
+                    if let Some((compare, value, goal)) = f(x) {
+                        if let Some(base) = base {
+                            let comparison_raw = (compare - base) / base * 100.0;
+                            (
+                                value,
+                                format!("{:+.1}%", comparison_raw),
+                                comparison_raw,
+                                goal,
+                            )
+                        } else {
+                            base = Some(compare);
+                            (value, "".to_owned(), 0.0, Goal::BiggerIsBetter)
+                        }
+                    } else {
+                        ("".to_owned(), "".to_owned(), 0.0, Goal::BiggerIsBetter)
+                    };
 
                 let color = if comparison_raw > 5.0 {
                     if let Goal::BiggerIsBetter = goal {


### PR DESCRIPTION
Previously the table row value format had no way to specify that no comparison should be made between two values.
This PR stores the value tuple in an Option (`Option<(f64, String, Goal)>`) allowing the comparison to be skipped for empty values.
Currently this only occurs on a rare edge case, when a bench reports less seconds than other benches.
But my true motivation is to support this functionality for the special pubsub table formatting that kafka will require.

I also threw in a cargo alias for windsock because its so handy.
Now we can just `cargo windsock; cargo windsock --results-by-tag "" ` to run every bench and display all the results in a table.