### PR TITLE
windsock: nextest compatibility

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -64,7 +64,7 @@ jobs:
     - name: Build tests
       run: |
         cargo test --doc ${{ matrix.cargo_flags }} --all-features -- --show-output --nocapture
-        cargo nextest archive --archive-file nextest-${{ matrix.profile }}.tar.zst ${{ matrix.cargo_flags }} --all-features
+        cargo nextest archive --archive-file nextest-${{ matrix.profile }}.tar.zst ${{ matrix.cargo_flags }} --all-features --all-targets
     - name: Upload built tests to workflow
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/windsock_benches.yaml
+++ b/.github/workflows/windsock_benches.yaml
@@ -24,7 +24,7 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Ensure that custom benches run
       run: |
-        cargo windsock --bench-length-seconds 5 --operations-per-second 100
+        # run some extra cases that arent handled by nextest
         cargo windsock --bench-length-seconds 5 --operations-per-second 100 --profilers flamegraph --name cassandra,compression=none,driver=scylla,operation=read_i64,protocol=v4,shotover=standard,topology=single
         cargo windsock --bench-length-seconds 5 --operations-per-second 100 --profilers sys_monitor --name kafka,shotover=standard,size=1B,topology=single
 

--- a/windsock/src/list.rs
+++ b/windsock/src/list.rs
@@ -1,0 +1,18 @@
+use crate::{bench::BenchState, cli::Args};
+
+pub fn list(args: &Args, benches: &[BenchState]) {
+    if args.nextest_list_all() {
+        // list all windsock benches in nextest format
+        for bench in benches {
+            println!("{}: benchmark", bench.tags.get_name());
+        }
+    } else if args.nextest_list_ignored() {
+        // windsock does not support ignored tests
+    } else {
+        // regular usage
+        println!("Benches:");
+        for bench in benches {
+            println!("{}", bench.tags.get_name());
+        }
+    }
+}


### PR DESCRIPTION
Move windsock CI testing into nextest to take advantage of its test sharding for huge CI runtime wins.

libtest is the default test harness used by cargo.
Custom test and benchmark frameworks can reimplement the libtest CLI API in order to be called by `cargo test`.
Both tests and benchmarks follow this same libtest API.
This allows benchmarks to be run as tests, when run as a test a benchmark usually only performs one iteration to complete the test run as quickly as possible.

nextest follows this same libtest API in order to call the default libtest api and any other test framework compatible with libtest.
But in order to support being run by nextest you only need to implement a small subset of libtest's API.
Since we dont use `cargo test` anymore, we can instead just target nextests's subset of the API for a much simpler implementation.
This subset is [documented here](https://nexte.st/book/custom-test-harnesses.html#manually-implementing-a-test-harness).

This PR implements the libtest subset needed by nextest and then swaps our CI over to running windsock via nextest instead of through windsock.
There are still some extra windsock test cases left around as they are not compatible through the nextest test runner.

## Results
With this PR CI takes the same amount of time as before.
Previously the windsock workflow took 45mins and the integration test workflow took 35mins.
Now thats swapped and the windsock workflow takes 35mins while the integration test workflow take 45mins.

However this sets up for a large win once we make use of more parallelization in the integration test workflow by https://github.com/shotover/shotover-proxy/pull/1299