### PR TITLE
windsock: add redis benches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
+name = "arcstr"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f907281554a3d0312bb7aab855a8e0ef6cbf1614d06de54105039ca8b34460e"
+
+[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,6 +292,15 @@ name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
@@ -994,6 +1009,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,12 +1075,25 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "atty",
+ "humantime 1.3.0",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "env_logger"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 2.1.0",
  "log",
  "regex",
  "termcolor",
@@ -1130,6 +1168,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "float_eq"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,6 +1210,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fred"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e02c21b098d77b0e99fe0054ebd3e7c9f81bffb42aa843021415ffa793124a6"
+dependencies = [
+ "arc-swap",
+ "arcstr",
+ "async-trait",
+ "bytes",
+ "bytes-utils",
+ "cfg-if",
+ "float-cmp",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "pretty_env_logger",
+ "rand",
+ "redis-protocol",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-webpki",
+ "semver",
+ "sha-1",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-util",
+ "url",
 ]
 
 [[package]]
@@ -1438,7 +1517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac",
- "digest",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -1474,6 +1553,15 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "humantime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+dependencies = [
+ "quick-error",
+]
 
 [[package]]
 name = "humantime"
@@ -1802,8 +1890,8 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
  "opaque-debug",
 ]
 
@@ -2351,6 +2439,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
 
 [[package]]
