### PR TITLE
fix tokio thread_name

### DIFF
--- a/shotover/src/runner.rs
+++ b/shotover/src/runner.rs
@@ -182,7 +182,7 @@ impl Shotover {
         let mut runtime_builder = runtime::Builder::new_multi_thread();
         runtime_builder
             .enable_all()
-            .thread_name("Shotover-Proxy-Thread")
+            .thread_name("shotover-worker")
             .thread_stack_size(stack_size);
         if let Some(worker_threads) = worker_threads {
             runtime_builder.worker_threads(worker_threads);


### PR DESCRIPTION
pulled out of and continuing discussion from https://github.com/shotover/shotover-proxy/pull/1315#discussion_r1311109557

After enabling "show custom thread names" in htop (its [disabled by default](https://askubuntu.com/questions/987957/how-to-see-thread-name-in-htop)) we get output like this:
![image](https://github.com/shotover/shotover-proxy/assets/5120858/8cdf116a-9eb2-431c-97b8-e0fc1eba4e5e)
It looks truncated because linux does not support thread names that long.

This PR fixes the issue by using a shorter thread name.
It now looks like this:
![image](https://github.com/shotover/shotover-proxy/assets/5120858/59957141-b42f-4d4e-9dd1-126e1b4d8cac)

While there could theoretically be some obscure case out there, at our current scale I dont believe this will cause any issues due to the change of name.
Scripts that invoke things like `killall shotover-proxy` will be unaffected because the main thread is still called `shotover-proxy`.