### PR TITLE
Add shotover metrics profiler

### DIFF
--- a/.github/workflows/windsock_benches.yaml
+++ b/.github/workflows/windsock_benches.yaml
@@ -40,6 +40,7 @@ jobs:
         cargo windsock --bench-length-seconds 5 --operations-per-second 100 --profilers flamegraph --name cassandra,compression=none,driver=scylla,operation=read_i64,protocol=v4,shotover=standard,topology=single
         cargo windsock --bench-length-seconds 5 --operations-per-second 100 --profilers samply --name cassandra,compression=none,driver=scylla,operation=read_i64,protocol=v4,shotover=standard,topology=single
         cargo windsock --bench-length-seconds 5 --operations-per-second 100 --profilers sys_monitor --name kafka,shotover=standard,size=1B,topology=single
+        cargo windsock --bench-length-seconds 5 --operations-per-second 100 --profilers shotover_metrics --name redis,encryption=none,operation=get,shotover=standard,topology=single
 
         # windsock/examples/cassandra.rs - this can stay here until windsock is moved to its own repo
         cargo run --release --example cassandra -- --bench-length-seconds 5 --operations-per-second 100

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3412,6 +3412,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus-parse"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2aa5feb83bf4b2c8919eaf563f51dbab41183de73ba2353c0e03cd7b6bd892"
+dependencies = [
+ "chrono",
+ "itertools 0.10.5",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
 name = "quanta"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4450,11 +4462,13 @@ dependencies = [
  "itertools 0.12.0",
  "nix 0.27.1",
  "opensearch",
+ "prometheus-parse",
  "rand 0.8.5",
  "rand_distr",
  "redis",
  "redis-protocol",
  "regex",
+ "reqwest",
  "rstest",
  "rstest_reuse",
  "rustls-pemfile",

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -11,6 +11,8 @@ license = "Apache-2.0"
 shotover = { path = "../shotover" }
 
 [dev-dependencies]
+prometheus-parse = "0.2.4"
+reqwest.workspace = true
 scylla.workspace = true
 anyhow.workspace = true
 tokio.workspace = true

--- a/shotover-proxy/benches/windsock/cassandra.rs
+++ b/shotover-proxy/benches/windsock/cassandra.rs
@@ -552,7 +552,8 @@ impl Bench for CassandraBench {
             }
         }
         let mut profiler =
-            CloudProfilerRunner::new(self.name(), profiling, profiler_instances).await;
+            CloudProfilerRunner::new(self.name(), profiling, profiler_instances, &shotover_ip)
+                .await;
 
         let cassandra_nodes = vec![
             AwsNodeInfo {

--- a/shotover-proxy/benches/windsock/kafka.rs
+++ b/shotover-proxy/benches/windsock/kafka.rs
@@ -245,11 +245,11 @@ impl Bench for KafkaBench {
             }
         }
 
-        let mut profiler =
-            CloudProfilerRunner::new(self.name(), profiling, profiler_instances).await;
-
         let kafka_ip = kafka_instance1.instance.private_ip().to_string();
         let shotover_ip = shotover_instance.instance.private_ip().to_string();
+
+        let mut profiler =
+            CloudProfilerRunner::new(self.name(), profiling, profiler_instances, &kafka_ip).await;
 
         let kafka_instances = vec![
             kafka_instance1.clone(),

--- a/shotover-proxy/benches/windsock/profilers/shotover_metrics.rs
+++ b/shotover-proxy/benches/windsock/profilers/shotover_metrics.rs
@@ -1,0 +1,148 @@
+use prometheus_parse::Value;
+use std::{collections::HashMap, time::Duration};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use windsock::{Goal, Metric, ReportArchive};
+
+pub struct ShotoverMetrics {
+    shutdown_tx: mpsc::Sender<()>,
+    task: JoinHandle<()>,
+}
+type ParsedMetrics = HashMap<String, Vec<Value>>;
+
+impl ShotoverMetrics {
+    pub fn new(bench_name: String, shotover_ip: &str) -> Self {
+        let url = format!("http://{shotover_ip}:9001/metrics");
+        let (shutdown_tx, mut shutdown_rx) = mpsc::channel(1);
+        let task = tokio::spawn(async move {
+            let mut results: ParsedMetrics = HashMap::new();
+            loop {
+                tokio::select! {
+                    _ = shutdown_rx.recv() => {
+                        break;
+                    }
+                    _ = Self::get_metrics(&mut results, &url) => {}
+                }
+            }
+
+            // The bench will start after sar has started so we need to throw away all sar metrics that were recorded before the bench started.
+            // let time_diff = report.bench_started_at - sar.started_at;
+            // let inital_values_to_discard = time_diff.as_seconds_f32().round() as usize;
+            // for values in sar.named_values.values_mut() {
+            //     values.drain(0..inital_values_to_discard);
+            // }
+
+            let mut new_metrics = vec![];
+            for (name, value) in results {
+                match value[0] {
+                    Value::Gauge(_) => {
+                        new_metrics.push(Metric::EachSecond {
+                            name,
+                            values: value
+                                .iter()
+                                .map(|x| {
+                                    let Value::Gauge(x) = x else {
+                                        panic!("metric type changed during bench run")
+                                    };
+                                    (*x, x.to_string(), Goal::SmallerIsBetter) // TODO: Goal::None
+                                })
+                                .collect(),
+                        });
+                    }
+                    Value::Counter(_) => {
+                        let mut prev = 0.0;
+                        new_metrics.push(Metric::EachSecond {
+                            name,
+                            values: value
+                                .iter()
+                                .map(|x| {
+                                    let Value::Counter(x) = x else {
+                                        panic!("metric type changed during bench run")
+                                    };
+                                    let diff = x - prev;
+                                    prev = *x;
+                                    (diff, diff.to_string(), Goal::SmallerIsBetter)
+                                    // TODO: Goal::None
+                                })
+                                .collect(),
+                        });
+                    }
+                    Value::Summary(_) => {
+                        let last = value.last().unwrap();
+                        let Value::Summary(summary) = last else {
+                            panic!("metric type changed during bench run")
+                        };
+                        let values = summary
+                            .iter()
+                            .map(|x| {
+                                (
+                                    x.count,
+                                    format!("{} - {:.4}ms", x.quantile, x.count * 1000.0),
+                                    Goal::SmallerIsBetter,
+                                )
+                            })
+                            .collect();
+                        // TODO: add a Metric::QuantileLatency and use instead
+                        new_metrics.push(Metric::EachSecond { name, values });
+                    }
+                    _ => {
+                        tracing::warn!("Unused shotover metric: {name}")
+                    }
+                }
+            }
+            new_metrics.sort_by_key(|x| {
+                let name = x.name();
+                // move latency metrics to the top
+                if name.starts_with("chain_latency") || name.starts_with("transform_latency") {
+                    format!("aaa_{name}")
+                }
+                // move failure metrics to the bottom.
+                else if name.starts_with("transform_failures")
+                    || name.starts_with("failed_requests")
+                    || name.starts_with("chain_failures")
+                {
+                    format!("zzz_{name}")
+                } else {
+                    name.to_owned()
+                }
+            });
+
+            let mut report = ReportArchive::load(&bench_name).unwrap();
+            report.metrics.extend(new_metrics);
+            report.save();
+        });
+        ShotoverMetrics { task, shutdown_tx }
+    }
+
+    async fn get_metrics(results: &mut ParsedMetrics, url: &str) {
+        let metrics = tokio::time::timeout(Duration::from_secs(3), reqwest::get(url))
+            .await
+            .unwrap()
+            .unwrap()
+            .text()
+            .await
+            .unwrap();
+
+        let metrics =
+            prometheus_parse::Scrape::parse(metrics.lines().map(|x| Ok(x.to_owned()))).unwrap();
+        for sample in metrics.samples {
+            let key = format!(
+                "{}{{{}}}",
+                sample
+                    .metric
+                    .strip_prefix("shotover_")
+                    .unwrap_or(&sample.metric),
+                sample.labels
+            );
+
+            results.entry(key).or_default().push(sample.value);
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await
+    }
+
+    pub fn insert_results_to_bench_archive(self) {
+        std::mem::drop(self.shutdown_tx);
+        // TODO: asyncify it all or something
+        futures::executor::block_on(async { self.task.await.unwrap() })
+    }
+}

--- a/shotover-proxy/benches/windsock/profilers/shotover_metrics.rs
+++ b/shotover-proxy/benches/windsock/profilers/shotover_metrics.rs
@@ -73,7 +73,7 @@ impl ShotoverMetrics {
                                 let Value::Gauge(x) = x else {
                                     panic!("metric type changed during bench run")
                                 };
-                                (*x, x.to_string(), Goal::SmallerIsBetter) // TODO: Goal::None
+                                (*x, x.to_string(), Goal::None)
                             })
                             .collect(),
                     });
@@ -90,8 +90,7 @@ impl ShotoverMetrics {
                                 };
                                 let diff = x - prev;
                                 prev = *x;
-                                (diff, diff.to_string(), Goal::SmallerIsBetter)
-                                // TODO: Goal::None
+                                (diff, diff.to_string(), Goal::None)
                             })
                             .collect(),
                     });

