### PR TITLE
windsock: filter: match any of multiple values

### DIFF
--- a/windsock/src/filter.rs
+++ b/windsock/src/filter.rs
@@ -1,8 +1,13 @@
 use crate::bench::Tags;
 use anyhow::{anyhow, Result};
 
+struct FilterTag {
+    key: String,
+    values: Vec<String>,
+}
+
 pub(crate) struct Filter {
-    filter: Vec<[String; 2]>,
+    filter: Vec<FilterTag>,
 }
 
 impl Filter {
@@ -10,9 +15,9 @@ impl Filter {
         let mut filter = vec![];
         for pair in query.split_whitespace() {
             let mut iter = pair.split('=');
-            let key = iter.next().unwrap();
-            let value = match iter.next() {
-                Some(value) => value,
+            let key = iter.next().unwrap().to_owned();
+            let values = match iter.next() {
+                Some(rhs) => rhs.split('|').map(|x| x.to_owned()).collect(),
                 None => {
                     return Err(anyhow!(
                         "Expected exactly one '=' but found no '=' in tag {pair:?}"
@@ -24,16 +29,16 @@ impl Filter {
                     "Expected exactly one '=' but found multiple '=' in tag {pair:?}"
                 ));
             }
-            filter.push([key.to_owned(), value.to_owned()])
+            filter.push(FilterTag { key, values })
         }
         Ok(Filter { filter })
     }
 
     pub(crate) fn matches(&self, tags: &Tags) -> bool {
-        for [key, value] in &self.filter {
+        for FilterTag { key, values } in &self.filter {
             match tags.0.get(key) {
-                Some(other_value) => {
-                    if value != other_value {
+                Some(check_value) => {
+                    if !values.contains(check_value) {
                         return false;
                     }
                 }


### PR DESCRIPTION
Demonstration of usage:
![image](https://github.com/shotover/shotover-proxy/assets/5120858/23ebd93b-8df3-4bf2-a1dc-55171599d2fe)


Redis benches support `shotover=none`, `shotover=standard` and `shotover=message-parsed`.

By specifying `shotover=standard|none` we include `shotover=none` and `shotover=standard` benches but exclude `shotover=message-parsed` benches.

The `|` syntax makes sense to me, its often as an "or" in the form of `||` and it also feels like its separating multiple possible values.

An alternate approach would be allowing `shotover=none shotover=standard`.
That would involve less special syntax but I think the `|` syntax is better as this approach would mess up the semantics of each key=value pair making the filter more specific.
Under this approach some key=value pairs would make the filter less specific.