### PR TITLE
Rename to requests

### DIFF
--- a/custom-transforms-example/src/redis_get_rewrite.rs
+++ b/custom-transforms-example/src/redis_get_rewrite.rs
@@ -45,7 +45,7 @@ pub struct RedisGetRewrite {
 impl Transform for RedisGetRewrite {
     async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
         let mut get_indices = vec![];
-        for (i, message) in message_wrapper.messages.iter_mut().enumerate() {
+        for (i, message) in message_wrapper.requests.iter_mut().enumerate() {
             if let Some(frame) = message.frame() {
                 if is_get(frame) {
                     get_indices.push(i);

--- a/custom-transforms-example/src/redis_get_rewrite.rs
+++ b/custom-transforms-example/src/redis_get_rewrite.rs
@@ -43,16 +43,16 @@ pub struct RedisGetRewrite {
 
 #[async_trait]
 impl Transform for RedisGetRewrite {
-    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
+    async fn transform<'a>(&'a mut self, mut requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         let mut get_indices = vec![];
-        for (i, message) in message_wrapper.requests.iter_mut().enumerate() {
+        for (i, message) in requests_wrapper.requests.iter_mut().enumerate() {
             if let Some(frame) = message.frame() {
                 if is_get(frame) {
                     get_indices.push(i);
                 }
             }
         }
-        let mut responses = message_wrapper.call_next_transform().await?;
+        let mut responses = requests_wrapper.call_next_transform().await?;
 
         for i in get_indices {
             if let Some(frame) = responses[i].frame() {

--- a/shotover/src/transforms/cassandra/peers_rewrite.rs
+++ b/shotover/src/transforms/cassandra/peers_rewrite.rs
@@ -55,7 +55,7 @@ impl Transform for CassandraPeersRewrite {
         // Find the indices of queries to system.peers & system.peers_v2
         // we need to know which columns in which CQL queries in which messages have system peers
         let column_names: Vec<(usize, Vec<Identifier>)> = message_wrapper
-            .messages
+            .requests
             .iter_mut()
             .enumerate()
             .filter_map(|(i, m)| {
@@ -81,7 +81,7 @@ impl Transform for CassandraPeersRewrite {
         &'a mut self,
         mut message_wrapper: Wrapper<'a>,
     ) -> Result<Messages> {
-        for message in &mut message_wrapper.messages {
+        for message in &mut message_wrapper.requests {
             if let Some(Frame::Cassandra(frame)) = message.frame() {
                 if let Event(ServerEvent::StatusChange(StatusChange { addr, .. })) =
                     &mut frame.operation

--- a/shotover/src/transforms/cassandra/sink_cluster/mod.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/mod.rs
@@ -716,14 +716,14 @@ fn is_use_statement_successful(response: Option<Result<Response>>) -> bool {
 #[async_trait]
 impl Transform for CassandraSinkCluster {
     async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
-        self.send_message(message_wrapper.messages).await
+        self.send_message(message_wrapper.requests).await
     }
 
     async fn transform_pushed<'a>(
         &'a mut self,
         mut message_wrapper: Wrapper<'a>,
     ) -> Result<Messages> {
-        message_wrapper.messages.retain_mut(|message| {
+        message_wrapper.requests.retain_mut(|message| {
             if let Some(Frame::Cassandra(CassandraFrame {
                 operation: CassandraOperation::Event(event),
                 ..

--- a/shotover/src/transforms/cassandra/sink_cluster/mod.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/mod.rs
@@ -715,15 +715,15 @@ fn is_use_statement_successful(response: Option<Result<Response>>) -> bool {
 
 #[async_trait]
 impl Transform for CassandraSinkCluster {
-    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
-        self.send_message(message_wrapper.requests).await
+    async fn transform<'a>(&'a mut self, requests_wrapper: Wrapper<'a>) -> Result<Messages> {
+        self.send_message(requests_wrapper.requests).await
     }
 
     async fn transform_pushed<'a>(
         &'a mut self,
-        mut message_wrapper: Wrapper<'a>,
+        mut requests_wrapper: Wrapper<'a>,
     ) -> Result<Messages> {
-        message_wrapper.requests.retain_mut(|message| {
+        requests_wrapper.requests.retain_mut(|message| {
             if let Some(Frame::Cassandra(CassandraFrame {
                 operation: CassandraOperation::Event(event),
                 ..
@@ -739,7 +739,7 @@ impl Transform for CassandraSinkCluster {
                 true
             }
         });
-        message_wrapper.call_next_transform_pushed().await
+        requests_wrapper.call_next_transform_pushed().await
     }
 
     fn set_pushed_messages_tx(&mut self, pushed_messages_tx: mpsc::UnboundedSender<Messages>) {

--- a/shotover/src/transforms/cassandra/sink_single.rs
+++ b/shotover/src/transforms/cassandra/sink_single.rs
@@ -167,7 +167,7 @@ impl CassandraSinkSingle {
 #[async_trait]
 impl Transform for CassandraSinkSingle {
     async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
-        self.send_message(message_wrapper.messages).await
+        self.send_message(message_wrapper.requests).await
     }
 
     fn set_pushed_messages_tx(&mut self, pushed_messages_tx: mpsc::UnboundedSender<Messages>) {

--- a/shotover/src/transforms/cassandra/sink_single.rs
+++ b/shotover/src/transforms/cassandra/sink_single.rs
@@ -166,8 +166,8 @@ impl CassandraSinkSingle {
 
 #[async_trait]
 impl Transform for CassandraSinkSingle {
-    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
-        self.send_message(message_wrapper.requests).await
+    async fn transform<'a>(&'a mut self, requests_wrapper: Wrapper<'a>) -> Result<Messages> {
+        self.send_message(requests_wrapper.requests).await
     }
 
     fn set_pushed_messages_tx(&mut self, pushed_messages_tx: mpsc::UnboundedSender<Messages>) {

--- a/shotover/src/transforms/chain.rs
+++ b/shotover/src/transforms/chain.rs
@@ -92,7 +92,7 @@ impl BufferedChain {
             None => {
                 self.send_handle
                     .send(BufferedChainMessages::new(
-                        wrapper.messages,
+                        wrapper.requests,
                         wrapper.local_addr,
                         wrapper.flush,
                         one_tx,
@@ -104,7 +104,7 @@ impl BufferedChain {
                 self.send_handle
                     .send_timeout(
                         BufferedChainMessages::new(
-                            wrapper.messages,
+                            wrapper.requests,
                             wrapper.local_addr,
                             wrapper.flush,
                             one_tx,
@@ -134,7 +134,7 @@ impl BufferedChain {
                 None => {
                     self.send_handle
                         .send(BufferedChainMessages::new_with_no_return(
-                            wrapper.messages,
+                            wrapper.requests,
                             wrapper.local_addr,
                         ))
                         .map_err(|e| anyhow!("Couldn't send message to wrapped chain {:?}", e))
@@ -144,7 +144,7 @@ impl BufferedChain {
                     self.send_handle
                         .send_timeout(
                             BufferedChainMessages::new_with_no_return(
-                                wrapper.messages,
+                                wrapper.requests,
                                 wrapper.local_addr,
                             ),
                             Duration::from_micros(timeout),

--- a/shotover/src/transforms/coalesce.rs
+++ b/shotover/src/transforms/coalesce.rs
@@ -64,7 +64,7 @@ impl TransformBuilder for Coalesce {
 #[async_trait]
 impl Transform for Coalesce {
     async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
-        self.buffer.append(&mut message_wrapper.messages);
+        self.buffer.append(&mut message_wrapper.requests);
 
         let flush_buffer = message_wrapper.flush
             || self
@@ -80,7 +80,7 @@ impl Transform for Coalesce {
             if self.flush_when_millis_since_last_flush.is_some() {
                 self.last_write = Instant::now()
             }
-            std::mem::swap(&mut self.buffer, &mut message_wrapper.messages);
+            std::mem::swap(&mut self.buffer, &mut message_wrapper.requests);
             message_wrapper.call_next_transform().await
         } else {
             Ok(vec![])

--- a/shotover/src/transforms/coalesce.rs
+++ b/shotover/src/transforms/coalesce.rs
@@ -63,10 +63,10 @@ impl TransformBuilder for Coalesce {
 
 #[async_trait]
 impl Transform for Coalesce {
-    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
-        self.buffer.append(&mut message_wrapper.requests);
+    async fn transform<'a>(&'a mut self, mut requests_wrapper: Wrapper<'a>) -> Result<Messages> {
+        self.buffer.append(&mut requests_wrapper.requests);
 
-        let flush_buffer = message_wrapper.flush
+        let flush_buffer = requests_wrapper.flush
             || self
                 .flush_when_buffered_message_count
                 .map(|n| self.buffer.len() >= n)
@@ -80,8 +80,8 @@ impl Transform for Coalesce {
             if self.flush_when_millis_since_last_flush.is_some() {
                 self.last_write = Instant::now()
             }
-            std::mem::swap(&mut self.buffer, &mut message_wrapper.requests);
-            message_wrapper.call_next_transform().await
+            std::mem::swap(&mut self.buffer, &mut requests_wrapper.requests);
+            requests_wrapper.call_next_transform().await
         } else {
             Ok(vec![])
         }
@@ -112,28 +112,28 @@ mod test {
             .map(|_| Message::from_frame(Frame::Redis(RedisFrame::Null)))
             .collect();
 
-        let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await.unwrap().len(), 0);
+        let mut requests_wrapper = Wrapper::new(messages.clone());
+        requests_wrapper.reset(&mut chain);
+        assert_eq!(coalesce.transform(requests_wrapper).await.unwrap().len(), 0);
 
-        let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await.unwrap().len(), 0);
+        let mut requests_wrapper = Wrapper::new(messages.clone());
+        requests_wrapper.reset(&mut chain);
+        assert_eq!(coalesce.transform(requests_wrapper).await.unwrap().len(), 0);
 
-        let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await.unwrap().len(), 0);
+        let mut requests_wrapper = Wrapper::new(messages.clone());
+        requests_wrapper.reset(&mut chain);
+        assert_eq!(coalesce.transform(requests_wrapper).await.unwrap().len(), 0);
 
-        let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.reset(&mut chain);
+        let mut requests_wrapper = Wrapper::new(messages.clone());
+        requests_wrapper.reset(&mut chain);
         assert_eq!(
-            coalesce.transform(message_wrapper).await.unwrap().len(),
+            coalesce.transform(requests_wrapper).await.unwrap().len(),
             100
         );
 
-        let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await.unwrap().len(), 0);
+        let mut requests_wrapper = Wrapper::new(messages.clone());
+        requests_wrapper.reset(&mut chain);
+        assert_eq!(coalesce.transform(requests_wrapper).await.unwrap().len(), 0);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -151,25 +151,28 @@ mod test {
             .map(|_| Message::from_frame(Frame::Redis(RedisFrame::Null)))
             .collect();
 
-        let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await.unwrap().len(), 0);
+        let mut requests_wrapper = Wrapper::new(messages.clone());
+        requests_wrapper.reset(&mut chain);
+        assert_eq!(coalesce.transform(requests_wrapper).await.unwrap().len(), 0);
 
         tokio::time::sleep(Duration::from_millis(10_u64)).await;
 
-        let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await.unwrap().len(), 0);
+        let mut requests_wrapper = Wrapper::new(messages.clone());
+        requests_wrapper.reset(&mut chain);
+        assert_eq!(coalesce.transform(requests_wrapper).await.unwrap().len(), 0);
 
         tokio::time::sleep(Duration::from_millis(100_u64)).await;
 
-        let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await.unwrap().len(), 75);
+        let mut requests_wrapper = Wrapper::new(messages.clone());
+        requests_wrapper.reset(&mut chain);
+        assert_eq!(
+            coalesce.transform(requests_wrapper).await.unwrap().len(),
+            75
+        );
 
-        let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await.unwrap().len(), 0);
+        let mut requests_wrapper = Wrapper::new(messages.clone());
+        requests_wrapper.reset(&mut chain);
+        assert_eq!(coalesce.transform(requests_wrapper).await.unwrap().len(), 0);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -187,43 +190,46 @@ mod test {
             .map(|_| Message::from_frame(Frame::Redis(RedisFrame::Null)))
             .collect();
 
-        let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await.unwrap().len(), 0);
+        let mut requests_wrapper = Wrapper::new(messages.clone());
+        requests_wrapper.reset(&mut chain);
+        assert_eq!(coalesce.transform(requests_wrapper).await.unwrap().len(), 0);
 
         tokio::time::sleep(Duration::from_millis(10_u64)).await;
 
-        let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await.unwrap().len(), 0);
+        let mut requests_wrapper = Wrapper::new(messages.clone());
+        requests_wrapper.reset(&mut chain);
+        assert_eq!(coalesce.transform(requests_wrapper).await.unwrap().len(), 0);
 
         tokio::time::sleep(Duration::from_millis(100_u64)).await;
 
-        let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await.unwrap().len(), 75);
-
-        let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await.unwrap().len(), 0);
-
-        let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await.unwrap().len(), 0);
-
-        let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await.unwrap().len(), 0);
-
-        let mut message_wrapper = Wrapper::new(messages.clone());
-        message_wrapper.reset(&mut chain);
+        let mut requests_wrapper = Wrapper::new(messages.clone());
+        requests_wrapper.reset(&mut chain);
         assert_eq!(
-            coalesce.transform(message_wrapper).await.unwrap().len(),
+            coalesce.transform(requests_wrapper).await.unwrap().len(),
+            75
+        );
+
+        let mut requests_wrapper = Wrapper::new(messages.clone());
+        requests_wrapper.reset(&mut chain);
+        assert_eq!(coalesce.transform(requests_wrapper).await.unwrap().len(), 0);
+
+        let mut requests_wrapper = Wrapper::new(messages.clone());
+        requests_wrapper.reset(&mut chain);
+        assert_eq!(coalesce.transform(requests_wrapper).await.unwrap().len(), 0);
+
+        let mut requests_wrapper = Wrapper::new(messages.clone());
+        requests_wrapper.reset(&mut chain);
+        assert_eq!(coalesce.transform(requests_wrapper).await.unwrap().len(), 0);
+
+        let mut requests_wrapper = Wrapper::new(messages.clone());
+        requests_wrapper.reset(&mut chain);
+        assert_eq!(
+            coalesce.transform(requests_wrapper).await.unwrap().len(),
             100
         );
 
-        let mut message_wrapper = Wrapper::new(messages);
-        message_wrapper.reset(&mut chain);
-        assert_eq!(coalesce.transform(message_wrapper).await.unwrap().len(), 0);
+        let mut requests_wrapper = Wrapper::new(messages);
+        requests_wrapper.reset(&mut chain);
+        assert_eq!(coalesce.transform(requests_wrapper).await.unwrap().len(), 0);
     }
 }

--- a/shotover/src/transforms/debug/force_parse.rs
+++ b/shotover/src/transforms/debug/force_parse.rs
@@ -77,7 +77,7 @@ impl TransformBuilder for DebugForceParse {
 #[async_trait]
 impl Transform for DebugForceParse {
     async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
-        for message in &mut message_wrapper.messages {
+        for message in &mut message_wrapper.requests {
             if self.parse_requests {
                 message.frame();
             }

--- a/shotover/src/transforms/debug/force_parse.rs
+++ b/shotover/src/transforms/debug/force_parse.rs
@@ -76,8 +76,8 @@ impl TransformBuilder for DebugForceParse {
 
 #[async_trait]
 impl Transform for DebugForceParse {
-    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
-        for message in &mut message_wrapper.requests {
+    async fn transform<'a>(&'a mut self, mut requests_wrapper: Wrapper<'a>) -> Result<Messages> {
+        for message in &mut requests_wrapper.requests {
             if self.parse_requests {
                 message.frame();
             }
@@ -86,7 +86,7 @@ impl Transform for DebugForceParse {
             }
         }
 
-        let mut response = message_wrapper.call_next_transform().await;
+        let mut response = requests_wrapper.call_next_transform().await;
 
         if let Ok(response) = response.as_mut() {
             for message in response {

--- a/shotover/src/transforms/debug/log_to_file.rs
+++ b/shotover/src/transforms/debug/log_to_file.rs
@@ -71,8 +71,8 @@ pub struct DebugLogToFile {
 
 #[async_trait]
 impl Transform for DebugLogToFile {
-    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Vec<Message>> {
-        for message in &message_wrapper.requests {
+    async fn transform<'a>(&'a mut self, requests_wrapper: Wrapper<'a>) -> Result<Vec<Message>> {
+        for message in &requests_wrapper.requests {
             self.request_counter += 1;
             let path = self
                 .requests
@@ -80,7 +80,7 @@ impl Transform for DebugLogToFile {
             log_message(message, path.as_path()).await?;
         }
 
-        let response = message_wrapper.call_next_transform().await?;
+        let response = requests_wrapper.call_next_transform().await?;
 
         for message in &response {
             self.response_counter += 1;

--- a/shotover/src/transforms/debug/log_to_file.rs
+++ b/shotover/src/transforms/debug/log_to_file.rs
@@ -72,7 +72,7 @@ pub struct DebugLogToFile {
 #[async_trait]
 impl Transform for DebugLogToFile {
     async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Vec<Message>> {
-        for message in &message_wrapper.messages {
+        for message in &message_wrapper.requests {
             self.request_counter += 1;
             let path = self
                 .requests

--- a/shotover/src/transforms/debug/printer.rs
+++ b/shotover/src/transforms/debug/printer.rs
@@ -46,7 +46,7 @@ impl TransformBuilder for DebugPrinter {
 #[async_trait]
 impl Transform for DebugPrinter {
     async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
-        for request in &mut message_wrapper.messages {
+        for request in &mut message_wrapper.requests {
             info!("Request: {}", request.to_high_level_string());
         }
 

--- a/shotover/src/transforms/debug/printer.rs
+++ b/shotover/src/transforms/debug/printer.rs
@@ -45,13 +45,13 @@ impl TransformBuilder for DebugPrinter {
 
 #[async_trait]
 impl Transform for DebugPrinter {
-    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
-        for request in &mut message_wrapper.requests {
+    async fn transform<'a>(&'a mut self, mut requests_wrapper: Wrapper<'a>) -> Result<Messages> {
+        for request in &mut requests_wrapper.requests {
             info!("Request: {}", request.to_high_level_string());
         }
 
         self.counter += 1;
-        let mut responses = message_wrapper.call_next_transform().await?;
+        let mut responses = requests_wrapper.call_next_transform().await?;
 
         for response in &mut responses {
             info!("Response: {}", response.to_high_level_string());

--- a/shotover/src/transforms/debug/random_delay.rs
+++ b/shotover/src/transforms/debug/random_delay.rs
@@ -14,13 +14,13 @@ pub struct DebugRandomDelay {
 
 #[async_trait]
 impl Transform for DebugRandomDelay {
-    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
+    async fn transform<'a>(&'a mut self, requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         let delay = if let Some(dist) = self.distribution {
             Duration::from_millis(dist.sample(&mut rand::thread_rng()) as u64 + self.delay)
         } else {
             Duration::from_millis(self.delay)
         };
         tokio::time::sleep(delay).await;
-        message_wrapper.call_next_transform().await
+        requests_wrapper.call_next_transform().await
     }
 }

--- a/shotover/src/transforms/debug/returner.rs
+++ b/shotover/src/transforms/debug/returner.rs
@@ -54,10 +54,10 @@ impl TransformBuilder for DebugReturner {
 
 #[async_trait]
 impl Transform for DebugReturner {
-    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
+    async fn transform<'a>(&'a mut self, requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         match &self.response {
             Response::Message(message) => Ok(message.clone()),
-            Response::Redis(string) => Ok(message_wrapper
+            Response::Redis(string) => Ok(requests_wrapper
                 .requests
                 .iter()
                 .map(|_| {

--- a/shotover/src/transforms/debug/returner.rs
+++ b/shotover/src/transforms/debug/returner.rs
@@ -58,7 +58,7 @@ impl Transform for DebugReturner {
         match &self.response {
             Response::Message(message) => Ok(message.clone()),
             Response::Redis(string) => Ok(message_wrapper
-                .messages
+                .requests
                 .iter()
                 .map(|_| {
                     Message::from_frame(Frame::Redis(RedisFrame::BulkString(

--- a/shotover/src/transforms/distributed/tuneable_consistency_scatter.rs
+++ b/shotover/src/transforms/distributed/tuneable_consistency_scatter.rs
@@ -183,7 +183,7 @@ enum Resolver {
 impl Transform for TuneableConsistentencyScatter {
     async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
         let consistency: Vec<_> = message_wrapper
-            .messages
+            .requests
             .iter_mut()
             .map(|m| match get_upper_command_name(m).as_slice() {
                 b"DBSIZE" => Consistency {
@@ -234,7 +234,7 @@ impl Transform for TuneableConsistentencyScatter {
         drop(rec_fu);
 
         Ok(if results.len() < max_required_successes as usize {
-            let mut messages = message_wrapper.messages;
+            let mut messages = message_wrapper.requests;
             for message in &mut messages {
                 *message = message.to_error_response("Not enough responses".into())?
             }

--- a/shotover/src/transforms/distributed/tuneable_consistency_scatter.rs
+++ b/shotover/src/transforms/distributed/tuneable_consistency_scatter.rs
@@ -181,8 +181,8 @@ enum Resolver {
 
 #[async_trait]
 impl Transform for TuneableConsistentencyScatter {
-    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
-        let consistency: Vec<_> = message_wrapper
+    async fn transform<'a>(&'a mut self, mut requests_wrapper: Wrapper<'a>) -> Result<Messages> {
+        let consistency: Vec<_> = requests_wrapper
             .requests
             .iter_mut()
             .map(|m| match get_upper_command_name(m).as_slice() {
@@ -217,7 +217,7 @@ impl Transform for TuneableConsistentencyScatter {
 
         //TODO: FuturesUnordered does bias to polling the first submitted task - this will bias all requests
         for chain in self.route_map.iter_mut() {
-            rec_fu.push(chain.process_request(message_wrapper.clone(), None));
+            rec_fu.push(chain.process_request(requests_wrapper.clone(), None));
         }
 
         let mut results = Vec::new();
@@ -234,7 +234,7 @@ impl Transform for TuneableConsistentencyScatter {
         drop(rec_fu);
 
         Ok(if results.len() < max_required_successes as usize {
-            let mut messages = message_wrapper.requests;
+            let mut messages = requests_wrapper.requests;
             for message in &mut messages {
                 *message = message.to_error_response("Not enough responses".into())?
             }

--- a/shotover/src/transforms/filter.rs
+++ b/shotover/src/transforms/filter.rs
@@ -43,7 +43,7 @@ impl TransformBuilder for QueryTypeFilter {
 impl Transform for QueryTypeFilter {
     async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
         let removed_indexes: Result<Vec<(usize, Message)>> = message_wrapper
-            .messages
+            .requests
             .iter_mut()
             .enumerate()
             .filter_map(|(i, m)| {
@@ -65,7 +65,7 @@ impl Transform for QueryTypeFilter {
         let removed_indexes = removed_indexes?;
 
         for (i, _) in removed_indexes.iter().rev() {
-            message_wrapper.messages.remove(*i);
+            message_wrapper.requests.remove(*i);
         }
 
         let mut shown_error = SHOWN_ERROR.load(Ordering::Relaxed);

--- a/shotover/src/transforms/filter.rs
+++ b/shotover/src/transforms/filter.rs
@@ -41,8 +41,8 @@ impl TransformBuilder for QueryTypeFilter {
 
 #[async_trait]
 impl Transform for QueryTypeFilter {
-    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
-        let removed_indexes: Result<Vec<(usize, Message)>> = message_wrapper
+    async fn transform<'a>(&'a mut self, mut requests_wrapper: Wrapper<'a>) -> Result<Messages> {
+        let removed_indexes: Result<Vec<(usize, Message)>> = requests_wrapper
             .requests
             .iter_mut()
             .enumerate()
@@ -65,12 +65,12 @@ impl Transform for QueryTypeFilter {
         let removed_indexes = removed_indexes?;
 
         for (i, _) in removed_indexes.iter().rev() {
-            message_wrapper.requests.remove(*i);
+            requests_wrapper.requests.remove(*i);
         }
 
         let mut shown_error = SHOWN_ERROR.load(Ordering::Relaxed);
 
-        message_wrapper
+        requests_wrapper
             .call_next_transform()
             .await
             .map(|mut messages| {
@@ -124,9 +124,9 @@ mod test {
             })
             .collect();
 
-        let mut message_wrapper = Wrapper::new(messages);
-        message_wrapper.reset(&mut chain);
-        let result = filter_transform.transform(message_wrapper).await.unwrap();
+        let mut requests_wrapper = Wrapper::new(messages);
+        requests_wrapper.reset(&mut chain);
+        let result = filter_transform.transform(requests_wrapper).await.unwrap();
 
         assert_eq!(result.len(), 26);
 

--- a/shotover/src/transforms/kafka/sink_cluster.rs
+++ b/shotover/src/transforms/kafka/sink_cluster.rs
@@ -119,7 +119,7 @@ pub struct KafkaSinkCluster {
 
 #[async_trait]
 impl Transform for KafkaSinkCluster {
-    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
+    async fn transform<'a>(&'a mut self, requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         if self.outbound.is_none() {
             let codec = KafkaCodecBuilder::new(Direction::Sink);
             let tcp_stream = tcp::tcp_stream(
@@ -132,7 +132,7 @@ impl Transform for KafkaSinkCluster {
         }
 
         let outbound = self.outbound.as_mut().unwrap();
-        let responses = send_requests(message_wrapper.requests, outbound)?;
+        let responses = send_requests(requests_wrapper.requests, outbound)?;
 
         // TODO: since kafka will never send requests out of order I wonder if it would be faster to use an mpsc instead of a oneshot or maybe just directly run the sending/receiving here?
         let mut responses = if let Some(read_timeout) = self.read_timeout {

--- a/shotover/src/transforms/kafka/sink_cluster.rs
+++ b/shotover/src/transforms/kafka/sink_cluster.rs
@@ -132,7 +132,7 @@ impl Transform for KafkaSinkCluster {
         }
 
         let outbound = self.outbound.as_mut().unwrap();
-        let responses = send_requests(message_wrapper.messages, outbound)?;
+        let responses = send_requests(message_wrapper.requests, outbound)?;
 
         // TODO: since kafka will never send requests out of order I wonder if it would be faster to use an mpsc instead of a oneshot or maybe just directly run the sending/receiving here?
         let mut responses = if let Some(read_timeout) = self.read_timeout {

--- a/shotover/src/transforms/kafka/sink_single.rs
+++ b/shotover/src/transforms/kafka/sink_single.rs
@@ -102,7 +102,7 @@ pub struct KafkaSinkSingle {
 
 #[async_trait]
 impl Transform for KafkaSinkSingle {
-    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
+    async fn transform<'a>(&'a mut self, mut requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         if self.outbound.is_none() {
             let codec = KafkaCodecBuilder::new(Direction::Sink);
             let tcp_stream = tcp::tcp_stream(self.connect_timeout, &self.address).await?;
@@ -111,7 +111,7 @@ impl Transform for KafkaSinkSingle {
         }
 
         // Rewrite requests to use kafkas port instead of shotovers port
-        for request in &mut message_wrapper.requests {
+        for request in &mut requests_wrapper.requests {
             if let Some(Frame::Kafka(KafkaFrame::Request {
                 body: RequestBody::LeaderAndIsr(leader_and_isr),
                 ..
@@ -125,7 +125,7 @@ impl Transform for KafkaSinkSingle {
         }
 
         let outbound = self.outbound.as_mut().unwrap();
-        let responses = send_requests(message_wrapper.requests, outbound)?;
+        let responses = send_requests(requests_wrapper.requests, outbound)?;
 
         // TODO: since kafka will never send requests out of order I wonder if it would be faster to use an mpsc instead of a oneshot or maybe just directly run the sending/receiving here?
         let mut responses = if let Some(read_timeout) = self.read_timeout {
@@ -136,7 +136,7 @@ impl Transform for KafkaSinkSingle {
 
         // Rewrite responses to use shotovers port instead of kafkas port
         for response in &mut responses {
-            let port = message_wrapper.local_addr.port() as i32;
+            let port = requests_wrapper.local_addr.port() as i32;
             match response.frame() {
                 Some(Frame::Kafka(KafkaFrame::Response {
                     body: ResponseBody::FindCoordinator(find_coordinator),

--- a/shotover/src/transforms/kafka/sink_single.rs
+++ b/shotover/src/transforms/kafka/sink_single.rs
@@ -111,7 +111,7 @@ impl Transform for KafkaSinkSingle {
         }
 
         // Rewrite requests to use kafkas port instead of shotovers port
-        for request in &mut message_wrapper.messages {
+        for request in &mut message_wrapper.requests {
             if let Some(Frame::Kafka(KafkaFrame::Request {
                 body: RequestBody::LeaderAndIsr(leader_and_isr),
                 ..
@@ -125,7 +125,7 @@ impl Transform for KafkaSinkSingle {
         }
 
         let outbound = self.outbound.as_mut().unwrap();
-        let responses = send_requests(message_wrapper.messages, outbound)?;
+        let responses = send_requests(message_wrapper.requests, outbound)?;
 
         // TODO: since kafka will never send requests out of order I wonder if it would be faster to use an mpsc instead of a oneshot or maybe just directly run the sending/receiving here?
         let mut responses = if let Some(read_timeout) = self.read_timeout {

--- a/shotover/src/transforms/load_balance.rs
+++ b/shotover/src/transforms/load_balance.rs
@@ -68,7 +68,7 @@ pub struct ConnectionBalanceAndPool {
 
 #[async_trait]
 impl Transform for ConnectionBalanceAndPool {
-    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
+    async fn transform<'a>(&'a mut self, requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         if self.active_connection.is_none() {
             let mut all_connections = self.all_connections.lock().await;
             if all_connections.len() < self.max_connections {
@@ -86,7 +86,7 @@ impl Transform for ConnectionBalanceAndPool {
         self.active_connection
             .as_mut()
             .unwrap()
-            .process_request(message_wrapper, None)
+            .process_request(requests_wrapper, None)
             .await
     }
 }

--- a/shotover/src/transforms/loopback.rs
+++ b/shotover/src/transforms/loopback.rs
@@ -22,7 +22,7 @@ impl TransformBuilder for Loopback {
 
 #[async_trait]
 impl Transform for Loopback {
-    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
-        Ok(message_wrapper.requests)
+    async fn transform<'a>(&'a mut self, requests_wrapper: Wrapper<'a>) -> Result<Messages> {
+        Ok(requests_wrapper.requests)
     }
 }

--- a/shotover/src/transforms/loopback.rs
+++ b/shotover/src/transforms/loopback.rs
@@ -23,6 +23,6 @@ impl TransformBuilder for Loopback {
 #[async_trait]
 impl Transform for Loopback {
     async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
-        Ok(message_wrapper.messages)
+        Ok(message_wrapper.requests)
     }
 }

--- a/shotover/src/transforms/mod.rs
+++ b/shotover/src/transforms/mod.rs
@@ -123,69 +123,69 @@ impl Debug for Transforms {
 }
 
 impl Transforms {
-    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
+    async fn transform<'a>(&'a mut self, requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         match self {
-            Transforms::KafkaSinkSingle(c) => c.transform(message_wrapper).await,
-            Transforms::KafkaSinkCluster(c) => c.transform(message_wrapper).await,
-            Transforms::CassandraSinkSingle(c) => c.transform(message_wrapper).await,
-            Transforms::CassandraSinkCluster(c) => c.transform(message_wrapper).await,
-            Transforms::CassandraPeersRewrite(c) => c.transform(message_wrapper).await,
-            Transforms::RedisCache(r) => r.transform(message_wrapper).await,
-            Transforms::Tee(m) => m.transform(message_wrapper).await,
-            Transforms::DebugPrinter(p) => p.transform(message_wrapper).await,
-            Transforms::DebugLogToFile(p) => p.transform(message_wrapper).await,
-            Transforms::DebugForceParse(p) => p.transform(message_wrapper).await,
-            Transforms::NullSink(n) => n.transform(message_wrapper).await,
-            Transforms::Loopback(n) => n.transform(message_wrapper).await,
-            Transforms::Protect(p) => p.transform(message_wrapper).await,
-            Transforms::DebugReturner(p) => p.transform(message_wrapper).await,
-            Transforms::DebugRandomDelay(p) => p.transform(message_wrapper).await,
-            Transforms::TuneableConsistencyScatter(tc) => tc.transform(message_wrapper).await,
-            Transforms::RedisSinkSingle(r) => r.transform(message_wrapper).await,
-            Transforms::RedisTimestampTagger(r) => r.transform(message_wrapper).await,
-            Transforms::RedisClusterPortsRewrite(r) => r.transform(message_wrapper).await,
-            Transforms::RedisSinkCluster(r) => r.transform(message_wrapper).await,
-            Transforms::ParallelMap(s) => s.transform(message_wrapper).await,
-            Transforms::PoolConnections(s) => s.transform(message_wrapper).await,
-            Transforms::Coalesce(s) => s.transform(message_wrapper).await,
-            Transforms::QueryTypeFilter(s) => s.transform(message_wrapper).await,
-            Transforms::QueryCounter(s) => s.transform(message_wrapper).await,
-            Transforms::RequestThrottling(s) => s.transform(message_wrapper).await,
-            Transforms::Custom(s) => s.transform(message_wrapper).await,
+            Transforms::KafkaSinkSingle(c) => c.transform(requests_wrapper).await,
+            Transforms::KafkaSinkCluster(c) => c.transform(requests_wrapper).await,
+            Transforms::CassandraSinkSingle(c) => c.transform(requests_wrapper).await,
+            Transforms::CassandraSinkCluster(c) => c.transform(requests_wrapper).await,
+            Transforms::CassandraPeersRewrite(c) => c.transform(requests_wrapper).await,
+            Transforms::RedisCache(r) => r.transform(requests_wrapper).await,
+            Transforms::Tee(m) => m.transform(requests_wrapper).await,
+            Transforms::DebugPrinter(p) => p.transform(requests_wrapper).await,
+            Transforms::DebugLogToFile(p) => p.transform(requests_wrapper).await,
+            Transforms::DebugForceParse(p) => p.transform(requests_wrapper).await,
+            Transforms::NullSink(n) => n.transform(requests_wrapper).await,
+            Transforms::Loopback(n) => n.transform(requests_wrapper).await,
+            Transforms::Protect(p) => p.transform(requests_wrapper).await,
+            Transforms::DebugReturner(p) => p.transform(requests_wrapper).await,
+            Transforms::DebugRandomDelay(p) => p.transform(requests_wrapper).await,
+            Transforms::TuneableConsistencyScatter(tc) => tc.transform(requests_wrapper).await,
+            Transforms::RedisSinkSingle(r) => r.transform(requests_wrapper).await,
+            Transforms::RedisTimestampTagger(r) => r.transform(requests_wrapper).await,
+            Transforms::RedisClusterPortsRewrite(r) => r.transform(requests_wrapper).await,
+            Transforms::RedisSinkCluster(r) => r.transform(requests_wrapper).await,
+            Transforms::ParallelMap(s) => s.transform(requests_wrapper).await,
+            Transforms::PoolConnections(s) => s.transform(requests_wrapper).await,
+            Transforms::Coalesce(s) => s.transform(requests_wrapper).await,
+            Transforms::QueryTypeFilter(s) => s.transform(requests_wrapper).await,
+            Transforms::QueryCounter(s) => s.transform(requests_wrapper).await,
+            Transforms::RequestThrottling(s) => s.transform(requests_wrapper).await,
+            Transforms::Custom(s) => s.transform(requests_wrapper).await,
         }
     }
 
-    async fn transform_pushed<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
+    async fn transform_pushed<'a>(&'a mut self, requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         match self {
-            Transforms::KafkaSinkSingle(c) => c.transform_pushed(message_wrapper).await,
-            Transforms::KafkaSinkCluster(c) => c.transform_pushed(message_wrapper).await,
-            Transforms::CassandraSinkSingle(c) => c.transform_pushed(message_wrapper).await,
-            Transforms::CassandraSinkCluster(c) => c.transform_pushed(message_wrapper).await,
-            Transforms::CassandraPeersRewrite(c) => c.transform_pushed(message_wrapper).await,
-            Transforms::RedisCache(r) => r.transform_pushed(message_wrapper).await,
-            Transforms::Tee(m) => m.transform_pushed(message_wrapper).await,
-            Transforms::DebugPrinter(p) => p.transform_pushed(message_wrapper).await,
-            Transforms::DebugLogToFile(p) => p.transform_pushed(message_wrapper).await,
-            Transforms::DebugForceParse(p) => p.transform_pushed(message_wrapper).await,
-            Transforms::NullSink(n) => n.transform_pushed(message_wrapper).await,
-            Transforms::Loopback(n) => n.transform_pushed(message_wrapper).await,
-            Transforms::Protect(p) => p.transform_pushed(message_wrapper).await,
-            Transforms::DebugReturner(p) => p.transform_pushed(message_wrapper).await,
-            Transforms::DebugRandomDelay(p) => p.transform_pushed(message_wrapper).await,
+            Transforms::KafkaSinkSingle(c) => c.transform_pushed(requests_wrapper).await,
+            Transforms::KafkaSinkCluster(c) => c.transform_pushed(requests_wrapper).await,
+            Transforms::CassandraSinkSingle(c) => c.transform_pushed(requests_wrapper).await,
+            Transforms::CassandraSinkCluster(c) => c.transform_pushed(requests_wrapper).await,
+            Transforms::CassandraPeersRewrite(c) => c.transform_pushed(requests_wrapper).await,
+            Transforms::RedisCache(r) => r.transform_pushed(requests_wrapper).await,
+            Transforms::Tee(m) => m.transform_pushed(requests_wrapper).await,
+            Transforms::DebugPrinter(p) => p.transform_pushed(requests_wrapper).await,
+            Transforms::DebugLogToFile(p) => p.transform_pushed(requests_wrapper).await,
+            Transforms::DebugForceParse(p) => p.transform_pushed(requests_wrapper).await,
+            Transforms::NullSink(n) => n.transform_pushed(requests_wrapper).await,
+            Transforms::Loopback(n) => n.transform_pushed(requests_wrapper).await,
+            Transforms::Protect(p) => p.transform_pushed(requests_wrapper).await,
+            Transforms::DebugReturner(p) => p.transform_pushed(requests_wrapper).await,
+            Transforms::DebugRandomDelay(p) => p.transform_pushed(requests_wrapper).await,
             Transforms::TuneableConsistencyScatter(tc) => {
-                tc.transform_pushed(message_wrapper).await
+                tc.transform_pushed(requests_wrapper).await
             }
-            Transforms::RedisSinkSingle(r) => r.transform_pushed(message_wrapper).await,
-            Transforms::RedisTimestampTagger(r) => r.transform_pushed(message_wrapper).await,
-            Transforms::RedisClusterPortsRewrite(r) => r.transform_pushed(message_wrapper).await,
-            Transforms::RedisSinkCluster(r) => r.transform_pushed(message_wrapper).await,
-            Transforms::ParallelMap(s) => s.transform_pushed(message_wrapper).await,
-            Transforms::PoolConnections(s) => s.transform_pushed(message_wrapper).await,
-            Transforms::Coalesce(s) => s.transform_pushed(message_wrapper).await,
-            Transforms::QueryTypeFilter(s) => s.transform_pushed(message_wrapper).await,
-            Transforms::QueryCounter(s) => s.transform_pushed(message_wrapper).await,
-            Transforms::RequestThrottling(s) => s.transform_pushed(message_wrapper).await,
-            Transforms::Custom(s) => s.transform_pushed(message_wrapper).await,
+            Transforms::RedisSinkSingle(r) => r.transform_pushed(requests_wrapper).await,
+            Transforms::RedisTimestampTagger(r) => r.transform_pushed(requests_wrapper).await,
+            Transforms::RedisClusterPortsRewrite(r) => r.transform_pushed(requests_wrapper).await,
+            Transforms::RedisSinkCluster(r) => r.transform_pushed(requests_wrapper).await,
+            Transforms::ParallelMap(s) => s.transform_pushed(requests_wrapper).await,
+            Transforms::PoolConnections(s) => s.transform_pushed(requests_wrapper).await,
+            Transforms::Coalesce(s) => s.transform_pushed(requests_wrapper).await,
+            Transforms::QueryTypeFilter(s) => s.transform_pushed(requests_wrapper).await,
+            Transforms::QueryCounter(s) => s.transform_pushed(requests_wrapper).await,
+            Transforms::RequestThrottling(s) => s.transform_pushed(requests_wrapper).await,
+            Transforms::Custom(s) => s.transform_pushed(requests_wrapper).await,
         }
     }
 
@@ -452,26 +452,26 @@ pub trait Transform: Send {
     /// for example pipelined Redis queries or batched Cassandra queries.
     ///
     /// Shotover expects the same number of messages in [`wrapper.requests`](crate::transforms::Wrapper) to be returned as was passed
-    /// into the method via the parameter message_wrapper. For in order protocols (such as Redis) you will
+    /// into the method via the parameter requests_wrapper. For in order protocols (such as Redis) you will
     /// also need to ensure the order of responses matches the order of the queries.
     ///
     /// You can modify the messages in the wrapper struct to achieve your own designs. Your transform
-    /// can also modify the response from `message_wrapper.call_next_transform()` if it needs
+    /// can also modify the response from `requests_wrapper.call_next_transform()` if it needs
     /// to. As long as you return the same number of messages as you received, you won't break behavior
     /// from other transforms.
     ///
     /// ## Invariants
     /// Your transform method at a minimum needs to
     /// * _Non-terminating_ - If your transform does not send the message to an external system or generate its own response to the query,
-    /// it will need to call and return the response from `message_wrapper.call_next_transform()`. This ensures that your
+    /// it will need to call and return the response from `requests_wrapper.call_next_transform()`. This ensures that your
     /// transform will call any subsequent downstream transforms without needing to know about what they
     /// do. This type of transform is called an non-terminating transform.
-    /// * _Terminating_ - Your transform can also choose not to call `message_wrapper.call_next_transform()` if it sends the
+    /// * _Terminating_ - Your transform can also choose not to call `requests_wrapper.call_next_transform()` if it sends the
     /// messages to an external system or generates its own response to the query e.g.
     /// [`crate::transforms::cassandra::sink_single::CassandraSinkSingle`]. This type of transform
     /// is called a Terminating transform (as no subsequent transforms in the chain will be called).
-    /// * _Message count_ - message_wrapper.requests will contain 0 or more messages.
-    /// Your transform should return the same number of responses as messages received in message_wrapper.requests. Transforms that
+    /// * _Message count_ - requests_wrapper.requests will contain 0 or more messages.
+    /// Your transform should return the same number of responses as messages received in requests_wrapper.requests. Transforms that
     /// don't do this explicitly for each call, should return the same number of responses as messages it receives over the lifetime
     /// of the transform chain. A good example of this is the [`crate::transforms::coalesce::Coalesce`] transform. The
     /// [`crate::transforms::sampler::Sampler`] transform is also another example of this, with a slightly different twist.
@@ -481,11 +481,11 @@ pub trait Transform: Send {
     /// ## Naming
     /// Transforms also have different naming conventions.
     /// * Transforms that interact with an external system are called Sinks.
-    /// * Transforms that don't call subsequent chains via `message_wrapper.call_next_transform()` are called terminating transforms.
-    /// * Transforms that do call subsquent chains via `message_wrapper.call_next_transform()` are non-terminating transforms.
+    /// * Transforms that don't call subsequent chains via `requests_wrapper.call_next_transform()` are called terminating transforms.
+    /// * Transforms that do call subsquent chains via `requests_wrapper.call_next_transform()` are non-terminating transforms.
     ///
     /// You can have have a transforms that is both non-terminating and a sink.
-    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages>;
+    async fn transform<'a>(&'a mut self, requests_wrapper: Wrapper<'a>) -> Result<Messages>;
 
     /// This method should be should be implemented by your transform if it is required to process pushed messages (typically events
     /// or messages that your source is subscribed to. The wrapper object contains the queries/frames
@@ -495,14 +495,14 @@ pub trait Transform: Send {
     /// This method processes one pushed message before sending it in reverse on the chain back to the source.
     ///
     /// You can modify the messages in the wrapper struct to achieve your own designs. Your transform can
-    /// also modify the response from `message_wrapper.call_next_transform_pushed` if it needs to. As long as the message
+    /// also modify the response from `requests_wrapper.call_next_transform_pushed` if it needs to. As long as the message
     /// carries on through the chain, it will function correctly. You are able to add or remove messages as this method is not expecting
     /// request/response pairs.
     ///
     /// ## Invariants
     /// * _Non-terminating_ - Your `transform_pushed` method should not be terminating as the messages should get passed back to the source, where they will terminate.
-    async fn transform_pushed<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
-        let response = message_wrapper.call_next_transform_pushed().await?;
+    async fn transform_pushed<'a>(&'a mut self, requests_wrapper: Wrapper<'a>) -> Result<Messages> {
+        let response = requests_wrapper.call_next_transform_pushed().await?;
         Ok(response)
     }
 

--- a/shotover/src/transforms/noop.rs
+++ b/shotover/src/transforms/noop.rs
@@ -20,7 +20,7 @@ impl Default for NoOp {
 
 #[async_trait]
 impl Transform for NoOp {
-    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
-        message_wrapper.call_next_transform().await
+    async fn transform<'a>(&'a mut self, requests_wrapper: Wrapper<'a>) -> Result<Messages> {
+        requests_wrapper.call_next_transform().await
     }
 }

--- a/shotover/src/transforms/null.rs
+++ b/shotover/src/transforms/null.rs
@@ -35,10 +35,10 @@ impl TransformBuilder for NullSink {
 #[async_trait]
 impl Transform for NullSink {
     async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
-        for message in &mut message_wrapper.messages {
+        for message in &mut message_wrapper.requests {
             *message =
                 message.to_error_response("Handled by shotover null transform".to_string())?;
         }
-        Ok(message_wrapper.messages)
+        Ok(message_wrapper.requests)
     }
 }

--- a/shotover/src/transforms/null.rs
+++ b/shotover/src/transforms/null.rs
@@ -34,11 +34,11 @@ impl TransformBuilder for NullSink {
 
 #[async_trait]
 impl Transform for NullSink {
-    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
-        for message in &mut message_wrapper.requests {
+    async fn transform<'a>(&'a mut self, mut requests_wrapper: Wrapper<'a>) -> Result<Messages> {
+        for message in &mut requests_wrapper.requests {
             *message =
                 message.to_error_response("Handled by shotover null transform".to_string())?;
         }
-        Ok(message_wrapper.requests)
+        Ok(requests_wrapper.requests)
     }
 }

--- a/shotover/src/transforms/parallel_map.rs
+++ b/shotover/src/transforms/parallel_map.rs
@@ -89,8 +89,8 @@ impl TransformConfig for ParallelMapConfig {
 #[async_trait]
 impl Transform for ParallelMap {
     async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
-        let mut results = Vec::with_capacity(message_wrapper.messages.len());
-        let mut message_iter = message_wrapper.messages.into_iter();
+        let mut results = Vec::with_capacity(message_wrapper.requests.len());
+        let mut message_iter = message_wrapper.requests.into_iter();
         while message_iter.len() != 0 {
             let mut future = UOFutures::new(self.ordered);
             for chain in self.chains.iter_mut() {

--- a/shotover/src/transforms/parallel_map.rs
+++ b/shotover/src/transforms/parallel_map.rs
@@ -88,9 +88,9 @@ impl TransformConfig for ParallelMapConfig {
 
 #[async_trait]
 impl Transform for ParallelMap {
-    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
-        let mut results = Vec::with_capacity(message_wrapper.requests.len());
-        let mut message_iter = message_wrapper.requests.into_iter();
+    async fn transform<'a>(&'a mut self, requests_wrapper: Wrapper<'a>) -> Result<Messages> {
+        let mut results = Vec::with_capacity(requests_wrapper.requests.len());
+        let mut message_iter = requests_wrapper.requests.into_iter();
         while message_iter.len() != 0 {
             let mut future = UOFutures::new(self.ordered);
             for chain in self.chains.iter_mut() {
@@ -99,7 +99,7 @@ impl Transform for ParallelMap {
                         Wrapper::new_with_chain_name(
                             vec![message],
                             chain.name.clone(),
-                            message_wrapper.local_addr,
+                            requests_wrapper.local_addr,
                         ),
                         "Parallel".to_string(),
                     ));

--- a/shotover/src/transforms/protect/mod.rs
+++ b/shotover/src/transforms/protect/mod.rs
@@ -165,9 +165,9 @@ impl Protect {
 
 #[async_trait]
 impl Transform for Protect {
-    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
+    async fn transform<'a>(&'a mut self, mut requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         // encrypt the values included in any INSERT or UPDATE queries
-        for message in message_wrapper.requests.iter_mut() {
+        for message in requests_wrapper.requests.iter_mut() {
             let mut invalidate_cache = false;
 
             if let Some(Frame::Cassandra(CassandraFrame { operation, .. })) = message.frame() {
@@ -180,8 +180,8 @@ impl Transform for Protect {
             }
         }
 
-        let mut original_messages = message_wrapper.requests.clone();
-        let mut result = message_wrapper.call_next_transform().await?;
+        let mut original_messages = requests_wrapper.requests.clone();
+        let mut result = requests_wrapper.call_next_transform().await?;
 
         for (response, request) in result.iter_mut().zip(original_messages.iter_mut()) {
             let mut invalidate_cache = false;

--- a/shotover/src/transforms/protect/mod.rs
+++ b/shotover/src/transforms/protect/mod.rs
@@ -167,7 +167,7 @@ impl Protect {
 impl Transform for Protect {
     async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
         // encrypt the values included in any INSERT or UPDATE queries
-        for message in message_wrapper.messages.iter_mut() {
+        for message in message_wrapper.requests.iter_mut() {
             let mut invalidate_cache = false;
 
             if let Some(Frame::Cassandra(CassandraFrame { operation, .. })) = message.frame() {
@@ -180,7 +180,7 @@ impl Transform for Protect {
             }
         }
 
-        let mut original_messages = message_wrapper.messages.clone();
+        let mut original_messages = message_wrapper.requests.clone();
         let mut result = message_wrapper.call_next_transform().await?;
 
         for (response, request) in result.iter_mut().zip(original_messages.iter_mut()) {

--- a/shotover/src/transforms/query_counter.rs
+++ b/shotover/src/transforms/query_counter.rs
@@ -39,7 +39,7 @@ impl TransformBuilder for QueryCounter {
 #[async_trait]
 impl Transform for QueryCounter {
     async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
-        for m in &mut message_wrapper.messages {
+        for m in &mut message_wrapper.requests {
             match m.frame() {
                 Some(Frame::Cassandra(frame)) => {
                     for statement in frame.operation.queries() {

--- a/shotover/src/transforms/query_counter.rs
+++ b/shotover/src/transforms/query_counter.rs
@@ -38,8 +38,8 @@ impl TransformBuilder for QueryCounter {
 
 #[async_trait]
 impl Transform for QueryCounter {
-    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
-        for m in &mut message_wrapper.requests {
+    async fn transform<'a>(&'a mut self, mut requests_wrapper: Wrapper<'a>) -> Result<Messages> {
+        for m in &mut requests_wrapper.requests {
             match m.frame() {
                 Some(Frame::Cassandra(frame)) => {
                     for statement in frame.operation.queries() {
@@ -65,7 +65,7 @@ impl Transform for QueryCounter {
             }
         }
 
-        message_wrapper.call_next_transform().await
+        requests_wrapper.call_next_transform().await
     }
 }
 

--- a/shotover/src/transforms/redis/cache.rs
+++ b/shotover/src/transforms/redis/cache.rs
@@ -326,7 +326,7 @@ impl SimpleRedisCache {
     ) -> Result<Messages> {
         let local_addr = message_wrapper.local_addr;
         let mut request_messages: Vec<_> = message_wrapper
-            .messages
+            .requests
             .iter_mut()
             .map(|message| message.frame().cloned())
             .collect();
@@ -569,7 +569,7 @@ fn build_redis_key_from_cql3(
 impl Transform for SimpleRedisCache {
     async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
         let cache_responses = self
-            .read_from_cache(&mut message_wrapper.messages, message_wrapper.local_addr)
+            .read_from_cache(&mut message_wrapper.requests, message_wrapper.local_addr)
             .await
             .unwrap_or_else(|err| {
                 error!("Failed to fetch from cache: {err:?}");
@@ -578,7 +578,7 @@ impl Transform for SimpleRedisCache {
 
         // remove requests we succesfully got back a cached response for
         for (_, cache_index) in cache_responses.iter().rev() {
-            message_wrapper.messages.remove(*cache_index);
+            message_wrapper.requests.remove(*cache_index);
         }
 
         let mut responses = self

--- a/shotover/src/transforms/redis/cache.rs
+++ b/shotover/src/transforms/redis/cache.rs
@@ -322,15 +322,15 @@ impl SimpleRedisCache {
     /// calls the next transform and process the result for caching.
     async fn execute_upstream_and_write_to_cache<'a>(
         &mut self,
-        mut message_wrapper: Wrapper<'a>,
+        mut requests_wrapper: Wrapper<'a>,
     ) -> Result<Messages> {
-        let local_addr = message_wrapper.local_addr;
-        let mut request_messages: Vec<_> = message_wrapper
+        let local_addr = requests_wrapper.local_addr;
+        let mut request_messages: Vec<_> = requests_wrapper
             .requests
             .iter_mut()
             .map(|message| message.frame().cloned())
             .collect();
-        let mut response_messages = message_wrapper.call_next_transform().await?;
+        let mut response_messages = requests_wrapper.call_next_transform().await?;
 
         let mut cache_messages = vec![];
         for (request, response) in request_messages
@@ -567,9 +567,9 @@ fn build_redis_key_from_cql3(
 
 #[async_trait]
 impl Transform for SimpleRedisCache {
-    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
+    async fn transform<'a>(&'a mut self, mut requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         let cache_responses = self
-            .read_from_cache(&mut message_wrapper.requests, message_wrapper.local_addr)
+            .read_from_cache(&mut requests_wrapper.requests, requests_wrapper.local_addr)
             .await
             .unwrap_or_else(|err| {
                 error!("Failed to fetch from cache: {err:?}");
@@ -578,11 +578,11 @@ impl Transform for SimpleRedisCache {
 
         // remove requests we succesfully got back a cached response for
         for (_, cache_index) in cache_responses.iter().rev() {
-            message_wrapper.requests.remove(*cache_index);
+            requests_wrapper.requests.remove(*cache_index);
         }
 
         let mut responses = self
-            .execute_upstream_and_write_to_cache(message_wrapper)
+            .execute_upstream_and_write_to_cache(requests_wrapper)
             .await?;
 
         // mix cached response in with our non cached responses

--- a/shotover/src/transforms/redis/cluster_ports_rewrite.rs
+++ b/shotover/src/transforms/redis/cluster_ports_rewrite.rs
@@ -50,7 +50,7 @@ impl Transform for RedisClusterPortsRewrite {
         let mut cluster_slots_indices = vec![];
         let mut cluster_nodes_indices = vec![];
 
-        for (i, message) in message_wrapper.messages.iter_mut().enumerate() {
+        for (i, message) in message_wrapper.requests.iter_mut().enumerate() {
             if let Some(frame) = message.frame() {
                 if is_cluster_slots(frame) {
                     cluster_slots_indices.push(i);

--- a/shotover/src/transforms/redis/cluster_ports_rewrite.rs
+++ b/shotover/src/transforms/redis/cluster_ports_rewrite.rs
@@ -45,12 +45,12 @@ impl RedisClusterPortsRewrite {
 
 #[async_trait]
 impl Transform for RedisClusterPortsRewrite {
-    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
+    async fn transform<'a>(&'a mut self, mut requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         // Find the indices of cluster slot messages
         let mut cluster_slots_indices = vec![];
         let mut cluster_nodes_indices = vec![];
 
-        for (i, message) in message_wrapper.requests.iter_mut().enumerate() {
+        for (i, message) in requests_wrapper.requests.iter_mut().enumerate() {
             if let Some(frame) = message.frame() {
                 if is_cluster_slots(frame) {
                     cluster_slots_indices.push(i);
@@ -62,7 +62,7 @@ impl Transform for RedisClusterPortsRewrite {
             }
         }
 
-        let mut response = message_wrapper.call_next_transform().await?;
+        let mut response = requests_wrapper.call_next_transform().await?;
 
         // Rewrite the ports in the cluster slots responses
         for i in cluster_slots_indices {

--- a/shotover/src/transforms/redis/sink_cluster.rs
+++ b/shotover/src/transforms/redis/sink_cluster.rs
@@ -958,7 +958,7 @@ impl Transform for RedisSinkCluster {
 
         let mut responses = FuturesOrdered::new();
 
-        for message in message_wrapper.messages {
+        for message in message_wrapper.requests {
             responses.push_back(match self.dispatch_message(message).await {
                 Ok(response) => response,
                 Err(e) => short_circuit(RedisFrame::Error(format!("ERR {e}").into())).unwrap(),

--- a/shotover/src/transforms/redis/sink_cluster.rs
+++ b/shotover/src/transforms/redis/sink_cluster.rs
@@ -949,7 +949,7 @@ impl TransformBuilder for RedisSinkCluster {
 
 #[async_trait]
 impl Transform for RedisSinkCluster {
-    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
+    async fn transform<'a>(&'a mut self, requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         if self.rebuild_connections {
             if let Err(err) = self.build_connections(self.token.clone()).await {
                 tracing::warn!("Error when rebuilding connections {err:?}");
@@ -958,7 +958,7 @@ impl Transform for RedisSinkCluster {
 
         let mut responses = FuturesOrdered::new();
 
-        for message in message_wrapper.requests {
+        for message in requests_wrapper.requests {
             responses.push_back(match self.dispatch_message(message).await {
                 Ok(response) => response,
                 Err(e) => short_circuit(RedisFrame::Error(format!("ERR {e}").into())).unwrap(),

--- a/shotover/src/transforms/redis/sink_single.rs
+++ b/shotover/src/transforms/redis/sink_single.rs
@@ -109,11 +109,11 @@ pub struct RedisSinkSingle {
 
 #[async_trait]
 impl Transform for RedisSinkSingle {
-    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
+    async fn transform<'a>(&'a mut self, mut requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         // Return immediately if we have no messages.
         // If we tried to send no messages we would block forever waiting for a reply that will never come.
-        if message_wrapper.requests.is_empty() {
-            return Ok(message_wrapper.requests);
+        if requests_wrapper.requests.is_empty() {
+            return Ok(requests_wrapper.requests);
         }
 
         if self.connection.is_none() {
@@ -153,7 +153,7 @@ impl Transform for RedisSinkSingle {
 
         let connection = self.connection.as_mut().unwrap();
 
-        for message in &mut message_wrapper.requests {
+        for message in &mut requests_wrapper.requests {
             let ty = if let Some(Frame::Redis(RedisFrame::Array(array))) = message.frame() {
                 if let Some(RedisFrame::BulkString(bytes)) = array.first() {
                     match bytes.to_ascii_uppercase().as_slice() {
@@ -176,10 +176,10 @@ impl Transform for RedisSinkSingle {
                 .map_err(|_| anyhow!("Failed to send message type because RedisSinkSingle response processing task is dead"))?;
         }
 
-        let messages_len = message_wrapper.requests.len();
+        let messages_len = requests_wrapper.requests.len();
         connection
             .outbound_tx
-            .send(message_wrapper.requests)
+            .send(requests_wrapper.requests)
             .await
             .map_err(|err| anyhow!("Failed to send messages to redis destination: {err:?}"))?;
 

--- a/shotover/src/transforms/redis/timestamp_tagging.rs
+++ b/shotover/src/transforms/redis/timestamp_tagging.rs
@@ -187,7 +187,7 @@ impl Transform for RedisTimestampTagger {
         // TODO: This is wrong. We need more robust handling of transactions
         let mut exec_block = false;
 
-        for message in message_wrapper.messages.iter_mut() {
+        for message in message_wrapper.requests.iter_mut() {
             if let Some(Frame::Redis(frame)) = message.frame() {
                 if let RedisFrame::Array(array) = frame {
                     if array

--- a/shotover/src/transforms/redis/timestamp_tagging.rs
+++ b/shotover/src/transforms/redis/timestamp_tagging.rs
@@ -181,13 +181,13 @@ fn unwrap_response(message: &mut Message) -> Result<()> {
 
 #[async_trait]
 impl Transform for RedisTimestampTagger {
-    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
+    async fn transform<'a>(&'a mut self, mut requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         // TODO: This is wrong. We need to keep track of tagged_success per message
         let mut tagged_success = true;
         // TODO: This is wrong. We need more robust handling of transactions
         let mut exec_block = false;
 
-        for message in message_wrapper.requests.iter_mut() {
+        for message in requests_wrapper.requests.iter_mut() {
             if let Some(Frame::Redis(frame)) = message.frame() {
                 if let RedisFrame::Array(array) = frame {
                     if array
@@ -211,7 +211,7 @@ impl Transform for RedisTimestampTagger {
             }
         }
 
-        let mut response = message_wrapper.call_next_transform().await;
+        let mut response = requests_wrapper.call_next_transform().await;
         debug!("tagging transform got {:?}", response);
         if let Ok(messages) = &mut response {
             if tagged_success || exec_block {

--- a/shotover/src/transforms/sampler.rs
+++ b/shotover/src/transforms/sampler.rs
@@ -44,21 +44,21 @@ impl Sampler {
 
 #[async_trait]
 impl Transform for Sampler {
-    async fn transform<'a>(&'a mut self, message_wrapper: Wrapper<'a>) -> Result<Messages> {
+    async fn transform<'a>(&'a mut self, requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         let chance = thread_rng_n(self.denominator);
         if chance < self.numerator {
-            let sample = message_wrapper.clone();
+            let sample = requests_wrapper.clone();
             let (sample, downstream) = tokio::join!(
                 self.sample_chain
                     .process_request(sample, self.get_name().to_string()),
-                message_wrapper.call_next_transform()
+                requests_wrapper.call_next_transform()
             );
             if sample.is_err() {
                 warn!("Could not sample request {:?}", sample);
             }
             downstream
         } else {
-            message_wrapper.call_next_transform().await
+            requests_wrapper.call_next_transform().await
         }
     }
 }

--- a/shotover/src/transforms/throttling.rs
+++ b/shotover/src/transforms/throttling.rs
@@ -62,17 +62,17 @@ impl TransformBuilder for RequestThrottling {
 
 #[async_trait]
 impl Transform for RequestThrottling {
-    async fn transform<'a>(&'a mut self, mut message_wrapper: Wrapper<'a>) -> Result<Messages> {
-        // extract throttled messages from the message_wrapper
-        let throttled_messages: Vec<(Message, usize)> = (0..message_wrapper.requests.len())
+    async fn transform<'a>(&'a mut self, mut requests_wrapper: Wrapper<'a>) -> Result<Messages> {
+        // extract throttled messages from the requests_wrapper
+        let throttled_messages: Vec<(Message, usize)> = (0..requests_wrapper.requests.len())
             .rev()
             .filter_map(|i| {
                 if self
                     .limiter
-                    .check_n(message_wrapper.requests[i].cell_count().ok()?)
+                    .check_n(requests_wrapper.requests[i].cell_count().ok()?)
                     .is_err()
                 {
-                    let message = message_wrapper.requests.remove(i);
+                    let message = requests_wrapper.requests.remove(i);
                     Some((message, i))
                 } else {
                     None
@@ -81,9 +81,9 @@ impl Transform for RequestThrottling {
             .collect();
 
         // if every message got backpressured we can skip this
-        let mut responses = if !message_wrapper.requests.is_empty() {
+        let mut responses = if !requests_wrapper.requests.is_empty() {
             // send allowed messages to Cassandra
-            message_wrapper.call_next_transform().await?
+            requests_wrapper.call_next_transform().await?
         } else {
             vec![]
         };


### PR DESCRIPTION
closes https://github.com/shotover/shotover-proxy/issues/1220

* "message_wrapper" args become requests_wrapper
* "messages" field becomes "requests"