### PR TITLE
windsock: add sys monitor profiler - archive support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5803,6 +5803,7 @@ dependencies = [
  "scylla",
  "serde",
  "strum 0.25.0",
+ "time 0.3.25",
  "tokio",
 ]
 

--- a/windsock/Cargo.toml
+++ b/windsock/Cargo.toml
@@ -16,6 +16,7 @@ copy_dir = "0.1.2"
 docker-compose-runner = "0.1.0"
 serde = { workspace = true, features = ["derive"] }
 strum = { version = "0.25.0", features = ["derive"] }
+time = { version = "0.3.25", features = ["serde"] }
 tokio.workspace = true
 
 [dev-dependencies]

--- a/windsock/src/lib.rs
+++ b/windsock/src/lib.rs
@@ -7,7 +7,8 @@ mod report;
 mod tables;
 
 pub use bench::{Bench, BenchParameters, BenchTask, Profiling};
-pub use report::{Report, ReportArchive};
+pub use report::{Metric, Report, ReportArchive};
+pub use tables::Goal;
 
 use anyhow::{anyhow, Result};
 use bench::BenchState;


### PR DESCRIPTION
## Goals

Something I've been missing for a while now in windsock is the ability to record system usage metrics.
I can ssh into the instances and run htop but:
* That is a lot of manual setup for each benchmark run, making it infeasible when performing many bench runs which teardown and recreate ec2 instances for each run.
* I need to be able to view a log of system usage, its hard to analyze anything while it flys by on htop
* I need to be able to correlate system usage to particular benchmarks
* I need to be able to correlate system usage to per second benchmark results.

Being able to do those things will allow us to:
* Use changes in system usage metrics as another data point when evaluating shotover changes
* Evaluate how well our benchmarks are designed.
    + Allow us to track down the cause of noisy benchmarks
    + Make sure shotover is the bottleneck so that changes to shotover show up in the results.

## Implementation

Implementation wise, I've decided to achieve this by running the unix `sar` command on each instance and then processing its output.
We could swap out `sar` for something else in the future but it seems reasonable enough and sar also supports disk and network usage so we will be able to make use of that in the future.

The process for sys monitoring looks like this:
1. We begin running sar before the bench runs.
2. The bench completes and writes the bench archive to disk.
3. we read all the remaining sar output, parse it and terminate sar
4. Load the bench archive from disk
5. Use the parsed sar metrics to insert metrics into the bench archive
6. Write the bench archive back to disk.
7. Then when the bench archive is displayed the user generated metrics are included in the results tables.

## Example

I ran:
```shell
cargo windsock --cloud --profilers sys_monitor "name=cassandra topology=single driver=scylla"
cargo windsock --results-by-tags "name=cassandra topology=single driver=scylla"
```

And the output is screenshotted below.

![image](https://github.com/shotover/shotover-proxy/assets/5120858/b4e2a821-1939-4de6-ac83-f1e61f5e6c11)
![image](https://github.com/shotover/shotover-proxy/assets/5120858/cc1ff37f-7b2a-4abb-b40b-a653c5a182af)

If an instance was not used for a certain bench then it just shows up as empty in the table, as can be seen by shotover in the above screenshot.

Future work:
* record disk and network usage metrics
* Add another table type to windsock for displaying all the results of a single bench in a table.
    * Currently when displaying a single bench the results are effectively a list as we only have one column. We should instead display a single bench with each "per second" results as their own column.