### PR TITLE
Remove wait_for_socket_to_open test helper

### DIFF
--- a/shotover-proxy/benches/benches/redis.rs
+++ b/shotover-proxy/benches/benches/redis.rs
@@ -1,6 +1,5 @@
 use criterion::{criterion_group, Criterion};
 use redis::Cmd;
-use std::path::Path;
 use test_helpers::connection::redis_connection;
 use test_helpers::docker_compose::{docker_compose, DockerCompose};
 use test_helpers::lazy::new_lazy_shared;
@@ -96,50 +95,6 @@ fn redis(c: &mut Criterion) {
             );
         }
     }
-
-    // Only need to test one case here as the type of command shouldnt affect TLS
-    group.bench_with_input(
-        "single_tls",
-        || {
-            test_helpers::cert::generate_test_certs(Path::new(
-                "tests/test-configs/redis-tls/certs",
-            ));
-            BenchResources::new(
-                "tests/test-configs/redis-tls/topology.yaml",
-                "tests/test-configs/redis-tls/docker-compose.yaml",
-            )
-        },
-        move |b, state| {
-            b.iter(|| {
-                redis::cmd("SET")
-                    .arg("foo")
-                    .arg(42)
-                    .execute(&mut state.connection);
-            })
-        },
-    );
-
-    // Only need to test one case here as the type of command shouldnt affect TLS
-    group.bench_with_input(
-        "cluster_tls",
-        || {
-            test_helpers::cert::generate_test_certs(Path::new(
-                "tests/test-configs/redis-tls/certs",
-            ));
-            BenchResources::new(
-                "tests/test-configs/redis-cluster-tls/topology.yaml",
-                "tests/test-configs/redis-cluster-tls/docker-compose.yaml",
-            )
-        },
-        move |b, state| {
-            b.iter(|| {
-                redis::cmd("SET")
-                    .arg("foo")
-                    .arg(42)
-                    .execute(&mut state.connection);
-            })
-        },
-    );
 }
 
 criterion_group!(benches, redis);

--- a/shotover-proxy/tests/redis_int_tests/mod.rs
+++ b/shotover-proxy/tests/redis_int_tests/mod.rs
@@ -34,10 +34,10 @@ async fn passthrough() {
     )
     .start()
     .await;
-    let mut connection = redis_connection::new_async(6379).await;
+    let connection = || redis_connection::new_async(6379);
     let mut flusher = Flusher::new_single_connection(redis_connection::new_async(6379).await).await;
 
-    run_all(&mut connection, &mut flusher).await;
+    run_all(&connection, &mut flusher).await;
     test_invalid_frame().await;
     shotover
         .shutdown_and_then_consume_events(&[invalid_frame_event()])
@@ -112,11 +112,11 @@ async fn tls_source_and_tls_single_sink() {
                 .start()
                 .await;
 
-        let mut connection = redis_connection::new_async_tls(6380).await;
+        let connection = || redis_connection::new_async_tls(6380);
         let mut flusher =
             Flusher::new_single_connection(redis_connection::new_async_tls(6380).await).await;
 
-        run_all(&mut connection, &mut flusher).await;
+        run_all(&connection, &mut flusher).await;
 
         shotover.shutdown_and_then_consume_events(&[]).await;
     }
@@ -217,7 +217,8 @@ async fn cluster_auth() {
     let mut connection = redis_connection::new_async(6379).await;
 
     test_auth(&mut connection).await;
-    test_auth_isolation(&mut connection).await;
+    let connection = || redis_connection::new_async(6379);
+    test_auth_isolation(&connection).await;
 
     shotover.shutdown_and_then_consume_events(&[]).await;
 }

