### PR TITLE
windsock: basic thread count control

### DIFF
--- a/windsock/src/bench.rs
+++ b/windsock/src/bench.rs
@@ -41,6 +41,11 @@ impl BenchState {
         let report = process.await.unwrap();
         crate::tables::display_results_table(&[report]);
     }
+
+    // TODO: will return None when running in non-local setup
+    pub fn cores_required(&self) -> Option<usize> {
+        Some(self.bench.cores_required())
+    }
 }
 
 /// Implement this to define your benchmarks
@@ -59,6 +64,11 @@ pub trait Bench {
         operations_per_second: Option<u64>,
         reporter: UnboundedSender<Report>,
     );
+
+    /// How many cores to assign the async runtime in which the bench runs.
+    fn cores_required(&self) -> usize {
+        1
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/windsock/src/lib.rs
+++ b/windsock/src/lib.rs
@@ -110,8 +110,9 @@ impl Windsock {
         Ok(())
     }
 }
+
 fn run_bench(bench: &mut BenchState, args: &Args, running_in_release: bool) {
-    let runtime = create_runtime(Some(1));
+    let runtime = create_runtime(bench.cores_required());
     runtime.block_on(async {
         bench.run(args, running_in_release).await;
     });


### PR DESCRIPTION
its a little unfinished, some things to do later on are:
* control cassandra instance thread count - docker provides a way to do this but will need to pass arbitrary values into the docker-compose.yaml
* scale thread usage according to hardware core count.

But I want to land this now so we can start setting kafka and cassandra thread usage separately.

This PR should not change any performance numbers as I am setting all the thread counts to the same values that were previously used by default.