### PR TITLE
KafkaEncoder: precompute message sizes to avoid allocations

### DIFF
--- a/shotover/src/frame/mod.rs
+++ b/shotover/src/frame/mod.rs
@@ -77,6 +77,17 @@ impl Frame {
         }
     }
 
+    /// Return the amount of bytes needed to hold the frame when encoded into bytes.
+    /// It is ok for protocols to return more than they need, but they should never return less as that will require at least one reallocation during encoding
+    pub fn bytes_len(&self) -> Result<usize> {
+        match self {
+            Frame::Redis(_) => unimplemented!(),
+            Frame::Cassandra(_) => unimplemented!(),
+            Frame::Kafka(kafka) => kafka.bytes_len(),
+            Frame::Dummy => Ok(0),
+        }
+    }
+
     pub fn name(&self) -> &'static str {
         match self {
             Frame::Redis(_) => "Redis",

--- a/shotover/src/message/mod.rs
+++ b/shotover/src/message/mod.rs
@@ -184,6 +184,14 @@ impl Message {
         }
     }
 
+    pub fn bytes_len(&self) -> Result<usize> {
+        match self.inner.as_ref().unwrap() {
+            MessageInner::RawBytes { bytes, .. } => Ok(bytes.len()),
+            MessageInner::Parsed { bytes, .. } => Ok(bytes.len()),
+            MessageInner::Modified { frame } => frame.bytes_len(),
+        }
+    }
+
     pub fn into_encodable(self) -> Encodable {
         match self.inner.unwrap() {
             MessageInner::RawBytes { bytes, .. } => Encodable::Bytes(bytes),


### PR DESCRIPTION
closes https://github.com/shotover/shotover-proxy/issues/1198

This PR implements the suggestions from the issue: All messages in a batch of kafka messages have their required space reserved in the destination buffer before encoding begins.

The microbenchmarks demonstrate improvements from this PR:
![image](https://github.com/shotover/shotover-proxy/assets/5120858/625c3d91-7492-4fd9-871d-a1266f998d5f)

Edit:
Looking deeper into this I think the microbenchmarks are misleading.
The buffer is actually preallocated to 8K by tokio: https://github.com/tokio-rs/tokio/blob/6cb106c3538cf527495ef5491c088d1365b14c8e/tokio-util/src/codec/framed_impl.rs#L53
From reading the implementation it seems this internal buffer is reused forever. Once the split off BytesMut's are rejoined the capacity is reused?
So we can probably just allow it to grow and stabilize to reasonable number without having to worry about preallocations?

Things to do from here:
* Add a bench case with preallocated buffer.
* abandon this PR?

Waiting on https://github.com/shotover/shotover-proxy/pull/1281 to land so we can properly evaluate this.