### PR TITLE
Update to rust 1.72 🦀🦀🦀

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["windsock", "shotover", "shotover-proxy", "test-helpers", "custom-transforms-example", "ec2-cargo"]
+resolver = "2"
 
 # https://deterministic.space/high-performance-rust.html
 [profile.release]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.71"
+channel = "1.72"
 components = [ "rustfmt", "clippy" ]
 targets = [ "aarch64-unknown-linux-gnu" ]

--- a/shotover-proxy/benches/windsock/profilers/sar.rs
+++ b/shotover-proxy/benches/windsock/profilers/sar.rs
@@ -114,7 +114,12 @@ pub fn parse_sar(rx: &mut UnboundedReceiver<String>) -> ParsedSar {
     let mut named_values = HashMap::new();
 
     // read date command
-    let Ok(started_at) = rx.try_recv() else { return ParsedSar { started_at: OffsetDateTime::UNIX_EPOCH, named_values: HashMap::new()}};
+    let Ok(started_at) = rx.try_recv() else {
+        return ParsedSar {
+            started_at: OffsetDateTime::UNIX_EPOCH,
+            named_values: HashMap::new(),
+        };
+    };
     let started_at =
         OffsetDateTime::from_unix_timestamp_nanos(started_at.parse().unwrap()).unwrap();
 
@@ -128,9 +133,24 @@ pub fn parse_sar(rx: &mut UnboundedReceiver<String>) -> ParsedSar {
 
     // keep reading until we exhaust the receiver
     loop {
-        let Ok(_blank_line) = rx.try_recv() else { return ParsedSar { started_at, named_values } };
-        let Ok(header) = rx.try_recv() else { return ParsedSar { started_at, named_values } };
-        let Ok(data) = rx.try_recv() else { return ParsedSar { started_at, named_values } };
+        let Ok(_blank_line) = rx.try_recv() else {
+            return ParsedSar {
+                started_at,
+                named_values,
+            };
+        };
+        let Ok(header) = rx.try_recv() else {
+            return ParsedSar {
+                started_at,
+                named_values,
+            };
+        };
+        let Ok(data) = rx.try_recv() else {
+            return ParsedSar {
+                started_at,
+                named_values,
+            };
+        };
         for (head, data) in header
             .split_whitespace()
             .zip(data.split_whitespace())

--- a/shotover/src/transforms/redis/cache.rs
+++ b/shotover/src/transforms/redis/cache.rs
@@ -189,7 +189,7 @@ impl SimpleRedisCache {
     ) -> Vec<(Message, usize)> {
         redis_responses
             .iter_mut()
-            .zip(redis_indices.into_iter())
+            .zip(redis_indices)
             .filter_map(|(redis_response, redis_index)| {
                 match redis_response.frame() {
                     Some(Frame::Redis(redis_frame)) => {


### PR DESCRIPTION
* into_iter removal was from new clippy lint
* `resolver = "2"` was needed to resolve a new cargo warning
* `sar.rs` formatting changes were needed because the new cargo fmt has now started formatting `let else` statements.