### PR TITLE
Fix accepting inbound connections log

### DIFF
--- a/custom-transforms-example/tests/test.rs
+++ b/custom-transforms-example/tests/test.rs
@@ -48,8 +48,7 @@ async fn shotover_proxy(topology_path: &str) -> BinProcess {
         shotover.wait_for(
             &EventMatcher::new()
                 .with_level(Level::Info)
-                .with_target("shotover::server")
-                .with_message("accepting inbound connections"),
+                .with_message("Shotover is now accepting inbound connections"),
         ),
     )
     .await

--- a/shotover/src/config/topology.rs
+++ b/shotover/src/config/topology.rs
@@ -104,10 +104,11 @@ impl Topology {
                                                     self.sources.keys().cloned().collect::<Vec<_>>()));
             }
         }
-        info!(
-            "Loaded sources [{:?}] and linked to chains",
-            &self.source_to_chain_mapping.keys()
-        );
+
+        // This info log is considered part of our external API.
+        // Users rely on this to know when shotover is ready in their integration tests.
+        // In production they would probably just have some kind of retry mechanism though.
+        info!("Shotover is now accepting inbound connections");
         Ok(sources_list)
     }
 }

--- a/shotover/src/server.rs
+++ b/shotover/src/server.rs
@@ -20,7 +20,7 @@ use tokio::time::timeout;
 use tokio::time::Duration;
 use tokio_util::codec::{FramedRead, FramedWrite};
 use tracing::Instrument;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, warn};
 
 pub struct TcpCodecListener<C: CodecBuilder> {
     chain_builder: TransformChainBuilder,
@@ -118,8 +118,6 @@ impl<C: CodecBuilder + 'static> TcpCodecListener<C> {
     /// itself. One strategy for handling this is to implement a back off
     /// strategy, which is what we do here.
     pub async fn run(&mut self) -> Result<()> {
-        info!("accepting inbound connections");
-
         loop {
             // Wait for a permit to become available
             let permit = if self.hard_connection_limit {

--- a/test-helpers/src/docker_compose.rs
+++ b/test-helpers/src/docker_compose.rs
@@ -30,10 +30,6 @@ pub fn new_moto() -> DockerCompose {
 fn get_image_waiters() -> &'static [Image] {
     &[
         Image {
-            name: "shotover/shotover-proxy",
-            log_regex_to_wait_for: r"accepting inbound connections",
-        },
-        Image {
             name: "motoserver/moto",
             log_regex_to_wait_for: r"Press CTRL\+C to quit",
         },

--- a/test-helpers/src/shotover_process.rs
+++ b/test-helpers/src/shotover_process.rs
@@ -70,8 +70,7 @@ observability_interface: "127.0.0.1:{observability_port}"
             shotover.wait_for(
                 &EventMatcher::new()
                     .with_level(Level::Info)
-                    .with_target("shotover::server")
-                    .with_message("accepting inbound connections"),
+                    .with_message("Shotover is now accepting inbound connections"),
             ),
         )
         .await


### PR DESCRIPTION
closes https://github.com/shotover/shotover-proxy/issues/1201

This PR should fix the intermittent failure described in the issue.

I removed the `shotover   00:07:04.851460Z  INFO shotover::config::topology: Loaded sources [["redis_prod"]] and linked to chains` log because it wasnt conveying any information that wasnt already conveyed.
We already know which sources we are loading due to previous logs and now the "Shotover is now accepting inbound connections" log tells us that the sources are finished loading.

I've removed the with_target from the wait event matcher to make it more robust to changing modules which is an implementation detail.
The wait event matcher is internal to our testing but I also expect it to get copied around when users test custom transforms.