### PR TITLE
KafkaSinkSingle: remove dest host config, rely solely on dest port

### DIFF
--- a/shotover-proxy/tests/test-configs/kafka/bench/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/bench/docker-compose.yaml
@@ -3,8 +3,8 @@ services:
   kafka:
     image: 'bitnami/kafka:3.4.0-debian-11-r22'
     ports:
-      - '9092:9092'
+      - '9192:9192'
     environment:
-      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
-      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://127.0.0.1:9092
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9192,CONTROLLER://:9093
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://127.0.0.1:9192
       - ALLOW_PLAINTEXT_LISTENER=yes

--- a/shotover-proxy/tests/test-configs/kafka/passthrough/topology-encode.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/passthrough/topology-encode.yaml
@@ -8,5 +8,5 @@ sources:
             encode_requests: true
             encode_responses: true
         - KafkaSinkSingle:
-            remote_address: "127.0.0.1:9092"
+            destination_port: 9092
             connect_timeout_ms: 3000

--- a/shotover-proxy/tests/test-configs/kafka/passthrough/topology.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/passthrough/topology.yaml
@@ -5,5 +5,5 @@ sources:
       listen_addr: "127.0.0.1:9192"
       chain:
         - KafkaSinkSingle:
-            remote_address: "127.0.0.1:9092"
+            destination_port: 9092
             connect_timeout_ms: 3000


### PR DESCRIPTION
As per the comment I added:
KafkaSinkSingle is designed solely for the use case of running a shotover instance on the same machine as each kafka instance.

I cannot think of a valid configuration where the destination host is set to a value other than the private ip of the machine.
It could technically be set to `localhost` but AFAIK that doesnt offer any advantages over just using the private ip.
Is there a case i'm missing?

So given this, allowing the user to set the full address is just a footgun so we should remove this config instead only allowing the user to set the port.