### PR TITLE
Initial KafkaSinkCluster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3341,6 +3341,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "string",
  "strum_macros 0.24.3",
  "thiserror",
  "tokio",
@@ -3354,6 +3355,7 @@ dependencies = [
  "typetag",
  "uuid",
  "version-compare",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -4475,6 +4477,12 @@ name = "xml-rs"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52839dc911083a8ef63efa4d039d1f58b5e409f923e44c80828f206f66e5541c"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "735a71d46c4d68d71d4b24d03fdc2b98e38cea81730595801db779c04fe80d70"
 
 [[package]]
 name = "yasna"

--- a/deny.toml
+++ b/deny.toml
@@ -75,7 +75,8 @@ allow = [
     "Apache-2.0",
     "BSD-3-Clause",
     "BSD-2-Clause",
-    "Unicode-DFS-2016"
+    "Unicode-DFS-2016",
+    "BSL-1.0"
 ]
 # List of explictly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses

--- a/shotover-proxy/tests/kafka_int_tests/mod.rs
+++ b/shotover-proxy/tests/kafka_int_tests/mod.rs
@@ -41,3 +41,77 @@ async fn passthrough_encode() {
 
     shotover.shutdown_and_then_consume_events(&[]).await;
 }
+
+// This test is a hack so that we can send messages through KafkaSinkCluster before we implement routing.
+// As soon as we have implemented routing such that the other cluster tests can send messages this test should be deleted.
+#[tokio::test]
+#[serial]
+async fn cluster_fake() {
+    let _docker_compose =
+        docker_compose("tests/test-configs/kafka/cluster-fake/docker-compose.yaml");
+    let shotover = ShotoverProcessBuilder::new_with_topology(
+        "tests/test-configs/kafka/cluster-fake/topology.yaml",
+    )
+    .start()
+    .await;
+
+    test_cases::basic("127.0.0.1:9192").await;
+
+    tokio::time::timeout(
+        Duration::from_secs(10),
+        shotover.shutdown_and_then_consume_events(&[]),
+    )
+    .await
+    .expect("Shotover did not shutdown within 10s");
+}
+
+#[tokio::test]
+#[serial]
+async fn cluster_single_shotover() {
+    let _docker_compose = docker_compose("tests/test-configs/kafka/cluster/docker-compose.yaml");
+    let shotover = ShotoverProcessBuilder::new_with_topology(
+        "tests/test-configs/kafka/cluster/topology-single.yaml",
+    )
+    .start()
+    .await;
+
+    // disabled until routing is implemented
+    //test_cases::basic("127.0.0.1:9192").await;
+
+    tokio::time::timeout(
+        Duration::from_secs(10),
+        shotover.shutdown_and_then_consume_events(&[]),
+    )
+    .await
+    .expect("Shotover did not shutdown within 10s");
+}
+
+#[tokio::test]
+#[serial]
+async fn cluster_multi_shotover() {
+    let _docker_compose = docker_compose("tests/test-configs/kafka/cluster/docker-compose.yaml");
+    let mut shotovers = vec![];
+    for i in 1..4 {
+        shotovers.push(
+            ShotoverProcessBuilder::new_with_topology(&format!(
+                "tests/test-configs/kafka/cluster/topology{i}.yaml"
+            ))
+            .with_log_name(&format!("shotover{i}"))
+            .with_observability_port(9000 + i)
+            .start()
+            .await,
+        );
+    }
+
+    // disabled until routing is implemented
+    //test_cases::basic("127.0.0.1:9192").await;
+
+    for shotover in shotovers {
+        tokio::time::timeout(
+            Duration::from_secs(10),
+            shotover.shutdown_and_then_consume_events(&[]),
+        )
+        .await
+        .expect("Shotover did not shutdown within 10s");
+    }
+}

--- a/shotover-proxy/tests/kafka_int_tests/test_cases.rs
+++ b/shotover-proxy/tests/kafka_int_tests/test_cases.rs
@@ -31,7 +31,7 @@ async fn produce_consume(brokers: &str, topic_name: &str) {
 
     let message = tokio::time::timeout(Duration::from_secs(10), consumer.recv())
         .await
-        .expect("Timeout while receiving from producer")
+        .expect("Timeout while receiving from consumer")
         .unwrap();
     let contents = message.payload_view::<str>().unwrap().unwrap();
     assert_eq!("Message", contents);
@@ -80,7 +80,7 @@ async fn produce_consume_acks0(brokers: &str) {
     for i in 0..10 {
         let message = tokio::time::timeout(Duration::from_secs(10), consumer.recv())
             .await
-            .expect("Timeout while receiving from producer")
+            .expect("Timeout while receiving from consumer")
             .unwrap();
         let contents = message.payload_view::<str>().unwrap().unwrap();
         assert_eq!("MessageAcks0", contents);

--- a/shotover-proxy/tests/test-configs/kafka/cluster-fake/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-fake/docker-compose.yaml
@@ -1,0 +1,25 @@
+version: "3"
+networks:
+  cluster_subnet:
+    name: cluster_subnet
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.16.1.0/24
+          gateway: 172.16.1.1
+services:
+  kafka:
+    networks:
+      cluster_subnet:
+        ipv4_address: 172.16.1.2
+    image: 'bitnami/kafka:3.4.0-debian-11-r22'
+    ports:
+      - '9092:9092'
+    environment:
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://127.0.0.1:9092
+      - ALLOW_PLAINTEXT_LISTENER=yes
+    volumes:
+      - type: tmpfs
+        target: /bitnami/kafka

--- a/shotover-proxy/tests/test-configs/kafka/cluster-fake/topology.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-fake/topology.yaml
@@ -1,0 +1,13 @@
+---
+sources:
+  kafka_source:
+    Kafka:
+      listen_addr: "127.0.0.1:9192"
+chain_config:
+  main_chain:
+    - KafkaSinkCluster:
+        shotover_nodes: ["127.0.0.1:9192"]
+        first_contact_points: ["172.16.1.2:9092"]
+        connect_timeout_ms: 3000
+source_to_chain_mapping:
+  kafka_source: main_chain

--- a/shotover-proxy/tests/test-configs/kafka/cluster/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster/docker-compose.yaml
@@ -1,0 +1,56 @@
+version: "3"
+networks:
+  cluster_subnet:
+    name: cluster_subnet
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.16.1.0/24
+          gateway: 172.16.1.1
+services:
+  kafka0:
+    image: 'bitnami/kafka:3.4.0-debian-11-r22'
+    networks:
+      cluster_subnet:
+        ipv4_address: 172.16.1.2
+    environment:
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://172.16.1.2:9092
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_KRAFT_CLUSTER_ID=abcdefghijklmnopqrstuv
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka0:9093,1@kafka1:9093,2@kafka2:9093
+      - KAFKA_CFG_NODE_ID=0
+    volumes:
+      - type: tmpfs
+        target: /bitnami/kafka
+  kafka1:
+    networks:
+      cluster_subnet:
+        ipv4_address: 172.16.1.3
+    image: 'bitnami/kafka:3.4.0-debian-11-r22'
+    environment:
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://172.16.1.3:9092
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_KRAFT_CLUSTER_ID=abcdefghijklmnopqrstuv
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka0:9093,1@kafka1:9093,2@kafka2:9093
+      - KAFKA_CFG_NODE_ID=1
+    volumes:
+      - type: tmpfs
+        target: /bitnami/kafka
+  kafka2:
+    networks:
+      cluster_subnet:
+        ipv4_address: 172.16.1.4
+    image: 'bitnami/kafka:3.4.0-debian-11-r22'
+    environment:
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://172.16.1.4:9092
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_KRAFT_CLUSTER_ID=abcdefghijklmnopqrstuv
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka0:9093,1@kafka1:9093,2@kafka2:9093
+      - KAFKA_CFG_NODE_ID=2
+    volumes:
+      - type: tmpfs
+        target: /bitnami/kafka

--- a/shotover-proxy/tests/test-configs/kafka/cluster/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster/docker-compose.yaml
@@ -10,47 +10,39 @@ networks:
           gateway: 172.16.1.1
 services:
   kafka0:
-    image: 'bitnami/kafka:3.4.0-debian-11-r22'
+    image: &image 'bitnami/kafka:3.4.0-debian-11-r22'
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.2
     environment:
-      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
-      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://172.16.1.2:9092
-      - ALLOW_PLAINTEXT_LISTENER=yes
-      - KAFKA_KRAFT_CLUSTER_ID=abcdefghijklmnopqrstuv
-      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka0:9093,1@kafka1:9093,2@kafka2:9093
-      - KAFKA_CFG_NODE_ID=0
+      &environment
+      KAFKA_CFG_LISTENERS: "PLAINTEXT://:9091,CONTROLLER://:9093"
+      KAFKA_CFG_ADVERTISED_LISTENERS: "PLAINTEXT://172.16.1.2:9092"
+      ALLOW_PLAINTEXT_LISTENER: "yes"
+      KAFKA_KRAFT_CLUSTER_ID: "abcdefghijklmnopqrstuv"
+      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: "0@kafka0:9093,1@kafka1:9093,2@kafka2:9093"
+      KAFKA_CFG_NODE_ID: 0
     volumes:
+      &volumes
       - type: tmpfs
         target: /bitnami/kafka
   kafka1:
+    image: *image
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.3
-    image: 'bitnami/kafka:3.4.0-debian-11-r22'
     environment:
-      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
-      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://172.16.1.3:9092
-      - ALLOW_PLAINTEXT_LISTENER=yes
-      - KAFKA_KRAFT_CLUSTER_ID=abcdefghijklmnopqrstuv
-      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka0:9093,1@kafka1:9093,2@kafka2:9093
-      - KAFKA_CFG_NODE_ID=1
-    volumes:
-      - type: tmpfs
-        target: /bitnami/kafka
+      <<: *environment
+      KAFKA_CFG_ADVERTISED_LISTENERS: "PLAINTEXT://172.16.1.3:9092"
+      KAFKA_CFG_NODE_ID: 1
+    volumes: *volumes
   kafka2:
+    image: *image
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.4
-    image: 'bitnami/kafka:3.4.0-debian-11-r22'
     environment:
-      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
-      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://172.16.1.4:9092
-      - ALLOW_PLAINTEXT_LISTENER=yes
-      - KAFKA_KRAFT_CLUSTER_ID=abcdefghijklmnopqrstuv
-      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka0:9093,1@kafka1:9093,2@kafka2:9093
-      - KAFKA_CFG_NODE_ID=2
-    volumes:
-      - type: tmpfs
-        target: /bitnami/kafka
+      <<: *environment
+      KAFKA_CFG_ADVERTISED_LISTENERS: "PLAINTEXT://172.16.1.4:9092"
+      KAFKA_CFG_NODE_ID: 2
+    volumes: *volumes

--- a/shotover-proxy/tests/test-configs/kafka/cluster/topology-single.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster/topology-single.yaml
@@ -1,0 +1,13 @@
+---
+sources:
+  kafka_source:
+    Kafka:
+      listen_addr: "127.0.0.1:9192"
+chain_config:
+  main_chain:
+    - KafkaSinkCluster:
+        shotover_nodes: ["127.0.0.1:9192"]
+        first_contact_points: ["172.16.1.2:9092"]
+        connect_timeout_ms: 3000
+source_to_chain_mapping:
+  kafka_source: main_chain

--- a/shotover-proxy/tests/test-configs/kafka/cluster/topology1.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster/topology1.yaml
@@ -1,0 +1,16 @@
+---
+sources:
+  kafka_source:
+    Kafka:
+      listen_addr: "127.0.0.1:9191"
+chain_config:
+  main_chain:
+    - KafkaSinkCluster:
+        shotover_nodes: 
+          - "127.0.0.1:9191"
+          - "127.0.0.1:9192"
+          - "127.0.0.1:9193"
+        first_contact_points: ["172.16.1.2:9092"]
+        connect_timeout_ms: 3000
+source_to_chain_mapping:
+  kafka_source: main_chain

--- a/shotover-proxy/tests/test-configs/kafka/cluster/topology2.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster/topology2.yaml
@@ -1,0 +1,16 @@
+---
+sources:
+  kafka_source:
+    Kafka:
+      listen_addr: "127.0.0.1:9192"
+chain_config:
+  main_chain:
+    - KafkaSinkCluster:
+        shotover_nodes: 
+          - "127.0.0.1:9191"
+          - "127.0.0.1:9192"
+          - "127.0.0.1:9193"
+        first_contact_points: ["172.16.1.2:9092"]
+        connect_timeout_ms: 3000
+source_to_chain_mapping:
+  kafka_source: main_chain

--- a/shotover-proxy/tests/test-configs/kafka/cluster/topology3.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster/topology3.yaml
@@ -1,0 +1,16 @@
+---
+sources:
+  kafka_source:
+    Kafka:
+      listen_addr: "127.0.0.1:9193"
+chain_config:
+  main_chain:
+    - KafkaSinkCluster:
+        shotover_nodes: 
+          - "127.0.0.1:9191"
+          - "127.0.0.1:9192"
+          - "127.0.0.1:9193"
+        first_contact_points: ["172.16.1.2:9092"]
+        connect_timeout_ms: 3000
+source_to_chain_mapping:
+  kafka_source: main_chain

--- a/shotover/Cargo.toml
+++ b/shotover/Cargo.toml
@@ -89,3 +89,5 @@ rustls = { version = "0.21.0", features = ["dangerous_configuration"] }
 tokio-rustls = "0.24"
 rustls-pemfile = "1.0.2"
 rustls-webpki = "0.100.1"
+string = "0.3.0"
+xxhash-rust = { version = "0.8.6", features = ["xxh3"] }

--- a/shotover/src/frame/kafka.rs
+++ b/shotover/src/frame/kafka.rs
@@ -6,7 +6,7 @@ use kafka_protocol::messages::{
     FindCoordinatorResponse, LeaderAndIsrRequest, MetadataResponse, ProduceRequest,
     ProduceResponse, RequestHeader, ResponseHeader,
 };
-use kafka_protocol::protocol::{Decodable, Encodable, HeaderVersion};
+use kafka_protocol::protocol::{Decodable, Encodable, HeaderVersion, StrBytes};
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 #[derive(Debug, PartialEq, Clone)]
@@ -233,4 +233,16 @@ fn encode<T: Encodable>(encodable: T, bytes: &mut BytesMut, version: i16) -> Res
         std::any::type_name::<T>(),
         version
     ))
+}
+
+/// This function is a helper to workaround a really degenerate rust compiler case.
+/// The problem is that the string crate defines a TryFrom which collides with the stdlib TryFrom
+/// and then naming the correct TryFrom becomes really annoying.
+pub fn strbytes(str: &str) -> StrBytes {
+    <StrBytes as string::TryFrom<Bytes>>::try_from(Bytes::copy_from_slice(str.as_bytes())).unwrap()
+}
+
+/// Allocationless version of kafka_strbytes
+pub fn strbytes_static(str: &'static str) -> StrBytes {
+    <StrBytes as string::TryFrom<Bytes>>::try_from(Bytes::from(str)).unwrap()
 }

--- a/shotover/src/transforms/kafka/common.rs
+++ b/shotover/src/transforms/kafka/common.rs
@@ -1,0 +1,49 @@
+use crate::{
+    frame::{
+        kafka::{KafkaFrame, RequestBody},
+        Frame,
+    },
+    message::Message,
+    transforms::util::{cluster_connection_pool::Connection, Request, Response},
+};
+use anyhow::{anyhow, Result};
+use tokio::sync::oneshot;
+
+pub fn send_requests(
+    messages: Vec<Message>,
+    outbound: &mut Connection,
+) -> Result<Vec<oneshot::Receiver<Response>>> {
+    messages
+        .into_iter()
+        .map(|mut message| {
+            let acks0 = if let Some(Frame::Kafka(KafkaFrame::Request {
+                body: RequestBody::Produce(produce),
+                ..
+            })) = message.frame()
+            {
+                produce.acks == 0
+            } else {
+                false
+            };
+
+            let (tx, rx) = oneshot::channel();
+            let return_chan = if acks0 {
+                tx.send(Response {
+                    original: Message::from_frame(Frame::Dummy),
+                    response: Ok(Message::from_frame(Frame::Dummy)),
+                })
+                .unwrap();
+                None
+            } else {
+                Some(tx)
+            };
+            outbound
+                .send(Request {
+                    message,
+                    return_chan,
+                })
+                .map(|_| rx)
+                .map_err(|_| anyhow!("Failed to send"))
+        })
+        .collect()
+}

--- a/shotover/src/transforms/kafka/common.rs
+++ b/shotover/src/transforms/kafka/common.rs
@@ -16,6 +16,8 @@ pub fn send_requests(
     messages
         .into_iter()
         .map(|mut message| {
+            // when a produce request has acks set to 0, the kafka instance will return no response.
+            // In order to maintain shotover transform invariants we need to return a dummy response instead.
             let acks0 = if let Some(Frame::Kafka(KafkaFrame::Request {
                 body: RequestBody::Produce(produce),
                 ..

--- a/shotover/src/transforms/kafka/mod.rs
+++ b/shotover/src/transforms/kafka/mod.rs
@@ -1,1 +1,3 @@
+mod common;
+pub mod sink_cluster;
 pub mod sink_single;

--- a/shotover/src/transforms/kafka/sink_cluster.rs
+++ b/shotover/src/transforms/kafka/sink_cluster.rs
@@ -1,5 +1,5 @@
 use crate::codec::{kafka::KafkaCodecBuilder, CodecBuilder, Direction};
-use crate::frame::kafka::{KafkaFrame, RequestBody, ResponseBody};
+use crate::frame::kafka::{strbytes, KafkaFrame, ResponseBody};
 use crate::frame::Frame;
 use crate::message::Messages;
 use crate::tcp;
@@ -9,15 +9,18 @@ use crate::transforms::util::Response;
 use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
+use kafka_protocol::protocol::StrBytes;
 use serde::Deserialize;
+use std::hash::Hasher;
+use std::net::SocketAddr;
 use std::time::Duration;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::timeout;
 
 #[derive(Deserialize, Debug)]
-pub struct KafkaSinkSingleConfig {
-    #[serde(rename = "remote_address")]
-    pub address: String,
+pub struct KafkaSinkClusterConfig {
+    pub first_contact_points: Vec<String>,
+    pub shotover_nodes: Vec<String>,
     pub connect_timeout_ms: u64,
     pub read_timeout: Option<u64>,
 }
@@ -26,12 +29,13 @@ pub struct KafkaSinkSingleConfig {
 use crate::transforms::TransformConfig;
 
 #[cfg(feature = "alpha-transforms")]
-#[typetag::deserialize(name = "KafkaSinkSingle")]
+#[typetag::deserialize(name = "KafkaSinkCluster")]
 #[async_trait(?Send)]
-impl TransformConfig for KafkaSinkSingleConfig {
+impl TransformConfig for KafkaSinkClusterConfig {
     async fn get_builder(&self, chain_name: String) -> Result<Box<dyn TransformBuilder>> {
-        Ok(Box::new(KafkaSinkSingleBuilder::new(
-            self.address.clone(),
+        Ok(Box::new(KafkaSinkClusterBuilder::new(
+            self.first_contact_points.clone(),
+            self.shotover_nodes.clone(),
             chain_name,
             self.connect_timeout_ms,
             self.read_timeout,
@@ -39,43 +43,50 @@ impl TransformConfig for KafkaSinkSingleConfig {
     }
 }
 
-pub struct KafkaSinkSingleBuilder {
+pub struct KafkaSinkClusterBuilder {
     // contains address and port
-    address: String,
-    address_port: u16,
+    first_contact_points: Vec<String>,
+    shotover_nodes: Vec<KafkaAddress>,
     connect_timeout: Duration,
     read_timeout: Option<Duration>,
 }
 
-impl KafkaSinkSingleBuilder {
+impl KafkaSinkClusterBuilder {
     pub fn new(
-        address: String,
+        first_contact_points: Vec<String>,
+        shotover_nodes: Vec<String>,
         _chain_name: String,
         connect_timeout_ms: u64,
         timeout: Option<u64>,
-    ) -> KafkaSinkSingleBuilder {
+    ) -> KafkaSinkClusterBuilder {
         let receive_timeout = timeout.map(Duration::from_secs);
-        let address_port = address
-            .rsplit(':')
-            .next()
-            .and_then(|str| str.parse().ok())
-            .unwrap_or(9092);
 
-        KafkaSinkSingleBuilder {
-            address,
-            address_port,
+        let shotover_nodes = shotover_nodes
+            .into_iter()
+            .map(|node| {
+                let address: SocketAddr = node.parse().unwrap();
+                KafkaAddress {
+                    host: strbytes(&address.ip().to_string()),
+                    port: address.port() as i32,
+                }
+            })
+            .collect();
+
+        KafkaSinkClusterBuilder {
+            first_contact_points,
+            shotover_nodes,
             connect_timeout: Duration::from_millis(connect_timeout_ms),
             read_timeout: receive_timeout,
         }
     }
 }
 
-impl TransformBuilder for KafkaSinkSingleBuilder {
+impl TransformBuilder for KafkaSinkClusterBuilder {
     fn build(&self) -> Transforms {
-        Transforms::KafkaSinkSingle(KafkaSinkSingle {
+        Transforms::KafkaSinkCluster(KafkaSinkCluster {
             outbound: None,
-            address: self.address.clone(),
-            address_port: self.address_port,
+            first_contact_points: self.first_contact_points.clone(),
+            shotover_nodes: self.shotover_nodes.clone(),
             pushed_messages_tx: None,
             connect_timeout: self.connect_timeout,
             read_timeout: self.read_timeout,
@@ -83,7 +94,7 @@ impl TransformBuilder for KafkaSinkSingleBuilder {
     }
 
     fn get_name(&self) -> &'static str {
-        "KafkaSinkSingle"
+        "KafkaClusterSingle"
     }
 
     fn is_terminating(&self) -> bool {
@@ -91,9 +102,15 @@ impl TransformBuilder for KafkaSinkSingleBuilder {
     }
 }
 
-pub struct KafkaSinkSingle {
-    address: String,
-    address_port: u16,
+#[derive(Clone)]
+struct KafkaAddress {
+    host: StrBytes,
+    port: i32,
+}
+
+pub struct KafkaSinkCluster {
+    first_contact_points: Vec<String>,
+    shotover_nodes: Vec<KafkaAddress>,
     outbound: Option<Connection>,
     pushed_messages_tx: Option<mpsc::UnboundedSender<Messages>>,
     connect_timeout: Duration,
@@ -101,27 +118,17 @@ pub struct KafkaSinkSingle {
 }
 
 #[async_trait]
-impl Transform for KafkaSinkSingle {
-    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
+impl Transform for KafkaSinkCluster {
+    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
         if self.outbound.is_none() {
             let codec = KafkaCodecBuilder::new(Direction::Sink);
-            let tcp_stream = tcp::tcp_stream(self.connect_timeout, &self.address).await?;
+            let tcp_stream = tcp::tcp_stream(
+                self.connect_timeout,
+                self.first_contact_points.first().unwrap(),
+            )
+            .await?;
             let (rx, tx) = tcp_stream.into_split();
             self.outbound = Some(spawn_read_write_tasks(&codec, rx, tx));
-        }
-
-        // Rewrite requests to use kafkas port instead of shotovers port
-        for request in &mut message_wrapper.messages {
-            if let Some(Frame::Kafka(KafkaFrame::Request {
-                body: RequestBody::LeaderAndIsr(leader_and_isr),
-                ..
-            })) = request.frame()
-            {
-                for leader in &mut leader_and_isr.live_leaders {
-                    leader.port = self.address_port as i32;
-                }
-                request.invalidate_cache();
-            }
         }
 
         let outbound = self.outbound.as_mut().unwrap();
@@ -136,7 +143,7 @@ impl Transform for KafkaSinkSingle {
 
         // Rewrite responses to use shotovers port instead of kafkas port
         for response in &mut responses {
-            let port = message_wrapper.local_addr.port() as i32;
+            tracing::info!("{:?}", response.to_high_level_string());
             match response.frame() {
                 Some(Frame::Kafka(KafkaFrame::Response {
                     body: ResponseBody::FindCoordinator(find_coordinator),
@@ -144,10 +151,18 @@ impl Transform for KafkaSinkSingle {
                     ..
                 })) => {
                     if *version <= 3 {
-                        find_coordinator.port = port;
+                        rewrite_address(
+                            &self.shotover_nodes,
+                            &mut find_coordinator.host,
+                            &mut find_coordinator.port,
+                        )
                     } else {
                         for coordinator in &mut find_coordinator.coordinators {
-                            coordinator.port = port;
+                            rewrite_address(
+                                &self.shotover_nodes,
+                                &mut coordinator.host,
+                                &mut coordinator.port,
+                            )
                         }
                     }
                     response.invalidate_cache();
@@ -157,7 +172,11 @@ impl Transform for KafkaSinkSingle {
                     ..
                 })) => {
                     for broker in &mut metadata.brokers {
-                        broker.1.port = port;
+                        rewrite_address(
+                            &self.shotover_nodes,
+                            &mut broker.1.host,
+                            &mut broker.1.port,
+                        )
                     }
                     response.invalidate_cache();
                 }
@@ -166,7 +185,11 @@ impl Transform for KafkaSinkSingle {
                     ..
                 })) => {
                     for broker in &mut describe_cluster.brokers {
-                        broker.1.port = port;
+                        rewrite_address(
+                            &self.shotover_nodes,
+                            &mut broker.1.host,
+                            &mut broker.1.port,
+                        )
                     }
                     response.invalidate_cache();
                 }
@@ -188,4 +211,24 @@ async fn read_responses(responses: Vec<oneshot::Receiver<Response>>) -> Result<M
         result.push(response.await.unwrap().response?);
     }
     Ok(result)
+}
+
+fn hash_address(host: &str, port: i32) -> u64 {
+    let mut hasher = xxhash_rust::xxh3::Xxh3::new();
+    hasher.write(host.as_bytes());
+    hasher.write(&port.to_be_bytes());
+    hasher.finish()
+}
+
+fn rewrite_address(shotover_nodes: &[KafkaAddress], host: &mut StrBytes, port: &mut i32) {
+    //tracing::info!("rewriting {} {}", host, port);
+
+    // do not attempt to rewrite if the port is not provided (-1)
+    // this is known to occur in an error response
+    if *port >= 0 {
+        let shotover_node =
+            &shotover_nodes[hash_address(host, *port) as usize % shotover_nodes.len()];
+        *host = shotover_node.host.clone();
+        *port = shotover_node.port;
+    }
 }

--- a/shotover/src/transforms/kafka/sink_cluster.rs
+++ b/shotover/src/transforms/kafka/sink_cluster.rs
@@ -143,7 +143,6 @@ impl Transform for KafkaSinkCluster {
 
         // Rewrite responses to use shotovers port instead of kafkas port
         for response in &mut responses {
-            tracing::info!("{:?}", response.to_high_level_string());
             match response.frame() {
                 Some(Frame::Kafka(KafkaFrame::Response {
                     body: ResponseBody::FindCoordinator(find_coordinator),
@@ -221,8 +220,6 @@ fn hash_address(host: &str, port: i32) -> u64 {
 }
 
 fn rewrite_address(shotover_nodes: &[KafkaAddress], host: &mut StrBytes, port: &mut i32) {
-    //tracing::info!("rewriting {} {}", host, port);
-
     // do not attempt to rewrite if the port is not provided (-1)
     // this is known to occur in an error response
     if *port >= 0 {

--- a/shotover/src/transforms/mod.rs
+++ b/shotover/src/transforms/mod.rs
@@ -12,6 +12,7 @@ use crate::transforms::debug::random_delay::DebugRandomDelay;
 use crate::transforms::debug::returner::DebugReturner;
 use crate::transforms::distributed::tuneable_consistency_scatter::TuneableConsistentencyScatter;
 use crate::transforms::filter::QueryTypeFilter;
+use crate::transforms::kafka::sink_cluster::KafkaSinkCluster;
 use crate::transforms::kafka::sink_single::KafkaSinkSingle;
 use crate::transforms::load_balance::ConnectionBalanceAndPool;
 use crate::transforms::loopback::Loopback;
@@ -87,6 +88,7 @@ impl Debug for dyn TransformBuilder {
 #[derive(IntoStaticStr)]
 pub enum Transforms {
     KafkaSinkSingle(KafkaSinkSingle),
+    KafkaSinkCluster(KafkaSinkCluster),
     CassandraSinkSingle(CassandraSinkSingle),
     CassandraSinkCluster(Box<CassandraSinkCluster>),
     RedisSinkSingle(RedisSinkSingle),
@@ -124,6 +126,7 @@ impl Transforms {
     async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
         match self {
             Transforms::KafkaSinkSingle(c) => c.transform(message_wrapper).await,
+            Transforms::KafkaSinkCluster(c) => c.transform(message_wrapper).await,
             Transforms::CassandraSinkSingle(c) => c.transform(message_wrapper).await,
             Transforms::CassandraSinkCluster(c) => c.transform(message_wrapper).await,
             Transforms::CassandraPeersRewrite(c) => c.transform(message_wrapper).await,
@@ -155,6 +158,7 @@ impl Transforms {
     async fn transform_pushed<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
         match self {
             Transforms::KafkaSinkSingle(c) => c.transform_pushed(message_wrapper).await,
+            Transforms::KafkaSinkCluster(c) => c.transform_pushed(message_wrapper).await,
             Transforms::CassandraSinkSingle(c) => c.transform_pushed(message_wrapper).await,
             Transforms::CassandraSinkCluster(c) => c.transform_pushed(message_wrapper).await,
             Transforms::CassandraPeersRewrite(c) => c.transform_pushed(message_wrapper).await,
@@ -192,6 +196,7 @@ impl Transforms {
     fn set_pushed_messages_tx(&mut self, pushed_messages_tx: mpsc::UnboundedSender<Messages>) {
         match self {
             Transforms::KafkaSinkSingle(c) => c.set_pushed_messages_tx(pushed_messages_tx),
+            Transforms::KafkaSinkCluster(c) => c.set_pushed_messages_tx(pushed_messages_tx),
             Transforms::CassandraSinkSingle(c) => c.set_pushed_messages_tx(pushed_messages_tx),
             Transforms::CassandraSinkCluster(c) => c.set_pushed_messages_tx(pushed_messages_tx),
             Transforms::CassandraPeersRewrite(c) => c.set_pushed_messages_tx(pushed_messages_tx),


### PR DESCRIPTION
Completes the first chunk of work listed in https://github.com/shotover/shotover-proxy/issues/1214

Because the transform lacks routing it can only be used with a 1 node kafka cluster.
This still brings some value as we can host shotover on a different IP which KafkaSinkSingle does not allow.

The logic in the new `send_requests` method has been pulled out of the two sinks.

Introduces the xxhash-rust crate under the BSL license which should pose no issue as its just a more lenient version of the MIT license.