### PR TITLE
Improve kafka support for DebugPrinter

### DIFF
--- a/shotover/src/frame/mod.rs
+++ b/shotover/src/frame/mod.rs
@@ -132,7 +132,7 @@ impl Display for Frame {
         match self {
             Frame::Cassandra(frame) => write!(f, "Cassandra {}", frame),
             Frame::Redis(frame) => write!(f, "Redis {:?})", frame),
-            Frame::Kafka(frame) => write!(f, "Kafka {:?})", frame),
+            Frame::Kafka(frame) => write!(f, "Kafka {})", frame),
         }
     }
 }


### PR DESCRIPTION
This PR improves the KafkaFrame Display implementation so that DebugPrinter gives cleaner output:
![image](https://github.com/shotover/shotover-proxy/assets/5120858/f8211153-ee98-415a-82db-9867e39b68b5)

The only change is to cleanup the header which was previously really noisy, the body remains unchanged.