--- a/shotover-proxy/tests/runner/observability_int_tests.rs
+++ b/shotover-proxy/tests/runner/observability_int_tests.rs
@@ -17,7 +17,6 @@ async fn test_metrics() {
 # TYPE query_count counter
 # TYPE shotover_available_connections gauge
 # TYPE shotover_chain_failures counter
-# TYPE shotover_chain_latency summary
 # TYPE shotover_chain_total counter
 # TYPE shotover_transform_failures counter
 # TYPE shotover_transform_latency summary
@@ -25,15 +24,6 @@ async fn test_metrics() {
 query_count{name="redis-chain"}
 shotover_available_connections{source="RedisSource"}
 shotover_chain_failures{chain="redis_chain"}
-shotover_chain_latency_count{chain="redis_chain",client_details="127.0.0.1"}
-shotover_chain_latency_sum{chain="redis_chain",client_details="127.0.0.1"}
-shotover_chain_latency{chain="redis_chain",client_details="127.0.0.1",quantile="0"}
-shotover_chain_latency{chain="redis_chain",client_details="127.0.0.1",quantile="0.5"}
-shotover_chain_latency{chain="redis_chain",client_details="127.0.0.1",quantile="0.9"}
-shotover_chain_latency{chain="redis_chain",client_details="127.0.0.1",quantile="0.95"}
-shotover_chain_latency{chain="redis_chain",client_details="127.0.0.1",quantile="0.99"}
-shotover_chain_latency{chain="redis_chain",client_details="127.0.0.1",quantile="0.999"}
-shotover_chain_latency{chain="redis_chain",client_details="127.0.0.1",quantile="1"}
 shotover_chain_total{chain="redis_chain"}
 shotover_transform_failures{transform="NullSink"}
 shotover_transform_failures{transform="QueryCounter"}
@@ -82,8 +72,18 @@ shotover_transform_total{transform="QueryCounter"}
         .unwrap_err();
 
     let expected_new = r#"
+# TYPE shotover_chain_latency summary
 query_count{name="redis-chain",query="GET",type="redis"}
 query_count{name="redis-chain",query="SET",type="redis"}
+shotover_chain_latency_count{chain="redis_chain",client_details="127.0.0.1"}
+shotover_chain_latency_sum{chain="redis_chain",client_details="127.0.0.1"}
+shotover_chain_latency{chain="redis_chain",client_details="127.0.0.1",quantile="0"}
+shotover_chain_latency{chain="redis_chain",client_details="127.0.0.1",quantile="0.5"}
+shotover_chain_latency{chain="redis_chain",client_details="127.0.0.1",quantile="0.9"}
+shotover_chain_latency{chain="redis_chain",client_details="127.0.0.1",quantile="0.95"}
+shotover_chain_latency{chain="redis_chain",client_details="127.0.0.1",quantile="0.99"}
+shotover_chain_latency{chain="redis_chain",client_details="127.0.0.1",quantile="0.999"}
+shotover_chain_latency{chain="redis_chain",client_details="127.0.0.1",quantile="1"}
 "#;
     assert_metrics_has_keys(expected, expected_new).await;
 

--- a/shotover-proxy/tests/test-configs/redis-tls/topology.yaml
+++ b/shotover-proxy/tests/test-configs/redis-tls/topology.yaml
@@ -1,8 +1,5 @@
 ---
 sources:
-  redis_prod:
-    Redis:
-      listen_addr: "127.0.0.1:6379"
   redis_prod_tls:
     Redis:
       listen_addr: "127.0.0.1:6380"
@@ -20,5 +17,4 @@ chain_config:
           private_key_path: "tests/test-configs/redis-tls/certs/localhost.key"
           verify_hostname: true
 source_to_chain_mapping:
-  redis_prod: redis_chain_tls
   redis_prod_tls: redis_chain_tls

--- a/shotover-proxy/tests/transforms/log_to_file.rs
+++ b/shotover-proxy/tests/transforms/log_to_file.rs
@@ -16,14 +16,13 @@ async fn log_to_file() {
     let mut connection = redis_connection::new_async(6379).await;
 
     assert_ok(redis::cmd("SET").arg("foo").arg(42), &mut connection).await;
-    // skip connection 1 as that comes from the redis_connection::new_async creating a dummy connection to the server to see if its awake yet
-    let request = std::fs::read("message-log/2/requests/message1.bin").unwrap();
+    let request = std::fs::read("message-log/1/requests/message1.bin").unwrap();
     assert_eq!(
         request,
         "*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$2\r\n42\r\n".as_bytes()
     );
 
-    let response = std::fs::read("message-log/2/responses/message1.bin").unwrap();
+    let response = std::fs::read("message-log/1/responses/message1.bin").unwrap();
     assert_eq!(response, "+OK\r\n".as_bytes());
 
     shotover.shutdown_and_then_consume_events(&[]).await;

--- a/test-helpers/src/connection/cassandra.rs
+++ b/test-helpers/src/connection/cassandra.rs
@@ -208,10 +208,6 @@ impl CassandraConnection {
         tls: Option<Tls>,
         protocol: Option<ProtocolVersion>,
     ) -> Self {
-        for contact_point in contact_points.split(',') {
-            crate::wait_for_socket_to_open(contact_point, port);
-        }
-
         match driver {
             #[cfg(feature = "cassandra-cpp-driver-tests")]
             CassandraDriver::Datastax => {

--- a/test-helpers/src/lib.rs
+++ b/test-helpers/src/lib.rs
@@ -8,24 +8,8 @@ pub mod metrics;
 pub mod mock_cassandra;
 pub mod shotover_process;
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, Result};
 use subprocess::{Exec, Redirection};
-
-pub fn wait_for_socket_to_open(address: &str, port: u16) {
-    try_wait_for_socket_to_open(address, port).unwrap();
-}
-
-pub fn try_wait_for_socket_to_open(address: &str, port: u16) -> Result<()> {
-    let mut tries = 0;
-    while std::net::TcpStream::connect((address, port)).is_err() {
-        std::thread::sleep(std::time::Duration::from_millis(100));
-        if tries > 50 {
-            bail!("Ran out of retries to connect to the socket");
-        }
-        tries += 1;
-    }
-    Ok(())
-}
 
 fn run_command_to_stdout(command: &str, args: &[&str]) {
     assert!(


### PR DESCRIPTION
I believe that this has been unneeded since moving to tokio-bin-process as that has logic that will wait until shotover is ready to accept connections.

It is causing issues with TLS tests because it forces us to provide a non TLS connection which in turn gets accidentally used by other parts of the test.

I've resolved the issues with the TLS tests by using a connection_creator to ensure TLS tests always create their connections in TLS.

I believe the change to the metrics test occurred because the connection close was triggering a chain flush which runs the chain and triggers the new shotover_chain_latency metrics.
Now those same metrics appear delayed because the chain is not run until the first message is received.

I removed the TLS redis benches because they were completely broken and not testing TLS at all, and now failing because of this, and they will be soon replaced with windsock benches so its not worth fixing.