### PR TITLE
windsock: apply shell escaping where needed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4314,6 +4314,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-quote"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab31b1e46a3f14300977ece8c355009deddc6c531de49d55951e795bbad42957"
+
+[[package]]
 name = "shellfish"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4434,6 +4440,7 @@ dependencies = [
  "scylla",
  "serde",
  "serde_json",
+ "shell-quote",
  "shotover",
  "test-helpers",
  "time",
@@ -5619,6 +5626,7 @@ dependencies = [
 name = "windsock-cloud-docker"
 version = "0.1.0"
 dependencies = [
+ "shell-quote",
  "subprocess",
 ]
 

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+shell-quote = "0.3.0"
 shotover = { path = "../shotover" }
 
 [dev-dependencies]

--- a/shotover-proxy/benches/windsock/aws/mod.rs
+++ b/shotover-proxy/benches/windsock/aws/mod.rs
@@ -186,8 +186,9 @@ sudo docker system prune -af"#,
         // start container
         let mut env_args = String::new();
         for (key, value) in envs {
-            // TODO: shell escape key and value
-            env_args.push_str(&format!(" -e \"{key}={value}\""))
+            let key_value =
+                String::from_utf8(shell_quote::bash::escape(format!("{key}={value}"))).unwrap();
+            env_args.push_str(&format!(" -e {key_value}"))
         }
         let output = self
             .instance

--- a/windsock-cloud-docker/Cargo.toml
+++ b/windsock-cloud-docker/Cargo.toml
@@ -7,4 +7,5 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+shell-quote = "0.3.0"
 subprocess.workspace = true

--- a/windsock-cloud-docker/src/main.rs
+++ b/windsock-cloud-docker/src/main.rs
@@ -6,7 +6,9 @@ use subprocess::{Exec, Redirection};
 fn main() {
     let mut args = std::env::args();
     args.next(); // skip binary name
-    let args: Vec<String> = args.collect();
+    let args: Vec<String> = args
+        .map(|x| String::from_utf8(shell_quote::bash::escape(x)).unwrap())
+        .collect();
     let args = args.join(" ");
 
     // ensure container is setup


### PR DESCRIPTION
Fixes a TODO and a previously unknown case where shell escaping was missing.
This fix allows the running of `cargo run --package windsock-cloud-docker --cloud "name=redis encryption=none"` which previously failed due to `"name=redis encryption=none"` losing its quotes.