### PR TITLE
windsock: windsock calls itself to run bencher

### DIFF
--- a/windsock/src/cli.rs
+++ b/windsock/src/cli.rs
@@ -66,4 +66,8 @@ pub struct Args {
     /// Prevent release mode safety check from triggering to allow running in debug mode
     #[clap(long)]
     pub disable_release_safety_check: bool,
+
+    /// Not for human use. Call this from your bench orchestration method to launch your bencher.
+    #[clap(long)]
+    pub internal_run: Option<String>,
 }


### PR DESCRIPTION
Just checking CI for now

Pulled out of https://github.com/shotover/shotover-proxy/pull/1232, refer to it for more context.

In order to allow running the bencher in CI we need to split up the orchestration logic (setup+teardown) and the bencher logic.
This pr achieves this by having the orchestration logic execute a second instance of the windsock executable that performs the actual benching.
In order to keep the local benchmarks as close as possible to the cloud benchmarks (to make local benchmarks a good way to debug cloud benchmarks), running a local benchmark executes a new windsock instance just like in the cloud.

The shotover bench implementations are largely the same, the previous `Bench::run` implementations split pretty cleanly into the new `Bench::run_bencher` and `Bench::orchestrate_local` implementations.

The `cloud_orchestrate` method is currently unused, it will start to be used in a follow up PR. For now it just demonstrates the API that will be used for cloud orchestration.