### PR TITLE
cassandra_int_tests: add cqlsh smoke test

### DIFF
--- a/ec2-cargo/src/main.rs
+++ b/ec2-cargo/src/main.rs
@@ -56,7 +56,7 @@ until sudo apt-get update -qq
 do
   sleep 1
 done
-sudo apt-get install -y cmake pkg-config g++ libssl-dev librdkafka-dev uidmap
+sudo apt-get install -y cmake pkg-config g++ libssl-dev librdkafka-dev uidmap python3-venv
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 curl -sSL https://get.docker.com/ | sudo sh

--- a/shotover-proxy/tests/cassandra_int_tests/cqlsh.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cqlsh.rs
@@ -1,0 +1,88 @@
+use std::path::Path;
+use tokio::process::Command;
+
+const CQLSH_VERSION: &str = "6.1.2";
+
+fn venv_path() -> &'static Path {
+    Path::new("../target/cqlsh_venv")
+}
+
+pub async fn check_basic_cqlsh(address: &str, port: u16, ca_cert: Option<&str>) {
+    setup_cqlsh().await;
+
+    let mut args = vec!["-e", "SELECT rack FROM system.local"];
+
+    if ca_cert.is_some() {
+        args.push("--ssl");
+    }
+
+    args.push(address);
+    let port = port.to_string();
+    args.push(&port);
+
+    let output = run(Command::new(venv_path().join("bin").join("cqlsh"))
+        .args(args)
+        .env("SSL_CERTFILE", ca_cert.unwrap_or("")))
+    .await;
+    let expected = r#"
+ rack
+-------
+ rack1
+
+(1 rows)
+"#;
+    assert_eq!(expected, output);
+}
+
+async fn setup_cqlsh() {
+    if need_to_reinstall().await {
+        std::fs::remove_dir_all(venv_path()).ok();
+        run(Command::new("python3").args(["-m", "venv", venv_path().to_str().unwrap()])).await;
+        run(Command::new(venv_path().join("bin").join("pip"))
+            .args(["install", &format!("cqlsh=={CQLSH_VERSION}")]))
+        .await;
+    }
+}
+
+async fn need_to_reinstall() -> bool {
+    if !venv_path().exists() {
+        tracing::warn!("Installing cqlsh because it is not installed");
+        return true;
+    }
+    match Command::new(venv_path().join("bin").join("pip"))
+        .args(["show", "cqlsh"])
+        .output()
+        .await
+    {
+        Err(err) => {
+            tracing::warn!("Reinstalling cqlsh because venv is broken, failed to run pip {err}");
+            true
+        }
+        Ok(output) => {
+            let stdout = String::from_utf8(output.stdout).unwrap();
+            let stderr = String::from_utf8(output.stderr).unwrap();
+            if !output.status.success() {
+                tracing::warn!("Reinstalling cqlsh because `pip show cqlsh` failed\nstdout: {stdout}\nstderr: {stderr}");
+                return true;
+            }
+
+            if stdout.contains(&format!("Version: {CQLSH_VERSION}")) {
+                //the correct version of cqlsh is installed
+                false
+            } else {
+                tracing::warn!("Reinstalling cqlsh because it is not the correct version");
+                true
+            }
+        }
+    }
+}
+
+async fn run(command: &mut Command) -> String {
+    let output = command.output().await.unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    if !output.status.success() {
+        panic!("command failed:\n{command:?}\nstdout:\n{stdout}\nstderr:\n{stderr}",);
+    }
+    stdout
+}

--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -28,6 +28,7 @@ mod batch_statements;
 mod cache;
 mod cluster;
 mod collections;
+mod cqlsh;
 mod functions;
 mod keyspace;
 mod native_types;
@@ -75,6 +76,11 @@ async fn passthrough_standard(#[case] driver: CassandraDriver) {
     let connection = || CassandraConnectionBuilder::new("127.0.0.1", 9042, driver).build();
 
     standard_test_suite(&connection, driver).await;
+
+    // It would be too needlessly expensive for cqlsh to have its own entire test case, so instead we just latch onto the cdrs-tokio test case
+    if driver == CassandraDriver::CdrsTokio {
+        cqlsh::check_basic_cqlsh("127.0.0.1", 9042, None).await;
+    }
 
     shotover.shutdown_and_then_consume_events(&[]).await;
 }
@@ -138,6 +144,11 @@ async fn source_tls_and_single_tls(#[case] driver: CassandraDriver) {
     };
 
     standard_test_suite(&connection, driver).await;
+
+    // It would be too needlessly expensive for cqlsh to have its own entire test case, so instead we just latch onto the cdrs-tokio test case
+    if driver == CassandraDriver::CdrsTokio {
+        cqlsh::check_basic_cqlsh("127.0.0.1", 9042, Some(ca_cert)).await;
+    }
 
     shotover.shutdown_and_then_consume_events(&[]).await;
 }


### PR DESCRIPTION
Run a very basic test for cqlsh against a single instance and a single TLS instance.
This is part of my investigation into why cqlsh is failing to connect to shotover since the switch to rustls

The `need_to_reinstall` logic is possibly a little overengineered, but it should make us robust to both changes to CQLSH_VERSION and to venvs in a broken state, possibly due to the system level python being upgraded.
Possibly we would be better off just nuking the venv every time we run the test but I think its worth cutting off the 5s cost of recreating it.

a python venv is an isolated python install where you can install python packages isolated from the rest of the system.
Here i've created and used a venv inside the target directory to ensure we are not fiddling with or relying on system state in our tests.