### PR TITLE
ec2-cargo: fix broken tests by using docker as root

### DIFF
--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -22,6 +22,9 @@ On Ubuntu you can install them via `sudo apt-get install cmake gcc g++ libssl-de
 #### Docker
 
 While not required for building Shotover, installing `docker` and `docker-compose` will allow you to run Shotover's integration tests and also build the static libc version of Shotover.
+This setup script might work for you: `curl -sSL https://get.docker.com/ | sudo sh`
+Do not use the rootless install as many of our tests rely on the user created bridge networks having their interface exposed to the host, which rootless install does not support.
+Instead add your user to the docker group: `usermod -aG docker $USER`
 
 ## Building Shotover
 

--- a/ec2-cargo/src/main.rs
+++ b/ec2-cargo/src/main.rs
@@ -58,8 +58,17 @@ do
 done
 sudo apt-get install -y cmake pkg-config g++ libssl-dev librdkafka-dev uidmap
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
 curl -sSL https://get.docker.com/ | sudo sh
-dockerd-rootless-setuptool.sh install
+
+# silly hack to let us run root docker without having to relogin for a group change to take affect
+sudo mv /bin/docker /bin/docker1
+echo '#!/bin/bash
+sudo /bin/docker1 "$@"
+' | sudo dd of=/bin/docker
+sudo chmod +x /bin/docker
+
+# hack to work around docker-compose command not being present on this machine
 echo '#!/bin/bash
 docker compose "$@"
 ' | sudo dd of=/bin/docker-compose


### PR DESCRIPTION
closes https://github.com/shotover/shotover-proxy/issues/1258
All of our clustered integration tests access containers directly by its IP in order to properly test clustering behavior across distinct addresses.
However this would fail on ec2-cargo instances because they were setup with rootless docker.
The problem is that rootless docker does not expose user created networks to the host so we cant access containers by IP.
This PR fixes that by replacing rootless docker with the root approach to docker.

Usually to allow the user access to docker, you would then add the user to the `docker` group.
But that would require restarting the ssh session which takes about 5 seconds.
So instead I setup docker as a script that runs actual docker with sudo.
This should be effectively the same.
