### PR TITLE
windsock: add support for running some Kafka benches on AWS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
+name = "async-once-cell"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fddec5f567375e0a634f94bc8dab1059b9d59a8aba12134c32f5ee21ce3f5f89"
+
+[[package]]
 name = "async-recursion"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4382,7 +4388,9 @@ name = "shotover-proxy"
 version = "0.1.10"
 dependencies = [
  "anyhow",
+ "async-once-cell",
  "async-trait",
+ "aws-throwaway",
  "bincode",
  "bytes",
  "cassandra-cpp",
@@ -4412,6 +4420,7 @@ dependencies = [
  "shotover",
  "test-helpers",
  "tokio",
+ "tokio-bin-process",
  "tokio-util",
  "tracing",
  "tracing-appender",

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -44,8 +44,11 @@ rand_distr.workspace = true
 async-trait.workspace = true
 tracing-subscriber.workspace = true
 tracing-appender = "0.2.0"
+async-once-cell = "0.5.2"
 fred = { version = "6.3.0", features = ["enable-rustls"] }
+tokio-bin-process = "0.2.0"
 rustls-pemfile = "1.0.2"
+aws-throwaway = { path = "../aws-throwaway"}
 windsock = { path = "../windsock" }
 cql-ws = { git = "https://github.com/conorbros/cql-ws" }
 

--- a/shotover-proxy/build.rs
+++ b/shotover-proxy/build.rs
@@ -1,0 +1,7 @@
+use std::env;
+
+fn main() {
+    let profile = env::var("PROFILE").unwrap();
+    println!("cargo:rustc-env=PROFILE={profile}");
+    println!("cargo:rerun-if-env-changed=PROFILE");
+}

--- a/shotover-proxy/examples/windsock/aws/cloud.rs
+++ b/shotover-proxy/examples/windsock/aws/cloud.rs
@@ -1,0 +1,25 @@
+use async_trait::async_trait;
+use aws_throwaway::Aws;
+use windsock::cloud::Cloud;
+
+use super::AWS;
+
+pub struct AwsCloud;
+
+impl AwsCloud {
+    pub fn new_boxed() -> Box<dyn Cloud> {
+        Box::new(AwsCloud)
+    }
+}
+
+#[async_trait]
+impl Cloud for AwsCloud {
+    async fn cleanup_resources(&self) {
+        match AWS.get() {
+            // AWS is initialized, it'll be faster to cleanup resources making use of the initialization
+            Some(aws) => aws.cleanup_resources().await,
+            // AWS is not initialized, it'll be faster to cleanup resources skipping initialization
+            None => Aws::cleanup_resources_static().await,
+        }
+    }
+}

--- a/shotover-proxy/examples/windsock/aws/mod.rs
+++ b/shotover-proxy/examples/windsock/aws/mod.rs
@@ -1,0 +1,308 @@
+//! Windsock specific logic built on top of aws_throwaway
+
+pub mod cloud;
+
+use async_once_cell::OnceCell;
+use aws_throwaway::{ec2_instance::Ec2Instance, Aws, InstanceType};
+use std::fmt::Write;
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+use test_helpers::docker_compose::get_image_waiters;
+use tokio::sync::RwLock;
+use tokio_bin_process::event::{Event, Level};
+use windsock::ReportArchive;
+
+static AWS: OnceCell<WindsockAws> = OnceCell::new();
+
+pub struct WindsockAws {
+    shotover_instance: RwLock<Option<Arc<Ec2InstanceWithShotover>>>,
+    bencher_instance: RwLock<Option<Arc<Ec2InstanceWithBencher>>>,
+    docker_instances: RwLock<Vec<Arc<Ec2InstanceWithDocker>>>,
+    aws: Aws,
+}
+
+impl WindsockAws {
+    pub async fn get() -> &'static Self {
+        AWS.get_or_init(async move {
+            WindsockAws {
+                shotover_instance: RwLock::new(None),
+                bencher_instance: RwLock::new(None),
+                docker_instances: RwLock::new(vec![]),
+                aws: Aws::new().await,
+            }
+        })
+        .await
+    }
+
+    pub async fn create_bencher_instance(&self) -> Arc<Ec2InstanceWithBencher> {
+        if let Some(instance) = &*self.bencher_instance.read().await {
+            if Arc::strong_count(instance) != 1 {
+                panic!("Only one bencher instance can be held at once, make sure you drop the previous instance before calling this method again.")
+            }
+            return instance.clone();
+        }
+
+        let instance = Arc::new(Ec2InstanceWithBencher {
+            instance: self.aws.create_ec2_instance(InstanceType::T2Micro).await,
+        });
+        instance
+            .instance
+            .ssh()
+            .push_file(
+                std::env::current_exe().unwrap().as_ref(),
+                Path::new("windsock"),
+            )
+            .await;
+        *self.bencher_instance.write().await = Some(instance.clone());
+
+        instance
+    }
+
+    pub async fn create_docker_instance(&self) -> Arc<Ec2InstanceWithDocker> {
+        for instance in &*self.docker_instances.read().await {
+            if Arc::strong_count(instance) == 1 {
+                return instance.clone();
+            }
+        }
+        let instance = self.aws.create_ec2_instance(InstanceType::T2Micro).await;
+        instance
+        .ssh()
+            .shell(
+                r#"
+# Need to retry until succeeds as apt-get update may fail if run really quickly after starting the instance
+until sudo apt-get update -qq
+do
+  sleep 1
+done
+curl -sSL https://get.docker.com/ | sudo sh"#,
+            )
+            .await;
+
+        let instance = Arc::new(Ec2InstanceWithDocker { instance });
+        (*self.docker_instances.write().await).push(instance.clone());
+        instance
+    }
+
+    pub async fn create_shotover_instance(&self) -> Arc<Ec2InstanceWithShotover> {
+        if let Some(instance) = &*self.shotover_instance.read().await {
+            if Arc::strong_count(instance) != 1 {
+                panic!("Only one shotover instance can be held at once, make sure you drop the previous instance before calling this method again.")
+            }
+            return instance.clone();
+        }
+
+        let instance = Arc::new(Ec2InstanceWithShotover {
+            instance: self.aws.create_ec2_instance(InstanceType::T2Micro).await,
+        });
+
+        // PROFILE is set in build.rs from PROFILE listed in https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts
+        let profile = if env!("PROFILE") == "release" {
+            "release"
+        } else {
+            "dev"
+        };
+        let output = tokio::process::Command::new(env!("CARGO"))
+            .args(["build", "--all-features", "--profile", profile])
+            .output()
+            .await
+            .unwrap();
+        if !output.status.success() {
+            let stdout = String::from_utf8(output.stdout).unwrap();
+            let stderr = String::from_utf8(output.stderr).unwrap();
+            panic!("Bench run failed:\nstdout:\n{stdout}\nstderr:\n{stderr}")
+        }
+        instance
+            .instance
+            .ssh()
+            .push_file(
+                &std::env::current_exe()
+                    .unwrap()
+                    .parent()
+                    .unwrap()
+                    .parent()
+                    .unwrap()
+                    .join("shotover-proxy"),
+                Path::new("shotover-bin"),
+            )
+            .await;
+        instance
+            .instance
+            .ssh()
+            .push_file(Path::new("config/config.yaml"), Path::new("config.yaml"))
+            .await;
+        *self.shotover_instance.write().await = Some(instance.clone());
+
+        instance
+    }
+
+    pub async fn cleanup_resources(&self) {
+        self.aws.cleanup_resources().await;
+    }
+}
+
+pub struct Ec2InstanceWithDocker {
+    pub instance: Ec2Instance,
+}
+
+impl Ec2InstanceWithDocker {
+    pub async fn run_container(&self, image: &str, envs: &[(String, String)]) {
+        // cleanup old resources
+        self.instance
+            .ssh()
+            .shell(
+                r#"
+CONTAINERS=$(sudo docker ps -a -q)
+if [ -n "$CONTAINERS" ]
+then
+    sudo docker stop $CONTAINERS
+    sudo docker rm $CONTAINERS
+fi
+sudo docker system prune -af"#,
+            )
+            .await;
+
+        // start container
+        let mut env_args = String::new();
+        for (key, value) in envs {
+            // TODO: shell escape key and value
+            env_args.push_str(&format!(" -e \"{key}={value}\""))
+        }
+        let output = self
+            .instance
+            .ssh()
+            .shell(&format!(
+                "sudo docker run -qd --network host {env_args} {image}"
+            ))
+            .await;
+        let container_id = output.stdout;
+
+        // wait for container to finish starting
+        let mut receiver = self
+            .instance
+            .ssh()
+            .shell_stdout_lines(&format!("sudo docker logs -f {container_id}"))
+            .await;
+        let image_waiter = get_image_waiters()
+            .iter()
+            .find(|x| x.name == image)
+            .unwrap_or_else(|| {
+                panic!("The image {image:?} is not configured in get_image_waiters")
+            });
+        let mut logs = String::new();
+        loop {
+            match receiver.recv().await {
+                Some(line) => {
+                    writeln!(logs, "{}", line).unwrap();
+                    if line.contains(image_waiter.log_regex_to_wait_for) {
+                        return;
+                    }
+                }
+                None => panic!(
+                    "Docker container of image {:?} shutdown before {:?} occurred in the logs. Docker logs:\n{logs}",
+                    image,
+                    image_waiter.log_regex_to_wait_for
+                ),
+            }
+        }
+    }
+}
+
+pub struct Ec2InstanceWithBencher {
+    pub instance: Ec2Instance,
+}
+
+impl Ec2InstanceWithBencher {
+    pub async fn run_bencher(&self, args: &str, name: &str) {
+        self.instance
+            .ssh()
+            .shell(&format!("RUST_BACKTRACE=1 ./windsock {args}"))
+            .await;
+
+        let source = PathBuf::from("windsock_data").join("last_run").join(name);
+        let dest = ReportArchive::last_run_path().join(name);
+        self.instance.ssh().pull_file(&source, &dest).await;
+    }
+}
+
+pub struct Ec2InstanceWithShotover {
+    pub instance: Ec2Instance,
+}
+
+impl Ec2InstanceWithShotover {
+    pub async fn run_shotover(self: Arc<Self>, topology: &str) -> RunningShotover {
+        self.instance
+            .ssh()
+            .push_file_from_bytes(topology.as_bytes(), Path::new("topology.yaml"))
+            .await;
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        tokio::task::spawn(async move {
+            let mut receiver = self
+            .instance
+            .ssh()
+            // TODO: invoke current_exe --harnessed-startup shotover --name $benchname --profilers $profilers
+            .shell_stdout_lines(r#"
+killall -w shotover-bin > /dev/null || true
+RUST_BACKTRACE=1 ./shotover-bin --config-file config.yaml --topology-file topology.yaml --log-format json"#)
+            .await;
+            loop {
+                tokio::select! {
+                    line = receiver.recv() => {
+                        match line {
+                            Some(line) => {
+                                let event = Event::from_json_str(&line).unwrap();
+                                if let Level::Warn = event.level {
+                                    tracing::error!("shotover warn:\n    {event}");
+                                }
+                                if let Level::Error = event.level {
+                                    tracing::error!("shotover error:\n    {event}");
+                                }
+                                if tx.send(event).is_err() {
+                                    return
+                                }
+                            }
+                            None => return,
+                        }
+                    },
+                    _ = tx.closed() => {
+                        return;
+                    },
+                };
+            }
+        });
+
+        // wait for shotover to startup
+        loop {
+            let event = rx
+                .recv()
+                .await
+                .expect("Shotover shutdown before indicating that it had started");
+            if let Level::Warn | Level::Error = event.level {
+                panic!("Received error/warn event from shotover:\n     {event}")
+            }
+            if event.fields.message == "Shotover is now accepting inbound connections" {
+                break;
+            }
+        }
+        RunningShotover { rx }
+    }
+}
+
+pub struct RunningShotover {
+    rx: tokio::sync::mpsc::UnboundedReceiver<Event>,
+}
+
+impl RunningShotover {
+    pub async fn shutdown(mut self) {
+        while let Ok(event) = self.rx.try_recv() {
+            if let Level::Warn | Level::Error = event.level {
+                panic!("Received error/warn event from shotover:\n     {event}")
+            }
+        }
+
+        // dropping rx instructs the task to shutdown causing shotover to be terminated
+        std::mem::drop(self.rx)
+    }
+}

--- a/shotover-proxy/examples/windsock/common.rs
+++ b/shotover-proxy/examples/windsock/common.rs
@@ -1,3 +1,6 @@
+use anyhow::anyhow;
+use std::path::Path;
+
 #[derive(Clone, Copy)]
 pub enum Shotover {
     None,
@@ -16,4 +19,15 @@ impl Shotover {
             },
         )
     }
+}
+
+pub async fn rewritten_file(path: &Path, find_replace: &[(&str, &str)]) -> String {
+    let mut text = tokio::fs::read_to_string(path)
+        .await
+        .map_err(|e| anyhow!(e).context(format!("Failed to read from {path:?}")))
+        .unwrap();
+    for (find, replace) in find_replace {
+        text = text.replace(find, replace);
+    }
+    text
 }

