### PR TITLE
Fix mdbook link to custom transforms

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -7,6 +7,7 @@
   - [Concepts](./user-guide/concepts.md)
   - [Configuration](./user-guide/configuration.md)
   - [Observability](./user-guide/observability.md)
+  - [Custom Transforms](./user-guide/writing-custom-transforms.md)
 - [Sources](./sources.md)
 - [Transforms](./transforms.md)
 - [Examples]()


### PR DESCRIPTION
The writing-custom-transforms.md page exists but we were previously not linking to it anywhere.

You can test locally by running `docs/mdbook.sh`