### PR TITLE
scylla driver: disable topology refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4202,8 +4202,7 @@ dependencies = [
 [[package]]
 name = "scylla"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b9aa2b618718b5d4873926cecb99fe181a3b8c52b4983e2b20d6d833bfa9c1b"
+source = "git+https://github.com/scylladb/scylla-rust-driver/#e1fa6ff346cd14663fc1a0e483b68045885ec306"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4238,8 +4237,7 @@ dependencies = [
 [[package]]
 name = "scylla-cql"
 version = "0.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048bdf0be96308ec0f5aeed2847bb2270f53355425b3afd67e64efc99d70b3e3"
+source = "git+https://github.com/scylladb/scylla-rust-driver/#e1fa6ff346cd14663fc1a0e483b68045885ec306"
 dependencies = [
  "async-trait",
  "bigdecimal 0.2.2",
@@ -4259,12 +4257,11 @@ dependencies = [
 [[package]]
 name = "scylla-macros"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d777dadbf7163d1524ea4f5a095146298d263a686febb96d022cf46d06df32"
+source = "git+https://github.com/scylladb/scylla-rust-driver/#e1fa6ff346cd14663fc1a0e483b68045885ec306"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.28",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ debug = true
 codegen-units = 1
 
 [workspace.dependencies]
-scylla = { version = "0.9.0", features = ["ssl"] }
+scylla = { version = "0.9.0", features = ["ssl"], git = "https://github.com/scylladb/scylla-rust-driver/" }
 bytes = "1.0.0"
 tokio = { version = "1.25.0", features = ["full", "macros"] }
 tokio-util = { version = "0.7.7" }

--- a/shotover-proxy/benches/windsock/cassandra.rs
+++ b/shotover-proxy/benches/windsock/cassandra.rs
@@ -584,6 +584,9 @@ impl Bench for CassandraBench {
                 ScyllaSessionBuilder::new()
                     .known_nodes([address])
                     .user("cassandra", "cassandra")
+                    // We do not need to refresh metadata as there is nothing else fiddling with the topology or schema.
+                    // By default the metadata refreshes every 60s and that can cause performance issues so we disable it by using an absurdly high refresh interval
+                    .cluster_metadata_refresh_interval(Duration::from_secs(10000000000))
                     .compression(match self.compression {
                         Compression::None => None,
                         Compression::Lz4 => Some(ScyllaCompression::Lz4),

--- a/test-helpers/src/connection/cassandra.rs
+++ b/test-helpers/src/connection/cassandra.rs
@@ -306,6 +306,9 @@ impl CassandraConnection {
                             .collect::<Vec<String>>(),
                     )
                     .user("cassandra", "cassandra")
+                    // We do not need to refresh metadata as there is nothing else fiddling with the topology or schema.
+                    // By default the metadata refreshes every 60s and that can cause performance issues so we disable it by using an absurdly high refresh interval
+                    .cluster_metadata_refresh_interval(Duration::from_secs(10000000000))
                     .compression(compression.map(|x| match x {
                         Compression::Snappy => scylla::transport::Compression::Snappy,
                         Compression::Lz4 => scylla::transport::Compression::Lz4,

--- a/windsock/Cargo.toml
+++ b/windsock/Cargo.toml
@@ -20,4 +20,4 @@ time = { version = "0.3.25", features = ["serde"] }
 tokio.workspace = true
 
 [dev-dependencies]
-scylla = { version = "0.9.0", features = ["ssl"] }
+scylla = { version = "0.9.0", features = ["ssl"], git = "https://github.com/scylladb/scylla-rust-driver/" }

--- a/windsock/examples/cassandra.rs
+++ b/windsock/examples/cassandra.rs
@@ -87,6 +87,9 @@ impl Bench for CassandraBench {
         let session = Arc::new(
             SessionBuilder::new()
                 .known_nodes(["172.16.1.2:9042"])
+                // We do not need to refresh metadata as there is nothing else fiddling with the topology or schema.
+                // By default the metadata refreshes every 60s and that can cause performance issues so we disable it by using an absurdly high refresh interval
+                .cluster_metadata_refresh_interval(Duration::from_secs(10000000000))
                 .user("cassandra", "cassandra")
                 .compression(self.compression)
                 .build()


### PR DESCRIPTION
progress towards: https://github.com/shotover/shotover-proxy/issues/1274

We cant disable topology refresh but setting an absurdly long refresh interval is close enough.

This resolves the dip in OPS that can be observed in cassandra benches between 42-45s into the bench:
![image](https://github.com/shotover/shotover-proxy/assets/5120858/3197c658-4099-4615-8305-ec6a7c1d9f4f)