--- a/shotover-proxy/examples/windsock/main.rs
+++ b/shotover-proxy/examples/windsock/main.rs
@@ -1,3 +1,4 @@
+mod aws;
 mod cassandra;
 mod common;
 mod kafka;
@@ -21,13 +22,15 @@ fn main() {
 
     // The benches and tests automatically set the working directory to CARGO_MANIFEST_DIR.
     // We need to do the same as the DockerCompose + ShotoverProcess types rely on this.
-    std::env::set_current_dir(
-        Path::new(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .unwrap()
-            .join("shotover-proxy"),
-    )
-    .unwrap();
+    if Path::new(env!("CARGO_MANIFEST_DIR")).exists() {
+        std::env::set_current_dir(
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .unwrap()
+                .join("shotover-proxy"),
+        )
+        .unwrap();
+    }
 
     let cassandra_benches = itertools::iproduct!(
         [CassandraDb::Cassandra],
@@ -116,7 +119,7 @@ fn main() {
         .chain(kafka_benches)
         .chain(redis_benches)
         .collect(),
-        None,
+        Some(aws::cloud::AwsCloud::new_boxed()),
         &["release"],
     )
     .run();

--- a/shotover-proxy/examples/windsock/readme.md
+++ b/shotover-proxy/examples/windsock/readme.md
@@ -1,0 +1,30 @@
+# Shotover windsock
+
+## Running locally
+
+Just `cargo windsock` will run every bench.
+Refer to the windsock docs and `cargo windsock --help` for more flags.
+
+## Running in AWS
+
+### Aws credentials
+
+Refer to the [aws-sdk docs](https://docs.aws.amazon.com/sdk-for-rust/latest/dg/credentials.html) for full information on credentials.
+
+But two easiest ways are:
+
+* Setting the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables
+* Logging in from the AWS CLI
+
+### Script setup
+
+To run the shotover windsock benches in AWS through the environment variables, create a script like the following *OUTSIDE* of any repository.
+
+```bash
+cd shotover-proxy
+AWS_ACCESS_KEY_ID=TODO AWS_SECRET_ACCESS_KEY=TODO cargo windsock "$@"
+```
+
+Replace `TODO` with your credentials.
+
+Then invoke like `aws-windsock.sh your-windsock-flags-here`

--- a/shotover-proxy/tests/test-configs/kafka/bench/topology-cloud.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/bench/topology-cloud.yaml
@@ -1,0 +1,12 @@
+---
+sources:
+  kafka_source:
+    Kafka:
+      listen_addr: "HOST_ADDRESS:9092"
+chain_config:
+  main_chain:
+    - KafkaSinkSingle:
+        remote_address: "KAFKA_ADDRESS:9092"
+        connect_timeout_ms: 3000
+source_to_chain_mapping:
+  kafka_source: main_chain

--- a/shotover-proxy/tests/test-configs/kafka/bench/topology-encode-cloud.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/bench/topology-encode-cloud.yaml
@@ -1,0 +1,15 @@
+---
+sources:
+  kafka_source:
+    Kafka:
+      listen_addr: "HOST_ADDRESS:9092"
+chain_config:
+  main_chain:
+    - DebugForceEncode:
+        encode_requests: true
+        encode_responses: true
+    - KafkaSinkSingle:
+        remote_address: "KAFKA_ADDRESS:9092"
+        connect_timeout_ms: 3000
+source_to_chain_mapping:
+  kafka_source: main_chain

--- a/test-helpers/src/docker_compose.rs
+++ b/test-helpers/src/docker_compose.rs
@@ -27,7 +27,7 @@ pub fn new_moto() -> DockerCompose {
     docker_compose("tests/transforms/docker-compose-moto.yaml")
 }
 
-fn get_image_waiters() -> &'static [Image] {
+pub fn get_image_waiters() -> &'static [Image] {
     &[
         Image {
             name: "motoserver/moto",

--- a/windsock/src/cli.rs
+++ b/windsock/src/cli.rs
@@ -36,6 +36,11 @@ pub struct Args {
     #[clap(long)]
     pub generate_webpage: bool,
 
+    /// By default windsock will run benches on your local machine.
+    /// Set this flag to have windsock run the benches in your configured cloud.
+    #[clap(long)]
+    pub cloud: bool,
+
     /// Windsock will automatically cleanup cloud resources after benches have been run.
     /// However this command exists to force cleanup in case windsock panicked before automatic cleanup could occur.
     #[clap(long)]

--- a/windsock/src/report.rs
+++ b/windsock/src/report.rs
@@ -80,7 +80,7 @@ impl Percentile {
 type Percentiles = [Duration; Percentile::COUNT];
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct ReportArchive {
+pub struct ReportArchive {
     pub(crate) running_in_release: bool,
     pub(crate) tags: Tags,
     pub(crate) operations_report: Option<OperationsReport>,
@@ -196,7 +196,9 @@ impl ReportArchive {
     }
 
     pub fn last_run_path() -> PathBuf {
-        windsock_path().join("last_run")
+        let path = windsock_path().join("last_run");
+        std::fs::create_dir_all(&path).unwrap();
+        path
     }
 
     pub fn baseline_path() -> PathBuf {


### PR DESCRIPTION
Refer to the readme for how to setup credentials.
This PR enables the benches in `cargo windsock --cloud name=kafka size=1B` to run successfully in AWS.
Results from this command:
![image](https://github.com/shotover/shotover-proxy/assets/5120858/7cd988e2-ea9d-417d-ba07-ae1da2d2bf30)



This PR contains the following changes:
* Completes cloud support in windsock
* Introduces aws abstractions
* Makes use of them to allow a subset of kafka benches to run in AWS.

If its preferred I could further split this PR into those 3 components, but I've kept them together since we wouldn't be able to individually test the 3 components.

AWS support for more benches will come in follow up PRs.

