### PR TITLE
CI: give visibility into disk usage

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -77,6 +77,15 @@ jobs:
       with:
         name: nextest-${{ matrix.profile }}
         path: nextest-${{ matrix.profile }}.tar.zst
+    - name: Report disk usage
+      run: |
+        df -h
+
+        echo -e "\ntarget dir usage:"
+        du -h $PWD/target
+
+        echo -e "\n.cargo dir usage:"
+        du -h ~/.cargo
     - name: Cleanup archive
       run: rm nextest-${{ matrix.profile }}.tar.zst
     - name: Ensure that tests did not create or modify any files that arent .gitignore'd


### PR DESCRIPTION
This adds 2-5s to our CI runtime but in return we get visibility into disk usage when we need it.
Checking this in rather than just manually adding it when debugging failures is useful because we can go back over previous PRs to see how disk usage changed over time (for as long as github holds onto the CI logs)