### PR TITLE
update governor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,7 +843,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b48814962d2fd604c50d2b9433c2a41a0ab567779ee2c02f7fba6eca1221f082"
 dependencies = [
  "cached_proc_macro_types",
- "darling",
+ "darling 0.14.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -950,9 +950,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "51f1226cd9da55587234753d1245dd5b132343ea240f26b6a9003d68706141ba"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cdrs-tokio"
@@ -3418,22 +3421,6 @@ dependencies = [
 
 [[package]]
 name = "quanta"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20afe714292d5e879d8b12740aa223c6a88f118af41870e8b6196e39a02238a8"
-dependencies = [
- "crossbeam-utils",
- "libc",
- "mach",
- "once_cell",
- "raw-cpuid",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "quanta"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a17e662a7a8291a865152364c20c7abc5e60486ab2001e8ec10b24862de0b9ab"
@@ -5845,9 +5832,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd122eb777186e60c3fdf765a58ac76e41c582f1f535fbf3314434c6b58f3f7"
+checksum = "f46aab759304e4d7b2075a9aecba26228bb073ee8c50db796b2c72c676b5d807"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "aws-throwaway"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae7c585d17af2f92f38daf7c01969dfdf9be19257e4c2eb097aec71b21c4c5c"
+checksum = "ca89b714ead78b84f690a9c5f603937da8e32f8664f330edd0ed8884f59301fa"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -843,7 +843,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b48814962d2fd604c50d2b9433c2a41a0ab567779ee2c02f7fba6eca1221f082"
 dependencies = [
  "cached_proc_macro_types",
- "darling 0.14.4",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 1.0.109",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2135,9 +2135,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "governor"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c390a940a5d157878dd057c78680a33ce3415bcd05b4799509ea44210914b4d5"
+checksum = "821239e5672ff23e2a7060901fa622950bbd80b649cdaadd78d1c1767ed14eb4"
 dependencies = [
  "cfg-if",
  "futures",
@@ -2145,7 +2145,7 @@ dependencies = [
  "no-std-compat",
  "nonzero_ext",
  "parking_lot",
- "quanta 0.9.3",
+ "quanta",
  "rand 0.8.5",
  "smallvec",
 ]
@@ -2638,15 +2638,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mach"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "mach2"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2728,7 +2719,7 @@ dependencies = [
  "ipnet",
  "metrics",
  "metrics-util",
- "quanta 0.11.1",
+ "quanta",
  "thiserror",
  "tokio",
  "tracing",
@@ -2756,7 +2747,7 @@ dependencies = [
  "hashbrown 0.13.2",
  "metrics",
  "num_cpus",
- "quanta 0.11.1",
+ "quanta",
  "sketches-ddsketch",
 ]
 

--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -655,7 +655,14 @@ async fn request_throttling(#[case] driver: CassandraDriver) {
 
     tokio::time::sleep(std::time::Duration::from_secs(1)).await; // sleep to reset the window
 
-    shotover.shutdown_and_then_consume_events(&[EventMatcher::new().with_level(Level::Warn).with_target("shotover::transforms::throttling").with_message(r#"A message was received that could never have been successfully delivered since it contains more sub messages than can ever be allowed through via the `RequestThrottling` transforms `max_requests_per_second` configuration."#)]).await;
+    let event_watcher_message = r#"A message was received that could never have been successfully delivered since it contains more sub messages than can ever be allowed through via the `RequestThrottling` transforms `max_requests_per_second` configuration."#;
+
+    shotover
+        .shutdown_and_then_consume_events(&[EventMatcher::new()
+            .with_level(Level::Warn)
+            .with_target("shotover::transforms::throttling")
+            .with_message(event_watcher_message)])
+        .await;
 }
 
 #[cfg(feature = "alpha-transforms")]

--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -655,7 +655,7 @@ async fn request_throttling(#[case] driver: CassandraDriver) {
 
     tokio::time::sleep(std::time::Duration::from_secs(1)).await; // sleep to reset the window
 
-    shotover.shutdown_and_then_consume_events(&[]).await;
+    shotover.shutdown_and_then_consume_events(&[EventMatcher::new().with_level(Level::Warn).with_target("shotover::transforms::throttling").with_message(r#"A message was received that could never have been successfully delivered since it contains more sub messages than can ever be allowed through via the `RequestThrottling` transforms `max_requests_per_second` configuration."#)]).await;
 }
 
 #[cfg(feature = "alpha-transforms")]

--- a/shotover/Cargo.toml
+++ b/shotover/Cargo.toml
@@ -21,7 +21,7 @@ bytes-utils = "0.1.1"
 derivative = "2.1.1"
 cached = "0.44"
 async-recursion = "1.0"
-governor = { version = "0.5.0", default-features = false, features = ["std", "jitter", "quanta"] }
+governor = { version = "0.6", default-features = false, features = ["std", "jitter", "quanta"] }
 nonzero_ext = "0.3.0"
 version-compare = "0.1"
 rand = { features = ["small_rng"], workspace = true }

--- a/shotover/src/transforms/throttling.rs
+++ b/shotover/src/transforms/throttling.rs
@@ -71,11 +71,14 @@ impl Transform for RequestThrottling {
                     .limiter
                     .check_n(requests_wrapper.requests[i].cell_count().ok()?)
                 {
+                    // occurs if all cells can be accommodated and 
                     Ok(Ok(())) => None,
+                    // occurs if not all cells can be accommodated.
                     Ok(Err(_)) => {
                         let message = requests_wrapper.requests.remove(i);
                         Some((message, i))
                     }
+                    // occurs when the batch can never go through, meaning the rate limiter's quota's burst size is too low for the given number of cells to be ever allowed through
                     Err(_) => {
                         tracing::warn!("A message was received that could never have been successfully delivered since it contains more sub messages than can ever be allowed through via the `RequestThrottling` transforms `max_requests_per_second` configuration.");
                         let message = requests_wrapper.requests.remove(i);

--- a/shotover/src/transforms/throttling.rs
+++ b/shotover/src/transforms/throttling.rs
@@ -76,8 +76,8 @@ impl Transform for RequestThrottling {
                         let message = requests_wrapper.requests.remove(i);
                         Some((message, i))
                     }
-                    Err(e) => {
-                        tracing::info!("{e}");
+                    Err(_) => {
+                        tracing::warn!("A message was received that could never have been successfully delivered since it contains more sub messages than can ever be allowed through via the `RequestThrottling` transforms `max_requests_per_second` configuration.");
                         let message = requests_wrapper.requests.remove(i);
                         Some((message, i))
                     }


### PR DESCRIPTION
https://docs.rs/governor/latest/governor/struct.RateLimiter.html#method.check_n

https://docs.rs/governor/0.5.0/governor/struct.RateLimiter.html#method.check_n

Updates the `governor` dependency for our request throttling. The links above demonstrate the changes between versions that caused the test failures described in https://github.com/shotover/shotover-proxy/pull/1261. The changes in this PR keep the behaviour the same. 

The new method succeeds in one way and can now fail in two ways, compared to just one previously. `Ok(Ok())` occurs if all cells can be accommodated and `Ok(Err(_))` occurs if not all cells can be accommodated.

A failure occurs when the batch can never go through, meaning the rate limiter's quota's burst size is too low for the given number of cells to be ever allowed through.