### PR TITLE
windsock: rework profiler support

### DIFF
--- a/.github/workflows/windsock_benches.yaml
+++ b/.github/workflows/windsock_benches.yaml
@@ -25,7 +25,8 @@ jobs:
     - name: Ensure that custom benches run
       run: |
         cargo windsock --bench-length-seconds 5 --operations-per-second 100
-        cargo windsock --bench-length-seconds 5 --operations-per-second 100 --flamegraph "name=cassandra shotover=standard"
+        cargo windsock --bench-length-seconds 5 --operations-per-second 100 --profilers flamegraph --name cassandra,compression=none,operation=read_i64,shotover=standard,topology=single
+        cargo windsock --bench-length-seconds 5 --operations-per-second 100 --profilers flamegraph --name kafka,shotover=standard,size=1B,topology=single
 
         # windsock/examples/cassandra.rs - this can stay here until windsock is moved to its own repo
         cargo run --release --example cassandra -- --bench-length-seconds 5 --operations-per-second 100

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,5 @@
 /target
 .idea/
-/old_builds
-*.data
-*.data.old
-tests/soaktest-*
 *.gz
 /.vscode
 /shotover-proxy/tests/test-configs/redis-tls/certs
@@ -14,13 +10,8 @@ tests/soaktest-*
 /shotover-proxy/tests/test-configs/docker-images/cassandra-tls-4.0.6/certs/*.csr
 /shotover-proxy/tests/test-configs/docker-images/cassandra-tls-4.0.6/certs/*.crt
 .workspace.code-workspace
-output.txt
 **/.DS_Store
 /.project
 /docs/book
 /docs/mdbook_bin
-shotover-proxy/read-127.0.0.1:9042.json
-shotover-proxy/read-127.0.0.1:9043.json
-shotover-proxy/read-172.16.1.2:9044.json
-shotover-proxy/flamegraph.svg
 /shotover-proxy/build/packages

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,13 @@ codegen-units = 1
 lto = "fat"
 codegen-units = 1
 
+# used for e.g. generating flamegraphs
+[profile.profiling]
+inherits = "release"
+lto = false
+debug = true
+codegen-units = 1
+
 [workspace.dependencies]
 bytes = "1.0.0"
 tokio = { version = "1.25.0", features = ["full", "macros"] }

--- a/shotover-proxy/examples/windsock/kafka.rs
+++ b/shotover-proxy/examples/windsock/kafka.rs
@@ -1,4 +1,5 @@
 use crate::common::Shotover;
+use crate::profilers::ProfilerRunner;
 use async_trait::async_trait;
 use futures::StreamExt;
 use rdkafka::config::ClientConfig;
@@ -7,11 +8,9 @@ use rdkafka::producer::{FutureProducer, FutureRecord};
 use rdkafka::util::Timeout;
 use std::sync::Arc;
 use std::{collections::HashMap, time::Duration};
-use test_helpers::{
-    docker_compose::docker_compose, flamegraph::Perf, shotover_process::ShotoverProcessBuilder,
-};
+use test_helpers::{docker_compose::docker_compose, shotover_process::ShotoverProcessBuilder};
 use tokio::{sync::mpsc::UnboundedSender, task::JoinHandle, time::Instant};
