### PR TITLE
windsock-cloud-runner: misc fixes

### DIFF
--- a/windsock-cloud-docker/src/main.rs
+++ b/windsock-cloud-docker/src/main.rs
@@ -7,7 +7,13 @@ fn main() {
     let mut args = std::env::args();
     args.next(); // skip binary name
     let args: Vec<String> = args
-        .map(|x| String::from_utf8(shell_quote::bash::escape(x)).unwrap())
+        .map(|x| {
+            if x.is_empty() {
+                String::from("''")
+            } else {
+                String::from_utf8(shell_quote::bash::escape(x)).unwrap()
+            }
+        })
         .collect();
     let args = args.join(" ");
 
@@ -65,7 +71,7 @@ AWS_ACCESS_KEY_ID={access_key_id} AWS_SECRET_ACCESS_KEY={secret_access_key} CARG
 
     // extract windsock results
     let local_windsock_data = root.join("target").join("windsock_data");
-    std::fs::remove_dir_all(&local_windsock_data).unwrap();
+    std::fs::remove_dir_all(&local_windsock_data).ok();
     docker(&[
         "cp",
         "windsock-cloud:/target/windsock_data",


### PR DESCRIPTION
* The escape function will add quotes if needed. e.g. `foo bar` becomes `'foo bar'`. However `""` becomes ` ` which fails to parse when running something like `--results-by-tags ""` as that just becomes `--results-by-tags` and --results-by-tags needs to have a single argument.
* The windsock_data directory wont exist if its the first time running, so we have to ignore failures.