### PR TITLE
CI: split lints + tests into seperate workflows

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -57,17 +57,10 @@ jobs:
         key: ubuntu-20.04-packages
     - name: Install ubuntu packages
       run: shotover-proxy/build/install_ubuntu_packages.sh
-    - name: Install cargo-hack and nextest
+    - name: Install nextest
       uses: taiki-e/install-action@v2
       with:
-        tool: cargo-hack@0.6.4,nextest@0.9.57
-    - name: Check `cargo fmt` was run
-      run: cargo fmt --all -- --check
-    - name: Ensure that all crates compile and have no warnings under every possible combination of features
-      # some things to explicitly point out:
-      # * clippy also reports rustc warnings and errors
-      # * clippy --all-targets causes clippy to run against tests and examples which it doesnt do by default.
-      run: cargo hack --feature-powerset clippy --all-targets --locked ${{ matrix.cargo_flags }} -- -D warnings
+        tool: nextest@0.9.57
     - name: Build tests
       run: |
         cargo test --doc ${{ matrix.cargo_flags }} --all-features -- --show-output --nocapture

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,65 @@
+name: Formatting and lints
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+# Cancel already running jobs
+concurrency:
+  group: lints
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  job:
+    name: Formatting and lints
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+    - uses: Swatinem/rust-cache@v2
+      with:
+        # this line means that only the main branch writes to the cache
+        # benefits:
+        # * prevents main branch caches from being evicted in favor of a PR cache
+        # * saves about 1min per workflow by skipping the actual cache write
+        # downsides:
+        # * PRs that update rust version or changes deps will be slow to iterate on due to changes not being cached.
+        save-if: ${{ github.ref == 'refs/heads/main' }}
+    - name: cache custom ubuntu packages
+      uses: actions/cache@v3
+      with:
+        path: shotover-proxy/build/packages
+        key: ubuntu-20.04-packages
+    - name: Install ubuntu packages
+      run: shotover-proxy/build/install_ubuntu_packages.sh
+    - name: Install cargo-hack
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-hack@0.6.4
+    - name: Ensure `cargo fmt --all` was run
+      run: cargo fmt --all -- --check
+    - name: Ensure that all crates compile and have no warnings under every possible combination of features
+      # some things to explicitly point out:
+      # * clippy also reports rustc warnings and errors
+      # * clippy --all-targets causes clippy to run against tests and examples which it doesnt do by default.
+      run: cargo hack --feature-powerset clippy --all-targets --locked -- -D warnings
+    - name: Report disk usage
+      run: |
+        df -h
+
+        echo -e "\ntarget dir usage:"
+        du -h $PWD/target
+
+        echo -e "\n.cargo dir usage:"
+        du -h ~/.cargo
+    - name: Ensure that tests did not create or modify any files that arent .gitignore'd
+      run: |
+        if [ -n "$(git status --porcelain)" ]; then
+          git status
+          exit 1
+        fi


### PR DESCRIPTION
This will have a few benefits:
* Make CI "out of disk space" issues less frequent - linting and testing both produce a lot of shared artifacts but they also produce a lot of large unshared artifacts, by splitting them up across separate instances we can give each more disk space to work with. This benefit was my main motivation as I hit this issue again today.
* Make CI cached runs complete 3 mins faster - linting has become slow recently, taking ~3mins on a cached run due to having to test every combination of compile time feature. - A very nice incidental win.
* A linting failure does not prevent seeing test results.

Downsides are some more duplication in our CI configuration.