### PR TITLE
tee switch main chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4447,6 +4447,7 @@ dependencies = [
  "futures",
  "hex",
  "hex-literal",
+ "hyper",
  "inferno",
  "itertools 0.11.0",
  "nix 0.27.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,3 +64,4 @@ typetag = "0.2.5"
 aws-throwaway = "0.2.0"
 tokio-bin-process = "0.4.0"
 ordered-float = { version = "4.0.0", features = ["serde"] }
+hyper = { version = "0.14.14", features = ["server"] }

--- a/docs/src/transforms.md
+++ b/docs/src/transforms.md
@@ -508,9 +508,9 @@ The response from the down-chain transform is returned back up-chain but various
 
 Tee also exposes an optional HTTP API to switch which chain to use as the "result source", that is the chain to return responses from.
 
-`GET` `/result-source` will return `"regular-chain"` or `"tee-chain"` indicating what chain is being used for the result source.
+`GET` `/transform/tee/result-source` will return `regular-chain` or `tee-chain` indicating which chain is being used for the result source.
 
-`PUT` `/result-source` with the body content as either `regular-chain` or `tee-chain` to set the result source.
+`PUT` `/transform/tee/result-source` with the body content as either `regular-chain` or `tee-chain` to set the result source.
 
 ```yaml
 - Tee:
@@ -534,8 +534,10 @@ Tee also exposes an optional HTTP API to switch which chain to use as the "resul
     #         filter: Read
     #     - NullSink
 
-    # Optional port to for the HTTP chain switcher API to listen on
-    # switch_port: 1234
+    # The port that the HTTP API will listen on.
+    # When this field is not provided the HTTP API will not be run.
+    # http_api_port: 1234
+    #
     # Timeout for sending to the sub chain in microseconds
     timeout_micros: 1000
     # The number of message batches that the tee can hold onto in its buffer of messages to send.

--- a/docs/src/transforms.md
+++ b/docs/src/transforms.md
@@ -506,11 +506,11 @@ This is mainly used in conjunction with the `TuneableConsistencyScatter` transfo
 This transform sends messages to both the defined sub chain and the remaining down-chain transforms.
 The response from the down-chain transform is returned back up-chain but various behaviours can be defined by the `behaviour` field to handle the case when the responses from the sub chain and down-chain do not match.
 
-Tee also exposes an optional HTTP API to switch which chain is the "sub-chain" and which chain is the "primary chain", that being the chain which responses are returned to the client from.
+Tee also exposes an optional HTTP API to switch which chain to use as the "result source", that is the chain to return responses from.
 
-`GET` `/switched` will return `"true"` or `"false"` indicating whether the chain has been switched from what was ooriginally defined in the topology file.
+`GET` `/result-source` will return `"regular-chain"` or `"tee-chain"` indicating what chain is being used for the result source.
 
-`PUT` `/switch` with the body content as either `true` or `false` will either switch the chain or revert it to the definition in the topology file.
+`PUT` `/result-source` with the body content as either `regular-chain` or `tee-chain` to set the result source.
 
 ```yaml
 - Tee:

--- a/docs/src/transforms.md
+++ b/docs/src/transforms.md
@@ -506,6 +506,12 @@ This is mainly used in conjunction with the `TuneableConsistencyScatter` transfo
 This transform sends messages to both the defined sub chain and the remaining down-chain transforms.
 The response from the down-chain transform is returned back up-chain but various behaviours can be defined by the `behaviour` field to handle the case when the responses from the sub chain and down-chain do not match.
 
+Tee also exposes an optional HTTP API to switch which chain is the "sub-chain" and which chain is the "primary chain", that being the chain which responses are returned to the client from.
+
+`GET` `/switched` will return `"true"` or `"false"` indicating whether the chain has been switched from what was ooriginally defined in the topology file.
+
+`PUT` `/switch` with the body content as either `true` or `false` will either switch the chain or revert it to the definition in the topology file.
+
 ```yaml
 - Tee:
     # Ignore responses returned by the sub chain
@@ -528,6 +534,8 @@ The response from the down-chain transform is returned back up-chain but various
     #         filter: Read
     #     - NullSink
 
+    # Optional port to for the HTTP chain switcher API to listen on
+    # switch_port: 1234
     # Timeout for sending to the sub chain in microseconds
     timeout_micros: 1000
     # The number of message batches that the tee can hold onto in its buffer of messages to send.

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -54,6 +54,7 @@ serde_json = "1.0.103"
 time = { version = "0.3.25" }
 inferno = { version = "0.11.15", default-features = false, features = ["multithreaded", "nameattr"] }
 shell-quote = "0.3.0"
+hyper.workspace = true
 
 [features]
 # Include WIP alpha transforms in the public API

--- a/shotover-proxy/config/config.yaml
+++ b/shotover-proxy/config/config.yaml
@@ -1,3 +1,3 @@
 ---
-main_log_level: "info,shotover_proxy=info"
+main_log_level: "debug,shotover_proxy=debug"
 observability_interface: "0.0.0.0:9001"

--- a/shotover-proxy/config/config.yaml
+++ b/shotover-proxy/config/config.yaml
@@ -1,3 +1,3 @@
 ---
-main_log_level: "debug,shotover_proxy=debug"
+main_log_level: "info,shotover_proxy=info"
 observability_interface: "0.0.0.0:9001"

--- a/shotover-proxy/tests/test-configs/tee/switch_chain.yaml
+++ b/shotover-proxy/tests/test-configs/tee/switch_chain.yaml
@@ -1,0 +1,46 @@
+---
+sources:
+  - Redis:
+      name: "redis-1"
+      listen_addr: "127.0.0.1:6371"
+      connection_limit: 
+      chain:
+        - Tee:
+            behavior: Ignore
+            buffer_size: 10000
+            switch_port: 1231
+            chain:
+              - DebugReturner:
+                  Redis: "b"
+        - DebugReturner:
+            Redis: "a"
+  - Redis:
+      name: "redis-3"
+      listen_addr: "127.0.0.1:6372"
+      connection_limit: 
+      chain:
+        - Tee:
+            behavior: 
+              SubchainOnMismatch:
+                - NullSink
+            buffer_size: 10000
+            switch_port: 1232
+            chain:
+              - DebugReturner:
+                  Redis: "b"
+        - DebugReturner:
+            Redis: "a"
+  - Redis:
+      name: "redis-3"
+      listen_addr: "127.0.0.1:6373"
+      connection_limit: 
+      chain:
+        - Tee:
+            behavior: LogWarningOnMismatch
+            buffer_size: 10000
+            switch_port: 1233
+            chain:
+              - DebugReturner:
+                  Redis: "b"
+        - DebugReturner:
+            Redis: "a"

--- a/shotover-proxy/tests/transforms/tee.rs
+++ b/shotover-proxy/tests/transforms/tee.rs
@@ -234,20 +234,20 @@ async fn test_switch_main_chain() {
         assert_eq!("a", result);
 
         let _ = hyper_request(
-            format!("http://localhost:{}/switch", switch_port),
+            format!("http://localhost:{}/result-source", switch_port),
             Method::PUT,
-            Body::from("true"),
+            Body::from("tee-chain"),
         )
         .await;
 
         let res = hyper_request(
-            format!("http://localhost:{}/switched", switch_port),
+            format!("http://localhost:{}/result-source", switch_port),
             Method::GET,
             Body::empty(),
         )
         .await;
         let body = read_response_body(res).await.unwrap();
-        assert_eq!("true", body);
+        assert_eq!("tee-chain", body);
 
         let result = redis::cmd("SET")
             .arg("key")
@@ -259,9 +259,9 @@ async fn test_switch_main_chain() {
         assert_eq!("b", result);
 
         let _ = hyper_request(
-            format!("http://localhost:{}/switch", switch_port),
+            format!("http://localhost:{}/result-source", switch_port),
             Method::PUT,
-            Body::from("false"),
+            Body::from("regular-chain"),
         )
         .await;
 

--- a/shotover-proxy/tests/transforms/tee.rs
+++ b/shotover-proxy/tests/transforms/tee.rs
@@ -234,14 +234,20 @@ async fn test_switch_main_chain() {
         assert_eq!("a", result);
 
         let _ = hyper_request(
-            format!("http://localhost:{}/result-source", switch_port),
+            format!(
+                "http://localhost:{}/transform/tee/result-source",
+                switch_port
+            ),
             Method::PUT,
             Body::from("tee-chain"),
         )
         .await;
 
         let res = hyper_request(
-            format!("http://localhost:{}/result-source", switch_port),
+            format!(
+                "http://localhost:{}/transform/tee/result-source",
+                switch_port
+            ),
             Method::GET,
             Body::empty(),
         )
@@ -259,7 +265,10 @@ async fn test_switch_main_chain() {
         assert_eq!("b", result);
 
         let _ = hyper_request(
-            format!("http://localhost:{}/result-source", switch_port),
+            format!(
+                "http://localhost:{}/transform/tee/result-source",
+                switch_port
+            ),
             Method::PUT,
             Body::from("regular-chain"),
         )

--- a/shotover-proxy/tests/transforms/tee.rs
+++ b/shotover-proxy/tests/transforms/tee.rs
@@ -1,4 +1,5 @@
 use crate::shotover_process;
+use hyper::{body, Body, Client, Method, Request, Response};
 use test_helpers::connection::redis_connection;
 use test_helpers::docker_compose::docker_compose;
 use test_helpers::shotover_process::{EventMatcher, Level};
@@ -192,4 +193,91 @@ async fn test_subchain_with_mismatch() {
 
     assert_eq!("myvalue", result);
     shotover.shutdown_and_then_consume_events(&[]).await;
+}
+
+async fn read_response_body(res: Response<Body>) -> Result<String, hyper::Error> {
+    let bytes = body::to_bytes(res.into_body()).await?;
+    Ok(String::from_utf8(bytes.to_vec()).expect("response was not valid utf-8"))
+}
+
+async fn hyper_request(uri: String, method: Method, body: Body) -> Response<Body> {
+    let client = Client::new();
+
+    let req = Request::builder()
+        .method(method)
+        .uri(uri)
+        .body(body)
+        .expect("request builder");
+
+    client.request(req).await.unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_switch_main_chain() {
+    let shotover = shotover_process("tests/test-configs/tee/switch_chain.yaml")
+        .start()
+        .await;
+
+    for i in 1..=3 {
+        let redis_port = 6370 + i;
+        let switch_port = 1230 + i;
+
+        let mut connection = redis_connection::new_async("127.0.0.1", redis_port).await;
+
+        let result = redis::cmd("SET")
+            .arg("key")
+            .arg("myvalue")
+            .query_async::<_, String>(&mut connection)
+            .await
+            .unwrap();
+
+        assert_eq!("a", result);
+
+        let _ = hyper_request(
+            format!("http://localhost:{}/switch", switch_port),
+            Method::PUT,
+            Body::from("true"),
+        )
+        .await;
+
+        let res = hyper_request(
+            format!("http://localhost:{}/switched", switch_port),
+            Method::GET,
+            Body::empty(),
+        )
+        .await;
+        let body = read_response_body(res).await.unwrap();
+        assert_eq!("true", body);
+
+        let result = redis::cmd("SET")
+            .arg("key")
+            .arg("myvalue")
+            .query_async::<_, String>(&mut connection)
+            .await
+            .unwrap();
+
+        assert_eq!("b", result);
+
+        let _ = hyper_request(
+            format!("http://localhost:{}/switch", switch_port),
+            Method::PUT,
+            Body::from("false"),
+        )
+        .await;
+
+        let result = redis::cmd("SET")
+            .arg("key")
+            .arg("myvalue")
+            .query_async::<_, String>(&mut connection)
+            .await
+            .unwrap();
+
+        assert_eq!("a", result);
+    }
+
+    shotover
+        .shutdown_and_then_consume_events(&[EventMatcher::new()
+            .with_level(Level::Warn)
+            .with_count(tokio_bin_process::event_matcher::Count::Times(3))])
+        .await;
 }

--- a/shotover/Cargo.toml
+++ b/shotover/Cargo.toml
@@ -65,7 +65,7 @@ metrics-exporter-prometheus = "0.12.0"
 tracing.workspace = true
 tracing-subscriber.workspace = true
 tracing-appender.workspace = true
-hyper = { version = "0.14.14", features = ["server"] }
+hyper.workspace = true
 halfbrown = "0.2.1"
 
 # Transform dependencies

--- a/shotover/src/transforms/tee.rs
+++ b/shotover/src/transforms/tee.rs
@@ -2,11 +2,18 @@ use crate::config::chain::TransformChainConfig;
 use crate::message::Messages;
 use crate::transforms::chain::{BufferedChain, TransformChainBuilder};
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
-use anyhow::Result;
+use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
+use bytes::Bytes;
+use hyper::{
+    service::{make_service_fn, service_fn},
+    Method, Request, StatusCode, {Body, Response, Server},
+};
 use metrics::{register_counter, Counter};
 use serde::{Deserialize, Serialize};
-use tracing::{debug, trace, warn};
+use std::{convert::Infallible, net::SocketAddr, str, sync::Arc};
+use tokio::sync::Mutex;
+use tracing::{debug, error, trace, warn};
 
 pub struct TeeBuilder {
     pub tx: TransformChainBuilder,
@@ -14,6 +21,8 @@ pub struct TeeBuilder {
     pub behavior: ConsistencyBehaviorBuilder,
     pub timeout_micros: Option<u64>,
     dropped_messages: Counter,
+    switch_port: Option<u16>,
+    switched_chain: Option<Arc<Mutex<bool>>>,
 }
 
 pub enum ConsistencyBehaviorBuilder {
@@ -29,6 +38,8 @@ impl TeeBuilder {
         buffer_size: usize,
         behavior: ConsistencyBehaviorBuilder,
         timeout_micros: Option<u64>,
+        switch_port: Option<u16>,
+        switched_chain: Option<Arc<Mutex<bool>>>,
     ) -> Self {
         let dropped_messages = register_counter!("tee_dropped_messages", "chain" => "Tee");
 
@@ -38,12 +49,20 @@ impl TeeBuilder {
             behavior,
             timeout_micros,
             dropped_messages,
+            switch_port,
+            switched_chain,
         }
     }
 }
 
 impl TransformBuilder for TeeBuilder {
     fn build(&self) -> Transforms {
+        if let Some(switch_port) = self.switch_port {
+            let chain_switch_listener =
+                ChainSwitchListener::new(SocketAddr::from(([127, 0, 0, 1], switch_port)));
+            tokio::spawn(chain_switch_listener.async_run(self.switched_chain.clone().unwrap()));
+        }
+
         Transforms::Tee(Tee {
             tx: self.tx.build_buffered(self.buffer_size),
             behavior: match &self.behavior {
@@ -59,6 +78,7 @@ impl TransformBuilder for TeeBuilder {
             buffer_size: self.buffer_size,
             timeout_micros: self.timeout_micros,
             dropped_messages: self.dropped_messages.clone(),
+            switched_chain: self.switched_chain.clone(),
         })
     }
 
@@ -97,6 +117,7 @@ pub struct Tee {
     pub behavior: ConsistencyBehavior,
     pub timeout_micros: Option<u64>,
     dropped_messages: Counter,
+    switched_chain: Option<Arc<Mutex<bool>>>,
 }
 
 pub enum ConsistencyBehavior {
@@ -113,6 +134,7 @@ pub struct TeeConfig {
     pub timeout_micros: Option<u64>,
     pub chain: TransformChainConfig,
     pub buffer_size: Option<usize>,
+    pub switch_port: Option<u16>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -153,6 +175,8 @@ impl TransformConfig for TeeConfig {
             buffer_size,
             behavior,
             self.timeout_micros,
+            self.switch_port,
+            Some(Arc::new(Mutex::new(false))),
         )))
     }
 }
@@ -160,19 +184,64 @@ impl TransformConfig for TeeConfig {
 #[async_trait]
 impl Transform for Tee {
     async fn transform<'a>(&'a mut self, requests_wrapper: Wrapper<'a>) -> Result<Messages> {
-        match &mut self.behavior {
-            ConsistencyBehavior::Ignore => {
-                let (tee_result, chain_result) = tokio::join!(
-                    self.tx
-                        .process_request_no_return(requests_wrapper.clone(), self.timeout_micros),
-                    requests_wrapper.call_next_transform()
-                );
-                if let Err(e) = tee_result {
-                    self.dropped_messages.increment(1);
-                    trace!("Tee Ignored error {e}");
-                }
-                chain_result
+        self.transform_inner(requests_wrapper).await
+    }
+}
+
+impl Tee {
+    async fn is_switched(&mut self) -> bool {
+        if let Some(switched_chain) = self.switched_chain.as_ref() {
+            let switched = switched_chain.lock().await;
+            *switched
+        } else {
+            false
+        }
+    }
+
+    async fn return_response(
+        &mut self,
+        tee_result: Messages,
+        chain_result: Messages,
+    ) -> Result<Messages> {
+        if self.is_switched().await {
+            Ok(tee_result)
+        } else {
+            Ok(chain_result)
+        }
+    }
+
+    async fn ignore_behaviour_inner<'a>(
+        &'a mut self,
+        requests_wrapper: Wrapper<'a>,
+    ) -> Result<Messages> {
+        if self.is_switched().await {
+            let (tee_result, chain_result) = tokio::join!(
+                self.tx
+                    .process_request(requests_wrapper.clone(), self.timeout_micros),
+                requests_wrapper.call_next_transform()
+            );
+            if let Err(e) = chain_result {
+                self.dropped_messages.increment(1);
+                trace!("Tee Ignored error {e}");
             }
+            tee_result
+        } else {
+            let (tee_result, chain_result) = tokio::join!(
+                self.tx
+                    .process_request_no_return(requests_wrapper.clone(), self.timeout_micros),
+                requests_wrapper.call_next_transform()
+            );
+            if let Err(e) = tee_result {
+                self.dropped_messages.increment(1);
+                trace!("Tee Ignored error {e}");
+            }
+            chain_result
+        }
+    }
+
+    async fn transform_inner<'a>(&'a mut self, requests_wrapper: Wrapper<'a>) -> Result<Messages> {
+        match &mut self.behavior {
+            ConsistencyBehavior::Ignore => self.ignore_behaviour_inner(requests_wrapper).await,
             ConsistencyBehavior::FailOnMismatch => {
                 let (tee_result, chain_result) = tokio::join!(
                     self.tx
@@ -200,7 +269,8 @@ impl Transform for Tee {
                             "ERR The responses from the Tee subchain and down-chain did not match and behavior is set to fail on mismatch".into())?;
                     }
                 }
-                Ok(chain_response)
+
+                self.return_response(tee_response, chain_response).await
             }
             ConsistencyBehavior::SubchainOnMismatch(mismatch_chain) => {
                 let failed_message = requests_wrapper.clone();
@@ -217,7 +287,7 @@ impl Transform for Tee {
                     mismatch_chain.process_request(failed_message, None).await?;
                 }
 
-                Ok(chain_response)
+                self.return_response(tee_response, chain_response).await
             }
             ConsistencyBehavior::LogWarningOnMismatch => {
                 let (tee_result, chain_result) = tokio::join!(
@@ -242,9 +312,93 @@ impl Transform for Tee {
                             .collect::<Vec<_>>()
                     );
                 }
-                Ok(chain_response)
+                self.return_response(tee_response, chain_response).await
             }
         }
+    }
+}
+
+struct ChainSwitchListener {
+    address: SocketAddr,
+}
+
+impl ChainSwitchListener {
+    fn new(address: SocketAddr) -> Self {
+        Self { address }
+    }
+
+    fn rsp(status: StatusCode, body: impl Into<Body>) -> Response<Body> {
+        Response::builder()
+            .status(status)
+            .body(body.into())
+            .expect("builder with known status code must not fail")
+    }
+
+    async fn set_switched_chain(body: Bytes, switched_chain: Arc<Mutex<bool>>) -> Result<()> {
+        let new_switched_chain_state_str = str::from_utf8(body.as_ref())?;
+        let new_switched_chain_state = new_switched_chain_state_str.parse::<bool>()?;
+        let mut switched = switched_chain.lock().await;
+        *switched = new_switched_chain_state;
+        Ok(())
+    }
+
+    async fn async_run(self, switched_chain: Arc<Mutex<bool>>) {
+        if let Err(err) = self.async_run_inner(switched_chain).await {
+            error!("Error in ChainSwitchListener: {}", err);
+        }
+    }
+
+    async fn async_run_inner(self, switched_chain: Arc<Mutex<bool>>) -> Result<()> {
+        let make_svc = make_service_fn(move |_| {
+            let switched_chain = switched_chain.clone();
+            async move {
+                Ok::<_, Infallible>(service_fn(move |req: Request<Body>| {
+                    let switched_chain = switched_chain.clone();
+                    async move {
+                        let response = match (req.method(), req.uri().path()) {
+                            (&Method::GET, "/switched") => {
+                                let switched_chain: bool = *switched_chain.lock().await;
+                                Self::rsp(StatusCode::OK, switched_chain.to_string())
+                            }
+                            (&Method::PUT, "/switch") => {
+                                match hyper::body::to_bytes(req.into_body()).await {
+                                    Ok(body) => {
+                                        match Self::set_switched_chain(body, switched_chain.clone())
+                                            .await
+                                        {
+                                            Err(error) => {
+                                                error!(?error, "switching chain failed");
+                                                Self::rsp(
+                                                    StatusCode::BAD_REQUEST,
+                                                    "switching chain failed",
+                                                )
+                                            }
+                                            Ok(()) => Self::rsp(StatusCode::OK, Body::empty()),
+                                        }
+                                    }
+                                    Err(error) => {
+                                        error!(%error, "setting filter failed - Couldn't read bytes");
+                                        Self::rsp(
+                                            StatusCode::INTERNAL_SERVER_ERROR,
+                                            format!("{error:?}"),
+                                        )
+                                    }
+                                }
+                            }
+                            _ => Self::rsp(StatusCode::NOT_FOUND, "/switched or /switch"),
+                        };
+                        Ok::<_, Infallible>(response)
+                    }
+                }))
+            }
+        });
+
+        let address = self.address;
+        Server::try_bind(&address)
+            .with_context(|| format!("Failed to bind to {}", address))?
+            .serve(make_svc)
+            .await
+            .map_err(|e| anyhow!(e))
     }
 }
 
@@ -260,6 +414,7 @@ mod tests {
             timeout_micros: None,
             chain: TransformChainConfig(vec![Box::new(NullSinkConfig)]),
             buffer_size: None,
+            switch_port: None,
         };
 
         let transform = config.get_builder("".to_owned()).await.unwrap();
@@ -274,6 +429,7 @@ mod tests {
             timeout_micros: None,
             chain: TransformChainConfig(vec![Box::new(NullSinkConfig), Box::new(NullSinkConfig)]),
             buffer_size: None,
+            switch_port: None,
         };
 
         let transform = config.get_builder("".to_owned()).await.unwrap();
@@ -291,6 +447,7 @@ mod tests {
             timeout_micros: None,
             chain: TransformChainConfig(vec![Box::new(NullSinkConfig)]),
             buffer_size: None,
+            switch_port: None,
         };
         let transform = config.get_builder("".to_owned()).await.unwrap();
         let result = transform.validate();
@@ -304,6 +461,7 @@ mod tests {
             timeout_micros: None,
             chain: TransformChainConfig(vec![Box::new(NullSinkConfig)]),
             buffer_size: None,
+            switch_port: None,
         };
         let transform = config.get_builder("".to_owned()).await.unwrap();
         let result = transform.validate();
@@ -319,6 +477,7 @@ mod tests {
             timeout_micros: None,
             chain: TransformChainConfig(vec![Box::new(NullSinkConfig)]),
             buffer_size: None,
+            switch_port: None,
         };
 
         let transform = config.get_builder("".to_owned()).await.unwrap();
@@ -338,6 +497,7 @@ mod tests {
             timeout_micros: None,
             chain: TransformChainConfig(vec![Box::new(NullSinkConfig)]),
             buffer_size: None,
+            switch_port: None,
         };
 
         let transform = config.get_builder("".to_owned()).await.unwrap();


### PR DESCRIPTION
This change allows the user to switch which chain to "read" responses from within Tee. The purpose in mind for this is switching from the source cluster to the target cluster during OpenSearch dual writing. More details can be found in `transforms.md`. 