### PR TITLE
windsock: profiling support in AWS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5800,6 +5800,7 @@ dependencies = [
  "console",
  "copy_dir",
  "docker-compose-runner",
+ "nix",
  "scylla",
  "serde",
  "strum 0.25.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,8 @@ members = ["windsock", "shotover", "shotover-proxy", "test-helpers", "custom-tra
 
 # https://deterministic.space/high-performance-rust.html
 [profile.release]
-lto = "fat"
+#lto = "fat"
+lto = false
 codegen-units = 1
 
 [profile.bench]

--- a/shotover-proxy/build.rs
+++ b/shotover-proxy/build.rs
@@ -1,7 +1,0 @@
-use std::env;
-
-fn main() {
-    let profile = env::var("PROFILE").unwrap();
-    println!("cargo:rustc-env=PROFILE={profile}");
-    println!("cargo:rerun-if-changed=build.rs");
-}

--- a/shotover-proxy/examples/windsock/cassandra.rs
+++ b/shotover-proxy/examples/windsock/cassandra.rs
@@ -1,7 +1,7 @@
 use crate::{
     aws::{Ec2InstanceWithDocker, Ec2InstanceWithShotover, RunningShotover},
     common::{rewritten_file, Shotover},
-    profilers::{self, CloudProfilerRunner, ProfilerRunner},
+    profilers::{self, ProfilerRunner},
 };
 use anyhow::Result;
 use async_trait::async_trait;
@@ -39,7 +39,7 @@ use test_helpers::{
     mock_cassandra::MockHandle,
     shotover_process::ShotoverProcessBuilder,
 };
-use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::{mpsc::UnboundedSender, oneshot};
 use windsock::{Bench, BenchParameters, BenchTask, Profiling, Report};
 
 const ROW_COUNT: usize = 1000;
@@ -446,7 +446,7 @@ impl Bench for CassandraBench {
             aws.create_docker_instance(),
             aws.create_docker_instance(),
             aws.create_bencher_instance(),
-            aws.create_shotover_instance()
+            aws.create_shotover_instance("release")
         );
 
         let cassandra_ip = cassandra_instance1.instance.private_ip().to_string();
@@ -467,8 +467,6 @@ impl Bench for CassandraBench {
                 profiler_instances.insert("cassandra".to_owned(), &cassandra_instance1.instance);
             }
         }
-        let mut profiler =
-            CloudProfilerRunner::new(self.name(), profiling, profiler_instances).await;
 
         let cassandra_nodes = vec![
             AwsNodeInfo {
@@ -488,6 +486,8 @@ impl Bench for CassandraBench {
         let (_, running_shotover) = futures::join!(
             run_aws_cassandra(cassandra_nodes, self.topology.clone()),
             run_aws_shotover(
+                self.name(),
+                profiling,
                 shotover_instance.clone(),
                 self.shotover,
                 cassandra_ip.clone(),
@@ -503,13 +503,14 @@ impl Bench for CassandraBench {
         let destination = format!("{destination_ip}:9042");
 
         bench_instance
-            .run_bencher(&self.run_args(&destination, &parameters), &self.name())
+            .run_bencher(
+                &self.run_bencher_args(&destination, &parameters),
+                &self.name(),
+            )
             .await;
 
-        profiler.finish();
-
         if let Some(running_shotover) = running_shotover {
-            running_shotover.shutdown().await;
+            running_shotover.shutdown(self.name()).await;
         }
         Ok(())
     }
@@ -559,7 +560,7 @@ impl Bench for CassandraBench {
         };
         profiler.run(&shotover);
 
-        self.execute_run(address, &parameters).await;
+        self.execute_run_bencher(address, &parameters).await;
 
         if let Some(shotover) = shotover {
             shotover.shutdown_and_then_consume_events(&[]).await;
@@ -621,9 +622,20 @@ impl Bench for CassandraBench {
 
         self.operation.run(&session, reporter, parameters).await;
     }
+
+    async fn run_service(
+        &self,
+        _resources: &str,
+        _running_in_release: bool,
+        _profiling: Profiling,
+        _shutdown: oneshot::Receiver<()>,
+    ) {
+    }
 }
 
 async fn run_aws_shotover(
+    bench_name: String,
+    profiling: Profiling,
     instance: Arc<Ec2InstanceWithShotover>,
     shotover: Shotover,
     cassandra_ip: String,
@@ -649,7 +661,11 @@ async fn run_aws_shotover(
                 &[("HOST_ADDRESS", &ip), ("CASSANDRA_ADDRESS", &cassandra_ip)],
             )
             .await;
-            Some(instance.run_shotover(&topology).await)
+            Some(
+                instance
+                    .run_shotover(bench_name, profiling, &topology)
+                    .await,
+            )
         }
         Shotover::None => None,
     }

--- a/windsock/Cargo.toml
+++ b/windsock/Cargo.toml
@@ -14,6 +14,7 @@ clap.workspace = true
 console = "0.15.5"
 copy_dir = "0.1.2"
 docker-compose-runner = "0.1.0"
+nix.workspace = true
 serde = { workspace = true, features = ["derive"] }
 strum = { version = "0.25.0", features = ["derive"] }
 tokio.workspace = true

--- a/windsock/examples/cassandra.rs
+++ b/windsock/examples/cassandra.rs
@@ -10,6 +10,7 @@ use std::{
     time::{Duration, Instant},
 };
 use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::oneshot;
 use windsock::{Bench, BenchParameters, BenchTask, Profiling, Report, Windsock};
 
 fn main() {
@@ -73,7 +74,7 @@ impl Bench for CassandraBench {
         let _docker_compose = docker_compose("examples/cassandra-docker-compose.yaml");
         let address = "127.0.0.1:9042";
 
-        self.execute_run(address, &parameters).await;
+        self.execute_run_bencher(address, &parameters).await;
 
         Ok(())
     }
@@ -115,6 +116,15 @@ impl Bench for CassandraBench {
         for task in tasks {
             task.await.unwrap();
         }
+    }
+
+    async fn run_service(
+        &self,
+        _resources: &str,
+        _running_in_release: bool,
+        _profiling: Profiling,
+        _shutdown: oneshot::Receiver<()>,
+    ) {
     }
 }
 

--- a/windsock/src/cli.rs
+++ b/windsock/src/cli.rs
@@ -109,5 +109,9 @@ pub struct Args {
 
     /// Not for human use. Call this from your bench orchestration method to launch your bencher.
     #[clap(long, verbatim_doc_comment)]
-    pub internal_run: Option<String>,
+    pub internal_run_bencher: Option<String>,
+
+    /// Not for human use. Call this from your bench orchestration method to launch your service.
+    #[clap(long, verbatim_doc_comment)]
+    pub internal_run_service: Option<String>,
 }


### PR DESCRIPTION
This almost works, just need to investigate whats going wrong with the flamegraph download.
Possibly I want to abandon this approach though.

I think having local benches go through `run_service` could be really nice in the future.
At the moment it makes things way more complicated and brittle without much benefit.
If we are able to generate our topology.yaml entirely within run_service then it might be worth it.
We should explore topology.yaml generation for local benches first.

We might want to land this with only cloud runs using `run_service` and the local runs remaining as is. But there is still some weirdness on the cloud side: shotover log handling is wonky.