+name = "pretty_env_logger"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
+dependencies = [
+ "env_logger 0.7.1",
+ "log",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2400,6 +2498,12 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
@@ -2794,7 +2898,7 @@ dependencies = [
  "base64 0.13.1",
  "bytes",
  "chrono",
- "digest",
+ "digest 0.9.0",
  "futures",
  "hex",
  "hmac",
@@ -2850,6 +2954,18 @@ dependencies = [
  "ring",
  "rustls-webpki",
  "sct",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -3095,6 +3211,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3106,10 +3233,10 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.9.0",
  "opaque-debug",
 ]
 
@@ -3209,6 +3336,7 @@ dependencies = [
  "clap",
  "criterion",
  "csv",
+ "fred",
  "futures",
  "hex",
  "hex-literal",
@@ -3220,6 +3348,7 @@ dependencies = [
  "redis",
  "redis-protocol",
  "rstest",
+ "rustls-pemfile",
  "scylla",
  "serde",
  "serial_test",

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -43,6 +43,8 @@ rand_distr.workspace = true
 async-trait.workspace = true
 tracing-subscriber.workspace = true
 tracing-appender = "0.2.0"
+fred = { version = "6.3.0", features = ["enable-rustls"] }
+rustls-pemfile = "1.0.2"
 windsock = { path = "../windsock" }
 
 [[bench]]

--- a/shotover-proxy/examples/windsock/common.rs
+++ b/shotover-proxy/examples/windsock/common.rs
@@ -1,3 +1,4 @@
+#[derive(Clone, Copy)]
 pub enum Shotover {
     None,
     Standard,
@@ -5,7 +6,7 @@ pub enum Shotover {
 }
 
 impl Shotover {
-    pub fn to_tag(&self) -> (String, String) {
+    pub fn to_tag(self) -> (String, String) {
         (
             "shotover".to_owned(),
             match self {

--- a/shotover-proxy/examples/windsock/main.rs
+++ b/shotover-proxy/examples/windsock/main.rs
@@ -1,13 +1,15 @@
 mod cassandra;
 mod common;
 mod kafka;
+mod redis;
 
-use cassandra::*;
-use common::*;
-use kafka::*;
+use crate::cassandra::*;
+use crate::common::*;
+use crate::kafka::*;
+use crate::redis::*;
 use std::path::Path;
 use tracing_subscriber::EnvFilter;
-use windsock::Windsock;
+use windsock::{Bench, Windsock};
 
 fn main() {
     let (non_blocking, _guard) = tracing_appender::non_blocking(std::io::stdout());
@@ -28,7 +30,7 @@ fn main() {
 
     Windsock::new(
         vec![
-            Box::new(KafkaBench::new(Shotover::None, Size::B1)),
+            Box::new(KafkaBench::new(Shotover::None, Size::B1)) as Box<dyn Bench>,
             Box::new(KafkaBench::new(Shotover::None, Size::KB1)),
             Box::new(KafkaBench::new(Shotover::None, Size::KB100)),
             Box::new(KafkaBench::new(Shotover::Standard, Size::B1)),
@@ -97,7 +99,25 @@ fn main() {
                 Shotover::Standard,
                 Compression::None,
             )),
-        ],
+        ]
+        .into_iter()
+        .chain(
+            itertools::iproduct!(
+                [RedisTopology::Cluster3, RedisTopology::Single],
+                [
+                    Shotover::None,
+                    Shotover::Standard,
+                    Shotover::ForcedMessageParsed
+                ],
+                [RedisOperation::Get, RedisOperation::Set],
+                [Encryption::None, Encryption::Tls]
+            )
+            .map(|(topology, shotover, operation, encryption)| {
+                Box::new(RedisBench::new(topology, shotover, operation, encryption))
+                    as Box<dyn Bench>
+            }),
+        )
+        .collect(),
         &["release"],
     )
     .run();

--- a/shotover-proxy/examples/windsock/redis.rs
+++ b/shotover-proxy/examples/windsock/redis.rs
@@ -1,0 +1,293 @@
+use crate::common::Shotover;
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
+use fred::{
+    prelude::*,
+    rustls::{Certificate, ClientConfig, PrivateKey, RootCertStore},
+};
+use rustls_pemfile::{certs, Item};
+use std::{
+    collections::HashMap,
+    fs::File,
+    io::BufReader,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+use test_helpers::{
+    docker_compose::docker_compose,
+    flamegraph::Perf,
+    shotover_process::{Count, EventMatcher, Level, ShotoverProcessBuilder},
+};
+use tokio::sync::mpsc::UnboundedSender;
+use windsock::{Bench, BenchTask, Report};
+
+#[derive(Clone, Copy)]
+pub enum RedisOperation {
+    Set,
+    Get,
+}
+
+#[derive(Clone, Copy)]
+pub enum RedisTopology {
+    Single,
+    Cluster3,
+}
+
+#[derive(Clone, Copy)]
+pub enum Encryption {
+    None,
+    Tls,
+}
+
+pub struct RedisBench {
+    topology: RedisTopology,
+    shotover: Shotover,
+    operation: RedisOperation,
+    encryption: Encryption,
+}
+
+impl RedisBench {
+    pub fn new(
+        topology: RedisTopology,
+        shotover: Shotover,
+        operation: RedisOperation,
+        encryption: Encryption,
+    ) -> Self {
+        RedisBench {
+            topology,
+            shotover,
+            operation,
+            encryption,
+        }
+    }
+}
+
+#[async_trait]
+impl Bench for RedisBench {
+    fn tags(&self) -> HashMap<String, String> {
+        [
+            ("name".to_owned(), "redis".to_owned()),
+            (
+                "topology".to_owned(),
+                match &self.topology {
+                    RedisTopology::Single => "single".to_owned(),
+                    RedisTopology::Cluster3 => "cluster3".to_owned(),
+                },
+            ),
+            (
+                "operation".to_owned(),
+                match &self.operation {
+                    RedisOperation::Set => "set".to_owned(),
+                    RedisOperation::Get => "get".to_owned(),
+                },
+            ),
+            (
+                "encryption".to_owned(),
+                match &self.encryption {
+                    Encryption::None => "none".to_owned(),
+                    Encryption::Tls => "tls".to_owned(),
+                },
+            ),
+            self.shotover.to_tag(),
+        ]
+        .into_iter()
+        .collect()
+    }
+
+    fn cores_required(&self) -> usize {
+        2
+    }
+
+    async fn run(
+        &self,
+        flamegraph: bool,
+        _local: bool,
+        runtime_seconds: u32,
+        operations_per_second: Option<u64>,
+        reporter: UnboundedSender<Report>,
+    ) {
+        test_helpers::cert::generate_redis_test_certs();
+
+        // rediss:// url is not needed to enable TLS because we overwrite the TLS config later on
+        let address = match (self.topology, self.shotover) {
+            (RedisTopology::Single, Shotover::None) => "redis://127.0.0.1:1111",
+            (RedisTopology::Cluster3, Shotover::None) => "redis-cluster://172.16.1.2:6379",
+            (
+                RedisTopology::Single | RedisTopology::Cluster3,
+                Shotover::Standard | Shotover::ForcedMessageParsed,
+            ) => "redis://127.0.0.1:6379",
+        };
+        let config_dir = match (self.topology, self.encryption) {
+            (RedisTopology::Single, Encryption::None) => "tests/test-configs/redis-passthrough",
+            (RedisTopology::Cluster3, Encryption::None) => {
+                "tests/test-configs/redis-cluster-hiding"
+            }
+            (RedisTopology::Single, Encryption::Tls) => "tests/test-configs/redis-tls",
+            (RedisTopology::Cluster3, Encryption::Tls) => "tests/test-configs/redis-cluster-tls",
+        };
+        let _compose = docker_compose(&format!("{config_dir}/docker-compose.yaml"));
+        let shotover = match self.shotover {
+            Shotover::Standard => Some(
+                ShotoverProcessBuilder::new_with_topology(&format!("{config_dir}/topology.yaml"))
+                    .start()
+                    .await,
+            ),
+            Shotover::ForcedMessageParsed => Some(
+                ShotoverProcessBuilder::new_with_topology(&format!(
+                    "{config_dir}/topology-encode.yaml"
+                ))
+                .start()
+                .await,
+            ),
+            Shotover::None => None,
+        };
+        let perf = if flamegraph {
+            if let Some(shotover) = &shotover {
+                Some(Perf::new(shotover.child.as_ref().unwrap().id().unwrap()))
+            } else {
+                todo!()
+            }
+        } else {
+            None
+        };
+
+        let mut config = RedisConfig::from_url(address).unwrap();
+        if let Encryption::Tls = self.encryption {
+            let private_key = load_private_key("tests/test-configs/redis-tls/certs/localhost.key");
+            let certs = load_certs("tests/test-configs/redis-tls/certs/localhost.crt");
+            config.tls = Some(
+                ClientConfig::builder()
+                    .with_safe_defaults()
+                    .with_root_certificates(load_ca(
+                        "tests/test-configs/redis-tls/certs/localhost_CA.crt",
+                    ))
+                    .with_single_cert(certs, private_key)
+                    .unwrap()
+                    .into(),
+            );
+        }
+        let client = Arc::new(RedisClient::new(config, None, None));
+
+        // connect to the server, returning a handle to the task that drives the connection
+        let shutdown_handle = client.connect();
+        client.wait_for_connect().await.unwrap();
+
+        if let RedisOperation::Get = self.operation {
+            let _: () = client.set("foo", 42, None, None, false).await.unwrap();
+        }
+
+        let tasks = BenchTaskRedis {
+            client: client.clone(),
+            operation: self.operation,
+        }
+        .spawn_tasks(reporter.clone(), operations_per_second)
+        .await;
+
+        // warm up and then start
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        reporter.send(Report::Start).unwrap();
+        let start = Instant::now();
+
+        for _ in 0..runtime_seconds {
+            let second = Instant::now();
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            reporter
+                .send(Report::SecondPassed(second.elapsed()))
+                .unwrap();
+        }
+
+        reporter.send(Report::FinishedIn(start.elapsed())).unwrap();
+
+        // make sure the tasks complete before we drop the database they are connecting to
+        for task in tasks {
+            task.await.unwrap();
+        }
+
+        client.quit().await.unwrap();
+        shutdown_handle.await.unwrap().unwrap();
+
+        if let Some(shotover) = shotover {
+            shotover
+                .shutdown_and_then_consume_events(&[EventMatcher::new()
+                    .with_level(Level::Error)
+                    .with_message("encountered error in redis stream: Io(Kind(UnexpectedEof))")
+                    .with_target("shotover::transforms::redis::sink_single")
+                    .with_count(Count::Any)])
+                .await;
+        }
+
+        if let Some(perf) = perf {
+            perf.flamegraph();
+        }
+    }
+}
+
+fn load_certs(path: &str) -> Vec<Certificate> {
+    load_certs_inner(path)
+        .map_err(|err| anyhow!(err).context(format!("Failed to read certs at {path:?}")))
+        .unwrap()
+}
+fn load_certs_inner(path: &str) -> Result<Vec<Certificate>> {
+    certs(&mut BufReader::new(File::open(path)?))
+        .context("Error while parsing PEM")
+        .map(|certs| certs.into_iter().map(Certificate).collect())
+}
+
+fn load_private_key(path: &str) -> PrivateKey {
+    load_private_key_inner(path)
+        .map_err(|err| anyhow!(err).context(format!("Failed to read private key at {path:?}")))
+        .unwrap()
+}
+fn load_private_key_inner(path: &str) -> Result<PrivateKey> {
+    let keys = rustls_pemfile::read_all(&mut BufReader::new(File::open(path)?))
+        .context("Error while parsing PEM")?;
+    keys.into_iter()
+        .find_map(|item| match item {
+            Item::RSAKey(x) | Item::PKCS8Key(x) => Some(PrivateKey(x)),
+            _ => None,
+        })
+        .ok_or_else(|| anyhow!("No suitable keys found in PEM"))
+}
+
+fn load_ca(path: &str) -> RootCertStore {
+    load_ca_inner(path)
+        .map_err(|e| e.context(format!("Failed to load CA at {path:?}")))
+        .unwrap()
+}
+fn load_ca_inner(path: &str) -> Result<RootCertStore> {
+    let mut pem = BufReader::new(File::open(path)?);
+    let certs = rustls_pemfile::certs(&mut pem).context("Error while parsing PEM")?;
+
+    let mut root_cert_store = RootCertStore::empty();
+    for cert in certs {
+        root_cert_store
+            .add(&Certificate(cert))
+            .context("Failed to add cert to cert store")?;
+    }
+    Ok(root_cert_store)
+}
+
+#[derive(Clone)]
+struct BenchTaskRedis {
+    client: Arc<RedisClient>,
+    operation: RedisOperation,
+}
+
+#[async_trait]
+impl BenchTask for BenchTaskRedis {
+    async fn run_one_operation(&self) {
+        match self.operation {
+            RedisOperation::Set => {
+                let _: () = self
+                    .client
+                    .set("foo", "bar", None, None, false)
+                    .await
+                    .unwrap();
+            }
+            RedisOperation::Get => {
+                let result: u32 = self.client.get("foo").await.unwrap();
+                assert_eq!(result, 42);
+            }
+        }
+    }
+}

--- a/shotover-proxy/tests/redis_int_tests/mod.rs
+++ b/shotover-proxy/tests/redis_int_tests/mod.rs
@@ -83,11 +83,11 @@ Caused by:
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn tls_cluster_sink() {
-    test_helpers::cert::generate_test_certs(Path::new("tests/test-configs/redis-tls/certs"));
+    test_helpers::cert::generate_redis_test_certs();
 
     let _compose = docker_compose("tests/test-configs/redis-cluster-tls/docker-compose.yaml");
     let shotover = ShotoverProcessBuilder::new_with_topology(
-        "tests/test-configs/redis-cluster-tls/topology.yaml",
+        "tests/test-configs/redis-cluster-tls/topology-no-source-encryption.yaml",
     )
     .start()
     .await;
@@ -104,7 +104,7 @@ async fn tls_cluster_sink() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn tls_source_and_tls_single_sink() {
-    test_helpers::cert::generate_test_certs(Path::new("tests/test-configs/redis-tls/certs"));
+    test_helpers::cert::generate_redis_test_certs();
 
     {
         let _compose = docker_compose("tests/test-configs/redis-tls/docker-compose.yaml");

--- a/shotover-proxy/tests/test-configs/redis-cluster-hiding/topology-encode.yaml
+++ b/shotover-proxy/tests/test-configs/redis-cluster-hiding/topology-encode.yaml
@@ -1,0 +1,24 @@
+---
+sources:
+  redis_prod:
+    # define how shotover listens for incoming connections from our client application (`redis-benchmark`).
+    Redis:
+      listen_addr: "127.0.0.1:6379"
+chain_config:
+  redis_chain:
+    - DebugForceEncode:
+        encode_requests: true
+        encode_responses: true
+    # configure Shotover to connect to the Redis cluster via our defined contact points
+    - RedisSinkCluster:
+        first_contact_points:
+          - "172.16.1.2:6379"
+          - "172.16.1.3:6379"
+          - "172.16.1.4:6379"
+          - "172.16.1.5:6379"
+          - "172.16.1.6:6379"
+          - "172.16.1.7:6379"
+        connect_timeout_ms: 3000
+source_to_chain_mapping:
+  # connect our Redis source to our Redis cluster sink (transform).
+  redis_prod: redis_chain

--- a/shotover-proxy/tests/test-configs/redis-cluster-tls/topology-encode.yaml
+++ b/shotover-proxy/tests/test-configs/redis-cluster-tls/topology-encode.yaml
@@ -8,6 +8,9 @@ sources:
         private_key_path: "tests/test-configs/redis-tls/certs/localhost.key"
 chain_config:
   redis_chain:
+    - DebugForceEncode:
+        encode_requests: true
+        encode_responses: true
     - RedisSinkCluster:
         first_contact_points:
           - "172.16.1.2:6379"

--- a/shotover-proxy/tests/test-configs/redis-cluster-tls/topology-no-source-encryption.yaml
+++ b/shotover-proxy/tests/test-configs/redis-cluster-tls/topology-no-source-encryption.yaml
@@ -3,9 +3,6 @@ sources:
   redis_prod:
     Redis:
       listen_addr: "127.0.0.1:6379"
-      tls:
-        certificate_path: "tests/test-configs/redis-tls/certs/localhost.crt"
-        private_key_path: "tests/test-configs/redis-tls/certs/localhost.key"
 chain_config:
   redis_chain:
     - RedisSinkCluster:

--- a/shotover-proxy/tests/test-configs/redis-passthrough/topology-encode.yaml
+++ b/shotover-proxy/tests/test-configs/redis-passthrough/topology-encode.yaml
@@ -1,0 +1,15 @@
+---
+sources:
+  redis_prod:
+    Redis:
+      listen_addr: "127.0.0.1:6379"
+chain_config:
+  redis_chain:
+    - DebugForceEncode:
+        encode_requests: true
+        encode_responses: true
+    - RedisSinkSingle:
+        remote_address: "127.0.0.1:1111"
+        connect_timeout_ms: 3000
+source_to_chain_mapping:
+  redis_prod: redis_chain

--- a/shotover-proxy/tests/test-configs/redis-tls/topology-encode.yaml
+++ b/shotover-proxy/tests/test-configs/redis-tls/topology-encode.yaml
@@ -1,21 +1,18 @@
 ---
 sources:
-  redis_prod:
+  redis_prod_tls:
     Redis:
       listen_addr: "127.0.0.1:6379"
       tls:
         certificate_path: "tests/test-configs/redis-tls/certs/localhost.crt"
         private_key_path: "tests/test-configs/redis-tls/certs/localhost.key"
 chain_config:
-  redis_chain:
-    - RedisSinkCluster:
-        first_contact_points:
-          - "172.16.1.2:6379"
-          - "172.16.1.3:6379"
-          - "172.16.1.4:6379"
-          - "172.16.1.5:6379"
-          - "172.16.1.6:6379"
-          - "172.16.1.7:6379"
+  redis_chain_tls:
+    - DebugForceEncode:
+        encode_requests: true
+        encode_responses: true
+    - RedisSinkSingle:
+        remote_address: "localhost:1111"
         connect_timeout_ms: 3000
         tls:
           certificate_authority_path: "tests/test-configs/redis-tls/certs/localhost_CA.crt"
@@ -23,4 +20,4 @@ chain_config:
           private_key_path: "tests/test-configs/redis-tls/certs/localhost.key"
           verify_hostname: true
 source_to_chain_mapping:
-  redis_prod: redis_chain
+  redis_prod_tls: redis_chain_tls

--- a/test-helpers/src/cert.rs
+++ b/test-helpers/src/cert.rs
@@ -87,3 +87,7 @@ pub fn generate_cassandra_test_certs() {
     )
     .unwrap();
 }
+
+pub fn generate_redis_test_certs() {
+    generate_test_certs(Path::new("tests/test-configs/redis-tls/certs"));
+}


### PR DESCRIPTION
The redis benches largely follows the same structure as the cassandra benches.

I introduced a new redis driver (fred) because the `redis` crate is harder to drive from a benchmark due to requiring `&mut T` access to the driver to send a message. Fred however only requires `&T` to send messages making it easy to send messages from many tasks.
We might be able to wrap the redis crate in an MPSC receiving tokio task but it smelt like trouble so I just went with fred for now.
Might be worth doing a full comparison of the two crates one day but for now lets just land with fred.

Because there are so many bench combinations for redis I opted to use `itertools::iproduct` which conor discovered would be useful for generating all possible combinations of benches.

The results seem quite consistent, heres one run:
![image](https://github.com/shotover/shotover-proxy/assets/5120858/da6c5b69-c313-4a71-aeaf-b9261ec38383)


However there are some strange results, the TLS benches perform way better with shotover than without shotover:
![image](https://github.com/shotover/shotover-proxy/assets/5120858/40e509af-b4ce-4a30-86db-34e9789307e8)

