### PR TITLE
remove rust-version field

### DIFF
--- a/shotover/Cargo.toml
+++ b/shotover/Cargo.toml
@@ -3,7 +3,6 @@ name = "shotover"
 version = "0.1.10"
 authors = ["Ben <ben@instaclustr.com>"]
 edition = "2021"
-rust-version = "1.56"
 license = "Apache-2.0"
 repository = "https://github.com/shotover/shotover-proxy"
 description = "Shotover API for building custom transforms"

--- a/test-helpers/Cargo.toml
+++ b/test-helpers/Cargo.toml
@@ -2,7 +2,6 @@
 name = "test-helpers"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.56"
 license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
As evidenced by https://github.com/shotover/tokio-bin-process/pull/15 this field can prevent clippy lints from triggering and there is no point in keeping it because we do not commit to any kind of MSRV guarantee.

The rust version specified in rust-toolchain.toml is of course untouched.