### PR TITLE
run_command refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5727,7 +5727,7 @@ dependencies = [
 name = "windsock-cloud-docker"
 version = "0.1.0"
 dependencies = [
- "test-helpers",
+ "subprocess",
 ]
 
 [[package]]

--- a/windsock-cloud-docker/Cargo.toml
+++ b/windsock-cloud-docker/Cargo.toml
@@ -7,4 +7,4 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-test-helpers = {path = "../test-helpers"}
+subprocess.workspace = true


### PR DESCRIPTION
The core problem driving this PR is I observed that build files for windsock-cloud-docker was taking up 200MB in debug.
This is absurd for a small tool like this so I investigated how to fix it.
The problem was that test_helpers is huge and pulling in all sorts of stuff when all we wanted was a helper to run commands.
Once I moved `run_command` into its own minimal crate and windsock-cloud-docker was reduced to 8MB in debug.

So this PR:
* pulls run_command into its own crate.
    + This helper crate doesnt see as much use as it could because we often want to run commands asynchronously and I wanted to avoid including the tokio dependency here.
    + Alternatively we could just copy run_command into windsock-cloud-docker to avoid creating an entire new crate, I couldnt really decide either way so just went with this.
* While I was thinking about these abstractions I noticed an instance in `ec2-cargo/src/main.rs` where we didnt need to shell out so I removed it.