### PR TITLE
windsock: record and format error count and message

### DIFF
--- a/shotover-proxy/examples/windsock/redis.rs
+++ b/shotover-proxy/examples/windsock/redis.rs
@@ -334,20 +334,25 @@ struct BenchTaskRedis {
 
 #[async_trait]
 impl BenchTask for BenchTaskRedis {
-    async fn run_one_operation(&self) {
+    async fn run_one_operation(&self) -> Result<(), String> {
         match self.operation {
             RedisOperation::Set => {
                 let _: () = self
                     .client
                     .set("foo", "bar", None, None, false)
                     .await
-                    .unwrap();
+                    .map_err(|err| format!("{err}"))?;
             }
             RedisOperation::Get => {
-                let result: u32 = self.client.get("foo").await.unwrap();
+                let result: u32 = self
+                    .client
+                    .get("foo")
+                    .await
+                    .map_err(|err| format!("{err}"))?;
                 assert_eq!(result, 42);
             }
         }
+        Ok(())
     }
 }
 

--- a/windsock/examples/cassandra.rs
+++ b/windsock/examples/cassandra.rs
@@ -125,11 +125,12 @@ struct BenchTaskCassandra {
 
 #[async_trait]
 impl BenchTask for BenchTaskCassandra {
-    async fn run_one_operation(&self) {
+    async fn run_one_operation(&self) -> Result<(), String> {
         self.session
             .query("SELECT * FROM system.peers", ())
             .await
-            .unwrap();
+            .map_err(|err| format!("{err:?}"))
+            .map(|_| ())
     }
 }
 

--- a/windsock/readme.md
+++ b/windsock/readme.md
@@ -96,8 +96,8 @@ struct BenchTaskCassandra {
 
 #[async_trait]
 impl BenchTask for BenchTaskCassandra {
-    async fn run_one_operation(&self) {
-        self.session.query("SELECT * FROM table").await.unwrap();
+    async fn run_one_operation(&self) -> Result<(), String> {
+        self.session.query("SELECT * FROM table").await
     }
 }
 ```


### PR DESCRIPTION
This PR implements:
* a method for benches to report the errors they encounter
* storage of error data in records
* display of error messages and error rates in result tables

For example `/aws-windsock.sh "name=kafka size=100KB" --cloud` can now successfully complete since the errors are handled instead of panicking windsock entirely:
![image](https://github.com/shotover/shotover-proxy/assets/5120858/2840b57b-b2c6-41d6-b8e9-c562ada016eb)

To avoid error spam, recorded messages are capped to the first 5 unique error messages.
Once 6 unique errors occur a message is shown to indicate the list of messages is not complete.