### PR TITLE
aws-throwaway: configurable volume size

### DIFF
--- a/aws-throwaway/examples/aws-throwaway-test.rs
+++ b/aws-throwaway/examples/aws-throwaway-test.rs
@@ -11,7 +11,7 @@ async fn main() {
         .init();
 
     let aws = Aws::new().await;
-    let instance = aws.create_ec2_instance(InstanceType::T2Micro).await;
+    let instance = aws.create_ec2_instance(InstanceType::T2Micro, 8).await;
 
     instance
         .ssh()

--- a/aws-throwaway/examples/create-instance.rs
+++ b/aws-throwaway/examples/create-instance.rs
@@ -20,7 +20,7 @@ async fn main() {
 
         let aws = Aws::new().await;
         let instance_type = InstanceType::from_str(&instance_type).unwrap();
-        let instance = aws.create_ec2_instance(instance_type).await;
+        let instance = aws.create_ec2_instance(instance_type, 20).await;
 
         let result = instance.ssh().shell("lsb_release -a").await;
         println!("Created instance running:\n{}", result.stdout);

--- a/shotover-proxy/examples/windsock/aws/mod.rs
+++ b/shotover-proxy/examples/windsock/aws/mod.rs
@@ -45,7 +45,7 @@ impl WindsockAws {
         }
 
         let instance = Arc::new(Ec2InstanceWithBencher {
-            instance: self.aws.create_ec2_instance(InstanceType::T2Micro).await,
+            instance: self.aws.create_ec2_instance(InstanceType::T2Micro, 8).await,
         });
         instance
             .instance
@@ -66,7 +66,11 @@ impl WindsockAws {
                 return instance.clone();
             }
         }
-        let instance = self.aws.create_ec2_instance(InstanceType::T2Micro).await;
+        let instance = self
+            .aws
+            // databases will need more storage than the shotover or bencher instances
+            .create_ec2_instance(InstanceType::T2Micro, 40)
+            .await;
         instance
         .ssh()
             .shell(
@@ -94,7 +98,7 @@ curl -sSL https://get.docker.com/ | sudo sh"#,
         }
 
         let instance = Arc::new(Ec2InstanceWithShotover {
-            instance: self.aws.create_ec2_instance(InstanceType::T2Micro).await,
+            instance: self.aws.create_ec2_instance(InstanceType::T2Micro, 8).await,
         });
 
         // PROFILE is set in build.rs from PROFILE listed in https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts


### PR DESCRIPTION
Allow setting the root volume size.
By default it is 8GB which is not large enough for our heavier kafka benchmarks.
The volume size is made configurable, all other fields use the default configuration.