### PR TITLE
remove Response.original field

### DIFF
--- a/shotover/src/transforms/kafka/common.rs
+++ b/shotover/src/transforms/kafka/common.rs
@@ -13,7 +13,6 @@ pub fn produce_channel(
     let (tx, rx) = oneshot::channel();
     let return_chan = if produce.acks == 0 {
         tx.send(Response {
-            original: Message::from_frame(Frame::Dummy),
             response: Ok(Message::from_frame(Frame::Dummy)),
         })
         .unwrap();

--- a/shotover/src/transforms/util/mod.rs
+++ b/shotover/src/transforms/util/mod.rs
@@ -8,15 +8,17 @@ pub mod cluster_connection_pool;
 /// Represents a `Request` to a connection within Shotover
 #[derive(Debug)]
 pub struct Request {
-    pub message: Message, // Message to send upstream to connection
-    pub return_chan: Option<tokio::sync::oneshot::Sender<Response>>, // Channel to return the response to
+    // Message to send upstream to connection
+    pub message: Message,
+    // Channel to return the response to
+    pub return_chan: Option<tokio::sync::oneshot::Sender<Response>>,
 }
 
 /// Represents a `Response` to a `Request`
 #[derive(Debug)]
 pub struct Response {
-    pub original: Message,         // Original `Message` that this `Response` is to
-    pub response: Result<Message>, // Response to the original `Message`
+    // Response to the original `Message`
+    pub response: Result<Message>,
 }
 
 #[derive(thiserror::Error, Debug)]


### PR DESCRIPTION
cluster_connection_pool.rs provides some helpers for sending/receiving messages to a destination that gets reused across multiple protocols: redis, kafka and opensearch.

Only RedisSinkCluster makes use of the `original` field in `Response` struct so by just implementing this logic within RedisSinkCluster itself we will improve performance of other sinks by avoiding cloning messages which can be expensive.

Maybe RedisSinkCluster could be refactored to avoid needing the original messages entirely, but that is out of scope of this PR, this PR introduces 1 extra allocation but should otherwise be just as fast.