### PR TITLE
windsock aws: samply support

### DIFF
--- a/.github/workflows/windsock_benches.yaml
+++ b/.github/workflows/windsock_benches.yaml
@@ -32,6 +32,10 @@ jobs:
         save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: Ensure that custom benches run
       run: |
+        # This isnt needed locally because we run profilers via sudo.
+        # But for some reason on CI even with sudo we didnt have access to perf events.
+        echo '1' | sudo tee /proc/sys/kernel/perf_event_paranoid
+
         # run some extra cases that arent handled by nextest
         cargo windsock --bench-length-seconds 5 --operations-per-second 100 --profilers flamegraph --name cassandra,compression=none,driver=scylla,operation=read_i64,protocol=v4,shotover=standard,topology=single
         cargo windsock --bench-length-seconds 5 --operations-per-second 100 --profilers samply --name cassandra,compression=none,driver=scylla,operation=read_i64,protocol=v4,shotover=standard,topology=single

--- a/.github/workflows/windsock_benches.yaml
+++ b/.github/workflows/windsock_benches.yaml
@@ -34,6 +34,7 @@ jobs:
       run: |
         # run some extra cases that arent handled by nextest
         cargo windsock --bench-length-seconds 5 --operations-per-second 100 --profilers flamegraph --name cassandra,compression=none,driver=scylla,operation=read_i64,protocol=v4,shotover=standard,topology=single
+        cargo windsock --bench-length-seconds 5 --operations-per-second 100 --profilers samply --name cassandra,compression=none,driver=scylla,operation=read_i64,protocol=v4,shotover=standard,topology=single
         cargo windsock --bench-length-seconds 5 --operations-per-second 100 --profilers sys_monitor --name kafka,shotover=standard,size=1B,topology=single
 
         # windsock/examples/cassandra.rs - this can stay here until windsock is moved to its own repo

--- a/shotover-proxy/benches/windsock/cassandra.rs
+++ b/shotover-proxy/benches/windsock/cassandra.rs
@@ -559,7 +559,7 @@ impl Bench for CassandraBench {
             Shotover::None => None,
             Shotover::ForcedMessageParsed => todo!(),
         };
-        profiler.run(&shotover);
+        profiler.run(&shotover).await;
 
         self.execute_run(address, &parameters).await;
 

--- a/shotover-proxy/benches/windsock/cassandra.rs
+++ b/shotover-proxy/benches/windsock/cassandra.rs
@@ -496,6 +496,8 @@ impl Bench for CassandraBench {
             )
         );
 
