### PR TITLE
Add shotover crate badges to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
   <img width="400px" alt="Shotover logo" src="docs/src/logo.png">
 </p>
 
-[![Rust](https://github.com/shotover/shotover-proxy/workflows/Rust/badge.svg)](https://github.com/shotover/shotover-proxy/actions?query=workflow%3ARust)
+[![Crates.io](https://img.shields.io/crates/v/shotover.svg)](https://crates.io/crates/shotover)
+[![Docs](https://docs.rs/shotover/badge.svg)](https://docs.rs/shotover)
 [![dependency status](https://deps.rs/repo/github/shotover/shotover-proxy/status.svg)](https://deps.rs/repo/github/shotover/shotover-proxy)
 
 ## Documentation


### PR DESCRIPTION
Now that shotover crate is published we can add badges to easily navigate to its documentation and crates.io page.

I removed the github actions badge because it points to a workflow that no longer exists and there is also not much need for a github actions badge as github already displays github actions directly in its UI.