### PR TITLE
Remove slog dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,7 +945,6 @@ dependencies = [
  "libc",
  "log",
  "parking_lot",
- "slog",
  "uuid",
 ]
 
@@ -4563,12 +4562,6 @@ checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "slog"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
 
 [[package]]
 name = "smallvec"

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -17,7 +17,7 @@ tokio.workspace = true
 tracing.workspace = true
 clap.workspace = true
 rstest = "0.18.0"
-cassandra-cpp = { version = "2.0.0" }
+cassandra-cpp = { version = "2.0.0", default-features = false }
 test-helpers = { path = "../test-helpers" }
 #rdkafka = { version = "0.32", features = ["cmake-build"] }
 rdkafka = { branch = "updating_librdkafka_to_v2.1.1", git = "https://github.com/shotover/rust-rdkafka", features = ["cmake-build"] }

--- a/test-helpers/Cargo.toml
+++ b/test-helpers/Cargo.toml
@@ -15,7 +15,7 @@ subprocess.workspace = true
 tokio-bin-process.workspace = true
 cdrs-tokio.workspace = true
 cassandra-protocol.workspace = true
-cassandra-cpp = { version = "2.0.0", optional = true }
+cassandra-cpp = { version = "2.0.0", default-features = false, features = ["log"], optional = true }
 scylla.workspace = true
 openssl.workspace = true
 bytes.workspace = true


### PR DESCRIPTION
By setting cassandra-cpp to `default-features = false` and then manually adding back features we need, we can remove slog from our dep tree.