-use windsock::{Bench, Report};
+use windsock::{Bench, Profiling, Report};
 
 pub struct KafkaBench {
     shotover: Shotover,
@@ -54,9 +53,13 @@ impl Bench for KafkaBench {
         .collect()
     }
 
+    fn supported_profilers(&self) -> Vec<String> {
+        ProfilerRunner::supported_profilers(self.shotover)
+    }
+
     async fn run(
         &self,
-        flamegraph: bool,
+        profiling: Profiling,
         _local: bool,
         runtime_seconds: u32,
         operations_per_second: Option<u64>,
@@ -65,9 +68,11 @@ impl Bench for KafkaBench {
         let config_dir = "tests/test-configs/kafka/bench";
         let _compose = docker_compose(&format!("{}/docker-compose.yaml", config_dir));
 
+        let mut profiler = ProfilerRunner::new(profiling);
         let shotover = match self.shotover {
             Shotover::Standard => Some(
                 ShotoverProcessBuilder::new_with_topology(&format!("{config_dir}/topology.yaml"))
+                    .with_profile(profiler.shotover_profile())
                     .start()
                     .await,
             ),
@@ -76,20 +81,13 @@ impl Bench for KafkaBench {
                 ShotoverProcessBuilder::new_with_topology(&format!(
                     "{config_dir}/topology-encode.yaml"
                 ))
+                .with_profile(profiler.shotover_profile())
                 .start()
                 .await,
             ),
         };
 
-        let perf = if flamegraph {
-            if let Some(shotover) = &shotover {
-                Some(Perf::new(shotover.child().id().unwrap()))
-            } else {
-                todo!()
-            }
-        } else {
-            None
-        };
+        profiler.run(&shotover);
 
         let brokers = match self.shotover {
             Shotover::ForcedMessageParsed | Shotover::Standard => "127.0.0.1:9192",
@@ -153,10 +151,6 @@ impl Bench for KafkaBench {
 
         if let Some(shotover) = shotover {
             shotover.shutdown_and_then_consume_events(&[]).await;
-        }
-
-        if let Some(perf) = perf {
-            perf.flamegraph();
         }
     }
 }

--- a/shotover-proxy/examples/windsock/main.rs
+++ b/shotover-proxy/examples/windsock/main.rs
@@ -1,6 +1,7 @@
 mod cassandra;
 mod common;
 mod kafka;
+mod profilers;
 mod redis;
 
 use crate::cassandra::*;

--- a/shotover-proxy/examples/windsock/profilers.rs
+++ b/shotover-proxy/examples/windsock/profilers.rs
@@ -1,0 +1,62 @@
+use crate::common::Shotover;
+use std::path::PathBuf;
+use test_helpers::{flamegraph::Perf, shotover_process::BinProcess};
+use windsock::Profiling;
+
+pub struct ProfilerRunner {
+    run_flamegraph: bool,
+    results_path: PathBuf,
+    perf: Option<Perf>,
+}
+
+impl ProfilerRunner {
+    pub fn new(profiling: Profiling) -> Self {
+        let run_flamegraph = profiling
+            .profilers_to_use
+            .contains(&"flamegraph".to_owned());
+        ProfilerRunner {
+            run_flamegraph,
+            results_path: profiling.results_path,
+            perf: None,
+        }
+    }
+
+    pub fn run(&mut self, shotover: &Option<BinProcess>) {
+        self.perf = if self.run_flamegraph {
+            if let Some(shotover) = &shotover {
+                Some(Perf::new(
+                    self.results_path.clone(),
+                    shotover.child().id().unwrap(),
+                ))
+            } else {
+                panic!("flamegraph not supported when benching without shotover")
+            }
+        } else {
+            None
+        };
+    }
+
+    pub fn shotover_profile(&self) -> Option<&'static str> {
+        if self.run_flamegraph {
+            Some("profiling")
+        } else {
+            None
+        }
+    }
+
+    pub fn supported_profilers(shotover: Shotover) -> Vec<String> {
+        if let Shotover::None = shotover {
+            vec![]
+        } else {
+            vec!["flamegraph".to_owned()]
+        }
+    }
+}
+
+impl Drop for ProfilerRunner {
+    fn drop(&mut self) {
+        if let Some(perf) = self.perf.take() {
+            perf.flamegraph();
+        }
+    }
+}

--- a/test-helpers/src/flamegraph.rs
+++ b/test-helpers/src/flamegraph.rs
@@ -3,17 +3,23 @@ use inferno::collapse::Collapse;
 use inferno::flamegraph::{from_reader, Options};
 use std::fs::File;
 use std::io::{BufReader, BufWriter};
+use std::path::PathBuf;
 use std::process::{Child, Command};
 
 use crate::run_command;
 
-pub struct Perf(Child);
+pub struct Perf {
+    child: Child,
+    path: PathBuf,
+    perf_file: PathBuf,
+}
 
 impl Perf {
     /// Begin recording perf data to perf.data
-    pub fn new(pid: u32) -> Perf {
+    pub fn new(path: PathBuf, pid: u32) -> Perf {
+        let perf_file = path.join("perf.data");
         // remove perf.data if it exists to avoid generating perf.data.old clutter
-        std::fs::remove_file("perf.data").ok();
+        std::fs::remove_file(&perf_file).ok();
 
         // Run `sudo ls` so that we can get sudo to stop asking for password for a while.
         // It also lets us block until the user has entered the password, otherwise the rest of the test would continue before `perf` has started.
@@ -31,26 +37,48 @@ impl Perf {
             "dwarf,16384",
             "-g",
             "-o",
-            "perf.data",
+            perf_file.to_str().unwrap(),
             "-p",
             &pid.to_string(),
         ]);
 
-        Perf(command.spawn().unwrap())
+        Perf {
+            child: command.spawn().unwrap(),
+            path,
+            perf_file,
+        }
     }
 
     /// Blocks until the recorded process has terminated
     /// Generates a flamegraph at flamegraph.svg
     pub fn flamegraph(mut self) {
-        self.0.wait().unwrap();
+        self.child.wait().unwrap();
 
         run_command(
             "sudo",
-            &["chown", &std::env::var("USER").unwrap(), "perf.data"],
+            &[
+                "chown",
+                &std::env::var("USER").unwrap(),
+                self.perf_file.to_str().unwrap(),
+            ],
         )
         .unwrap();
 
-        let output = Command::new("perf").args(["script"]).output().unwrap();
+        let output = Command::new("perf")
+            .args([
+                "script",
+                "-i",
+                self.perf_file.to_str().unwrap(),
+                // --inline (the default) is so slow on CI that it times out after 5h 😭
+                //https://bugzilla.kernel.org/show_bug.cgi?id=202677
+                if std::env::var("CI").is_ok() {
+                    "--no-inline"
+                } else {
+                    "--inline"
+                },
+            ])
+            .output()
+            .unwrap();
         if !output.status.success() {
             panic!(
                 "unable to run 'perf script': ({}) {}",
@@ -70,10 +98,12 @@ impl Perf {
 
         let collapsed_reader = BufReader::new(&*collapsed);
 
-        let filename = "flamegraph.svg";
-        println!("writing flamegraph to {filename:?}");
-        let flamegraph_writer = BufWriter::new(File::create(filename).unwrap());
+        let flamegraph_file = self.path.join("flamegraph.svg");
+        println!("writing flamegraph to {flamegraph_file:?}");
+        let flamegraph_writer = BufWriter::new(File::create(flamegraph_file).unwrap());
 
-        from_reader(&mut Options::default(), collapsed_reader, flamegraph_writer).unwrap();
+        let mut options = Options::default();
+        options.title = self.path.file_name().unwrap().to_str().unwrap().to_owned();
+        from_reader(&mut options, collapsed_reader, flamegraph_writer).unwrap();
     }
 }

--- a/test-helpers/src/shotover_process.rs
+++ b/test-helpers/src/shotover_process.rs
@@ -10,6 +10,7 @@ pub struct ShotoverProcessBuilder {
     topology_path: String,
     log_name: Option<String>,
     cores: Option<String>,
+    profile: Option<String>,
     observability_port: Option<u16>,
 }
 
@@ -19,6 +20,7 @@ impl ShotoverProcessBuilder {
             topology_path: topology_path.to_owned(),
             log_name: None,
             cores: None,
+            profile: None,
             observability_port: None,
         }
     }
@@ -30,6 +32,13 @@ impl ShotoverProcessBuilder {
 
     pub fn with_cores(mut self, cores: u32) -> Self {
         self.cores = Some(cores.to_string());
+        self
+    }
+
+    pub fn with_profile(mut self, profile: Option<&str>) -> Self {
+        if let Some(profile) = profile {
+            self.profile = Some(profile.to_string());
+        }
         self
     }
 
@@ -63,7 +72,7 @@ observability_interface: "127.0.0.1:{observability_port}"
             "shotover-proxy",
             self.log_name.as_deref().unwrap_or("shotover"),
             &args,
-            None,
+            self.profile.as_deref(),
         )
         .await;
 

--- a/windsock/examples/cassandra.rs
+++ b/windsock/examples/cassandra.rs
@@ -9,7 +9,7 @@ use std::{
     time::{Duration, Instant},
 };
 use tokio::sync::mpsc::UnboundedSender;
-use windsock::{Bench, BenchTask, Report, Windsock};
+use windsock::{Bench, BenchTask, Profiling, Report, Windsock};
 
 fn main() {
     set_working_dir();
@@ -55,7 +55,7 @@ impl Bench for CassandraBench {
 
     async fn run(
         &self,
-        flamegraph: bool,
+        _profiling: Profiling,
         local: bool,
         runtime_seconds: u32,
         operations_per_second: Option<u64>,
@@ -66,9 +66,6 @@ impl Bench for CassandraBench {
         } else {
             todo!("create instances on real infrastructure that reflects production use, that might mean spinning up instances on AWS or deploying and using physical infrastructure")
         };
-        if flamegraph {
-            todo!("run flamegraph");
-        }
 
         let session = Arc::new(
             SessionBuilder::new()

--- a/windsock/src/bench.rs
+++ b/windsock/src/bench.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
+use std::path::PathBuf;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::task::JoinHandle;
@@ -11,12 +12,18 @@ use tokio::task::JoinHandle;
 pub struct BenchState {
     bench: Box<dyn Bench>,
     pub(crate) tags: Tags,
+    pub(crate) supported_profilers: Vec<String>,
 }
 
 impl BenchState {
     pub fn new(bench: Box<dyn Bench>) -> Self {
         let tags = Tags(bench.tags());
-        BenchState { bench, tags }
+        let supported_profilers = bench.supported_profilers();
+        BenchState {
+            bench,
+            tags,
+            supported_profilers,
+        }
     }
 
     pub async fn run(&mut self, args: &Args, running_in_release: bool) {
@@ -30,9 +37,24 @@ impl BenchState {
             args.operations_per_second,
             running_in_release,
         ));
+
+        let profilers_to_use = args.profilers.clone();
+        let results_path = if !profilers_to_use.is_empty() {
+            let path = crate::data::windsock_path()
+                .join("profiler_results")
+                .join(&name);
+            std::fs::create_dir_all(&path).unwrap();
+            path
+        } else {
+            PathBuf::new()
+        };
+
         self.bench
             .run(
-                args.flamegraph,
+                Profiling {
+                    results_path,
+                    profilers_to_use,
+                },
                 true,
                 args.bench_length_seconds.unwrap_or(15),
                 args.operations_per_second,
@@ -60,21 +82,32 @@ impl BenchState {
 pub trait Bench {
     /// Returns tags that are used for forming comparisons, graphs and naming the benchmark
     fn tags(&self) -> HashMap<String, String>;
-    /// Runs the benchmark.
-    /// Setup, benching and teardown all take place in here.
-    async fn run(
-        &self,
-        flamegraph: bool,
-        local: bool,
-        runtime_seconds: u32,
-        operations_per_second: Option<u64>,
-        reporter: UnboundedSender<Report>,
-    );
+
+    /// Returns the names of profilers that this bench can be run with
+    fn supported_profilers(&self) -> Vec<String> {
+        vec![]
+    }
 
     /// How many cores to assign the async runtime in which the bench runs.
     fn cores_required(&self) -> usize {
         1
     }
+
+    /// Runs the benchmark.
+    /// Setup, benching and teardown all take place in here.
+    async fn run(
+        &self,
+        profiling: Profiling,
+        local: bool,
+        runtime_seconds: u32,
+        operations_per_second: Option<u64>,
+        reporter: UnboundedSender<Report>,
+    );
+}
+
+pub struct Profiling {
+    pub results_path: PathBuf,
+    pub profilers_to_use: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/windsock/src/cli.rs
+++ b/windsock/src/cli.rs
@@ -12,9 +12,10 @@ pub struct Args {
     /// Run a specific bench with the name produced via `--list`
     #[clap(long)]
     pub name: Option<String>,
-    /// Instruct benches to profile the application under test and produce a flamegraph
+    /// Instruct benches to profile the application under test with the specified profilers
+    /// Benches that do not support the specified profilers will be skipped.
     #[clap(long)]
-    pub flamegraph: bool,
+    pub profilers: Vec<String>,
     /// How long in seconds to run each bench for
     #[clap(long)]
     pub bench_length_seconds: Option<u32>,

--- a/windsock/src/data.rs
+++ b/windsock/src/data.rs
@@ -1,0 +1,14 @@
+use std::path::PathBuf;
+
+pub fn windsock_path() -> PathBuf {
+    // If we are run via cargo (we are in a target directory) use the target directory for storage.
+    // Otherwise just fallback to the current working directory.
+    let mut path = std::env::current_exe().unwrap();
+    while path.pop() {
+        if path.file_name().map(|x| x == "target").unwrap_or(false) {
+            return path.join("windsock_data");
+        }
+    }
+
+    PathBuf::from("windsock_data")
+}

--- a/windsock/src/lib.rs
+++ b/windsock/src/lib.rs
@@ -1,9 +1,10 @@
 mod bench;
 mod cli;
+mod data;
 mod filter;
 mod report;
 mod tables;
-pub use bench::{Bench, BenchTask};
+pub use bench::{Bench, BenchTask, Profiling};
 pub use report::Report;
 
 use anyhow::{anyhow, Result};
@@ -80,7 +81,17 @@ impl Windsock {
         } else if let Some(name) = &args.name {
             ReportArchive::clear_last_run();
             match self.benches.iter_mut().find(|x| &x.tags.get_name() == name) {
-                Some(bench) => run_bench(bench, &args, running_in_release),
+                Some(bench) => {
+                    if args
+                        .profilers
+                        .iter()
+                        .all(|x| bench.supported_profilers.contains(x))
+                    {
+                        run_bench(bench, &args, running_in_release)
+                    } else {
+                        return Err(anyhow!("Specified bench {name:?} was requested to run with the profilers {:?} but it only supports the profilers {:?}", args.profilers, bench.supported_profilers));
+                    }
+                }
                 None => {
                     return Err(anyhow!("Specified bench {name:?} does not exist."));
                 }
@@ -105,7 +116,13 @@ impl Windsock {
             for bench in &mut self.benches {
                 if filter
                     .as_ref()
-                    .map(|x| x.matches(&bench.tags))
+                    .map(|x| {
+                        x.matches(&bench.tags)
+                            && args
+                                .profilers
+                                .iter()
+                                .all(|x| bench.supported_profilers.contains(x))
+                    })
                     .unwrap_or(true)
                 {
                     run_bench(bench, &args, running_in_release)

--- a/windsock/src/report.rs
+++ b/windsock/src/report.rs
@@ -1,4 +1,4 @@
-use crate::bench::Tags;
+use crate::{bench::Tags, data::windsock_path};
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 use std::{io::ErrorKind, path::PathBuf, time::Duration};
@@ -202,19 +202,6 @@ impl ReportArchive {
     pub fn baseline_path() -> PathBuf {
         windsock_path().join("baseline")
     }
-}
-
-pub fn windsock_path() -> PathBuf {
-    // If we are run via cargo (we are in a target directory) use the target directory for storage.
-    // Otherwise just fallback to the current working directory.
-    let mut path = std::env::current_exe().unwrap();
-    while path.pop() {
-        if path.file_name().map(|x| x == "target").unwrap_or(false) {
-            return path.join("windsock_data");
-        }
-    }
-
-    PathBuf::from("windsock_data")
 }
 
 pub(crate) async fn report_builder(


### PR DESCRIPTION
Makes progress on https://github.com/shotover/shotover-proxy/issues/1177

This PR introduces:
* Allow benches to support many kinds of profilers not just generating a flamegraph
* Benches run shotover in the `profiling` cargo profile when doing a flamegraph, this is necessary to get a useful flamegraph result, but the pre-windsock benches just instructed the user to temporarily modify the release profile.
* Store profiler results in a unique directory per bench, allowing multiple flamegraphs to be collected in the same windsock run.
* Filter out benches that do not support the user requested profiler. Previously windsock would just panic when attempting to run every bench with flamegraph because some benches did not support it.
* Moved tokio-bin-process to a git dep, the next release is blocked by https://github.com/shotover/tokio-bin-process/pull/7 , and we need access to the profile arg now.