### PR TITLE
Tee switch chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3107,18 +3107,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.1.5+3.1.3"
+version = "111.28.0+1.1.1w"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "559068e4c12950d7dcaa1857a61725c0d38d4fc03ff8e070ab31a75d6e316491"
+checksum = "3ce95ee1f6f999dfb95b8afd43ebe442758ea2104d1ccb99a94c30db22ae701f"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.93"
+version = "0.9.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
+checksum = "db7e971c2c2bba161b2d2fdf37080177eff520b3bc044787c7f1f5f9e78d869b"
 dependencies = [
  "cc",
  "libc",
@@ -4466,6 +4466,7 @@ dependencies = [
  "futures",
  "hex",
  "hex-literal",
+ "hyper",
  "inferno",
  "itertools 0.11.0",
  "nix 0.27.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ cassandra-protocol = "3.0"
 tracing = "0.1.15"
 tracing-subscriber = { version = "0.3.1", features = ["env-filter", "json"] }
 tracing-appender = "0.2.0"
-nix = { version = "0.27.0", features = ["signal"]}
+nix = { version = "0.27.0", features = ["signal"] }
 serde_json = "1.0"
 rcgen = "0.11.0"
 subprocess = "0.2.7"
@@ -64,6 +64,7 @@ typetag = "0.2.5"
 aws-throwaway = "0.2.0"
 tokio-bin-process = "0.4.0"
 ordered-float = { version = "4.0.0", features = ["serde"] }
+hyper = { version = "0.14.14", features = ["server"] }
 
 [patch.crates-io]
 bigdecimal = { git = "https://github.com/rukai/bigdecimal-rs", branch = "0.4.2"}

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -53,6 +53,7 @@ opensearch = "2.1.0"
 serde_json = "1.0.103"
 time = { version = "0.3.25" }
 inferno = { version = "0.11.15", default-features = false, features = ["multithreaded", "nameattr"] }
+hyper.workspace = true
 shell-quote = "0.3.0"
 
 [features]

--- a/shotover-proxy/tests/test-configs/redis/cluster-dr/topology.yaml
+++ b/shotover-proxy/tests/test-configs/redis/cluster-dr/topology.yaml
@@ -10,17 +10,18 @@ sources:
             behavior: Ignore
             buffer_size: 10000
             chain:
-            - QueryTypeFilter:
-                DenyList: [Read]
-            - Coalesce:
-                flush_when_buffered_message_count: 2000
-                # Use an unreasonably large timeout here so that integration tests dont break on slow hardware or a performance regression
-                flush_when_millis_since_last_flush: 1000000000
-            - QueryCounter:
-                name: "DR chain"
-            - RedisSinkCluster:
-                first_contact_points: [ "127.0.0.1:2120", "127.0.0.1:2121", "127.0.0.1:2122", "127.0.0.1:2123", "127.0.0.1:2124", "127.0.0.1:2125" ]
-                connect_timeout_ms: 3000
+              Single:
+                - QueryTypeFilter:
+                    DenyList: [Read]
+                - Coalesce:
+                    flush_when_buffered_message_count: 2000
+                    # Use an unreasonably large timeout here so that integration tests dont break on slow hardware or a performance regression
+                    flush_when_millis_since_last_flush: 1000000000
+                - QueryCounter:
+                    name: "DR chain"
+                - RedisSinkCluster:
+                    first_contact_points: [ "127.0.0.1:2120", "127.0.0.1:2121", "127.0.0.1:2122", "127.0.0.1:2123", "127.0.0.1:2124", "127.0.0.1:2125" ]
+                    connect_timeout_ms: 3000
         - QueryCounter:
             name: "Main chain"
         - RedisSinkCluster:

--- a/shotover-proxy/tests/test-configs/tee/fail.yaml
+++ b/shotover-proxy/tests/test-configs/tee/fail.yaml
@@ -9,9 +9,10 @@ sources:
             behavior: FailOnMismatch
             buffer_size: 10000
             chain:
-            - QueryTypeFilter:
-                DenyList: [Read]
-            - DebugReturner:
-                Redis: "42"
+              Single:
+                - QueryTypeFilter:
+                    DenyList: [Read]
+                - DebugReturner:
+                    Redis: "42"
         - DebugReturner:
             Redis: "42"

--- a/shotover-proxy/tests/test-configs/tee/fail_with_mismatch.yaml
+++ b/shotover-proxy/tests/test-configs/tee/fail_with_mismatch.yaml
@@ -9,9 +9,10 @@ sources:
             behavior: FailOnMismatch
             buffer_size: 10000
             chain:
-            - QueryTypeFilter:
-                DenyList: [Read]
-            - DebugReturner:
-                Redis: "41"
+              Single:
+                - QueryTypeFilter:
+                    DenyList: [Read]
+                - DebugReturner:
+                    Redis: "41"
         - DebugReturner:
             Redis: "42"

--- a/shotover-proxy/tests/test-configs/tee/ignore.yaml
+++ b/shotover-proxy/tests/test-configs/tee/ignore.yaml
@@ -9,9 +9,10 @@ sources:
             behavior: Ignore
             buffer_size: 10000
             chain:
-            - QueryTypeFilter:
-                DenyList: [Read]
-            - DebugReturner:
-                Redis: "42"
+              Single:
+                - QueryTypeFilter:
+                    DenyList: [Read]
+                - DebugReturner:
+                    Redis: "42"
         - DebugReturner:
             Redis: "42"

--- a/shotover-proxy/tests/test-configs/tee/ignore_with_mismatch.yaml
+++ b/shotover-proxy/tests/test-configs/tee/ignore_with_mismatch.yaml
@@ -9,9 +9,10 @@ sources:
             behavior: Ignore
             buffer_size: 10000
             chain:
-            - QueryTypeFilter:
-                DenyList: [Read]
-            - DebugReturner:
-                Redis: "41"
+              Single:
+                - QueryTypeFilter:
+                    DenyList: [Read]
+                - DebugReturner:
+                    Redis: "41"
         - DebugReturner:
             Redis: "42"

--- a/shotover-proxy/tests/test-configs/tee/log.yaml
+++ b/shotover-proxy/tests/test-configs/tee/log.yaml
@@ -9,9 +9,10 @@ sources:
             behavior: LogWarningOnMismatch
             buffer_size: 10000 
             chain:
-            - QueryTypeFilter:
-                DenyList: [Read]
-            - DebugReturner:
-                Redis: "42"
+              Single:
+                - QueryTypeFilter:
+                    DenyList: [Read]
+                - DebugReturner:
+                   Redis: "42"
         - DebugReturner:
             Redis: "42"

--- a/shotover-proxy/tests/test-configs/tee/log_with_mismatch.yaml
+++ b/shotover-proxy/tests/test-configs/tee/log_with_mismatch.yaml
@@ -9,9 +9,10 @@ sources:
             behavior: LogWarningOnMismatch
             buffer_size: 10000
             chain:
-            - QueryTypeFilter:
-                DenyList: [Read]
-            - DebugReturner:
-                Redis: "41"
+              Single:
+                - QueryTypeFilter:
+                    DenyList: [Read]
+                - DebugReturner:
+                    Redis: "41"
         - DebugReturner: 
             Redis: "42"

--- a/shotover-proxy/tests/test-configs/tee/subchain.yaml
+++ b/shotover-proxy/tests/test-configs/tee/subchain.yaml
@@ -15,7 +15,8 @@ sources:
                     connect_timeout_ms: 3000
             buffer_size: 10000
             chain:
-              - DebugReturner:
-                  Redis: "42"
+              Single:
+                - DebugReturner:
+                    Redis: "42"
         - DebugReturner:
             Redis: "42"

--- a/shotover-proxy/tests/test-configs/tee/subchain_with_mismatch.yaml
+++ b/shotover-proxy/tests/test-configs/tee/subchain_with_mismatch.yaml
@@ -15,9 +15,10 @@ sources:
                     remote_address: "127.0.0.1:1111"
                     connect_timeout_ms: 3000
             chain:
-              - QueryTypeFilter:
-                  DenyList: [Read]
-              - DebugReturner:
-                  Redis: "41"
+              Single:
+                - QueryTypeFilter:
+                    DenyList: [Read]
+                - DebugReturner:
+                    Redis: "41"
         - DebugReturner:
             Redis: "42"

--- a/shotover-proxy/tests/test-configs/tee/switch_chain.yaml
+++ b/shotover-proxy/tests/test-configs/tee/switch_chain.yaml
@@ -1,7 +1,7 @@
 ---
 sources:
   - Redis:
-      name: "redis"
+      name: "redis-1"
       listen_addr: "127.0.0.1:6379"
       connection_limit: 3000000
       chain:
@@ -14,6 +14,21 @@ sources:
                   - DebugReturner:
                       Redis: "a"
                 chain_b:
+                  - DebugReturner:
+                      Redis: "b"
+        - DebugReturner:
+            Redis: "a"
+  - Redis:
+      name: "redis-2"
+      listen_addr: "127.0.0.1:6378"
+      connection_limit: 
+      chain:
+        - Tee:
+            behavior: LogWarningOnMismatch
+            buffer_size: 10000
+            switch_port: 1234
+            chain:
+              Single:
                   - DebugReturner:
                       Redis: "b"
         - DebugReturner:

--- a/shotover-proxy/tests/test-configs/tee/switch_chain.yaml
+++ b/shotover-proxy/tests/test-configs/tee/switch_chain.yaml
@@ -1,0 +1,20 @@
+---
+sources:
+  - Redis:
+      name: "redis"
+      listen_addr: "127.0.0.1:6379"
+      connection_limit: 3000000
+      chain:
+        - Tee:
+            behavior: LogWarningOnMismatch
+            buffer_size: 10000
+            chain:
+              Multi:
+                chain_a: 
+                  - DebugReturner:
+                      Redis: "a"
+                chain_b:
+                  - DebugReturner:
+                      Redis: "b"
+        - DebugReturner:
+            Redis: "a"

--- a/shotover/src/observability/mod.rs
+++ b/shotover/src/observability/mod.rs
@@ -86,7 +86,7 @@ impl LogFilterHttpExporter {
                                                 format!("{:?}", error),
                                             )
                                         }
-                                        Ok(()) => rsp(StatusCode::NO_CONTENT, Body::empty()),
+                                        Ok(()) => rsp(StatusCode::OK, Body::empty()),
                                     },
                                     Err(error) => {
                                         error!(%error, "setting filter failed - Couldn't read bytes");

--- a/shotover/src/runner.rs
+++ b/shotover/src/runner.rs
@@ -1,30 +1,26 @@
 //! Tools for initializing shotover in the final binary.
-use crate::config::topology::Topology;
-use crate::config::Config;
+use crate::config::{topology::Topology, Config};
 use crate::observability::LogFilterHttpExporter;
-use crate::transforms::Transforms;
-use crate::transforms::Wrapper;
-use anyhow::Context;
-use anyhow::{anyhow, Result};
+use crate::transforms::{Transforms, Wrapper};
+use anyhow::{anyhow, Context, Result};
 use clap::{crate_version, Parser};
 use metrics_exporter_prometheus::PrometheusBuilder;
-use std::env;
-use std::net::SocketAddr;
+use std::{env, net::SocketAddr};
 use tokio::runtime::{self, Runtime};
 use tokio::signal::unix::{signal, SignalKind};
 use tokio::sync::watch;
 use tracing::{debug, error, info};
 use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
-use tracing_subscriber::filter::Directive;
-use tracing_subscriber::fmt::format::DefaultFields;
-use tracing_subscriber::fmt::format::Format;
-use tracing_subscriber::fmt::format::Full;
-use tracing_subscriber::fmt::format::Json;
-use tracing_subscriber::fmt::format::JsonFields;
-use tracing_subscriber::fmt::Layer;
-use tracing_subscriber::layer::Layered;
-use tracing_subscriber::reload::Handle;
-use tracing_subscriber::{EnvFilter, Registry};
+use tracing_subscriber::{
+    filter::Directive,
+    fmt::{
+        format::{DefaultFields, Format, Full, Json, JsonFields},
+        Layer,
+    },
+    layer::Layered,
+    reload::Handle,
+    EnvFilter, Registry,
+};
 
 #[derive(Parser, Clone)]
 #[clap(version = crate_version!(), author = "Instaclustr")]

--- a/shotover/src/transforms/cassandra/sink_cluster/rewrite.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/rewrite.rs
@@ -19,6 +19,7 @@ use futures::future::try_join_all;
 use itertools::Itertools;
 use std::fmt::Write;
 use std::net::{IpAddr, Ipv4Addr};
+use tracing::error;
 use uuid::Uuid;
 use version_compare::Cmp;
 
@@ -301,7 +302,7 @@ impl MessageRewriter {
                             ..
                         })) => Some(prepared),
                         other => {
-                            tracing::error!("Response to Prepare query was not a Prepared, was instead: {other:?}");
+                            error!("Response to Prepare query was not a Prepared, was instead: {other:?}");
                             warnings.push(format!("Shotover: Response to Prepare query was not a Prepared, was instead: {other:?}"));
                             None
                         }
@@ -316,7 +317,7 @@ impl MessageRewriter {
                                     output
                                 });
 
-                        tracing::error!(
+                        error!(
                             "Nodes did not return the same response to PREPARE statement {err_str}"
                         );
                         warnings.push(format!(


### PR DESCRIPTION
This change allows you to switch the subchain used by Tee with a HTTP API.

In a follow up PR I want to add the ability to swap between returning responses from the main chain and the tee subchain