### PR TITLE
KafkaSinkCluster: implement produce routing

### DIFF
--- a/shotover-proxy/tests/kafka_int_tests/mod.rs
+++ b/shotover-proxy/tests/kafka_int_tests/mod.rs
@@ -75,6 +75,7 @@ async fn cluster_single_shotover() {
     .start()
     .await;
 
+    test_cases::produce_only("127.0.0.1:9192").await;
     // disabled until routing is implemented
     //test_cases::basic("127.0.0.1:9192").await;
 
@@ -103,6 +104,7 @@ async fn cluster_multi_shotover() {
         );
     }
 
+    test_cases::produce_only("127.0.0.1:9192").await;
     // disabled until routing is implemented
     //test_cases::basic("127.0.0.1:9192").await;
 

--- a/shotover-proxy/tests/kafka_int_tests/test_cases.rs
+++ b/shotover-proxy/tests/kafka_int_tests/test_cases.rs
@@ -91,6 +91,26 @@ async fn produce_consume_acks0(brokers: &str) {
     }
 }
 
+pub async fn produce_only(brokers: &str) {
+    let producer: FutureProducer = ClientConfig::new()
+        .set("bootstrap.servers", brokers)
+        .set("message.timeout.ms", "5000")
+        .create()
+        .unwrap();
+
+    let delivery_status = producer
+        .send_result(
+            FutureRecord::to("test_produce")
+                .payload("Message")
+                .key("Key"),
+        )
+        .unwrap()
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(delivery_status, (0, 0));
+}
+
 pub async fn basic(address: &str) {
     produce_consume(address, "foo").await;
     produce_consume_acks0(address).await;

--- a/shotover-proxy/tests/test-configs/kafka/cluster/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
         ipv4_address: 172.16.1.2
     environment:
       &environment
-      KAFKA_CFG_LISTENERS: "PLAINTEXT://:9091,CONTROLLER://:9093"
+      KAFKA_CFG_LISTENERS: "PLAINTEXT://:9092,CONTROLLER://:9093"
       KAFKA_CFG_ADVERTISED_LISTENERS: "PLAINTEXT://172.16.1.2:9092"
       ALLOW_PLAINTEXT_LISTENER: "yes"
       KAFKA_KRAFT_CLUSTER_ID: "abcdefghijklmnopqrstuv"

--- a/shotover/src/transforms/kafka/common.rs
+++ b/shotover/src/transforms/kafka/common.rs
@@ -1,51 +1,25 @@
-use crate::{
-    frame::{
-        kafka::{KafkaFrame, RequestBody},
-        Frame,
-    },
-    message::Message,
-    transforms::util::{cluster_connection_pool::Connection, Request, Response},
-};
-use anyhow::{anyhow, Result};
+use crate::{frame::Frame, message::Message, transforms::util::Response};
+use kafka_protocol::messages::ProduceRequest;
 use tokio::sync::oneshot;
 
-pub fn send_requests(
-    messages: Vec<Message>,
-    outbound: &mut Connection,
-) -> Result<Vec<oneshot::Receiver<Response>>> {
-    messages
-        .into_iter()
-        .map(|mut message| {
-            // when a produce request has acks set to 0, the kafka instance will return no response.
-            // In order to maintain shotover transform invariants we need to return a dummy response instead.
-            let acks0 = if let Some(Frame::Kafka(KafkaFrame::Request {
-                body: RequestBody::Produce(produce),
-                ..
-            })) = message.frame()
-            {
-                produce.acks == 0
-            } else {
-                false
-            };
-
-            let (tx, rx) = oneshot::channel();
-            let return_chan = if acks0 {
-                tx.send(Response {
-                    original: Message::from_frame(Frame::Dummy),
-                    response: Ok(Message::from_frame(Frame::Dummy)),
-                })
-                .unwrap();
-                None
-            } else {
-                Some(tx)
-            };
-            outbound
-                .send(Request {
-                    message,
-                    return_chan,
-                })
-                .map(|_| rx)
-                .map_err(|_| anyhow!("Failed to send"))
+/// when a produce request has acks set to 0, the kafka instance will return no response.
+/// In order to maintain shotover transform invariants we need to return a dummy response instead.
+pub fn produce_channel(
+    produce: &ProduceRequest,
+) -> (
+    Option<oneshot::Sender<Response>>,
+    oneshot::Receiver<Response>,
+) {
+    let (tx, rx) = oneshot::channel();
+    let return_chan = if produce.acks == 0 {
+        tx.send(Response {
+            original: Message::from_frame(Frame::Dummy),
+            response: Ok(Message::from_frame(Frame::Dummy)),
         })
-        .collect()
+        .unwrap();
+        None
+    } else {
+        Some(tx)
+    };
+    (return_chan, rx)
 }


### PR DESCRIPTION
progress towards: https://github.com/shotover/shotover-proxy/issues/1214

With this PR we are now able to send produce messages to the kafka cluster.
Previously, due to incorrect routing, produce messages would likely end up at the wrong instance and be rejected.

I added a temporary `produce_only` test case to test the part of the test suite that we can pass so far.

I had to rewrite `common::send_requests` into `common::produce_channel` because the KafkaSinkCluster ended up needing more control over this logic then I expected.

The KafkaSinkCluster routing works by reading metadata messages that the client sends and using them to build up an internal topology structure (The `nodes` and `topics` fields) which are later used for routing messages. This is pretty similar to what we do for cassandra but we are relying purely on messages sent by the client without generating any ourselves.

In order to avoid complex message splitting I have assumed that all records in a message can be routed to the same kafka broker.
However this is not necessarily true since we rewrite messages, the client may end up putting two records that need to go to different brokers on the same message. We may have to revisit this logic later if this proves to be an issue.

I had to change the `cluster/docker-compose.yaml` because I realized it was misconfigured and not listening for clients.

