### PR TITLE
windsock: add support for cassandra benches on AWS

### DIFF
--- a/aws-throwaway/src/lib.rs
+++ b/aws-throwaway/src/lib.rs
@@ -264,8 +264,12 @@ impl Aws {
             .key_name(&self.keyname)
             .user_data(base64::engine::general_purpose::STANDARD.encode(format!(
                 r#"#!/bin/bash
+sudo systemctl stop ssh
 echo "{}" > /etc/ssh/ssh_host_ed25519_key.pub
 echo "{}" > /etc/ssh/ssh_host_ed25519_key
+
+echo "ClientAliveInterval 30" >> /etc/ssh/sshd_config
+sudo systemctl start ssh
             "#,
                 self.host_public_key, self.host_private_key
             )))

--- a/aws-throwaway/src/ssh.rs
+++ b/aws-throwaway/src/ssh.rs
@@ -296,7 +296,7 @@ fn check_results<T: Display>(
 
     match exit_status {
         Some(status) => {
-            if status == 1 {
+            if status != 0 {
                 panic!("{task} failed with exit code {status}\n{output}")
             }
         }

--- a/shotover-proxy/examples/windsock/kafka.rs
+++ b/shotover-proxy/examples/windsock/kafka.rs
@@ -79,8 +79,8 @@ impl Bench for KafkaBench {
         let shotover_ip = shotover_instance.instance.private_ip().to_string();
 
         let (_, running_shotover) = futures::join!(
-            run_aws_kafka(kafka_instance.clone()),
-            run_aws_shotover(shotover_instance.clone(), self.shotover, kafka_ip.clone())
+            run_aws_kafka(kafka_instance),
+            run_aws_shotover(shotover_instance, self.shotover, kafka_ip.clone())
         );
 
         let destination_ip = if running_shotover.is_some() {

--- a/shotover-proxy/tests/test-configs/cassandra/bench/topology-cloud.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra/bench/topology-cloud.yaml
@@ -1,0 +1,12 @@
+---
+sources:
+  cassandra_prod:
+    Cassandra:
+      listen_addr: "HOST_ADDRESS:9042"
+chain_config:
+  main_chain:
+    - CassandraSinkSingle:
+        remote_address: "CASSANDRA_ADDRESS:9042"
+        connect_timeout_ms: 3000
+source_to_chain_mapping:
+  cassandra_prod: main_chain

--- a/shotover-proxy/tests/test-configs/cassandra/bench/topology-cluster-cloud.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra/bench/topology-cluster-cloud.yaml
@@ -1,0 +1,18 @@
+---
+sources:
+  cassandra_prod:
+    Cassandra:
+      listen_addr: "HOST_ADDRESS:9042"
+chain_config:
+  main_chain:
+    - CassandraSinkCluster:
+        first_contact_points: ["CASSANDRA_ADDRESS:9042"]
+        local_shotover_host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
+        shotover_nodes:
+          - address: "HOST_ADDRESS:9042"
+            data_center: "dc1"
+            rack: "rack1"
+            host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
+        connect_timeout_ms: 3000
+source_to_chain_mapping:
+  cassandra_prod: main_chain

--- a/shotover-proxy/tests/test-configs/cassandra/bench/topology-cluster-encode-cloud.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra/bench/topology-cluster-encode-cloud.yaml
@@ -1,0 +1,21 @@
+---
+sources:
+  cassandra_prod:
+    Cassandra:
+      listen_addr: "HOST_ADDRESS:9042"
+chain_config:
+  main_chain:
+    - DebugForceEncode:
+        encode_requests: true
+        encode_responses: true
+    - CassandraSinkCluster:
+        first_contact_points: ["CASSANDRA_ADDRESS:9042"]
+        local_shotover_host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
+        shotover_nodes:
+          - address: "HOST_ADDRESS:9042"
+            data_center: "dc1"
+            rack: "rack1"
+            host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
+        connect_timeout_ms: 3000
+source_to_chain_mapping:
+  cassandra_prod: main_chain

--- a/shotover-proxy/tests/test-configs/cassandra/bench/topology-encode-cloud.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra/bench/topology-encode-cloud.yaml
@@ -1,0 +1,15 @@
+---
+sources:
+  cassandra_prod:
+    Cassandra:
+      listen_addr: "HOST_ADDRESS:9042"
+chain_config:
+  main_chain:
+    - DebugForceEncode:
+        encode_requests: true
+        encode_responses: true
+    - CassandraSinkSingle:
+        remote_address: "CASSANDRA_ADDRESS:9042"
+        connect_timeout_ms: 3000
+source_to_chain_mapping:
+  cassandra_prod: main_chain


### PR DESCRIPTION
I started working on this because I wanted it to help review https://github.com/shotover/shotover-proxy/pull/1230

The command `cargo windsock --cloud "name=cassandra driver=scylla"` now succeeds.
The cdrs-tokio driver benches hangs for some reason, I will leave fixing that out of this PR.

I ran the benches, set as a baseline, and then ran again comparing against the first run:
![image](https://github.com/shotover/shotover-proxy/assets/5120858/78dcac66-802b-4ad6-ad0a-139b40962c76)
Some of these results are quite noisy, I would like to investigate why in the future.

I upgraded the EC2 instance types from T2Micro to M6aLarge because I needed more ram for cassandra and I realized that M type instances are a lot better than T type for benchmarking since M has an entire cpu core to itself and wont have "bursting" messing with the results.

I added a timeout to docker container creation since it was getting stuck on cassandra and it helped to debug the cause.

Fixed a bug in exit code checking that was silently ignoring failures >.>

When a node receives no ssh communication for a while the connection will get stuck.
I introduced the `ClientAliveInterval 30` config to stop this from happening.

It does take a long time to run the benches because the cassandra docker containers take a long time to reinitialize for each bench.
Maybe in the future we can find a shortcut to prevent having to do this.