--- a/shotover-proxy/benches/windsock/profilers/shotover_metrics.rs
+++ b/shotover-proxy/benches/windsock/profilers/shotover_metrics.rs
@@ -1,143 +1,168 @@
 use prometheus_parse::Value;
 use std::{collections::HashMap, time::Duration};
-use tokio::sync::mpsc;
+use time::OffsetDateTime;
 use tokio::task::JoinHandle;
+use tokio::{sync::mpsc, time::MissedTickBehavior};
 use windsock::{Goal, Metric, ReportArchive};
 
 pub struct ShotoverMetrics {
     shutdown_tx: mpsc::Sender<()>,
     task: JoinHandle<()>,
 }
+
+pub struct RawPrometheusExposition {
+    timestamp: OffsetDateTime,
+    content: String,
+}
 type ParsedMetrics = HashMap<String, Vec<Value>>;
 
 impl ShotoverMetrics {
     pub fn new(bench_name: String, shotover_ip: &str) -> Self {
         let url = format!("http://{shotover_ip}:9001/metrics");
-        let (shutdown_tx, mut shutdown_rx) = mpsc::channel(1);
+        let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
         let task = tokio::spawn(async move {
-            let mut results: ParsedMetrics = HashMap::new();
-            loop {
-                tokio::select! {
-                    _ = shutdown_rx.recv() => {
-                        break;
-                    }
-                    _ = Self::get_metrics(&mut results, &url) => {}
-                }
-            }
+            // collect metrics until shutdown
+            let raw_metrics = Self::collect_metrics(shutdown_rx, &url).await;
 
-            // The bench will start after sar has started so we need to throw away all sar metrics that were recorded before the bench started.
-            // let time_diff = report.bench_started_at - sar.started_at;
-            // let inital_values_to_discard = time_diff.as_seconds_f32().round() as usize;
-            // for values in sar.named_values.values_mut() {
-            //     values.drain(0..inital_values_to_discard);
-            // }
-
-            let mut new_metrics = vec![];
-            for (name, value) in results {
-                match value[0] {
-                    Value::Gauge(_) => {
-                        new_metrics.push(Metric::EachSecond {
-                            name,
-                            values: value
-                                .iter()
-                                .map(|x| {
-                                    let Value::Gauge(x) = x else {
-                                        panic!("metric type changed during bench run")
-                                    };
-                                    (*x, x.to_string(), Goal::SmallerIsBetter) // TODO: Goal::None
-                                })
-                                .collect(),
-                        });
-                    }
-                    Value::Counter(_) => {
-                        let mut prev = 0.0;
-                        new_metrics.push(Metric::EachSecond {
-                            name,
-                            values: value
-                                .iter()
-                                .map(|x| {
-                                    let Value::Counter(x) = x else {
-                                        panic!("metric type changed during bench run")
-                                    };
-                                    let diff = x - prev;
-                                    prev = *x;
-                                    (diff, diff.to_string(), Goal::SmallerIsBetter)
-                                    // TODO: Goal::None
-                                })
-                                .collect(),
-                        });
-                    }
-                    Value::Summary(_) => {
-                        let last = value.last().unwrap();
-                        let Value::Summary(summary) = last else {
-                            panic!("metric type changed during bench run")
-                        };
-                        let values = summary
-                            .iter()
-                            .map(|x| {
-                                (
-                                    x.count,
-                                    format!("{} - {:.4}ms", x.quantile, x.count * 1000.0),
-                                    Goal::SmallerIsBetter,
-                                )
-                            })
-                            .collect();
-                        // TODO: add a Metric::QuantileLatency and use instead
-                        new_metrics.push(Metric::EachSecond { name, values });
-                    }
-                    _ => {
-                        tracing::warn!("Unused shotover metric: {name}")
-                    }
-                }
-            }
-            new_metrics.sort_by_key(|x| {
-                let name = x.name();
-                // move latency metrics to the top
-                if name.starts_with("chain_latency") || name.starts_with("transform_latency") {
-                    format!("aaa_{name}")
-                }
-                // move failure metrics to the bottom.
-                else if name.starts_with("transform_failures")
-                    || name.starts_with("failed_requests")
-                    || name.starts_with("chain_failures")
-                {
-                    format!("zzz_{name}")
-                } else {
-                    name.to_owned()
-                }
-            });
-
+            // we are now shutting down and need to process and save all collected metrics
             let mut report = ReportArchive::load(&bench_name).unwrap();
-            report.metrics.extend(new_metrics);
+            let parsed = Self::parse_metrics(raw_metrics, &report);
+            report.metrics.extend(Self::windsock_metrics(parsed));
             report.save();
         });
         ShotoverMetrics { task, shutdown_tx }
     }
 
-    async fn get_metrics(results: &mut ParsedMetrics, url: &str) {
-        let metrics = tokio::time::timeout(Duration::from_secs(3), reqwest::get(url))
-            .await
-            .unwrap()
-            .unwrap()
-            .text()
-            .await
-            .unwrap();
+    pub fn parse_metrics(
+        raw_metrics: Vec<RawPrometheusExposition>,
+        report: &ReportArchive,
+    ) -> ParsedMetrics {
+        let mut parsed_metrics: ParsedMetrics = HashMap::new();
+        for raw_metric in raw_metrics {
+            if raw_metric.timestamp > report.bench_started_at {
+                let metrics = prometheus_parse::Scrape::parse(
+                    raw_metric.content.lines().map(|x| Ok(x.to_owned())),
+                )
+                .unwrap();
+                for sample in metrics.samples {
+                    let key = format!(
+                        "{}{{{}}}",
+                        sample
+                            .metric
+                            .strip_prefix("shotover_")
+                            .unwrap_or(&sample.metric),
+                        sample.labels
+                    );
 
-        let metrics =
-            prometheus_parse::Scrape::parse(metrics.lines().map(|x| Ok(x.to_owned()))).unwrap();
-        for sample in metrics.samples {
-            let key = format!(
-                "{}{{{}}}",
-                sample
-                    .metric
-                    .strip_prefix("shotover_")
-                    .unwrap_or(&sample.metric),
-                sample.labels
-            );
-
-            results.entry(key).or_default().push(sample.value);
+                    parsed_metrics.entry(key).or_default().push(sample.value);
+                }
+            }
         }
-        tokio::time::sleep(Duration::from_secs(1)).await
+        parsed_metrics
+    }
+    pub fn windsock_metrics(parsed_metrics: ParsedMetrics) -> Vec<Metric> {
+        let mut new_metrics = vec![];
+        for (name, value) in parsed_metrics {
+            match value[0] {
+                Value::Gauge(_) => {
+                    new_metrics.push(Metric::EachSecond {
+                        name,
+                        values: value
+                            .iter()
+                            .map(|x| {
+                                let Value::Gauge(x) = x else {
+                                    panic!("metric type changed during bench run")
+                                };
+                                (*x, x.to_string(), Goal::SmallerIsBetter) // TODO: Goal::None
+                            })
+                            .collect(),
+                    });
+                }
+                Value::Counter(_) => {
+                    let mut prev = 0.0;
+                    new_metrics.push(Metric::EachSecond {
+                        name,
+                        values: value
+                            .iter()
+                            .map(|x| {
+                                let Value::Counter(x) = x else {
+                                    panic!("metric type changed during bench run")
+                                };
+                                let diff = x - prev;
+                                prev = *x;
+                                (diff, diff.to_string(), Goal::SmallerIsBetter)
+                                // TODO: Goal::None
+                            })
+                            .collect(),
+                    });
+                }
+                Value::Summary(_) => {
+                    let last = value.last().unwrap();
+                    let Value::Summary(summary) = last else {
+                        panic!("metric type changed during bench run")
+                    };
+                    let values = summary
+                        .iter()
+                        .map(|x| {
+                            (
+                                x.count,
+                                format!("{} - {:.4}ms", x.quantile, x.count * 1000.0),
+                                Goal::SmallerIsBetter,
+                            )
+                        })
+                        .collect();
+                    // TODO: add a Metric::QuantileLatency and use instead
+                    new_metrics.push(Metric::EachSecond { name, values });
+                }
+                _ => {
+                    tracing::warn!("Unused shotover metric: {name}")
+                }
+            }
+        }
+        new_metrics.sort_by_key(|x| {
+            let name = x.name();
+            // move latency metrics to the top
+            if name.starts_with("chain_latency") || name.starts_with("transform_latency") {
+                format!("aaa_{name}")
+            }
+            // move failure metrics to the bottom.
+            else if name.starts_with("transform_failures")
+                || name.starts_with("failed_requests")
+                || name.starts_with("chain_failures")
+            {
+                format!("zzz_{name}")
+            } else {
+                name.to_owned()
+            }
+        });
+        new_metrics
+    }
+
+    async fn collect_metrics(
+        mut shutdown_rx: mpsc::Receiver<()>,
+        url: &str,
+    ) -> Vec<RawPrometheusExposition> {
+        let mut results = vec![];
+
+        let mut interval = tokio::time::interval(Duration::from_secs(1));
+        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        loop {
+            tokio::select! {
+                _ = shutdown_rx.recv() => break,
+                _ = interval.tick() => {
+                    match tokio::time::timeout(Duration::from_secs(3), reqwest::get(url)).await.unwrap() {
+                        Ok(response) => {
+                            results.push(RawPrometheusExposition {
+                                timestamp: OffsetDateTime::now_utc(),
+                                content: response.text().await.unwrap(),
+                            });
+                        }
+                        Err(err) => tracing::debug!("Failed to request from metrics endpoint, probably not up yet, error was {err:?}")
+                    }
+                }
+            }
+        }
+        results
     }
 
     pub fn insert_results_to_bench_archive(self) {

--- a/shotover-proxy/benches/windsock/redis.rs
+++ b/shotover-proxy/benches/windsock/redis.rs
@@ -222,11 +222,13 @@ impl Bench for RedisBench {
                 profiler_instances.insert("redis".to_owned(), &instance.instance);
             }
         }
-        let mut profiler =
-            CloudProfilerRunner::new(self.name(), profiling, profiler_instances).await;
 
         let redis_ip = redis_instances.private_ips()[0].to_string();
         let shotover_ip = shotover_instance.instance.private_ip().to_string();
+
+        let mut profiler =
+            CloudProfilerRunner::new(self.name(), profiling, profiler_instances, &shotover_ip)
+                .await;
 
         let (_, running_shotover) = futures::join!(
             redis_instances.run(self.encryption),

--- a/windsock/src/lib.rs
+++ b/windsock/src/lib.rs
@@ -8,7 +8,10 @@ mod report;
 mod tables;
 
 pub use bench::{Bench, BenchParameters, BenchTask, Profiling};
-pub use report::{ExternalReport, Metric, OperationsReport, PubSubReport, Report, ReportArchive};
+pub use report::{
+    ExternalReport, LatencyPercentile, Metric, OperationsReport, PubSubReport, Report,
+    ReportArchive,
+};
 pub use tables::Goal;
 
 use anyhow::{anyhow, Result};

--- a/windsock/src/report.rs
+++ b/windsock/src/report.rs
@@ -161,6 +161,13 @@ pub enum Metric {
 }
 
 impl Metric {
+    pub fn name(&self) -> &str {
+        match self {
+            Metric::Total { name, .. } => name,
+            Metric::EachSecond { name, .. } => name,
+        }
+    }
+
     pub(crate) fn identifier(&self) -> MetricIdentifier {
         match self {
             Metric::Total { name, .. } => MetricIdentifier::Total {

--- a/windsock/src/report.rs
+++ b/windsock/src/report.rs
@@ -158,6 +158,27 @@ pub enum Metric {
         name: String,
         values: Vec<(f64, String, Goal)>,
     },
+    LatencyPercentiles {
+        name: String,
+        values: Vec<LatencyPercentile>,
+    },
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LatencyPercentile {
+    pub quantile: String,
+    pub value: f64,
+    pub value_display: String,
+}
+
+impl LatencyPercentile {
+    pub(crate) fn to_measurement(&self) -> (f64, String, Goal) {
+        (
+            self.value,
+            self.value_display.clone(),
+            Goal::SmallerIsBetter,
+        )
+    }
 }
 
 impl Metric {
@@ -165,6 +186,7 @@ impl Metric {
         match self {
             Metric::Total { name, .. } => name,
             Metric::EachSecond { name, .. } => name,
+            Metric::LatencyPercentiles { name, .. } => name,
         }
     }
 
@@ -176,6 +198,9 @@ impl Metric {
             Metric::EachSecond { name, .. } => MetricIdentifier::EachSecond {
                 name: name.to_owned(),
             },
+            Metric::LatencyPercentiles { name, .. } => MetricIdentifier::LatencyPercentiles {
+                name: name.to_owned(),
+            },
         }
     }
 
@@ -184,6 +209,7 @@ impl Metric {
         match self {
             Metric::Total { .. } => 1,
             Metric::EachSecond { values, .. } => values.len(),
+            Metric::LatencyPercentiles { values, .. } => values.len(),
         }
     }
 }
@@ -192,6 +218,7 @@ impl Metric {
 pub enum MetricIdentifier {
     Total { name: String },
     EachSecond { name: String },
+    LatencyPercentiles { name: String },
 }
 
 fn error_message_insertion(messages: &mut Vec<String>, new_message: String) {

--- a/windsock/src/tables.rs
+++ b/windsock/src/tables.rs
@@ -783,6 +783,7 @@ struct Measurement {
 pub enum Goal {
     BiggerIsBetter,
     SmallerIsBetter,
+    None,
 }
 
 enum Color {

--- a/windsock/src/tables.rs
+++ b/windsock/src/tables.rs
@@ -530,13 +530,13 @@ fn base(reports: &[ReportColumn], table_type: &str) {
                         .iter()
                         .find(|metric| metric.identifier() == metric_identifier)
                         .map(|metric| match metric {
-                            Metric::EachSecond { .. } => unreachable!(),
                             Metric::Total {
                                 compare,
                                 value,
                                 goal,
                                 ..
                             } => (*compare, value.to_owned(), *goal),
+                            _ => unreachable!(),
                         })
                 }));
             }
@@ -561,10 +561,48 @@ fn base(reports: &[ReportColumn], table_type: &str) {
                             .iter()
                             .find(|x| x.identifier() == metric_identifier)
                             .and_then(|metric| match metric {
-                                Metric::Total { .. } => unreachable!(),
                                 Metric::EachSecond { values, .. } => values.get(i).cloned(),
+                                _ => unreachable!(),
                             })
                     }));
+                }
+            }
+            MetricIdentifier::LatencyPercentiles { name } => {
+                rows.push(Row::Heading(format!("{name} Percentiles")));
+                for (i, largest_col) in reports
+                    .iter()
+                    .map(|x| {
+                        x.current
+                            .metrics
+                            .iter()
+                            .find(|x| x.identifier() == metric_identifier)
+                            .map(|metric| match metric {
+                                Metric::LatencyPercentiles { values, .. } => values.clone(),
+                                _ => unreachable!(),
+                            })
+                            .unwrap_or(vec![])
+                    })
+                    .max_by_key(|x| x.len())
+                    .unwrap()
+                    .into_iter()
+                    .enumerate()
+                {
+                    rows.push(Row::measurements(
+                        reports,
+                        &largest_col.quantile,
+                        |report| {
+                            report
+                                .metrics
+                                .iter()
+                                .find(|x| x.identifier() == metric_identifier)
+                                .and_then(|metric| match metric {
+                                    Metric::LatencyPercentiles { values, .. } => {
+                                        values.get(i).map(|x| x.to_measurement())
+                                    }
+                                    _ => unreachable!(),
+                                })
+                        },
+                    ));
                 }
             }
         }


### PR DESCRIPTION
Add a new windsock profiler (`--profilers shotover_metrics`) that fetches metrics from shotovers prometheus web interface.

When I implemented sar based system metrics, I set it up to extract specific hardcoded metrics from the full pool of metrics collected by sar. This made sense there as:
* sar collects a lot of metrics and only some of them are relevant
* sar's naming was quite poor and we can give better names for each item
* we can define an appropriate Goal value for each metric.

However for prometheus metrics I opted to include all metrics as long as we know how to handle that type of metric.
My reasoning is:
* Metrics are very dyanamic, new metrics are added or removed just by adding or removing transforms, so we need to dyanamically adapt to that.
* All metrics are relevant - no need to filter some out
* The names are fine as is - no need to rename them

Unfortunately this does come at the cost of not being able to define goals for some types of metrics.

Running with --cloud doesnt work yet due to EC2 security groups, this will be complicated to resolve, so for now lets land as is because I dont need it to work in the cloud yet.

Running:
```
cargo windsock --profilers shotover_metrics "name=kafka shotover=message-parsed topology=cluster1|single"
cargo windsock --results-by-tags ""
```
we get:
![image](https://github.com/shotover/shotover-proxy/assets/5120858/9ebad00d-493d-4dea-bb1a-aa962a986f20)
