### PR TITLE
add zlib to allowed licenses

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -76,7 +76,8 @@ allow = [
     "BSD-3-Clause",
     "BSD-2-Clause",
     "Unicode-DFS-2016",
-    "BSL-1.0"
+    "BSL-1.0",
+    "Zlib"
 ]
 # List of explictly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
@@ -106,7 +107,7 @@ confidence-threshold = 0.8
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
 exceptions = [
-    { allow = ["LGPL-3.0"], name = "pktparse", version = "*" }, # Allowed because its only used as a dev-dependency
+    # { allow = ["LGPL-3.0"], name = "pktparse", version = "*" },
 ]
 
 # ring is described as being ISC compatible by its license file: https://github.com/briansmith/ring/blob/main/LICENSE


### PR DESCRIPTION
The CI on #1298 is failing due to https://github.com/shotover/shotover-proxy/actions/runs/6180379036/job/16776751233?pr=1298#step:4:11

A dependency uses the zlib license which we have not allowed in our `deny.toml`.

Zlib is described as a permissive free software license and has been approved by the Free Software Foundation as a free software license and by the Open Source Initiative as an open source license. It is compatible with the GNU General Public License. [refs](https://en.wikipedia.org/wiki/Zlib_License)

I also removed `pktparse` from our exceptions as we no longer use it as a dependency.  