### PR TITLE
windsock: better support external benchers

### DIFF
--- a/windsock/src/lib.rs
+++ b/windsock/src/lib.rs
@@ -8,7 +8,7 @@ mod report;
 mod tables;
 
 pub use bench::{Bench, BenchParameters, BenchTask, Profiling};
-pub use report::{Metric, Report, ReportArchive};
+pub use report::{ExternalReport, Metric, OperationsReport, PubSubReport, Report, ReportArchive};
 pub use tables::Goal;
 
 use anyhow::{anyhow, Result};


### PR DESCRIPTION
For an internal project we needed to integrate an external benchmarking tool with windsock.
So this PR introduces a way to do this.

Usually we generate a ReportArchive by processing all the reports sent by the benchmark.
But with this alternate API the user is able to provide a complete fully formed ReportArchive in a single report message, this allows the user to easily convert the output of an external tool into a format usable by windsock.

Its unfortunate that we are exposing all of this internal state, but I think its justified because integration with existing benchmarking tools is an important use case.