### PR TITLE
server.rs refactor

### DIFF
--- a/shotover/src/server.rs
+++ b/shotover/src/server.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
-use tokio::sync::{mpsc, watch, Semaphore};
+use tokio::sync::{mpsc, watch, OwnedSemaphorePermit, Semaphore};
 use tokio::task::JoinHandle;
 use tokio::time;
 use tokio::time::timeout;
@@ -122,37 +122,21 @@ impl<C: CodecBuilder + 'static> TcpCodecListener<C> {
 
         loop {
             // Wait for a permit to become available
-            //
-            // `acquire` returns a permit that is bound via a lifetime to the
-            // semaphore. When the permit value is dropped, it is automatically
-            // returned to the semaphore. This is convenient in many cases.
-            // However, in this case, the permit must be returned in a different
-            // task than it is acquired in (the handler task). To do this, we
-            // "forget" the permit, which drops the permit value **without**
-            // incrementing the semaphore's permits. Then, in the handler task
-            // we manually add a new permit when processing completes.
-            if self.hard_connection_limit {
-                match self.limit_connections.try_acquire() {
-                    Ok(p) => {
-                        if self.listener.is_none() {
-                            self.listener = Some(create_listener(&self.listen_addr).await?);
-                        }
-                        p.forget();
-                    }
+            let permit = if self.hard_connection_limit {
+                match self.limit_connections.clone().try_acquire_owned() {
+                    Ok(p) => p,
                     Err(_e) => {
-                        if self.listener.is_some() {
-                            //close the socket too full!
-                            self.listener = None;
-                        }
-                        tokio::time::sleep(Duration::new(1, 0)).await;
+                        //close the socket too full!
+                        self.listener = None;
+                        tokio::time::sleep(Duration::from_secs(1)).await;
                         continue;
                     }
                 }
             } else {
-                self.limit_connections.acquire().await?.forget();
-                if self.listener.is_none() {
-                    self.listener = Some(create_listener(&self.listen_addr).await?);
-                }
+                self.limit_connections.clone().acquire_owned().await?
+            };
+            if self.listener.is_none() {
+                self.listener = Some(create_listener(&self.listen_addr).await?);
             }
 
             self.connection_count = self.connection_count.wrapping_add(1);
@@ -165,57 +149,32 @@ impl<C: CodecBuilder + 'static> TcpCodecListener<C> {
                 // Accept a new socket. This will attempt to perform error handling.
                 // The `accept` method internally attempts to recover errors, so an
                 // error here is non-recoverable.
-                let socket = self.accept().await?;
+                let stream = self.accept().await?;
 
                 debug!("got socket");
                 self.available_connections_gauge
                     .set(self.limit_connections.available_permits() as f64);
 
-                let peer = socket
-                    .peer_addr()
-                    .map(|p| format!("{}", p.ip()))
-                    .unwrap_or_else(|_| "Unknown peer".to_string());
-
-                let conn_string = socket
-                    .peer_addr()
-                    .map(|p| format!("{}:{}", p.ip(), p.port()))
-                    .unwrap_or_else(|_| "Unknown peer".to_string());
-
-                // Create the necessary per-connection handler state.
-                socket.set_nodelay(true)?;
-
                 let (pushed_messages_tx, pushed_messages_rx) =
                     tokio::sync::mpsc::unbounded_channel::<Messages>();
 
-                let mut handler = Handler {
+                let handler = Handler {
                     chain: self
                         .chain_builder
                         .build_with_pushed_messages(pushed_messages_tx),
-                    client_details: peer,
-                    conn_details: conn_string,
-                    source_details: self.source_name.clone(),
-
-                    // The connection state needs a handle to the max connections
-                    // semaphore. When the handler is done processing the
-                    // connection, a permit is added back to the semaphore.
                     codec: self.codec.clone(),
-                    limit_connections: self.limit_connections.clone(),
-
-                    // Receive shutdown notifications.
                     shutdown: Shutdown::new(self.trigger_shutdown_rx.clone()),
-
-                    terminate_tasks: None,
                     tls: self.tls.clone(),
                     timeout: self.timeout,
+                    pushed_messages_rx,
+                    _permit: permit,
                 };
 
                 // Spawn a new task to process the connections.
                 self.connection_handles.push(tokio::spawn(
                     async move {
-                        tracing::debug!("New connection from {}", handler.conn_details);
-
                         // Process the connection. If an error is encountered, log it.
-                        if let Err(err) = handler.run(socket, pushed_messages_rx).await {
+                        if let Err(err) = handler.run(stream).await {
                             error!(
                                 "{:?}",
                                 err.context("connection was unexpectedly terminated")
@@ -281,20 +240,8 @@ async fn create_listener(listen_addr: &str) -> Result<TcpListener> {
 
 pub struct Handler<C: CodecBuilder> {
     chain: TransformChain,
-    client_details: String,
-    conn_details: String,
-
-    #[allow(dead_code)]
-    source_details: String,
     codec: C,
-
-    /// Max connection semaphore.
-    ///
-    /// When the handler is dropped, a permit is returned to this semaphore. If
-    /// the listener is waiting for connections to close, it will be notified of
-    /// the newly available permit and resume accepting connections.
-    limit_connections: Arc<Semaphore>,
-
+    tls: Option<TlsAcceptor>,
     /// Listen for shutdown notifications.
     ///
     /// A wrapper around the `broadcast::Receiver` paired with the sender in
@@ -304,12 +251,10 @@ pub struct Handler<C: CodecBuilder> {
     /// processed for the peer is continued until it reaches a safe state, at
     /// which point the connection is terminated.
     shutdown: Shutdown,
-
-    terminate_tasks: Option<watch::Sender<()>>,
-    tls: Option<TlsAcceptor>,
-
     /// Timeout in seconds after which to kill an idle connection. No timeout means connections will never be timed out.
     timeout: Option<u64>,
+    pushed_messages_rx: UnboundedReceiver<Messages>,
+    _permit: OwnedSemaphorePermit,
 }
 
 fn spawn_read_write_tasks<
@@ -446,13 +391,16 @@ impl<C: CodecBuilder + 'static> Handler<C> {
     ///
     /// When the shutdown signal is received, the connection is processed until
     /// it reaches a safe state, at which point it is terminated.
-    pub async fn run(
-        &mut self,
-        stream: TcpStream,
-        pushed_messages_rx: UnboundedReceiver<Messages>,
-    ) -> Result<()> {
+    pub async fn run(mut self, stream: TcpStream) -> Result<()> {
+        stream.set_nodelay(true)?;
+
+        let client_details = stream
+            .peer_addr()
+            .map(|p| p.ip().to_string())
+            .unwrap_or_else(|_| "Unknown peer".to_string());
+        tracing::debug!("New connection from {}", client_details);
+
         let (terminate_tx, terminate_rx) = watch::channel::<()>(());
-        self.terminate_tasks = Some(terminate_tx);
 
         let (in_tx, in_rx) = mpsc::unbounded_channel::<Messages>();
         let (out_tx, out_rx) = mpsc::unbounded_channel::<Messages>();
@@ -489,7 +437,7 @@ impl<C: CodecBuilder + 'static> Handler<C> {
         };
 
         let result = self
-            .process_messages(local_addr, in_rx, out_tx, pushed_messages_rx)
+            .process_messages(&client_details, local_addr, in_rx, out_tx)
             .await;
 
         // Flush messages regardless of if we are shutting down due to a failure or due to application shutdown
@@ -497,7 +445,7 @@ impl<C: CodecBuilder + 'static> Handler<C> {
             .chain
             .process_request(
                 Wrapper::flush_with_chain_name(self.chain.name.clone()),
-                self.client_details.clone(),
+                client_details,
             )
             .await
         {
@@ -511,15 +459,17 @@ impl<C: CodecBuilder + 'static> Handler<C> {
             ),
         }
 
+        // shutdown the read/write tasks
+        std::mem::drop(terminate_tx);
         result
     }
 
     async fn process_messages(
         &mut self,
+        client_details: &str,
         local_addr: SocketAddr,
         mut in_rx: mpsc::UnboundedReceiver<Messages>,
         out_tx: mpsc::UnboundedSender<Messages>,
-        mut pushed_messages_rx: UnboundedReceiver<Messages>,
     ) -> Result<()> {
         // As long as the shutdown signal has not been received, try to read a
         // new request frame.
@@ -527,7 +477,7 @@ impl<C: CodecBuilder + 'static> Handler<C> {
 
         while !self.shutdown.is_shutdown() {
             // While reading a request frame, also listen for the shutdown signal
-            debug!("Waiting for message");
+            debug!("Waiting for message {client_details}");
             let mut reverse_chain = false;
 
             let messages = tokio::select! {
@@ -543,9 +493,9 @@ impl<C: CodecBuilder + 'static> Handler<C> {
                         Err(_) => {
                             if let Some(timeout) =  self.timeout {
                                 if idle_time_seconds < timeout {
-                                    debug!("Connection Idle for more than {} seconds {}", timeout, self.conn_details);
+                                    debug!("Connection Idle for more than {} seconds {}", timeout, client_details);
                                 } else {
-                                    debug!("Dropping. Connection Idle for more than {} seconds {}", timeout, self.conn_details);
+                                    debug!("Dropping. Connection Idle for more than {} seconds {}", timeout, client_details);
                                     return Ok(());
                                 }
                             }
@@ -554,7 +504,7 @@ impl<C: CodecBuilder + 'static> Handler<C> {
                         }
                     }
                 },
-                Some(res) = pushed_messages_rx.recv() => {
+                Some(res) = self.pushed_messages_rx.recv() => {
                     reverse_chain = true;
                     res
                 },
@@ -566,7 +516,6 @@ impl<C: CodecBuilder + 'static> Handler<C> {
             };
 
             debug!("Received raw messages {:?}", messages);
-            debug!("client details: {:?}", &self.client_details);
 
             let mut error_report_messages = if reverse_chain {
                 // Avoid allocating for reverse chains as we dont make use of this value in that case
@@ -578,20 +527,20 @@ impl<C: CodecBuilder + 'static> Handler<C> {
 
             let wrapper = Wrapper::new_with_client_details(
                 messages,
-                self.client_details.clone(),
+                client_details.to_owned(),
                 self.chain.name.clone(),
                 local_addr,
             );
 
             let modified_messages = if reverse_chain {
                 self.chain
-                    .process_request_rev(wrapper, self.client_details.clone())
+                    .process_request_rev(wrapper, client_details.to_owned())
                     .await
                     .context("Chain failed to receive pushed messages/events, the connection will now be closed.")?
             } else {
                 match self
                     .chain
-                    .process_request(wrapper, self.client_details.clone())
+                    .process_request(wrapper, client_details.to_owned())
                     .await
                     .context("Chain failed to send and/or receive messages, the connection will now be closed.")
                 {
@@ -627,26 +576,6 @@ impl<C: CodecBuilder + 'static> Handler<C> {
     }
 }
 
-impl<C: CodecBuilder> Drop for Handler<C> {
-    fn drop(&mut self) {
-        // Add a permit back to the semaphore.
-        //
-        // Doing so unblocks the listener if the max number of
-        // connections has been reached.
-        //
-        // This is done in a `Drop` implementation in order to guarantee that
-        // the permit is added even if the task handling the connection panics.
-        // If `add_permit` was called at the end of the `run` function and some
-        // bug causes a panic. The permit would never be returned to the
-        // semaphore.
-
-        self.limit_connections.add_permits(1);
-
-        if let Some(terminate_tasks) = &self.terminate_tasks {
-            terminate_tasks.send(()).ok();
-        }
-    }
-}
 /// Listens for the server shutdown signal.
 ///
 /// Shutdown is signaled using a `broadcast::Receiver`. Only a single value is


### PR DESCRIPTION
There are a few things going on here but no logic changes should have occurred in this PR.
1. our connection limiting logic was overly complicated because it was working around the lack of owned permits. Since then tokio has implemented [owned permits](https://docs.rs/tokio/latest/tokio/sync/struct.Semaphore.html#method.acquire_owned) so we should just use those instead. The now deleted comments did a pretty good job of explaining the workaround so you should refer to them.
2. I moved as much logic as possible out of the socket acceptor loop and into the Handle task. We want to be able to accept many connections quickly so the string generation and nodelay setting is better off occurring in the async task.
3. I combined the `conn_details` and `client_details` strings into a single string, I figured there was no reason for `conn_details` to exist we may as well just always use `client_details`. `client_details` is important, it gets used in our metrics but `conn_details` only gets used in `tracing::debug` logs which are very rarely examined.
4. terminate_tasks_rx/terminate_rx now just relies on terminate_tx being dropped instead of a message being sent.