### PR TITLE
Tweak CI disk usage

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -57,10 +57,10 @@ jobs:
         key: ubuntu-20.04-packages
     - name: Install ubuntu packages
       run: shotover-proxy/build/install_ubuntu_packages.sh
-    - name: Install nextest
-      uses: taiki-e/install-action@nextest
-    - name: Install cargo-hack
-      run: cargo install cargo-hack --version 0.5.8
+    - name: Install cargo-hack and nextest
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-hack@0.6.4,nextest@0.9.57
     - name: Check `cargo fmt` was run
       run: cargo fmt --all -- --check
     - name: Ensure that all crates compile and have no warnings under every possible combination of features
@@ -105,7 +105,9 @@ jobs:
     - name: Install ubuntu packages
       run: shotover-proxy/build/install_ubuntu_packages.sh
     - name: Install nextest
-      uses: taiki-e/install-action@nextest
+      uses: taiki-e/install-action@v2
+      with:
+        tool: nextest@0.9.57
     - run: mkdir -p ~/.cargo/bin
     - name: Download archive
       uses: actions/download-artifact@v3


### PR DESCRIPTION
`cargo install` uses a temp directory as its target folder and then deletes it when its finished, so there is no pollution due to intermediary build output.
However `cargo install` will download the source code to all the crates needed for the compilation into `.cargo/registry`, these are not deleted as they remain as a cache but many of those deps are unused by shotover so end up just wasting space.
So I've swapped `cargo-hack` to be installed via `install-action` which directly downloads a binary instead of compiling from source like `cargo install` does.
This should help reduce our disk usage and cache usage.

Not to mention this is also faster when CI is running uncached.

I've also taken the opportunity to add exact versions for these dependencies so that updates cannot break our CI.

## possible future work
Once the aws sdk team addresses [the compile time issues](https://github.com/awslabs/aws-sdk-rust/issues/113) I believe binary size will go down with it which should also help a lot.
If we end up needing to claim more space, I'll give this a go https://github.com/marketplace/actions/free-disk-space-ubuntu Would give us more than enough space at the cost of longer CI runtime.
I would like to avoid relying on paid runners as that would make it more difficult for users to use our CI as a reference for the development of custom transforms. But it is always an option if we need it.