### PR TITLE
Fix kafka benches to actually bench shotover

### DIFF
--- a/shotover-proxy/benches/windsock/aws/mod.rs
+++ b/shotover-proxy/benches/windsock/aws/mod.rs
@@ -109,6 +109,16 @@ curl -sSL https://get.docker.com/ | sudo sh"#,
             )
             .await;
 
+        let local_shotover_path = bin_path!("shotover-proxy");
+        instance
+            .ssh()
+            .push_file(local_shotover_path, Path::new("shotover-bin"))
+            .await;
+        instance
+            .ssh()
+            .push_file(Path::new("config/config.yaml"), Path::new("config.yaml"))
+            .await;
+
         let instance = Arc::new(Ec2InstanceWithDocker { instance });
         (*self.docker_instances.write().await).push(instance.clone());
         instance
@@ -162,6 +172,7 @@ sudo apt-get install -y sysstat"#,
     }
 }
 
+/// Despite the name can also run shotover
 pub struct Ec2InstanceWithDocker {
     pub instance: Ec2Instance,
 }
@@ -239,6 +250,15 @@ sudo docker system prune -af"#,
             }
         }
     }
+
+    #[cfg(feature = "rdkafka-driver-tests")]
+    pub async fn run_shotover(self: Arc<Self>, topology: &str) -> RunningShotover {
+        self.instance
+            .ssh()
+            .push_file_from_bytes(topology.as_bytes(), Path::new("topology.yaml"))
+            .await;
+        RunningShotover::new(&self.instance).await
+    }
 }
 
 fn get_compatible_instance_type() -> InstanceType {
@@ -278,17 +298,26 @@ impl Ec2InstanceWithShotover {
             .ssh()
             .push_file_from_bytes(topology.as_bytes(), Path::new("topology.yaml"))
             .await;
+        RunningShotover::new(&self.instance).await
+    }
+}
 
+pub struct RunningShotover {
+    shutdown_tx: tokio::sync::mpsc::UnboundedSender<()>,
+    event_rx: tokio::sync::mpsc::UnboundedReceiver<Event>,
+}
+
+impl RunningShotover {
+    async fn new(instance: &Ec2Instance) -> Self {
         let (shutdown_tx, mut shutdown_rx) = tokio::sync::mpsc::unbounded_channel();
         let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut receiver = instance
+                    .ssh()
+                    .shell_stdout_lines(r#"
+        killall -w shotover-bin > /dev/null || true
+        RUST_BACKTRACE=1 ./shotover-bin --config-file config.yaml --topology-file topology.yaml --log-format json"#)
+                    .await;
         tokio::task::spawn(async move {
-            let mut receiver = self
-            .instance
-            .ssh()
-            .shell_stdout_lines(r#"
-killall -w shotover-bin > /dev/null || true
-RUST_BACKTRACE=1 ./shotover-bin --config-file config.yaml --topology-file topology.yaml --log-format json"#)
-            .await;
             loop {
                 tokio::select! {
                     line = receiver.recv() => {
@@ -310,17 +339,11 @@ RUST_BACKTRACE=1 ./shotover-bin --config-file config.yaml --topology-file topolo
                         }
                     },
                     _ = shutdown_rx.recv() => {
-                        // shutdown_tx is dropped, instructing us to shutdown
-                        // we MUST drop self before dropping event_tx to ensure that the Arc<Ec2InstanceWithShotover> clone is dropped before the task indicates that it has terminated.
-                        // Otherwise we may hit a race condition and fail the assertion that there is only one Arc<Ec2InstanceWithShotover> clone alive.
-                        std::mem::drop(self);
-                        std::mem::drop(event_tx);
                         return;
                     },
                 }
             }
         });
-
         // wait for shotover to startup
         loop {
             let event = event_rx
@@ -334,20 +357,12 @@ RUST_BACKTRACE=1 ./shotover-bin --config-file config.yaml --topology-file topolo
                 break;
             }
         }
-
         RunningShotover {
             shutdown_tx,
             event_rx,
         }
     }
-}
 
-pub struct RunningShotover {
-    shutdown_tx: tokio::sync::mpsc::UnboundedSender<()>,
-    event_rx: tokio::sync::mpsc::UnboundedReceiver<Event>,
-}
-
-impl RunningShotover {
     pub async fn shutdown(mut self) {
         // dropping shutdown_tx instructs the task to shutdown causing shotover to be terminated
         std::mem::drop(self.shutdown_tx);


### PR DESCRIPTION
Before this PR our shotover benches were actually benching directly with kafka completely bypassing shotover!

The KafkaSinkSingle transform is designed to run only on the same machine as the kafka broker.
However the bench currently sets up kafka and shotover on different instances.

One would expect this to result in an error somewhere and the bench to fail.
But what actually happens is that shotover fails to rewrite the metadata query containing the kafka nodes in the cluster and as a result once the bencher receives the metadata query back from shotover it proceeds to send all the benchmark queries directly to kafka.

In more detail:
Shotover will overwrite the port of any brokers returned by the metadata requests.
When shotover and kafka are on different instances they both have ports of 9092.
So we are just overwriting 9092 with 9092, an unintentional noop, and so the client just connects directly to kafka without any error.

This silent failure is really bad and I've raised the following to prevent similar issues from occurring again:
* https://github.com/shotover/shotover-proxy/pull/1371
* https://github.com/shotover/shotover-proxy/issues/1370

This PR fixes the benchmark by moving shotover and kafka onto the same machine for the kafka benchmarks.


kafka windsock results with this PR:
![image](https://github.com/shotover/shotover-proxy/assets/5120858/8fc2208d-885a-474b-a320-516979d2abd7)
