### PR TITLE
windsock-cloud-docker: cleanup running processes when killed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5671,6 +5671,7 @@ version = "0.1.0"
 dependencies = [
  "shell-quote",
  "subprocess",
+ "tokio",
 ]
 
 [[package]]

--- a/shotover-proxy/benches/windsock/aws/mod.rs
+++ b/shotover-proxy/benches/windsock/aws/mod.rs
@@ -279,7 +279,6 @@ impl Ec2InstanceWithShotover {
             let mut receiver = self
             .instance
             .ssh()
-            // TODO: invoke current_exe --harnessed-startup shotover --name $benchname --profilers $profilers
             .shell_stdout_lines(r#"
 killall -w shotover-bin > /dev/null || true
 RUST_BACKTRACE=1 ./shotover-bin --config-file config.yaml --topology-file topology.yaml --log-format json"#)

--- a/windsock-cloud-docker/Cargo.toml
+++ b/windsock-cloud-docker/Cargo.toml
@@ -8,4 +8,5 @@ license = "Apache-2.0"
 
 [dependencies]
 shell-quote = "0.3.0"
+tokio.workspace = true
 subprocess.workspace = true

--- a/windsock-cloud-docker/src/container.rs
+++ b/windsock-cloud-docker/src/container.rs
@@ -1,0 +1,137 @@
+pub struct Container(());
+
+impl Container {
+    pub async fn new() -> Container {
+        // ensure container is setup
+        let container_status = docker(&[
+            "container",
+            "ls",
+            "-a",
+            "--filter",
+            "Name=windsock-cloud",
+            "--format",
+            "{{.Status}}",
+        ])
+        .await;
+        if container_status.starts_with("Exited") {
+            docker(&["start", "windsock-cloud"]).await;
+        } else if !container_status.starts_with("Up") {
+            docker(&[
+                "run",
+                "-d",
+                "--name",
+                "windsock-cloud",
+                "ubuntu:20.04",
+                "sleep",
+                "infinity",
+            ])
+            .await;
+            container_bash("apt-get update").await;
+            container_bash(
+            "DEBIAN_FRONTEND=noninteractive apt-get install -y curl git cmake pkg-config g++ libssl-dev librdkafka-dev uidmap psmisc",
+        ).await;
+            container_bash(
+                "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y",
+            )
+            .await;
+        } else {
+            cleanup().await;
+        }
+
+        Container(())
+    }
+
+    pub async fn run_windsock(&self) {
+        // copy in shotover project
+        let root = std::env::current_dir().unwrap();
+        container_bash("rm -rf /shotover-proxy").await;
+        // TODO: This copy will be very expensive if the user doesnt have their target directory setup as a symlink
+        // Maybe we should do something like:
+        // 1. rsync to target/shotover-copy-for-docker with the target directory filtered out
+        // 2. `docker cp target/shotover-copy-for-docker windsock-cloud:/shotover-proxy`
+        docker(&[
+            "cp",
+            root.to_str().unwrap(),
+            "windsock-cloud:/shotover-proxy",
+        ])
+        .await;
+        container_bash("rm -rf /shotover-proxy/target").await;
+
+        // run windsock
+        let mut args = std::env::args();
+        args.next(); // skip binary name
+        let args: Vec<String> = args
+            .map(|x| {
+                if x.is_empty() {
+                    String::from("''")
+                } else {
+                    String::from_utf8(shell_quote::bash::escape(x)).unwrap()
+                }
+            })
+            .collect();
+        let args = args.join(" ");
+        let access_key_id = std::env::var("AWS_ACCESS_KEY_ID").unwrap();
+        let secret_access_key = std::env::var("AWS_SECRET_ACCESS_KEY").unwrap();
+        container_bash(&format!(
+        r#"cd shotover-proxy;
+source "$HOME/.cargo/env";
+AWS_ACCESS_KEY_ID={access_key_id} AWS_SECRET_ACCESS_KEY={secret_access_key} CARGO_TERM_COLOR=always cargo test --target-dir /target --release --bench windsock --features alpha-transforms --features rdkafka-driver-tests -- {args}"#
+    )).await;
+
+        // extract windsock results
+        let local_windsock_data = root.join("target").join("windsock_data");
+        std::fs::remove_dir_all(&local_windsock_data).ok();
+        docker(&[
+            "cp",
+            "windsock-cloud:/target/windsock_data",
+            local_windsock_data.to_str().unwrap(),
+        ])
+        .await;
+    }
+}
+
+pub async fn cleanup() {
+    // killing a `docker exec` command will not propogate the kill onto the process within the container: https://github.com/moby/moby/issues/9098
+    // so instead we need to manually kill the containers cargo + rustc to avoid leaving a process running.
+    container_bash("killall cargo 2> /dev/null || true").await;
+    container_bash("killall rustc 2> /dev/null || true").await;
+}
+
+async fn docker(args: &[&str]) -> String {
+    run_command("docker", args).await
+}
+
+async fn container_bash(command: &str) {
+    run_command_to_stdout("docker", &["exec", "windsock-cloud", "bash", "-c", command]).await
+}
+
+async fn run_command_to_stdout(command: &str, args: &[&str]) {
+    let status = tokio::process::Command::new("docker")
+        .args(args)
+        .status()
+        .await
+        .unwrap();
+
+    if !status.success() {
+        println!(
+            "Failed to run windsock, command {} {:?} exited with {:?}",
+            command, args, status
+        );
+        std::process::exit(status.code().unwrap_or(1))
+    }
+}
+
+async fn run_command(command: &str, args: &[&str]) -> String {
+    let output = tokio::process::Command::new(command)
+        .args(args)
+        .output()
+        .await
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    if !output.status.success() {
+        panic!("command {command} {args:?} failed:\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    }
+    stdout
+}

--- a/windsock-cloud-docker/src/main.rs
+++ b/windsock-cloud-docker/src/main.rs
@@ -1,124 +1,21 @@
 // A helper to run `windsock --cloud` within docker to workaround libc issues
 // It is not possible to use this helper to run windsock locally as that would involve running docker within docker
 
-use subprocess::{Exec, Redirection};
+mod container;
 
-fn main() {
-    let mut args = std::env::args();
-    args.next(); // skip binary name
-    let args: Vec<String> = args
-        .map(|x| {
-            if x.is_empty() {
-                String::from("''")
-            } else {
-                String::from_utf8(shell_quote::bash::escape(x)).unwrap()
-            }
-        })
-        .collect();
-    let args = args.join(" ");
+use container::{cleanup, Container};
+use tokio::signal::unix::{signal, SignalKind};
 
-    // ensure container is setup
-    let container_status = docker(&[
-        "container",
-        "ls",
-        "-a",
-        "--filter",
-        "Name=windsock-cloud",
-        "--format",
-        "{{.Status}}",
-    ]);
-    if container_status.starts_with("Exited") {
-        docker(&["start", "windsock-cloud"]);
-    } else if !container_status.starts_with("Up") {
-        docker(&[
-            "run",
-            "-d",
-            "--name",
-            "windsock-cloud",
-            "ubuntu:20.04",
-            "sleep",
-            "infinity",
-        ]);
-        container_bash("apt-get update");
-        container_bash(
-            "DEBIAN_FRONTEND=noninteractive apt-get install -y curl git cmake pkg-config g++ libssl-dev librdkafka-dev uidmap",
-        );
-        container_bash("curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y");
-    }
+#[tokio::main]
+async fn main() {
+    let mut interrupt = signal(SignalKind::interrupt()).unwrap();
+    let mut terminate = signal(SignalKind::terminate()).unwrap();
 
-    // copy in shotover project
-    let root = std::env::current_dir().unwrap();
-    container_bash("rm -rf /shotover-proxy");
-    // TODO: This copy will be very expensive if the user doesnt have their target directory setup as a symlink
-    // Maybe we should do something like:
-    // 1. rsync to target/shotover-copy-for-docker with the target directory filtered out
-    // 2. `docker cp target/shotover-copy-for-docker windsock-cloud:/shotover-proxy`
-    docker(&[
-        "cp",
-        root.to_str().unwrap(),
-        "windsock-cloud:/shotover-proxy",
-    ]);
-    container_bash("rm -rf /shotover-proxy/target");
+    let container = Container::new().await;
 
-    // run windsock
-    let access_key_id = std::env::var("AWS_ACCESS_KEY_ID").unwrap();
-    let secret_access_key = std::env::var("AWS_SECRET_ACCESS_KEY").unwrap();
-    container_bash(&format!(
-        r#"cd shotover-proxy;
-source "$HOME/.cargo/env";
-AWS_ACCESS_KEY_ID={access_key_id} AWS_SECRET_ACCESS_KEY={secret_access_key} CARGO_TERM_COLOR=always cargo test --target-dir /target --release --bench windsock --features alpha-transforms --features rdkafka-driver-tests -- {args}"#
-    ));
-
-    // extract windsock results
-    let local_windsock_data = root.join("target").join("windsock_data");
-    std::fs::remove_dir_all(&local_windsock_data).ok();
-    docker(&[
-        "cp",
-        "windsock-cloud:/target/windsock_data",
-        local_windsock_data.to_str().unwrap(),
-    ]);
-}
-
-pub fn docker(args: &[&str]) -> String {
-    run_command("docker", args)
-}
-
-pub fn container_bash(command: &str) {
-    run_command_to_stdout("docker", &["exec", "windsock-cloud", "bash", "-c", command])
-}
-
-pub fn run_command_to_stdout(command: &str, args: &[&str]) {
-    let status = std::process::Command::new("docker")
-        .args(args)
-        .status()
-        .unwrap();
-
-    if !status.success() {
-        println!(
-            "Failed to run windsock, command {} {:?} exited with {:?}",
-            command, args, status
-        );
-        std::process::exit(status.code().unwrap_or(1))
-    }
-}
-
-pub fn run_command(command: &str, args: &[&str]) -> String {
-    let data = Exec::cmd(command)
-        .args(args)
-        .stdout(Redirection::Pipe)
-        .stderr(Redirection::Merge)
-        .capture()
-        .unwrap();
-
-    if data.exit_status.success() {
-        data.stdout_str()
-    } else {
-        panic!(
-            "command {} {:?} exited with {:?} and output:\n{}",
-            command,
-            args,
-            data.exit_status,
-            data.stdout_str()
-        )
-    }
+    tokio::select!(
+        _ = container.run_windsock() => {},
+        _ = interrupt.recv() => cleanup().await,
+        _ = terminate.recv() => cleanup().await,
+    );
 }


### PR DESCRIPTION
Refactor windsock-cloud-docker so that it cleans up the in progress cargo command.
Its very common to want to kill cargo while its building if I change my mind.
Currently when I do that to windsock-cloud-docker it leaves a stray cargo process running in the background which will:
* block new cargo compilations until the original cargo finishes compiling
* eventually proceed to spin up AWS resources, without me being aware

This is quite problematic.

To fix this I:
1. refactored windsock-cloud-docker to be async
2. split all the logic between a Container::new() and Container::run_windsock methods
3. then used tokio::select to allow sigint (ctrl-c) to terminate an in progress run + run cleanup code.
Doing this without async is quite difficult as we would need to refactor commands to be nonblocking, better to just go async at that point than manually dealing with non blocking commands.

The actual logic of setting up the container and running windsock remains the same, its just all asyncified.

This PR also removes an unrelated stray TODO which had already been addressed in a previous PR.