### PR TITLE
Rename Sources -> Source

### DIFF
--- a/shotover/src/config/topology.rs
+++ b/shotover/src/config/topology.rs
@@ -1,5 +1,5 @@
 use crate::config::chain::TransformChainConfig;
-use crate::sources::{Sources, SourcesConfig};
+use crate::sources::{Source, SourceConfig};
 use crate::transforms::chain::TransformChainBuilder;
 use anyhow::{anyhow, Context, Result};
 use itertools::Itertools;
@@ -10,7 +10,7 @@ use tracing::info;
 
 #[derive(Deserialize, Debug)]
 pub struct Topology {
-    pub sources: HashMap<String, SourcesConfig>,
+    pub sources: HashMap<String, SourceConfig>,
     pub chain_config: HashMap<String, TransformChainConfig>,
     pub source_to_chain_mapping: HashMap<String, String>,
 }
@@ -44,8 +44,8 @@ impl Topology {
     pub async fn run_chains(
         &self,
         trigger_shutdown_rx: watch::Receiver<bool>,
-    ) -> Result<Vec<Sources>> {
-        let mut sources_list: Vec<Sources> = Vec::new();
+    ) -> Result<Vec<Source>> {
+        let mut sources_list: Vec<Source> = Vec::new();
 
         let mut chains = self.build_chains().await?;
         info!("Loaded chains {:?}", chains.keys());
@@ -121,7 +121,7 @@ mod topology_tests {
     use crate::transforms::null::NullSinkConfig;
     use crate::transforms::TransformConfig;
     use crate::{
-        sources::{redis::RedisConfig, Sources, SourcesConfig},
+        sources::{redis::RedisConfig, Source, SourceConfig},
         transforms::{
             distributed::tuneable_consistency_scatter::TuneableConsistencyScatterConfig,
             parallel_map::ParallelMapConfig, redis::cache::RedisConfig as RedisCacheConfig,
@@ -134,12 +134,12 @@ mod topology_tests {
         chain: Vec<Box<dyn TransformConfig>>,
     ) -> (
         HashMap<String, TransformChainConfig>,
-        HashMap<String, SourcesConfig>,
+        HashMap<String, SourceConfig>,
     ) {
         let mut chain_config = HashMap::new();
         chain_config.insert("redis_chain".to_string(), TransformChainConfig(chain));
 
-        let redis_source = SourcesConfig::Redis(RedisConfig {
+        let redis_source = SourceConfig::Redis(RedisConfig {
             listen_addr: "127.0.0.1:0".to_string(),
             connection_limit: None,
             hard_connection_limit: None,
@@ -163,7 +163,7 @@ mod topology_tests {
     async fn run_test_topology(
         chain: Vec<Box<dyn TransformConfig>>,
         source_to_chain_mapping: HashMap<String, String>,
-    ) -> anyhow::Result<Vec<Sources>> {
+    ) -> anyhow::Result<Vec<Source>> {
         let (chain_config, sources) = create_chain_config_and_sources(chain);
 
         let topology = Topology {

--- a/shotover/src/sources/cassandra.rs
+++ b/shotover/src/sources/cassandra.rs
@@ -1,7 +1,7 @@
 use crate::codec::Direction;
 use crate::codec::{cassandra::CassandraCodecBuilder, CodecBuilder};
 use crate::server::TcpCodecListener;
-use crate::sources::Sources;
+use crate::sources::Source;
 use crate::tls::{TlsAcceptor, TlsAcceptorConfig};
 use crate::transforms::chain::TransformChainBuilder;
 use anyhow::Result;
@@ -25,8 +25,8 @@ impl CassandraConfig {
         &self,
         chain_builder: TransformChainBuilder,
         trigger_shutdown_rx: watch::Receiver<bool>,
-    ) -> Result<Vec<Sources>> {
-        Ok(vec![Sources::Cassandra(
+    ) -> Result<Vec<Source>> {
+        Ok(vec![Source::Cassandra(
             CassandraSource::new(
                 chain_builder,
                 self.listen_addr.clone(),

--- a/shotover/src/sources/kafka.rs
+++ b/shotover/src/sources/kafka.rs
@@ -1,6 +1,6 @@
 use crate::codec::{kafka::KafkaCodecBuilder, CodecBuilder, Direction};
 use crate::server::TcpCodecListener;
-use crate::sources::Sources;
+use crate::sources::Source;
 use crate::tls::{TlsAcceptor, TlsAcceptorConfig};
 use crate::transforms::chain::TransformChainBuilder;
 use anyhow::Result;
@@ -24,8 +24,8 @@ impl KafkaConfig {
         &self,
         chain_builder: TransformChainBuilder,
         trigger_shutdown_rx: watch::Receiver<bool>,
-    ) -> Result<Vec<Sources>> {
-        Ok(vec![Sources::Kafka(
+    ) -> Result<Vec<Source>> {
+        Ok(vec![Source::Kafka(
             KafkaSource::new(
                 chain_builder,
                 self.listen_addr.clone(),

--- a/shotover/src/sources/mod.rs
+++ b/shotover/src/sources/mod.rs
@@ -12,39 +12,39 @@ pub mod kafka;
 pub mod redis;
 
 #[derive(Debug)]
-pub enum Sources {
+pub enum Source {
     Cassandra(CassandraSource),
     Redis(RedisSource),
     Kafka(KafkaSource),
 }
 
-impl Sources {
+impl Source {
     pub fn into_join_handle(self) -> JoinHandle<()> {
         match self {
-            Sources::Cassandra(c) => c.join_handle,
-            Sources::Redis(r) => r.join_handle,
-            Sources::Kafka(r) => r.join_handle,
+            Source::Cassandra(c) => c.join_handle,
+            Source::Redis(r) => r.join_handle,
+            Source::Kafka(r) => r.join_handle,
         }
     }
 }
 
 #[derive(Deserialize, Debug, Clone)]
-pub enum SourcesConfig {
+pub enum SourceConfig {
     Cassandra(CassandraConfig),
     Redis(RedisConfig),
     Kafka(KafkaConfig),
 }
 
-impl SourcesConfig {
+impl SourceConfig {
     pub(crate) async fn get_source(
         &self,
         chain_builder: TransformChainBuilder,
         trigger_shutdown_rx: watch::Receiver<bool>,
-    ) -> Result<Vec<Sources>> {
+    ) -> Result<Vec<Source>> {
         match self {
-            SourcesConfig::Cassandra(c) => c.get_source(chain_builder, trigger_shutdown_rx).await,
-            SourcesConfig::Redis(r) => r.get_source(chain_builder, trigger_shutdown_rx).await,
-            SourcesConfig::Kafka(r) => r.get_source(chain_builder, trigger_shutdown_rx).await,
+            SourceConfig::Cassandra(c) => c.get_source(chain_builder, trigger_shutdown_rx).await,
+            SourceConfig::Redis(r) => r.get_source(chain_builder, trigger_shutdown_rx).await,
+            SourceConfig::Kafka(r) => r.get_source(chain_builder, trigger_shutdown_rx).await,
         }
     }
 }

--- a/shotover/src/sources/redis.rs
+++ b/shotover/src/sources/redis.rs
@@ -1,6 +1,6 @@
 use crate::codec::{redis::RedisCodecBuilder, CodecBuilder, Direction};
 use crate::server::TcpCodecListener;
-use crate::sources::Sources;
+use crate::sources::Source;
 use crate::tls::{TlsAcceptor, TlsAcceptorConfig};
 use crate::transforms::chain::TransformChainBuilder;
 use anyhow::Result;
@@ -24,7 +24,7 @@ impl RedisConfig {
         &self,
         chain_builder: TransformChainBuilder,
         trigger_shutdown_rx: watch::Receiver<bool>,
-    ) -> Result<Vec<Sources>> {
+    ) -> Result<Vec<Source>> {
         RedisSource::new(
             chain_builder,
             self.listen_addr.clone(),
@@ -35,7 +35,7 @@ impl RedisConfig {
             self.timeout,
         )
         .await
-        .map(|x| vec![Sources::Redis(x)])
+        .map(|x| vec![Source::Redis(x)])
     }
 }
 


### PR DESCRIPTION
The correct naming scheme for an enum is to not use plurals as it represents a single instance.
plurals *would* be used to, for example, name a vector of that enum.