### PR TITLE
Add user facing changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,17 @@
+# User Facing Changelog
+
+Any breaking changes to the `topology.yaml` or `shotover` rust API should be documented here.
+This assists us in knowing when to make the next release a breaking release and assists users with making upgrades to new breaking releases.
+
+## 0.1.10
+
+### topology.yaml
+
+* source TLS configurations will now enable client authentication when the `certificate_authority_path` field is present.
+  * Previously this field existed and was mandatory but had no affect on the TLS connection and client authentication was never enabled.
+  * If you are getting TLS failures after upgrading remove the `certificate_authority_path` field.
+    * Alternatively if you wish to use client authentication you can keep the field and setup your client to properly use client authentication.
+
+### shotover rust api
+
+* untracked


### PR DESCRIPTION
After spending a lot of time back and forth internally on an issue that was caused by us changing an API without documenting that change in an easily accessible place I have decided to introduce a changelog that we and users can refer to for information on such changes.

We already have the changelogs generated on releases such as https://github.com/shotover/shotover-proxy/releases/tag/v0.1.10 but they have so much noise from all the unrelated PRs and the PR descriptions are not directly useful when trying to upgrade to a new version or diagnose issues from an upgrade.

I think both systems can coexist, the automated changelogs are a complete list of every PR that went into the release while this changelog will be a hand curated reference to refer to when upgrading to new releases.