### PR TITLE
Split windsock into its own GA workflow

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -70,12 +70,6 @@ jobs:
       run: cargo hack --feature-powerset clippy --all-targets --locked ${{ matrix.cargo_flags }} -- -D warnings
     - name: Ensure that tests pass
       run: cargo test ${{ matrix.cargo_flags }} --all-features -- --include-ignored --show-output --nocapture ${{ matrix.test_flags }}
-    - name: Ensure that custom benches run
-      run: |
-        cargo run --release --example cassandra
-        cargo run --release --example windsock
-        cargo run --release --example windsock -- --flamegraph "name=cassandra shotover=standard"
-      if: ${{ matrix.name == 'Ubuntu 20.04 - Release' }}
     - name: Ensure that tests did not create or modify any files that arent .gitignore'd
       run: |
         if [ -n "$(git status --porcelain)" ]; then

--- a/.github/workflows/windsock_benches.yaml
+++ b/.github/workflows/windsock_benches.yaml
@@ -1,0 +1,37 @@
+name: Windsock Benches
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+# Cancel already running jobs
+concurrency:
+  group: windsock_benches_${{ github.head_ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  windsock_benches:
+    name: "Windsock benches"
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+    - uses: Swatinem/rust-cache@v2
+    - name: Ensure that custom benches run
+      run: |
+        cargo windsock --bench-length-seconds 5 --operations-per-second 100
+        cargo windsock --bench-length-seconds 5 --operations-per-second 100 --flamegraph "name=cassandra shotover=standard"
+
+        # windsock/examples/cassandra.rs - this can stay here until windsock is moved to its own repo
+        cargo run --release --example cassandra -- --bench-length-seconds 5 --operations-per-second 100
+    - name: Ensure that tests did not create or modify any files that arent .gitignore'd
+      run: |
+        if [ -n "$(git status --porcelain)" ]; then
+          git status
+          exit 1
+        fi


### PR DESCRIPTION
This doesnt actually bring down our total CI runtime on a clean build as it was not in the slowest workflow.
However splitting it up does mean that:
* Intermittent failures can be more quickly rerun
* We more quickly get feedback about a failure that occurred on a PR.