### PR TITLE
windsock: cleanup/improve --help output

### DIFF
--- a/windsock/src/cli.rs
+++ b/windsock/src/cli.rs
@@ -1,83 +1,117 @@
 use clap::Parser;
 
+const ABOUT: &str = r#"Bench Names:
+    Each benchmark has a unique name, this name is used by many options listed below.
+    The name is derived from its tags so you wont find it directly in the bench implementation but it will be listed in `--list`.
+
+Tag Filters:
+    Many options below take tag filters that specify which benches to include.
+    Tag filters specify which benches to include and the filter results are unioned.
+
+    So:
+    * The filter "foo=some_value" will include only benches with the tag key `foo` and the tag value `some_value`
+    * The filter "foo=some_value bar=another_value" will include only benches that match "foo=some_value" and "bar=another_value"
+    * The filter "" will include all benches"#;
+
 #[derive(Parser, Clone)]
-#[clap()]
+#[clap(about=ABOUT)]
 pub struct Args {
-    /// Run all benches that match the specified tag key/values
+    /// Run all benches that match the specified tag key/values.
     /// `tag_key=tag_value foo=bar`
+    #[clap(verbatim_doc_comment)]
     pub filter: Option<String>,
-    /// List the name of every bench
-    #[clap(long)]
+
+    /// List the name of every bench.
+    #[clap(long, verbatim_doc_comment)]
     pub list: bool,
-    /// Run a specific bench with the name produced via `--list`
-    #[clap(long)]
+
+    /// Run a specific bench with the name produced via `--list`.
+    #[clap(long, verbatim_doc_comment)]
     pub name: Option<String>,
-    /// Instruct benches to profile the application under test with the specified profilers
+
+    /// Instruct benches to profile the application under test with the specified profilers.
     /// Benches that do not support the specified profilers will be skipped.
-    #[clap(long)]
+    #[clap(long, verbatim_doc_comment)]
     pub profilers: Vec<String>,
-    /// How long in seconds to run each bench for
-    #[clap(long)]
+
+    /// How long in seconds to run each bench for.
+    /// By default benches will run for 15 seconds.
+    #[clap(long, verbatim_doc_comment)]
     pub bench_length_seconds: Option<u32>,
-    /// Max operations per second
-    #[clap(long)]
+
+    /// Instruct the benches to cap their operations per second to the specified amount.
+    /// By default the benches will run with unlimited operations per second.
+    #[clap(long, verbatim_doc_comment)]
     pub operations_per_second: Option<u64>,
 
     /// The results of the last benchmarks run becomes the new baseline from which following benchmark runs will be compared.
     /// Baseline bench results are merged with the results of following results under a `baseline=true` tag.
-    #[clap(long)]
+    #[clap(long, verbatim_doc_comment)]
     pub set_baseline: bool,
 
     /// Removes the stored baseline. Following runs will no longer compare against a baseline.
-    #[clap(long)]
+    #[clap(long, verbatim_doc_comment)]
     pub clear_baseline: bool,
 
-    /// Generate graphs webpage from the last benchmarks run
-    #[clap(long)]
+    /// Generate graphs webpage from the last benchmarks run.
+    #[clap(long, verbatim_doc_comment)]
     pub generate_webpage: bool,
 
     /// By default windsock will run benches on your local machine.
     /// Set this flag to have windsock run the benches in your configured cloud.
-    #[clap(long)]
+    #[clap(long, verbatim_doc_comment)]
     pub cloud: bool,
 
     /// Windsock will automatically cleanup cloud resources after benches have been run.
     /// However this command exists to force cleanup in case windsock panicked before automatic cleanup could occur.
-    #[clap(long)]
+    #[clap(long, verbatim_doc_comment)]
     pub cleanup_cloud_resources: bool,
 
-    /// Display results from the last benchmark run by: comparing various benches against a specific base bench
-    /// The first bench name listed becomes the base bench
-    /// --compare_by_name "base_name other_name1 other_name2"
-    #[clap(long)]
+    /// Display results from the last benchmark run by:
+    ///     Comparing various benches against a specific base bench.
+    ///
+    /// Usage: First provide the base benchmark name then provide benchmark names to compare against the base.
+    ///     --compare_by_name "base_name other_name1 other_name2"
+    #[clap(long, verbatim_doc_comment)]
     pub compare_by_name: Option<String>,
 
-    /// Display results from the last benchmark run by: comparing benches matching tag filters against a base named bench
-    /// First list the base_name then provide tag filters
-    /// --compare_by_tags "base_name db=kafka OPS=10000"
-    #[clap(long)]
+    /// Display results from the last benchmark run by:
+    ///     Comparing benches matching tag filters against a specific base bench.
+    ///
+    /// Usage: First provide the base benchmark name then provide tag filters
+    ///     --compare_by_tags "base_name db=kafka OPS=10000"
+    #[clap(long, verbatim_doc_comment)]
     pub compare_by_tags: Option<String>,
 
-    /// Display results from the last benchmark run by: comparing benches with specified bench names
-    /// --results-by-name "name1 name2 name3"
-    #[clap(long)]
+    /// Display results from the last benchmark run by:
+    ///     Comparing benches with specified bench names.
+    ///
+    /// Usage: Provide benchmark names to include
+    ///     --results-by-name "name1 name2 name3"
+    #[clap(long, verbatim_doc_comment)]
     pub results_by_name: Option<String>,
 
-    /// Display results from the last benchmark run by: listing bench results matching tag filters
-    /// --results-by-tags "db=kafka OPS=10000"
-    #[clap(long)]
+    /// Display results from the last benchmark run by:
+    ///     Listing bench results matching tag filters.
+    ///
+    /// Usage: Provide tag filters
+    ///     --results-by-tags "db=kafka OPS=10000"
+    #[clap(long, verbatim_doc_comment)]
     pub results_by_tags: Option<String>,
 
-    /// Display results from the last benchmark run by: comparing all benches matching tag filters against their results in the stored baseline from `--set-baseline`
-    /// --baseline-compare_by_tags "db=kafka OPS=10000"
-    #[clap(long)]
+    /// Display results from the last benchmark run by:
+    ///     Comparing all benches matching tag filters against their results in the stored baseline from `--set-baseline`.
+    ///
+    /// Usage: Provide tag filters
+    ///     --baseline-compare-by-tags "db=kafka OPS=10000"
+    #[clap(long, verbatim_doc_comment)]
     pub baseline_compare_by_tags: Option<String>,
 
     /// Prevent release mode safety check from triggering to allow running in debug mode
-    #[clap(long)]
+    #[clap(long, verbatim_doc_comment)]
     pub disable_release_safety_check: bool,
 
     /// Not for human use. Call this from your bench orchestration method to launch your bencher.
-    #[clap(long)]
+    #[clap(long, verbatim_doc_comment)]
     pub internal_run: Option<String>,
 }


### PR DESCRIPTION
About time this got some cleanup.

This PR:
* improves the formatting
* adds two paragraphs beforehand to explain bench names and tag filters
* Improves wording/explanations in various cases.

Before:
![image](https://github.com/shotover/shotover-proxy/assets/5120858/5036fbb6-1a8a-49ed-93fa-bbca75f1870a)

After:
![image](https://github.com/shotover/shotover-proxy/assets/5120858/46fcb290-3edd-4be1-a0ba-4fa1c74b48e0)

Without verbatim_doc_comment clap will strip all the custom formatting (newlines+whitespace)