### PR TITLE
ShotoverProcessBuilder: fix with_profile

### DIFF
--- a/.github/workflows/windsock_benches.yaml
+++ b/.github/workflows/windsock_benches.yaml
@@ -30,6 +30,13 @@ jobs:
         # downsides:
         # * PRs that update rust version or changes deps will be slow to iterate on due to changes not being cached.
         save-if: ${{ github.ref == 'refs/heads/main' }}
+    - name: cache custom ubuntu packages
+      uses: actions/cache@v3
+      with:
+        path: shotover-proxy/build/packages
+        key: ubuntu-20.04-packages
+    - name: Install ubuntu packages
+      run: shotover-proxy/build/install_ubuntu_packages.sh
     - name: Ensure that custom benches run
       run: |
         # This isnt needed locally because we run profilers via sudo.

--- a/.github/workflows/windsock_benches.yaml
+++ b/.github/workflows/windsock_benches.yaml
@@ -30,13 +30,6 @@ jobs:
         # downsides:
         # * PRs that update rust version or changes deps will be slow to iterate on due to changes not being cached.
         save-if: ${{ github.ref == 'refs/heads/main' }}
-    - name: cache custom ubuntu packages
-      uses: actions/cache@v3
-      with:
-        path: shotover-proxy/build/packages
-        key: ubuntu-20.04-packages
-    - name: Install ubuntu packages
-      run: shotover-proxy/build/install_ubuntu_packages.sh
     - name: Ensure that custom benches run
       run: |
         # This isnt needed locally because we run profilers via sudo.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1388,7 +1388,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset 0.9.0",
+ "memoffset",
  "scopeguard",
 ]
 
@@ -2701,15 +2701,6 @@ checksum = "f478948fd84d9f8e86967bf432640e46adfb5a4bd4f14ef7e864ab38220534ae"
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
@@ -2840,8 +2831,17 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset 0.7.1",
- "pin-utils",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.0",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -4104,7 +4104,7 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix",
+ "nix 0.26.4",
  "radix_trie",
  "scopeguard",
  "unicode-segmentation",
@@ -4504,7 +4504,7 @@ dependencies = [
  "hex-literal",
  "inferno",
  "itertools 0.10.5",
- "nix",
+ "nix 0.27.1",
  "opensearch",
  "rand 0.8.5",
  "rand_distr",
@@ -4930,14 +4930,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-bin-process"
-version = "0.3.0"
-source = "git+https://github.com/rukai/tokio-bin-process?branch=build_only_required_binary#0969ff3c1b1b29272e2aea386433d31fc03a1417"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65936e9fae86053f55710b806fa3b97d0d46f3182547e2961c166a3e924e1abf"
 dependencies = [
  "anyhow",
  "cargo_metadata",
  "chrono",
  "itertools 0.11.0",
- "nix",
+ "nix 0.27.1",
  "nu-ansi-term 0.49.0",
  "once_cell",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4931,8 +4931,7 @@ dependencies = [
 [[package]]
 name = "tokio-bin-process"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc341857366c329c8cdd4bf75a726560132ed68e8a193d9a69aab75b98a0e27"
+source = "git+https://github.com/rukai/tokio-bin-process?branch=build_only_required_binary#0969ff3c1b1b29272e2aea386433d31fc03a1417"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,4 +62,5 @@ clap = { version = "4.0.4", features = ["cargo", "derive"] }
 async-trait = "0.1.30"
 typetag = "0.2.5"
 aws-throwaway = "0.2.0"
-tokio-bin-process = "0.3.0"
+#tokio-bin-process = "0.3.0"
+tokio-bin-process = { git = "https://github.com/rukai/tokio-bin-process", branch = "build_only_required_binary" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ cassandra-protocol = "3.0"
 tracing = "0.1.15"
 tracing-subscriber = { version = "0.3.1", features = ["env-filter", "json"] }
 tracing-appender = "0.2.0"
-nix = "0.26.0"
+nix = { version = "0.27.0", features = ["signal"]}
 serde_json = "1.0"
 rcgen = "0.10.0"
 subprocess = "0.2.7"
@@ -62,5 +62,4 @@ clap = { version = "4.0.4", features = ["cargo", "derive"] }
 async-trait = "0.1.30"
 typetag = "0.2.5"
 aws-throwaway = "0.2.0"
-#tokio-bin-process = "0.3.0"
-tokio-bin-process = { git = "https://github.com/rukai/tokio-bin-process", branch = "build_only_required_binary" }
+tokio-bin-process = "0.4.0"


### PR DESCRIPTION
blocked on: https://github.com/shotover/tokio-bin-process/pull/22

`with_profile` should overwrite `with_bin`.
`with_bin` is a hint to `ShotoverProcessBuilder` that there is a precompiled binary available.
`with_profile` is demanding that we use a specific profile which has priority over `with_bin`.

This bug was causing windsock to profile shotover binaries not suitable for profiling.