### PR TITLE
add rstest_reuse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3874,6 +3874,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest_reuse"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88530b681abe67924d42cca181d070e3ac20e0740569441a9e35a7cedd2b34a4"
+dependencies = [
+ "quote",
+ "rand 0.8.5",
+ "rustc_version",
+ "syn 2.0.36",
+]
+
+[[package]]
 name = "russh"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4460,6 +4472,7 @@ dependencies = [
  "redis-protocol",
  "regex",
  "rstest",
+ "rstest_reuse",
  "rustls-pemfile",
  "scylla",
  "serde",

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -18,6 +18,7 @@ tokio.workspace = true
 tracing.workspace = true
 clap.workspace = true
 rstest = "0.18.0"
+rstest_reuse = "0.6.0"
 cassandra-cpp = { version = "2.0.0", default-features = false }
 test-helpers = { path = "../test-helpers" }
 redis.workspace = true

--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -7,6 +7,7 @@ use cdrs_tokio::frame::events::{
 use futures::future::join_all;
 use futures::Future;
 use rstest::rstest;
+use rstest_reuse::{self, *};
 #[cfg(feature = "cassandra-cpp-driver-tests")]
 use test_helpers::connection::cassandra::CassandraDriver::Datastax;
 use test_helpers::connection::cassandra::Compression;
@@ -58,10 +59,14 @@ where
     timestamp::test(&connection).await;
 }
 
+#[template]
 #[rstest]
 #[case::cdrs(CdrsTokio)]
 #[cfg_attr(feature = "cassandra-cpp-driver-tests", case::datastax(Datastax))]
 #[case::scylla(Scylla)]
+fn all_cassandra_drivers(#[case] driver: CassandraDriver) {}
+
+#[apply(all_cassandra_drivers)]
 #[tokio::test(flavor = "multi_thread")]
 async fn passthrough_standard(#[case] driver: CassandraDriver) {
     let _compose = docker_compose("tests/test-configs/cassandra/passthrough/docker-compose.yaml");
@@ -78,10 +83,7 @@ async fn passthrough_standard(#[case] driver: CassandraDriver) {
 }
 
 #[cfg(feature = "alpha-transforms")]
-#[rstest]
-#[case::cdrs(CdrsTokio)]
-#[cfg_attr(feature = "cassandra-cpp-driver-tests", case::datastax(Datastax))]
-#[case::scylla(Scylla)]
+#[apply(all_cassandra_drivers)]
 #[tokio::test(flavor = "multi_thread")]
 async fn passthrough_encode(#[case] driver: CassandraDriver) {
     let _compose = docker_compose("tests/test-configs/cassandra/passthrough/docker-compose.yaml");
@@ -172,10 +174,7 @@ async fn cluster_single_rack_v3(#[case] driver: CassandraDriver) {
     cluster::single_rack_v3::test_topology_task(None).await;
 }
 
-#[rstest]
-#[case::cdrs(CdrsTokio)]
-#[cfg_attr(feature = "cassandra-cpp-driver-tests", case::datastax(Datastax))]
-#[case::scylla(Scylla)]
+#[apply(all_cassandra_drivers)]
 #[tokio::test(flavor = "multi_thread")]
 async fn cluster_single_rack_v4(#[case] driver: CassandraDriver) {
     let mut compose = docker_compose("tests/test-configs/cassandra/cluster-v4/docker-compose.yaml");
@@ -329,10 +328,7 @@ async fn source_tls_and_cluster_tls(#[case] driver: CassandraDriver) {
     cluster::single_rack_v4::test_topology_task(Some(ca_cert), None).await;
 }
 
-#[rstest]
-#[case::cdrs(CdrsTokio)]
-#[cfg_attr(feature = "cassandra-cpp-driver-tests", case::datastax(Datastax))]
-#[case::scylla(Scylla)]
+#[apply(all_cassandra_drivers)]
 #[tokio::test(flavor = "multi_thread")]
 async fn cassandra_redis_cache(#[case] driver: CassandraDriver) {
     let _compose = docker_compose("tests/test-configs/cassandra/redis-cache/docker-compose.yaml");

--- a/shotover-proxy/tests/lib.rs
+++ b/shotover-proxy/tests/lib.rs
@@ -1,3 +1,7 @@
+#[cfg(test)]
+#[allow(clippy::single_component_path_imports)]
+use rstest_reuse;
+
 use test_helpers::shotover_process::ShotoverProcessBuilder;
 use tokio_bin_process::bin_path;
 

--- a/shotover-proxy/tests/lib.rs
+++ b/shotover-proxy/tests/lib.rs
@@ -1,4 +1,3 @@
-#[cfg(test)]
 #[allow(clippy::single_component_path_imports)]
 use rstest_reuse;
 


### PR DESCRIPTION
Small helper library that removes duplications from our rstest setup for the Cassandra integration tests. 