+        profiler.run(shotover_instance.clone()).await;
+
         let destination_ip = if running_shotover.is_some() {
             shotover_ip
         } else {
@@ -507,7 +509,7 @@ impl Bench for CassandraBench {
             .run_bencher(&self.run_args(&destination, &parameters), &self.name())
             .await;
 
-        profiler.finish();
+        profiler.finish().await;
 
         if let Some(running_shotover) = running_shotover {
             running_shotover.shutdown().await;

--- a/shotover-proxy/benches/windsock/kafka.rs
+++ b/shotover-proxy/benches/windsock/kafka.rs
@@ -93,8 +93,10 @@ impl Bench for KafkaBench {
 
         let (_, running_shotover) = futures::join!(
             run_aws_kafka(kafka_instance),
-            run_aws_shotover(shotover_instance, self.shotover, kafka_ip.clone())
+            run_aws_shotover(shotover_instance.clone(), self.shotover, kafka_ip.clone())
         );
+
+        profiler.run(shotover_instance.clone()).await;
 
         let destination_ip = if running_shotover.is_some() {
             shotover_ip
@@ -106,7 +108,7 @@ impl Bench for KafkaBench {
             .run_bencher(&self.run_args(&destination_ip, &parameters), &self.name())
             .await;
 
-        profiler.finish();
+        profiler.finish().await;
 
         if let Some(running_shotover) = running_shotover {
             running_shotover.shutdown().await;

--- a/shotover-proxy/benches/windsock/kafka.rs
+++ b/shotover-proxy/benches/windsock/kafka.rs
@@ -139,7 +139,7 @@ impl Bench for KafkaBench {
             Shotover::None => "127.0.0.1:9092",
         };
 
-        profiler.run(&shotover);
+        profiler.run(&shotover).await;
 
         self.execute_run(broker_address, &parameters).await;
 

--- a/shotover-proxy/benches/windsock/profilers.rs
+++ b/shotover-proxy/benches/windsock/profilers.rs
@@ -1,3 +1,4 @@
+use self::samply::Samply;
 use crate::common::Shotover;
 use aws_throwaway::Ec2Instance;
 use std::{collections::HashMap, path::PathBuf};
@@ -5,14 +6,17 @@ use test_helpers::{flamegraph::Perf, shotover_process::BinProcess};
 use tokio::sync::mpsc::UnboundedReceiver;
 use windsock::Profiling;
 
+mod samply;
 mod sar;
 
 pub struct ProfilerRunner {
     bench_name: String,
     run_flamegraph: bool,
+    run_samply: bool,
     run_sys_monitor: bool,
     results_path: PathBuf,
     perf: Option<Perf>,
+    samply: Option<Samply>,
     sys_monitor: Option<UnboundedReceiver<String>>,
 }
 
@@ -21,6 +25,7 @@ impl ProfilerRunner {
         let run_flamegraph = profiling
             .profilers_to_use
             .contains(&"flamegraph".to_owned());
+        let run_samply = profiling.profilers_to_use.contains(&"samply".to_owned());
         let run_sys_monitor = profiling
             .profilers_to_use
             .contains(&"sys_monitor".to_owned());
@@ -29,13 +34,15 @@ impl ProfilerRunner {
             bench_name,
             run_flamegraph,
             run_sys_monitor,
+            run_samply,
             results_path: profiling.results_path,
             perf: None,
+            samply: None,
             sys_monitor: None,
         }
     }
 
-    pub fn run(&mut self, shotover: &Option<BinProcess>) {
+    pub async fn run(&mut self, shotover: &Option<BinProcess>) {
         self.perf = if self.run_flamegraph {
             if let Some(shotover) = &shotover {
                 Some(Perf::new(
@@ -48,6 +55,15 @@ impl ProfilerRunner {
         } else {
             None
         };
+        self.samply = if self.run_samply {
+            if let Some(shotover) = &shotover {
+                Some(Samply::run(self.results_path.clone(), shotover.child().id().unwrap()).await)
+            } else {
+                panic!("samply not supported when benching without shotover")
+            }
+        } else {
+            None
+        };
         self.sys_monitor = if self.run_sys_monitor {
             Some(sar::run_sar_local())
         } else {
@@ -56,7 +72,7 @@ impl ProfilerRunner {
     }
 
     pub fn shotover_profile(&self) -> Option<&'static str> {
-        if self.run_flamegraph {
+        if self.run_flamegraph || self.run_samply {
             Some("profiling")
         } else {
             None
@@ -68,6 +84,9 @@ impl Drop for ProfilerRunner {
     fn drop(&mut self) {
         if let Some(perf) = self.perf.take() {
             perf.flamegraph();
+        }
+        if let Some(samply) = self.samply.take() {
+            samply.wait();
         }
         if let Some(mut rx) = self.sys_monitor.take() {
             sar::insert_sar_results_to_bench_archive(&self.bench_name, "", sar::parse_sar(&mut rx));
@@ -118,6 +137,10 @@ pub fn supported_profilers(shotover: Shotover) -> Vec<String> {
     if let Shotover::None = shotover {
         vec!["sys_monitor".to_owned()]
     } else {
-        vec!["flamegraph".to_owned(), "sys_monitor".to_owned()]
+        vec![
+            "flamegraph".to_owned(),
+            "samply".to_owned(),
+            "sys_monitor".to_owned(),
+        ]
     }
 }

--- a/shotover-proxy/benches/windsock/profilers/samply.rs
+++ b/shotover-proxy/benches/windsock/profilers/samply.rs
@@ -18,6 +18,8 @@ impl Samply {
         )
         .await;
         let output_file = results_path.join("samply.json");
+        let home = std::env::var("HOME").unwrap();
+
         // Run `sudo ls` so that we can get sudo to stop asking for password for a while.
         // It also lets us block until the user has entered the password, otherwise the rest of the test would continue before `perf` has started.
         // TODO: It would be more robust to get a single root prompt and then keep feeding commands into it.
@@ -28,7 +30,8 @@ impl Samply {
             run_command(
                 "sudo",
                 &[
-                    "samply",
+                    // specify the full path as CI has trouble finding it for some reason.
+                    &format!("{home}/.cargo/bin/samply"),
                     "record",
                     "-p",
                     &pid.to_string(),
@@ -58,7 +61,7 @@ async fn run_command(command: &str, args: &[&str]) -> String {
     let stdout = String::from_utf8(output.stdout).unwrap();
     let stderr = String::from_utf8(output.stderr).unwrap();
     if !output.status.success() {
-        panic!("Bench run failed:\nstdout:\n{stdout}\nstderr:\n{stderr}")
+        panic!("command {command} {args:?} failed:\nstdout:\n{stdout}\nstderr:\n{stderr}")
     }
     stdout
 }

--- a/shotover-proxy/benches/windsock/profilers/samply.rs
+++ b/shotover-proxy/benches/windsock/profilers/samply.rs
@@ -1,0 +1,64 @@
+use std::path::PathBuf;
+use tokio::task::JoinHandle;
+
+pub struct Samply(JoinHandle<()>);
+
+impl Samply {
+    pub async fn run(results_path: PathBuf, pid: u32) -> Samply {
+        run_command(
+            "cargo",
+            &[
+                "install",
+                "samply",
+                "--git",
+                "https://github.com/rukai/samply",
+                "--rev",
+                "af14e56ac9e809a445e4f0bd80fcd4fefc45b552",
+            ],
+        )
+        .await;
+        let output_file = results_path.join("samply.json");
+        // Run `sudo ls` so that we can get sudo to stop asking for password for a while.
+        // It also lets us block until the user has entered the password, otherwise the rest of the test would continue before `perf` has started.
+        // TODO: It would be more robust to get a single root prompt and then keep feeding commands into it.
+        //       But that would require a bunch of work so its out of scope for now.
+        run_command("sudo", &["ls"]).await;
+
+        Samply(tokio::spawn(async move {
+            run_command(
+                "sudo",
+                &[
+                    "samply",
+                    "record",
+                    "-p",
+                    &pid.to_string(),
+                    "--save-only",
+                    "--profile-name",
+                    results_path.file_name().unwrap().to_str().unwrap(),
+                    "--output",
+                    output_file.as_os_str().to_str().unwrap(),
+                ],
+            )
+            .await;
+        }))
+    }
+
+    pub fn wait(self) {
+        futures::executor::block_on(self.0).unwrap();
+    }
+}
+
+async fn run_command(command: &str, args: &[&str]) -> String {
+    let output = tokio::process::Command::new(command)
+        .args(args)
+        .output()
+        .await
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    if !output.status.success() {
+        panic!("Bench run failed:\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    }
+    stdout
+}

--- a/shotover-proxy/benches/windsock/profilers/samply.rs
+++ b/shotover-proxy/benches/windsock/profilers/samply.rs
@@ -1,22 +1,16 @@
-use std::path::PathBuf;
-use tokio::task::JoinHandle;
+use crate::aws::Ec2InstanceWithShotover;
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
+use tokio::{sync::mpsc::UnboundedReceiver, task::JoinHandle};
 
 pub struct Samply(JoinHandle<()>);
 
 impl Samply {
     pub async fn run(results_path: PathBuf, pid: u32) -> Samply {
-        run_command(
-            "cargo",
-            &[
-                "install",
-                "samply",
-                "--git",
-                "https://github.com/rukai/samply",
-                "--rev",
-                "af14e56ac9e809a445e4f0bd80fcd4fefc45b552",
-            ],
-        )
-        .await;
+        install_samply().await;
         let output_file = results_path.join("samply.json");
         let home = std::env::var("HOME").unwrap();
 
@@ -49,6 +43,85 @@ impl Samply {
     pub fn wait(self) {
         futures::executor::block_on(self.0).unwrap();
     }
+}
+
+pub struct SamplyCloud {
+    instance: Arc<Ec2InstanceWithShotover>,
+    receiver: UnboundedReceiver<String>,
+    results_path: PathBuf,
+}
+
+impl SamplyCloud {
+    /// Copy the samply binary to the passed instance and run it over ssh.
+    /// Each line of output is returned via the `UnboundedReceiver`
+    pub async fn run(
+        bench_name: &str,
+        instance: Arc<Ec2InstanceWithShotover>,
+        results_path: PathBuf,
+    ) -> Self {
+        let home = PathBuf::from(std::env::var("HOME").unwrap());
+        install_samply().await;
+        println!("{}", instance.instance.ssh_instructions());
+        instance
+            .instance
+            .ssh()
+            .push_file(
+                &home.join(".cargo").join("bin").join("samply"),
+                Path::new("samply"),
+            )
+            .await;
+
+        let receiver = instance.instance
+                .ssh()
+                .shell_stdout_lines(
+                    &format!("
+echo '1' | sudo tee /proc/sys/kernel/perf_event_paranoid > /dev/null;
+sudo ./samply record -p `pgrep shotover-bin` --save-only --profile-name {bench_name} --output samply.json && sudo cat samply.json;
+echo \"\" # workaround aws-throwaway bug that ignores lines without a newline")
+                )
+                .await;
+
+        SamplyCloud {
+            instance,
+            receiver,
+            results_path,
+        }
+    }
+
+    pub async fn download_results(mut self) {
+        // TODO: we should be able to expand aws-throwaway to allow sending a sigint directly to the running samply
+        self.instance
+            .instance
+            .ssh()
+            .shell("sudo killall -2 samply")
+            .await;
+        let mut output = String::new();
+        while let Some(line) = tokio::time::timeout(Duration::from_secs(30), self.receiver.recv())
+            .await
+            .unwrap()
+        {
+            output.push_str(&line);
+            output.push('\n');
+        }
+        tokio::fs::write(self.results_path.join("samply.json"), output.as_bytes())
+            .await
+            .unwrap();
+    }
+}
+
+async fn install_samply() {
+    run_command(
+        "cargo",
+        &[
+            "install",
+            "samply",
+            "--git",
+            "https://github.com/rukai/samply",
+            "--rev",
+            "af14e56ac9e809a445e4f0bd80fcd4fefc45b552",
+        ],
+    )
+    .await;
 }
 
 async fn run_command(command: &str, args: &[&str]) -> String {

--- a/shotover-proxy/benches/windsock/redis.rs
+++ b/shotover-proxy/benches/windsock/redis.rs
@@ -212,7 +212,7 @@ impl Bench for RedisBench {
             ),
             Shotover::None => None,
         };
-        profiler.run(&shotover);
+        profiler.run(&shotover).await;
 
         self.execute_run(address, &parameters).await;
 

--- a/shotover-proxy/benches/windsock/redis.rs
+++ b/shotover-proxy/benches/windsock/redis.rs
@@ -155,6 +155,8 @@ impl Bench for RedisBench {
         )
         .await;
 
+        profiler.run(shotover_instance.clone()).await;
+
         let destination_ip = if running_shotover.is_some() {
             format!("redis://{shotover_ip}")
         } else {
@@ -168,7 +170,7 @@ impl Bench for RedisBench {
             .run_bencher(&self.run_args(&destination_ip, &parameters), &self.name())
             .await;
 
-        profiler.finish();
+        profiler.finish().await;
 
         if let Some(running_shotover) = running_shotover {
             running_shotover.shutdown().await;

--- a/shotover/src/runner.rs
+++ b/shotover/src/runner.rs
@@ -182,7 +182,7 @@ impl Shotover {
         let mut runtime_builder = runtime::Builder::new_multi_thread();
         runtime_builder
             .enable_all()
-            .thread_name("Shotover-Proxy-Thread")
+            .thread_name("shotover-worker")
             .thread_stack_size(stack_size);
         if let Some(worker_threads) = worker_threads {
             runtime_builder.worker_threads(worker_threads);


### PR DESCRIPTION
blocked on https://github.com/shotover/shotover-proxy/pull/1315

This PR runs samply on an AWS instance and retrieves the results back to the local machine.
However for some reason the results contain only a single sample which is clearly broken, I will need to investigate whats going wrong.