### PR TITLE
fix opensearch codec bug

### DIFF
--- a/shotover/src/codec/opensearch.rs
+++ b/shotover/src/codec/opensearch.rs
@@ -210,6 +210,7 @@ impl Decoder for OpenSearchDecoder {
                     }
 
                     if src.len() < content_length {
+                        self.state = State::ReadingBody(http_headers, content_length);
                         return Ok(None);
                     }
 


### PR DESCRIPTION
This path was never being run and I didn't notice the error until a large enough message went through. 

The `match std::mem::replace(&mut self.state, State::ParsingResponse)` part is a bit misleading, it replaces `self.state` with `State::ParsingResponse` and returns what was there before, we want to set it back to `State::ReadingBody` if there is still more body to read. i.e. if `src.len() < content_length`