### PR TITLE
Improve GA config

### DIFF
--- a/.github/workflows/bench_run.yaml
+++ b/.github/workflows/bench_run.yaml
@@ -24,7 +24,7 @@ jobs:
         # PRs do not share caches, instead each PR initially pulls from the cache of the main branch for the first run.
         # This workflow does not run on main, so to make use of a cache before this workflow has completed once on a PR,
         # we need to manually recreate the key used by ubuntu-20.04 release builds.
-        shared-key: "ubuntu-20.04 - --release-build_and_test"
+        shared-key: "ubuntu-20.04 - --release-build_check_and_upload"
         save-if: false
     - name: cache custom ubuntu packages
       uses: actions/cache@v3

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -43,6 +43,13 @@ jobs:
         # Otherwise only the last build to finish would get saved to the cache.
         # We allow different test_flags to share a cache as they should have identical build outputs
         key: ${{ matrix.runner }} - ${{ matrix.cargo_flags }}
+        # this line means that only the main branch writes to the cache
+        # benefits:
+        # * prevents main branch caches from being evicted in favor of a PR cache
+        # * saves about 1min per workflow by skipping the actual cache write
+        # downsides:
+        # * PRs that update rust version or changes deps will be slow to iterate on due to changes not being cached.
+        save-if: ${{ github.ref == 'refs/head/main' }}
     - name: cache custom ubuntu packages
       uses: actions/cache@v3
       with:
@@ -83,9 +90,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        partition: [1, 2, 3, 4]
+        partition: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
         profile: ["release", "debug"]
-    name: Test ${{ matrix.profile}} ${{ matrix.partition }}/4
+    name: Test ${{ matrix.profile}} ${{ matrix.partition }}/15
     runs-on: ubuntu-20.04
     needs: build_check_and_upload
     steps:
@@ -107,7 +114,7 @@ jobs:
     - name: Run tests
       run: |
         ~/.cargo/bin/cargo-nextest nextest run --archive-file nextest-${{ matrix.profile }}.tar.zst \
-          --partition count:${{ matrix.partition }}/4 --extract-to . --run-ignored all
+          --partition count:${{ matrix.partition }}/15 --extract-to . --run-ignored all
     - name: Cleanup archive
       run: rm nextest-${{ matrix.profile }}.tar.zst
     - name: Ensure that tests did not create or modify any files that arent .gitignore'd

--- a/.github/workflows/windsock_benches.yaml
+++ b/.github/workflows/windsock_benches.yaml
@@ -22,6 +22,14 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: Swatinem/rust-cache@v2
+      with:
+        # this line means that only the main branch writes to the cache
+        # benefits:
+        # * prevents main branch caches from being evicted in favor of a PR cache
+        # * saves about 1min per workflow by skipping the actual cache write
+        # downsides:
+        # * PRs that update rust version or changes deps will be slow to iterate on due to changes not being cached.
+        save-if: ${{ github.ref == 'refs/head/main' }}
     - name: Ensure that custom benches run
       run: |
         cargo windsock --bench-length-seconds 5 --operations-per-second 100


### PR DESCRIPTION
This PR:
* Improves cache utilization by:
    + fixing a bug in bench_run.yaml's cache key
    + changing windsock_benches.yaml and build_and_test.yaml to only allow main branch to write to cache
        + prevents main branch caches from being evicted in favor of a PR cache
        + saves about 1min per workflow by skipping the actual cache write (our caches are about 1GB atm, so it takes a while to zip all of that)
* bumps build_and_test concurrency from 8 jobs to 30 jobs.
     + I believe we are on the pro plan which gives us 40 concurrent jobs, so this leaves 10 jobs for all our other miscellaneous workflows. 
     + brings runtime of this workflow down from 35min to 30min
     + The overall CI runtime is still bottlenecked by windsock benches which takes 45mins but once https://github.com/shotover/shotover-proxy/pull/1295 lands that bottleneck should disappear as it run it is run through these 30 jobs.