### PR TITLE
shotover-int-tests/cassandra-tls: no longer embeds cert directly in image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,12 +3,7 @@
 *.gz
 /.vscode
 /shotover-proxy/tests/test-configs/redis-tls/certs
-/shotover-proxy/tests/test-configs/docker-images/cassandra-tls-4.0.6/certs/*.jks
-/shotover-proxy/tests/test-configs/docker-images/cassandra-tls-4.0.6/certs/*.p12
-/shotover-proxy/tests/test-configs/docker-images/cassandra-tls-4.0.6/certs/*.key
-/shotover-proxy/tests/test-configs/docker-images/cassandra-tls-4.0.6/certs/*.srl
-/shotover-proxy/tests/test-configs/docker-images/cassandra-tls-4.0.6/certs/*.csr
-/shotover-proxy/tests/test-configs/docker-images/cassandra-tls-4.0.6/certs/*.crt
+/shotover-proxy/tests/test-configs/cassandra-tls/certs
 .workspace.code-workspace
 **/.DS_Store
 /.project

--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -115,7 +115,7 @@ async fn source_tls_and_single_tls(#[case] driver: CassandraDriver) {
         .start()
         .await;
 
-    let ca_cert = "tests/test-configs/docker-images/cassandra-tls-4.0.6/certs/localhost_CA.crt";
+    let ca_cert = "tests/test-configs/cassandra-tls/certs/localhost_CA.crt";
 
     {
         // Run a quick test straight to Cassandra to check our assumptions that Shotover and Cassandra TLS are behaving exactly the same
@@ -295,7 +295,7 @@ async fn cluster_multi_rack(#[case] driver: CassandraDriver) {
 #[serial]
 async fn source_tls_and_cluster_tls(#[case] driver: CassandraDriver) {
     test_helpers::cert::generate_cassandra_test_certs();
-    let ca_cert = "tests/test-configs/docker-images/cassandra-tls-4.0.6/certs/localhost_CA.crt";
+    let ca_cert = "tests/test-configs/cassandra-tls/certs/localhost_CA.crt";
 
     let _compose = docker_compose("tests/test-configs/cassandra-cluster-tls/docker-compose.yaml");
     {
@@ -942,7 +942,7 @@ async fn passthrough_tls_websockets() {
             .start()
             .await;
 
-    let ca_cert = "tests/test-configs/docker-images/cassandra-tls-4.0.6/certs/localhost_CA.crt";
+    let ca_cert = "tests/test-configs/cassandra-tls/certs/localhost_CA.crt";
 
     let mut session = cql_ws::Session::new_tls("wss://0.0.0.0:9042", ca_cert).await;
     let rows = session.query("SELECT bootstrapped FROM system.local").await;

--- a/shotover-proxy/tests/test-configs/cassandra-cluster-tls/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra-cluster-tls/docker-compose.yaml
@@ -30,6 +30,9 @@ services:
       &volumes
       - type: tmpfs
         target: /var/lib/cassandra
+      - type: bind
+        source: "../cassandra-tls/certs/keystore.p12"
+        target: "/etc/cassandra/certs/keystore.p12"
     command: &command cassandra -f -Dcassandra.initial_token="$$CASSANDRA_INITIAL_TOKENS"
 
   cassandra-two:

--- a/shotover-proxy/tests/test-configs/cassandra-cluster-tls/topology.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra-cluster-tls/topology.yaml
@@ -4,8 +4,8 @@ sources:
     Cassandra:
       listen_addr: "127.0.0.1:9042"
       tls:
-        certificate_path: "tests/test-configs/docker-images/cassandra-tls-4.0.6/certs/localhost.crt"
-        private_key_path: "tests/test-configs/docker-images/cassandra-tls-4.0.6/certs/localhost.key"
+        certificate_path: "tests/test-configs/cassandra-tls/certs/localhost.crt"
+        private_key_path: "tests/test-configs/cassandra-tls/certs/localhost.key"
 chain_config:
   main_chain:
     - CassandraSinkCluster:
@@ -18,9 +18,9 @@ chain_config:
             host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
         connect_timeout_ms: 3000
         tls:
-          certificate_authority_path: "tests/test-configs/docker-images/cassandra-tls-4.0.6/certs/localhost_CA.crt"
-          certificate_path: "tests/test-configs/docker-images/cassandra-tls-4.0.6/certs/localhost.crt"
-          private_key_path: "tests/test-configs/docker-images/cassandra-tls-4.0.6/certs/localhost.key"
+          certificate_authority_path: "tests/test-configs/cassandra-tls/certs/localhost_CA.crt"
+          certificate_path: "tests/test-configs/cassandra-tls/certs/localhost.crt"
+          private_key_path: "tests/test-configs/cassandra-tls/certs/localhost.key"
           verify_hostname: false
 source_to_chain_mapping:
   cassandra_prod: main_chain

--- a/shotover-proxy/tests/test-configs/cassandra-passthrough-websocket-tls/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra-passthrough-websocket-tls/docker-compose.yaml
@@ -11,4 +11,7 @@ services:
     volumes:
       - type: tmpfs
         target: /var/lib/cassandra
+      - type: bind
+        source: "../cassandra-tls/certs/keystore.p12"
+        target: "/etc/cassandra/certs/keystore.p12"
     command: cassandra -f -Dcassandra.skip_wait_for_gossip_to_settle=0 -Dcassandra.initial_token=0

--- a/shotover-proxy/tests/test-configs/cassandra-passthrough-websocket-tls/topology.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra-passthrough-websocket-tls/topology.yaml
@@ -5,17 +5,17 @@ sources:
       listen_addr: "127.0.0.1:9042"
       transport: WebSocket
       tls:
-        certificate_path: "tests/test-configs/docker-images/cassandra-tls-4.0.6/certs/localhost.crt"
-        private_key_path: "tests/test-configs/docker-images/cassandra-tls-4.0.6/certs/localhost.key"
+        certificate_path: "tests/test-configs/cassandra-tls/certs/localhost.crt"
+        private_key_path: "tests/test-configs/cassandra-tls/certs/localhost.key"
 chain_config:
   main_chain:
     - CassandraSinkSingle:
         remote_address: "127.0.0.1:9043"
         connect_timeout_ms: 3000
         tls:
-          certificate_authority_path: "tests/test-configs/docker-images/cassandra-tls-4.0.6/certs/localhost_CA.crt"
-          certificate_path: "tests/test-configs/docker-images/cassandra-tls-4.0.6/certs/localhost.crt"
-          private_key_path: "tests/test-configs/docker-images/cassandra-tls-4.0.6/certs/localhost.key"
+          certificate_authority_path: "tests/test-configs/cassandra-tls/certs/localhost_CA.crt"
+          certificate_path: "tests/test-configs/cassandra-tls/certs/localhost.crt"
+          private_key_path: "tests/test-configs/cassandra-tls/certs/localhost.key"
           verify_hostname: false
 source_to_chain_mapping:
   cassandra_prod: main_chain

--- a/shotover-proxy/tests/test-configs/cassandra-tls/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra-tls/docker-compose.yaml
@@ -11,4 +11,7 @@ services:
     volumes:
       - type: tmpfs
         target: /var/lib/cassandra
+      - type: bind
+        source: "./certs/keystore.p12"
+        target: "/etc/cassandra/certs/keystore.p12"
     command: cassandra -f -Dcassandra.skip_wait_for_gossip_to_settle=0 -Dcassandra.initial_token=0

--- a/shotover-proxy/tests/test-configs/cassandra-tls/topology-with-key.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra-tls/topology-with-key.yaml
@@ -4,17 +4,17 @@ sources:
     Cassandra:
       listen_addr: "127.0.0.1:9043"
       tls:
-        certificate_path: "tests/test-configs/docker-images/cassandra-tls-4.0.6/certs/localhost.crt"
-        private_key_path: "tests/test-configs/docker-images/cassandra-tls-4.0.6/certs/localhost.key"
+        certificate_path: "tests/test-configs/cassandra-tls/certs/localhost.crt"
+        private_key_path: "tests/test-configs/cassandra-tls/certs/localhost.key"
 chain_config:
   main_chain:
     - CassandraSinkSingle:
         remote_address: "localhost:9042"
         connect_timeout_ms: 3000
         tls:
-          certificate_authority_path: "tests/test-configs/docker-images/cassandra-tls-4.0.6/certs/localhost_CA.crt"
-          certificate_path: "tests/test-configs/docker-images/cassandra-tls-4.0.6/certs/localhost.crt"
-          private_key_path: "tests/test-configs/docker-images/cassandra-tls-4.0.6/certs/localhost.key"
+          certificate_authority_path: "tests/test-configs/cassandra-tls/certs/localhost_CA.crt"
+          certificate_path: "tests/test-configs/cassandra-tls/certs/localhost.crt"
+          private_key_path: "tests/test-configs/cassandra-tls/certs/localhost.key"
           verify_hostname: true
 source_to_chain_mapping:
   cassandra_prod: main_chain

--- a/shotover-proxy/tests/test-configs/cassandra-tls/topology.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra-tls/topology.yaml
@@ -4,15 +4,15 @@ sources:
     Cassandra:
       listen_addr: "127.0.0.1:9043"
       tls:
-        certificate_path: "tests/test-configs/docker-images/cassandra-tls-4.0.6/certs/localhost.crt"
-        private_key_path: "tests/test-configs/docker-images/cassandra-tls-4.0.6/certs/localhost.key"
+        certificate_path: "tests/test-configs/cassandra-tls/certs/localhost.crt"
+        private_key_path: "tests/test-configs/cassandra-tls/certs/localhost.key"
 chain_config:
   main_chain:
     - CassandraSinkSingle:
         remote_address: "localhost:9042"
         connect_timeout_ms: 3000
         tls:
-          certificate_authority_path: "tests/test-configs/docker-images/cassandra-tls-4.0.6/certs/localhost_CA.crt"
+          certificate_authority_path: "tests/test-configs/cassandra-tls/certs/localhost_CA.crt"
           verify_hostname: true
 source_to_chain_mapping:
   cassandra_prod: main_chain

--- a/shotover-proxy/tests/test-configs/docker-images/cassandra-tls-4.0.6/Dockerfile
+++ b/shotover-proxy/tests/test-configs/docker-images/cassandra-tls-4.0.6/Dockerfile
@@ -1,4 +1,3 @@
 FROM library/cassandra:4.0.6
 
 COPY ./cassandra.yaml /etc/cassandra/cassandra.yaml
-COPY certs/keystore.p12 /etc/cassandra/certs/keystore.p12

--- a/test-helpers/src/cert.rs
+++ b/test-helpers/src/cert.rs
@@ -68,8 +68,9 @@ pub fn generate_test_certs_with_sans(path: &Path, sans: Vec<SanType>) {
 }
 
 pub fn generate_cassandra_test_certs() {
-    let path = Path::new("tests/test-configs/docker-images/cassandra-tls-4.0.6/certs");
+    let path = Path::new("tests/test-configs/cassandra-tls/certs");
     generate_test_certs(path);
+    std::fs::remove_file(path.join("keystore.p12")).ok();
     run_command(
         "openssl",
         &[

--- a/test-helpers/src/docker_compose.rs
+++ b/test-helpers/src/docker_compose.rs
@@ -1,5 +1,5 @@
 use docker_compose_runner::*;
-use std::{env, path::Path};
+use std::env;
 use tracing_subscriber::fmt::TestWriter;
 
 pub use docker_compose_runner::DockerCompose;
@@ -104,8 +104,6 @@ fn build_images(service_to_image: &[&str]) {
     if service_to_image
         .iter()
         .any(|x| *x == "shotover-int-tests/cassandra-tls:4.0.6")
-        && Path::new("tests/test-configs/docker-images/cassandra-tls-4.0.6/certs/keystore.p12")
-            .exists()
     {
         crate::run_command(
             "docker",


### PR DESCRIPTION
progress towards: https://github.com/shotover/shotover-proxy/issues/1246

as an end goal I want to either:
* stop building custom images and just specify everything we need directly within docker-compose (currently leaning towards this)
* build our custom images in a seperate repo and publish them to the docker registry

This PR is a prereq to both of those possibilities, and also just feels a bit more sane.

`std::fs::remove_file(path.join("keystore.p12")).ok();` is now needed because of some container weirdness:
It seems that the only way to include a file into a container instance is with a bind volume. (which is what we used here for the keystore)
However when a container modifies a file included via a bind volume, the actual file on the local host is modified.
In this case cassandra changes the owner of the file to `999` which alters the permissions of the actual local host file.
If cassandra modified the contents of the file we would have concurrency issues, but since its just fiddling with permissions there is no concurrency issue.
However openssl keystore generation command does not like replacing the file when it is owned by 999, so when we recreate the key we first delete the `keystore.p12` file so that openssl does not have to interact with it

Note about .gitignore change:
The various `/shotover-proxy/tests/test-configs/docker-images/cassandra-tls-4.0.6/certs/*.jks` worked around an old implementation of our cert generator, we can ditch all of them for a single line now.