### PR TITLE
windsock: add --cleanup-cloud-resources flag

### DIFF
--- a/shotover-proxy/examples/windsock/main.rs
+++ b/shotover-proxy/examples/windsock/main.rs
@@ -116,6 +116,7 @@ fn main() {
         .chain(kafka_benches)
         .chain(redis_benches)
         .collect(),
+        None,
         &["release"],
     )
     .run();

--- a/windsock/examples/cassandra.rs
+++ b/windsock/examples/cassandra.rs
@@ -19,6 +19,7 @@ fn main() {
             Box::new(CassandraBench::new(Some(Compression::Lz4))),
             Box::new(CassandraBench::new(None)),
         ],
+        None,
         &["release"],
     )
     .run();

--- a/windsock/src/cli.rs
+++ b/windsock/src/cli.rs
@@ -36,6 +36,11 @@ pub struct Args {
     #[clap(long)]
     pub generate_webpage: bool,
 
+    /// Windsock will automatically cleanup cloud resources after benches have been run.
+    /// However this command exists to force cleanup in case windsock panicked before automatic cleanup could occur.
+    #[clap(long)]
+    pub cleanup_cloud_resources: bool,
+
     /// Display results from the last benchmark run by: comparing various benches against a specific base bench
     /// The first bench name listed becomes the base bench
     /// --compare_by_name "base_name other_name1 other_name2"

--- a/windsock/src/cloud.rs
+++ b/windsock/src/cloud.rs
@@ -1,0 +1,25 @@
+use async_trait::async_trait;
+
+/// Implement this to give windsock some control over your cloud.
+/// Currently the only thing windsock needs is the ability to cleanup resources since resource creation should happen within your own benches.
+#[async_trait]
+pub trait Cloud {
+    /// Cleanup all cloud resources created by windsock.
+    /// You should destroy not just resources created during this bench run but also resources created in past bench runs that might have missed cleanup due to a panic.
+    async fn cleanup_resources(&self);
+
+    /// Create a dummy instance for when the user isnt using windsock cloud functionality
+    fn none() -> Box<dyn Cloud>
+    where
+        Self: Sized,
+    {
+        Box::new(NoCloud)
+    }
+}
+
+pub(crate) struct NoCloud;
+
+#[async_trait]
+impl Cloud for NoCloud {
+    async fn cleanup_resources(&self) {}
+}


### PR DESCRIPTION
Introduces the `--cleanup-cloud-resources` flag and routes it to the Cloud trait so the user can define how to cleanup their cloud resources.

refer to https://github.com/shotover/shotover-proxy/pull/1232 for more context