### PR TITLE
server.rs close Handler when out_tx is closed

### DIFF
--- a/shotover/src/server.rs
+++ b/shotover/src/server.rs
@@ -569,7 +569,10 @@ impl<C: CodecBuilder + 'static> Handler<C> {
 
             debug!("sending message: {:?}", modified_messages);
             // send the result of the process up stream
-            out_tx.send(modified_messages)?;
+            if out_tx.send(modified_messages).is_err() {
+                // the client has disconnected so we should terminate this connection
+                return Ok(());
+            }
         }
 
         Ok(())


### PR DESCRIPTION
When the read/write tasks close while the chain is running the out_tx ends up closed at this point.
We should just cleanly shutdown the handler instead of returning an error.

This now matches the handling when in_rx is closed, which also cleanly shutsdown the Handler