### PR TITLE
Update redis-cluster images from redis 6 to 7

### DIFF
--- a/docs/src/examples/redis-clustering-aware.md
+++ b/docs/src/examples/redis-clustering-aware.md
@@ -24,7 +24,7 @@ Below we can see an example of a Redis node and it's Shotover sidecar. Notice th
 ```YAML
 
 redis-node-0:
-  image: bitnami/redis-cluster:6.0-debian-10
+  image: bitnami/redis-cluster:6.2.12-debian-11-r26
   networks:
     cluster_subnet:
       ipv4_address: 172.16.1.2

--- a/shotover-proxy/tests/test-configs/redis-cluster-auth/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/redis-cluster-auth/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3.3'
 services:
   redis-node-0:
-    image: &image bitnami/redis-cluster:6.0-debian-10
+    image: &image bitnami/redis-cluster:6.2.12-debian-11-r26
     ports:
       - "2230:6379"
     environment:

--- a/shotover-proxy/tests/test-configs/redis-cluster-dr/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/redis-cluster-dr/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3.3'
 services:
   redis-node-0:
-    image: &image bitnami/redis-cluster:6.0-debian-10
+    image: &image bitnami/redis-cluster:6.2.12-debian-11-r26
     ports:
       - "2220:6379"
     environment:

--- a/shotover-proxy/tests/test-configs/redis-cluster-handling/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/redis-cluster-handling/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.2
-    image: &image bitnami/redis-cluster:6.0-debian-10
+    image: &image bitnami/redis-cluster:6.2.12-debian-11-r26
     environment:
       &environment
       - 'ALLOW_EMPTY_PASSWORD=yes'
@@ -58,7 +58,7 @@ services:
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.8
-    image: bitnami/redis-cluster:6.0-debian-10
+    image: *image
     depends_on:
       - redis-node-0
       - redis-node-1

--- a/shotover-proxy/tests/test-configs/redis-cluster-hiding/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/redis-cluster-hiding/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.2
-    image: &image bitnami/redis-cluster:6.0-debian-10
+    image: &image bitnami/redis-cluster:6.2.12-debian-11-r26
     environment:
       &environment
       - 'ALLOW_EMPTY_PASSWORD=yes'
@@ -58,7 +58,7 @@ services:
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.8
-    image: bitnami/redis-cluster:6.0-debian-10
+    image: *image
     depends_on:
       - redis-node-0
       - redis-node-1

--- a/shotover-proxy/tests/test-configs/redis-cluster-ports-rewrite/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/redis-cluster-ports-rewrite/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3.3'
 services:
   redis-node-0:
-    image: &image bitnami/redis-cluster:6.0-debian-10
+    image: &image bitnami/redis-cluster:6.2.12-debian-11-r26
     ports:
       - "2220:6379"
     environment:
@@ -40,7 +40,7 @@ services:
     environment: *environment
 
   redis-cluster-init:
-    image: bitnami/redis-cluster:6.0-debian-10
+    image: *image
     depends_on:
       - redis-node-0
       - redis-node-1

--- a/shotover-proxy/tests/test-configs/redis-cluster-tls/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/redis-cluster-tls/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.2
-    image: &image bitnami/redis-cluster:6.0-debian-10
+    image: &image bitnami/redis-cluster:6.2.12-debian-11-r26
     volumes:
       - &keys ../redis-tls/certs:/usr/local/etc/redis/certs
 

--- a/test-helpers/src/docker_compose.rs
+++ b/test-helpers/src/docker_compose.rs
@@ -42,7 +42,7 @@ fn get_image_waiters() -> &'static [Image] {
             log_regex_to_wait_for: r"Ready to accept connections",
         },
         Image {
-            name: "bitnami/redis-cluster:6.0-debian-10",
+            name: "bitnami/redis-cluster:6.2.12-debian-11-r26",
             //`Cluster state changed` is created by the node services
             //`Cluster correctly created` is created by the init service
             log_regex_to_wait_for: r"Cluster state changed|Cluster correctly created",


### PR DESCRIPTION
This is a prereq to https://github.com/shotover/shotover-proxy/pull/1239

The current redis image we are on does not support arm64 which is preventing running tests on arm.
You can see what archs are supported here: https://hub.docker.com/r/bitnami/redis-cluster/tags

I remained on redis 6 instead of going to 7 to ensure we maintain compatibility with older versions.