### PR TITLE
redis tls tests use bitnami image

### DIFF
--- a/shotover-proxy/tests/test-configs/redis/tls-no-client-auth/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/redis/tls-no-client-auth/docker-compose.yaml
@@ -1,10 +1,15 @@
 version: "3.3"
 services:
   redis-one:
-    image: library/redis:6.2.5
+    image: bitnami/redis:6.2.13-debian-11-r73
     ports:
       - "1111:6379"
     volumes:
-      - ./redis.conf:/usr/local/etc/redis/redis.conf
-      - ../tls/certs:/usr/local/etc/redis/certs
-    command: [ "redis-server", "/usr/local/etc/redis/redis.conf" ]
+      - ../tls/certs:/certs
+    environment:
+      ALLOW_EMPTY_PASSWORD: "yes"
+      REDIS_TLS_ENABLED: "yes"
+      REDIS_TLS_CERT_FILE: "/certs/localhost.crt"
+      REDIS_TLS_KEY_FILE: "/certs/localhost.key"
+      REDIS_TLS_CA_FILE: "/certs/localhost_CA.crt"
+      REDIS_TLS_AUTH_CLIENTS: "no"

--- a/shotover-proxy/tests/test-configs/redis/tls-no-client-auth/redis.conf
+++ b/shotover-proxy/tests/test-configs/redis/tls-no-client-auth/redis.conf
@@ -1,7 +1,0 @@
-tls-cert-file /usr/local/etc/redis/certs/localhost.crt
-tls-key-file /usr/local/etc/redis/certs/localhost.key
-tls-ca-cert-file /usr/local/etc/redis/certs/localhost_CA.crt
-
-port 0
-tls-port 6379
-tls-auth-clients no

--- a/shotover-proxy/tests/test-configs/redis/tls-no-verify-hostname/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/redis/tls-no-verify-hostname/docker-compose.yaml
@@ -1,10 +1,15 @@
 version: "3.3"
 services:
   redis-one:
-    image: library/redis:6.2.5
+    image: bitnami/redis:6.2.13-debian-11-r73
     ports:
       - "1111:6379"
     volumes:
-      - ./redis.conf:/usr/local/etc/redis/redis.conf
-      - ../tls/certs:/usr/local/etc/redis/certs
-    command: [ "redis-server", "/usr/local/etc/redis/redis.conf" ]
+      - ../tls/certs:/certs
+    environment:
+      ALLOW_EMPTY_PASSWORD: "yes"
+      REDIS_TLS_ENABLED: "yes"
+      REDIS_TLS_CERT_FILE: "/certs/localhost.crt"
+      REDIS_TLS_KEY_FILE: "/certs/localhost.key"
+      REDIS_TLS_CA_FILE: "/certs/localhost_CA.crt"
+      REDIS_TLS_AUTH_CLIENTS: "yes"

--- a/shotover-proxy/tests/test-configs/redis/tls-no-verify-hostname/redis.conf
+++ b/shotover-proxy/tests/test-configs/redis/tls-no-verify-hostname/redis.conf
@@ -1,6 +1,0 @@
-tls-cert-file /usr/local/etc/redis/certs/localhost.crt
-tls-key-file /usr/local/etc/redis/certs/localhost.key
-tls-ca-cert-file /usr/local/etc/redis/certs/localhost_CA.crt
-
-port 0
-tls-port 6379

--- a/shotover-proxy/tests/test-configs/redis/tls/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/redis/tls/docker-compose.yaml
@@ -1,10 +1,15 @@
 version: "3.3"
 services:
   redis-one:
-    image: library/redis:6.2.5
+    image: bitnami/redis:6.2.13-debian-11-r73
     ports:
       - "1111:6379"
     volumes:
-      - ./redis.conf:/usr/local/etc/redis/redis.conf
-      - ./certs:/usr/local/etc/redis/certs
-    command: [ "redis-server", "/usr/local/etc/redis/redis.conf" ]
+      - ./certs:/certs
+    environment:
+      ALLOW_EMPTY_PASSWORD: "yes"
+      REDIS_TLS_ENABLED: "yes"
+      REDIS_TLS_CERT_FILE: "/certs/localhost.crt"
+      REDIS_TLS_KEY_FILE: "/certs/localhost.key"
+      REDIS_TLS_CA_FILE: "/certs/localhost_CA.crt"
+      REDIS_TLS_AUTH_CLIENTS: "yes"

--- a/shotover-proxy/tests/test-configs/redis/tls/redis.conf
+++ b/shotover-proxy/tests/test-configs/redis/tls/redis.conf
@@ -1,6 +1,0 @@
-tls-cert-file /usr/local/etc/redis/certs/localhost.crt
-tls-key-file /usr/local/etc/redis/certs/localhost.key
-tls-ca-cert-file /usr/local/etc/redis/certs/localhost_CA.crt
-
-port 0
-tls-port 6379

--- a/test-helpers/src/docker_compose.rs
+++ b/test-helpers/src/docker_compose.rs
@@ -45,6 +45,11 @@ pub fn get_image_waiters() -> &'static [Image] {
             timeout: 120,
         },
         Image {
+            name: "bitnami/redis:6.2.13-debian-11-r73",
+            log_regex_to_wait_for: r"Ready to accept connections",
+            timeout: 120,
+        },
+        Image {
             name: "bitnami/redis-cluster:6.2.12-debian-11-r26",
             //`Cluster state changed` is created by the node services
             //`Cluster correctly created` is created by the init service


### PR DESCRIPTION
Swap to the bitnami redis image for our redis TLS tests.
The advantage of this is we can specify our redis config entirely through environment variables instead of needing a seperate redis.conf

This will be a useful reference when implementing windsock aws redis benches as having less files to push the remote server will make our lives easier.