### PR TITLE
with_context refactor

### DIFF
--- a/shotover-proxy/examples/windsock/common.rs
+++ b/shotover-proxy/examples/windsock/common.rs
@@ -1,4 +1,4 @@
-use anyhow::anyhow;
+use anyhow::Context;
 use std::path::Path;
 
 #[derive(Clone, Copy)]
@@ -24,7 +24,7 @@ impl Shotover {
 pub async fn rewritten_file(path: &Path, find_replace: &[(&str, &str)]) -> String {
     let mut text = tokio::fs::read_to_string(path)
         .await
-        .map_err(|e| anyhow!(e).context(format!("Failed to read from {path:?}")))
+        .with_context(|| format!("Failed to read from {path:?}"))
         .unwrap();
     for (find, replace) in find_replace {
         text = text.replace(find, replace);

--- a/shotover-proxy/examples/windsock/redis.rs
+++ b/shotover-proxy/examples/windsock/redis.rs
@@ -283,7 +283,7 @@ impl Bench for RedisBench {
 
 fn load_certs(path: &str) -> Vec<Certificate> {
     load_certs_inner(path)
-        .map_err(|err| anyhow!(err).context(format!("Failed to read certs at {path:?}")))
+        .with_context(|| format!("Failed to read certs at {path:?}"))
         .unwrap()
 }
 fn load_certs_inner(path: &str) -> Result<Vec<Certificate>> {
@@ -294,7 +294,7 @@ fn load_certs_inner(path: &str) -> Result<Vec<Certificate>> {
 
 fn load_private_key(path: &str) -> PrivateKey {
     load_private_key_inner(path)
-        .map_err(|err| anyhow!(err).context(format!("Failed to read private key at {path:?}")))
+        .with_context(|| format!("Failed to read private key at {path:?}"))
         .unwrap()
 }
 fn load_private_key_inner(path: &str) -> Result<PrivateKey> {
@@ -310,7 +310,7 @@ fn load_private_key_inner(path: &str) -> Result<PrivateKey> {
 
 fn load_ca(path: &str) -> RootCertStore {
     load_ca_inner(path)
-        .map_err(|e| e.context(format!("Failed to load CA at {path:?}")))
+        .with_context(|| format!("Failed to load CA at {path:?}"))
         .unwrap()
 }
 fn load_ca_inner(path: &str) -> Result<RootCertStore> {

--- a/shotover/src/config/mod.rs
+++ b/shotover/src/config/mod.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use serde::Deserialize;
 
 pub mod chain;
@@ -12,9 +12,9 @@ pub struct Config {
 
 impl Config {
     pub fn from_file(filepath: String) -> Result<Config> {
-        let file = std::fs::File::open(&filepath).map_err(|err| {
-            anyhow!(err).context(format!("Couldn't open the config file {}", &filepath))
-        })?;
-        serde_yaml::from_reader(file).context(format!("Failed to parse config file {}", &filepath))
+        let file = std::fs::File::open(&filepath)
+            .with_context(|| format!("Couldn't open the config file {}", &filepath))?;
+        serde_yaml::from_reader(file)
+            .with_context(|| format!("Failed to parse config file {}", &filepath))
     }
 }

--- a/shotover/src/config/topology.rs
+++ b/shotover/src/config/topology.rs
@@ -17,13 +17,12 @@ pub struct Topology {
 
 impl Topology {
     pub fn from_file(filepath: &str) -> Result<Topology> {
-        let file = std::fs::File::open(filepath).map_err(|err| {
-            anyhow!(err).context(format!("Couldn't open the topology file {}", filepath))
-        })?;
+        let file = std::fs::File::open(filepath)
+            .with_context(|| format!("Couldn't open the topology file {}", filepath))?;
 
         let deserializer = serde_yaml::Deserializer::from_reader(file);
         serde_yaml::with::singleton_map_recursive::deserialize(deserializer)
-            .context(format!("Failed to parse topology file {}", filepath))
+            .with_context(|| format!("Failed to parse topology file {}", filepath))
     }
 
     async fn build_chains(&self) -> Result<HashMap<String, Option<TransformChainBuilder>>> {
@@ -79,8 +78,8 @@ impl Topology {
                         &mut source_config
                             .get_source(chain, trigger_shutdown_rx.clone())
                             .await
-                            .map_err(|e| {
-                                e.context(format!("Failed to initialize source {source_name}"))
+                            .with_context(|| {
+                                format!("Failed to initialize source {source_name}")
                             })?,
                     );
                 } else {

--- a/shotover/src/frame/kafka.rs
+++ b/shotover/src/frame/kafka.rs
@@ -263,19 +263,23 @@ impl KafkaFrame {
 }
 
 fn decode<T: Decodable>(bytes: &mut Bytes, version: i16) -> Result<T> {
-    T::decode(bytes, version).context(format!(
-        "Failed to decode {} v{} body",
-        std::any::type_name::<T>(),
-        version
-    ))
+    T::decode(bytes, version).with_context(|| {
+        format!(
+            "Failed to decode {} v{} body",
+            std::any::type_name::<T>(),
+            version
+        )
+    })
 }
 
 fn encode<T: Encodable>(encodable: T, bytes: &mut BytesMut, version: i16) -> Result<()> {
-    encodable.encode(bytes, version).context(format!(
-        "Failed to encode {} v{} body",
-        std::any::type_name::<T>(),
-        version
-    ))
+    encodable.encode(bytes, version).with_context(|| {
+        format!(
+            "Failed to encode {} v{} body",
+            std::any::type_name::<T>(),
+            version
+        )
+    })
 }
 
 /// This function is a helper to workaround a really degenerate rust compiler case.

--- a/shotover/src/observability/mod.rs
+++ b/shotover/src/observability/mod.rs
@@ -1,5 +1,5 @@
 use crate::runner::ReloadHandle;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use bytes::Bytes;
 use hyper::{
     service::{make_service_fn, service_fn},
@@ -104,7 +104,7 @@ impl LogFilterHttpExporter {
 
         let address = self.address;
         Server::try_bind(&address)
-            .map_err(|e| anyhow!(e).context(format!("Failed to bind to {}", address)))?
+            .with_context(|| format!("Failed to bind to {}", address))?
             .serve(make_svc)
             .await
             .map_err(|e| anyhow!(e))

--- a/shotover/src/tcp.rs
+++ b/shotover/src/tcp.rs
@@ -1,6 +1,6 @@
 //! Use to establish a TCP connection to a DB in a sink transform
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use std::time::Duration;
 use tokio::{
     net::{TcpStream, ToSocketAddrs},
@@ -18,7 +18,5 @@ pub async fn tcp_stream<A: ToSocketAddrs + std::fmt::Debug>(
                 "destination {destination:?} did not respond to connection attempt within {connect_timeout:?}"
             )
         })?
-        .map_err(|e| {
-            anyhow!(e).context(format!("Failed to connect to destination {destination:?}"))
-        })
+        .with_context(|| format!("Failed to connect to destination {destination:?}"))
 }

--- a/shotover/src/transforms/cassandra/sink_cluster/node_pool.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/node_pool.rs
@@ -124,10 +124,8 @@ impl NodePool {
         nodes.shuffle(rng);
         get_accessible_node(connection_factory, nodes)
             .await
-            .map_err(|err| {
-                err.context(format!(
-                    "Failed to open a connection to any nodes in the rack {rack:?}"
-                ))
+            .with_context(|| {
+                format!("Failed to open a connection to any nodes in the rack {rack:?}")
             })
     }
 

--- a/shotover/src/transforms/debug/log_to_file.rs
+++ b/shotover/src/transforms/debug/log_to_file.rs
@@ -1,6 +1,6 @@
 use crate::message::{Encodable, Message};
 use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
@@ -97,9 +97,9 @@ async fn log_message(message: &Message, path: &Path) -> Result<()> {
     info!("Logged message to {:?}", path);
     match message.clone().into_encodable() {
         Encodable::Bytes(bytes) => {
-            tokio::fs::write(path, bytes).await.map_err(|e| {
-                anyhow!(e).context(format!("failed to write message to disk at {path:?}"))
-            })?;
+            tokio::fs::write(path, bytes)
+                .await
+                .with_context(|| format!("failed to write message to disk at {path:?}"))?;
         }
         Encodable::Frame(_) => {
             error!("Failed to log message because it was a frame. Ensure this Transform is the first transform in the main chain to ensure it only receives unmodified messages.")

--- a/windsock/src/tables.rs
+++ b/windsock/src/tables.rs
@@ -3,7 +3,7 @@ use crate::{
     filter::Filter,
     report::{Percentile, ReportArchive},
 };
-use anyhow::Result;
+use anyhow::{Context, Result};
 use console::{pad_str, pad_str_with, style, Alignment};
 use std::{collections::HashSet, time::Duration};
 use strum::IntoEnumIterator;
@@ -52,7 +52,7 @@ pub fn results_by_name(names: &str) -> Result<()> {
 
 pub fn baseline_compare_by_tags(arg: &str) -> Result<()> {
     let filter = Filter::from_query(arg)
-        .map_err(|e| e.context(format!("Failed to parse tag filter from {:?}", arg)))?;
+        .with_context(|| format!("Failed to parse tag filter from {:?}", arg))?;
     let archives: Result<Vec<ReportColumn>> = ReportArchive::reports_in_last_run()
         .iter()
         .filter(|name| filter.matches(&Tags::from_name(name)))
@@ -72,7 +72,7 @@ pub fn compare_by_tags(arg: &str) -> Result<()> {
     let tag_args = tag_args.join(" ");
 
     let filter = Filter::from_query(&tag_args)
-        .map_err(|e| e.context(format!("Failed to parse tag filter from {:?}", tag_args)))?;
+        .with_context(|| format!("Failed to parse tag filter from {:?}", tag_args))?;
     let archives: Result<Vec<ReportColumn>> = ReportArchive::reports_in_last_run()
         .iter()
         .filter(|name| **name != base_name && filter.matches(&Tags::from_name(name)))
@@ -100,7 +100,7 @@ pub fn compare_by_tags(arg: &str) -> Result<()> {
 
 pub fn results_by_tags(arg: &str) -> Result<()> {
     let filter = Filter::from_query(arg)
-        .map_err(|e| e.context(format!("Failed to parse tag filter from {:?}", arg)))?;
+        .with_context(|| format!("Failed to parse tag filter from {:?}", arg))?;
     let archives: Result<Vec<ReportColumn>> = ReportArchive::reports_in_last_run()
         .iter()
         .filter(|name| filter.matches(&Tags::from_name(name)))


### PR DESCRIPTION
## 1
Refactor all instances of
```rust
result.map_err(|e| e.context(format!("message {object:?}")))
```
into
```rust
result.with_context(|| format!("message {object:?}")))
```
This is just simpler to read/write.

## 2
And also refactor all instances of
```rust
result.context(format!("message {object:?"))
```
into
```rust
result.with_context(|| format!("message {object:?"))
```
This actually fixes a performance issue.
Sometimes its just in initialization code and doesnt really matter.
But there are other times where its in really hot code.
e.g. Our kafka codec should should get a nice performance improvement from this.