### PR TITLE
Tool for running shotover tests in EC2 arm/x86

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -579,6 +579,8 @@ dependencies = [
  "clap",
  "russh",
  "russh-keys",
+ "rustyline",
+ "shellfish",
  "ssh-key",
  "tokio",
  "tracing",
@@ -1090,6 +1092,17 @@ name = "clap_lex"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+
+[[package]]
+name = "clipboard-win"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7191c27c2357d9b7ef96baac1773290d4ca63b24205b82a3fd8a0637afcf0362"
+dependencies = [
+ "error-code",
+ "str-buf",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "cmake"
@@ -1725,6 +1738,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1806,12 +1825,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
+dependencies = [
+ "libc",
+ "str-buf",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "fd-lock"
+version = "3.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
+dependencies = [
+ "cfg-if",
+ "rustix 0.38.3",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2783,6 +2823,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "nix"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3401,6 +3450,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
 ]
 
 [[package]]
@@ -4081,6 +4140,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc31bd9b61a32c31f9650d18add92aa83a49ba979c143eefd27fe7177b05bd5f"
 
 [[package]]
+name = "rustyline"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfc8644681285d1fb67a467fb3021bfea306b99b4146b166a1fe3ada965eece"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "clipboard-win",
+ "dirs-next",
+ "fd-lock",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "radix_trie",
+ "scopeguard",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4377,6 +4459,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "shellfish"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282267f3ef2fba020b1338f60827f4af3c68af0e2ceecc70c1c3b22f953274f3"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "rustyline",
+ "thiserror",
+ "version_check",
+ "yansi",
+]
+
+[[package]]
 name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4620,6 +4716,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "str-buf"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
 name = "str_stack"
@@ -5753,6 +5855,12 @@ name = "xxhash-rust"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "735a71d46c4d68d71d4b24d03fdc2b98e38cea81730595801db779c04fe80d70"
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "yasna"

--- a/aws-throwaway/Cargo.toml
+++ b/aws-throwaway/Cargo.toml
@@ -24,3 +24,5 @@ ssh-key = { version = "0.5.1", features = ["ed25519"] }
 tracing-subscriber.workspace = true
 tracing-appender = "0.2.0"
 clap = { version = "4.0.4", features = ["cargo", "derive"] }
+shellfish = { version = "0.8.0", features = ["async"] }
+rustyline = "11.0.0"

--- a/aws-throwaway/examples/create-instance.rs
+++ b/aws-throwaway/examples/create-instance.rs
@@ -26,15 +26,8 @@ async fn main() {
         println!("Created instance running:\n{}", result.stdout);
 
         println!(
-            "Run the following to ssh into it:
-```
-chmod 700 key 2> /dev/null || true
-echo '{}' > key
-chmod 400 key
-ssh -i key ubuntu@{}
-```",
-            instance.client_private_key(),
-            instance.public_ip()
+            "Run the following to ssh into it:\n{}",
+            instance.ssh_instructions()
         );
     } else {
         println!("Need to specify either --cleanup or --instance-type")

--- a/aws-throwaway/examples/ec2-cargo.rs
+++ b/aws-throwaway/examples/ec2-cargo.rs
@@ -1,0 +1,136 @@
+use aws_throwaway::{ec2_instance::Ec2Instance, Aws, InstanceType};
+use clap::Parser;
+use rustyline::DefaultEditor;
+use shellfish::{async_fn, handler::DefaultAsyncHandler, Command, Shell};
+use std::error::Error;
+use tracing_subscriber::EnvFilter;
+
+/// Spins up an EC2 instance and then presents a shell from which you can run `cargo test` on the ec2 instance.
+///
+/// TODO: Every time the shell runs a cargo command, any local changes to the repo are reuploaded to the ec2 instance.
+///
+/// When the shell is exited all created EC2 instances are destroyed.
+#[derive(Parser, Clone)]
+#[clap()]
+pub struct Args {
+    /// Specify the instance type to use for building and running tests.
+    #[clap(long, default_value = "c7g.2xlarge")]
+    pub instance_type: String,
+
+    /// Cleanup resources and then immediately terminate without opening the shell
+    #[clap(long)]
+    pub cleanup: bool,
+}
+
+#[tokio::main]
+async fn main() {
+    let (non_blocking, _guard) = tracing_appender::non_blocking(std::io::stdout());
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_writer(non_blocking)
+        .init();
+
+    let args = Args::parse();
+    if args.cleanup {
+        Aws::cleanup_resources_static().await;
+        println!("All AWS throwaway resources have been deleted");
+        return;
+    }
+
+    let aws = Aws::new().await;
+    let instance_type = InstanceType::from(args.instance_type.as_str());
+    let instance = aws.create_ec2_instance(instance_type, 40).await;
+
+    println!(
+        "If something goes wrong with setup you can ssh into the machine by:\n{}",
+        instance.ssh_instructions()
+    );
+
+    let mut receiver = instance
+        .ssh()
+        .shell_stdout_lines(r#"
+set -e
+set -u
+# Need to retry until succeeds as apt-get update may fail if run really quickly after starting the instance
+until sudo apt-get update -qq
+do
+  sleep 1
+done
+sudo apt-get install -y cmake pkg-config g++ libssl-dev librdkafka-dev uidmap
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+curl -sSL https://get.docker.com/ | sudo sh
+dockerd-rootless-setuptool.sh install
+echo '#!/bin/bash
+docker compose "$@"
+' | sudo dd of=/bin/docker-compose
+sudo chmod +x /bin/docker-compose
+
+git clone https://github.com/shotover/shotover-proxy
+echo "export RUST_BACKTRACE=1" >> .profile
+"#).await;
+    while let Some(line) = receiver.recv().await {
+        println!("{}", line)
+    }
+
+    println!("Finished creating instance.");
+
+    let mut shell = Shell::new_with_async_handler(
+        State { instance },
+        "ec2-cargo$ ",
+        DefaultAsyncHandler::default(),
+        DefaultEditor::new().unwrap(),
+    );
+    shell.commands.insert(
+        "test",
+        Command::new_async(
+            "Uploads changes and runs cargo test $args".to_owned(),
+            async_fn!(State, test),
+        ),
+    );
+    shell.commands.insert(
+        "ssh-instructions",
+        Command::new(
+            "Print a bash snippet that can be used to ssh into the machine".to_owned(),
+            ssh_instructions,
+        ),
+    );
+
+    shell.run_async().await.unwrap();
+
+    aws.cleanup_resources().await;
+    println!("All AWS throwaway resources have been deleted")
+}
+
+async fn test(state: &mut State, mut args: Vec<String>) -> Result<(), Box<dyn Error>> {
+    args.remove(0);
+    let args = args.join(" ");
+    let mut receiver = state
+        .instance
+        .ssh()
+        .shell_stdout_lines(&format!(
+            r#"
+cd shotover-proxy
+RUST_BACKTRACE=1 ~/.cargo/bin/cargo test --color always {} 2>&1
+"#,
+            args
+        ))
+        .await;
+    while let Some(line) = receiver.recv().await {
+        println!("{}", line)
+    }
+
+    Ok(())
+}
+
+fn ssh_instructions(state: &mut State, mut _args: Vec<String>) -> Result<(), Box<dyn Error>> {
+    println!(
+        "Run the following to ssh into the EC2 instance:\n{}",
+        state.instance.ssh_instructions()
+    );
+
+    Ok(())
+}
+
+struct State {
+    instance: Ec2Instance,
+}

--- a/aws-throwaway/src/ec2_instance.rs
+++ b/aws-throwaway/src/ec2_instance.rs
@@ -28,6 +28,20 @@ impl Ec2Instance {
         &self.ssh
     }
 
+    pub fn ssh_instructions(&self) -> String {
+        format!(
+            r#"
+```
+chmod 700 key 2> /dev/null || true
+echo '{}' > key
+chmod 400 key
+TERM=xterm ssh -i key ubuntu@{}
+```"#,
+            self.client_private_key(),
+            self.public_ip()
+        )
+    }
+
     pub(crate) async fn new(
         public_ip: IpAddr,
         private_ip: IpAddr,


### PR DESCRIPTION
This gives us an immediate win of being able to run shotover tests on arm.
But I also think this tool would be a good way to allow contributors without a local linux machine to run tests.

Currently it does the following:
1. Spins up an instance of the specified instance type
2. Installs everything needed for a shotover development environment on that instance.
3. Opens a custom shell for the user. Currently the shell just allows the following but we could add more later:
     * test $args - runs cargo test $args on the repo
     * ssh-instructions - print a bash snippet to directly ssh into the machine
     * quit - terminates the application and cleans up all AWS resources

Currently it just does `git clone https://github.com/shotover/shotover-proxy`
But in a follow up PR it should be expanded to perform an rsync of the repo (excluding `target/`) to the ec2 instance.
And then every time `test` is run we rerun rsync to include any new local changes.

Currently some tests pass and some tests fail on EC2, that should be investigated as a follow up.
In particular I've observed that all tests which run multiple containers at once fail, but they pass on debian instances after hacking around a permissions issue by running as root.
I've also observed the problem is the same on both arm and x86
