### PR TITLE
windsock: required-features = alpha-transforms

### DIFF
--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -64,3 +64,6 @@ rdkafka-driver-tests = ["test-helpers/rdkafka-driver-tests"]
 [[bench]]
 name = "windsock"
 harness = false
+# windsock is dependent on the DebugForceEncode transform for the shotover=message-parsed benches.
+# rather than manually adding #[cfg(feature = "alpha-transforms")] everywhere we just forbid compilation entirely without the alpha-transforms feature
+required-features = ["alpha-transforms"]


### PR DESCRIPTION
Previously it was possible to run windsock such that the built shotover was missing some of the transforms windsock expects to exist.
This PR fixes that.

As a bonus this PR enables writing custom sources (but not custom protocols)