### PR TITLE
routing bug fix

### DIFF
--- a/shotover/src/transforms/cassandra/sink_cluster/mod.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/mod.rs
@@ -398,7 +398,7 @@ impl CassandraSinkCluster {
 
                 match connection {
                     Ok(connection) => connection.send(message)?,
-                    Err(GetReplicaErr::NoKeyspaceMetadata) => {
+                    Err(GetReplicaErr::NoKeyspaceMetadata | GetReplicaErr::NoRoutingKey) => {
                         match self
                             .pool
                             .get_random_connection_in_dc_rack(

--- a/shotover/src/transforms/cassandra/sink_cluster/node_pool.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/node_pool.rs
@@ -27,6 +27,7 @@ pub enum GetReplicaErr {
     NoKeyspaceMetadata,
     NoNodeAvailable(anyhow::Error),
     Other(Error),
+    NoRoutingKey,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -198,7 +199,7 @@ impl NodePool {
             })?,
             version,
         )
-        .unwrap();
+        .ok_or(GetReplicaErr::NoRoutingKey)?;
 
         let replica_host_ids = self
             .token_map


### PR DESCRIPTION
The result to a prepare query in Cassandra has no `pk_indexes`: https://github.com/apache/cassandra/blob/2ff1ad4788a1e29b99f81f75b2966b7951ba8250/doc/native_protocol_v3.spec#L638

This was added in v4: https://github.com/apache/cassandra/blob/2ff1ad4788a1e29b99f81f75b2966b7951ba8250/doc/native_protocol_v4.spec#L1204

This means we aren't routing v3 execute requests properly and actually never had the ability to do so which is unfortunate but we should at least not be blowing up when it happens.