### PR TITLE
KafkaSinkCluster benches

### DIFF
--- a/shotover-proxy/benches/windsock/common.rs
+++ b/shotover-proxy/benches/windsock/common.rs
@@ -1,4 +1,4 @@
-use shotover::{config::topology::Topology, sources::SourceConfig};
+use shotover::{config::topology::Topology as ShotoverTopology, sources::SourceConfig};
 
 #[derive(Clone, Copy)]
 pub enum Shotover {
@@ -21,7 +21,7 @@ impl Shotover {
 }
 
 pub fn generate_topology(source: SourceConfig) -> String {
-    Topology {
+    ShotoverTopology {
         sources: vec![source],
     }
     .serialize()

--- a/shotover-proxy/benches/windsock/main.rs
+++ b/shotover-proxy/benches/windsock/main.rs
@@ -37,7 +37,7 @@ fn main() {
 
     let cassandra_benches = itertools::iproduct!(
         [CassandraDb::Cassandra],
-        [Topology::Single, Topology::Cluster3],
+        [CassandraTopology::Single, CassandraTopology::Cluster3],
         [Shotover::None, Shotover::Standard],
         [Compression::None, Compression::Lz4],
         [Operation::ReadI64, Operation::WriteBlob],
@@ -55,7 +55,7 @@ fn main() {
             }
 
             if driver == CassandraDriver::CdrsTokio
-                && (operation != Operation::ReadI64 || topology != Topology::Single)
+                && (operation != Operation::ReadI64 || topology != CassandraTopology::Single)
             {
                 return None;
             }
@@ -78,9 +78,16 @@ fn main() {
             Shotover::Standard,
             Shotover::ForcedMessageParsed
         ],
-        [Size::B1, Size::KB1, Size::KB100,]
+        [
+            KafkaTopology::Single,
+            KafkaTopology::Cluster1,
+            KafkaTopology::Cluster3
+        ],
+        [Size::B1, Size::KB1, Size::KB100]
     )
-    .map(|(shotover, size)| Box::new(KafkaBench::new(shotover, size)) as Box<dyn Bench>);
+    .map(|(shotover, topology, size)| {
+        Box::new(KafkaBench::new(shotover, topology, size)) as Box<dyn Bench>
+    });
     #[cfg(not(feature = "rdkafka-driver-tests"))]
     let kafka_benches = std::iter::empty();
 
@@ -102,7 +109,7 @@ fn main() {
         vec![
             Box::new(CassandraBench::new(
                 CassandraDb::Mocked,
-                Topology::Single,
+                CassandraTopology::Single,
                 Shotover::None,
                 Compression::None,
                 Operation::ReadI64,
@@ -111,7 +118,7 @@ fn main() {
             )) as Box<dyn Bench>,
             Box::new(CassandraBench::new(
                 CassandraDb::Mocked,
-                Topology::Single,
+                CassandraTopology::Single,
                 Shotover::Standard,
                 Compression::None,
                 Operation::ReadI64,


### PR DESCRIPTION
Previously for kafka we only had topology=single but this PR expands that to:
* topology=single - KafkaSinkSingle connecting to a single kafka instance
* topology=cluster1 - KafkaSinkCluster connecting to a single kafka instance
* topology=cluster3 - KafkaSinkCluster connecting a 3 node kafka cluster