### PR TITLE
Tweak chain naming

### DIFF
--- a/shotover-proxy/tests/cassandra_int_tests/cluster/multi_rack.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cluster/multi_rack.rs
@@ -156,7 +156,7 @@ pub async fn test(connection: &CassandraConnection) {
     test_rewrite_system_peers_v2(connection).await;
 
     let out_of_rack_request = get_metrics_value(
-        "out_of_rack_requests{chain=\"cassandra source chain\",transform=\"CassandraSinkCluster\"}",
+        "out_of_rack_requests{chain=\"cassandra source\",transform=\"CassandraSinkCluster\"}",
     )
     .await;
     assert_eq!(out_of_rack_request, "0");

--- a/shotover-proxy/tests/runner/observability_int_tests.rs
+++ b/shotover-proxy/tests/runner/observability_int_tests.rs
@@ -20,8 +20,8 @@ async fn test_metrics() {
 # TYPE shotover_transform_total counter
 query_count{name="redis-chain"}
 shotover_available_connections{source="redis"}
-shotover_chain_failures{chain="redis source chain"}
-shotover_chain_total{chain="redis source chain"}
+shotover_chain_failures{chain="redis source"}
+shotover_chain_total{chain="redis source"}
 shotover_transform_failures{transform="NullSink"}
 shotover_transform_failures{transform="QueryCounter"}
 shotover_transform_latency_count{transform="NullSink"}
@@ -72,15 +72,15 @@ shotover_transform_total{transform="QueryCounter"}
 # TYPE shotover_chain_latency summary
 query_count{name="redis-chain",query="GET",type="redis"}
 query_count{name="redis-chain",query="SET",type="redis"}
-shotover_chain_latency_count{chain="redis source chain",client_details="127.0.0.1"}
-shotover_chain_latency_sum{chain="redis source chain",client_details="127.0.0.1"}
-shotover_chain_latency{chain="redis source chain",client_details="127.0.0.1",quantile="0"}
-shotover_chain_latency{chain="redis source chain",client_details="127.0.0.1",quantile="0.5"}
-shotover_chain_latency{chain="redis source chain",client_details="127.0.0.1",quantile="0.9"}
-shotover_chain_latency{chain="redis source chain",client_details="127.0.0.1",quantile="0.95"}
-shotover_chain_latency{chain="redis source chain",client_details="127.0.0.1",quantile="0.99"}
-shotover_chain_latency{chain="redis source chain",client_details="127.0.0.1",quantile="0.999"}
-shotover_chain_latency{chain="redis source chain",client_details="127.0.0.1",quantile="1"}
+shotover_chain_latency_count{chain="redis source",client_details="127.0.0.1"}
+shotover_chain_latency_sum{chain="redis source",client_details="127.0.0.1"}
+shotover_chain_latency{chain="redis source",client_details="127.0.0.1",quantile="0"}
+shotover_chain_latency{chain="redis source",client_details="127.0.0.1",quantile="0.5"}
+shotover_chain_latency{chain="redis source",client_details="127.0.0.1",quantile="0.9"}
+shotover_chain_latency{chain="redis source",client_details="127.0.0.1",quantile="0.95"}
+shotover_chain_latency{chain="redis source",client_details="127.0.0.1",quantile="0.99"}
+shotover_chain_latency{chain="redis source",client_details="127.0.0.1",quantile="0.999"}
+shotover_chain_latency{chain="redis source",client_details="127.0.0.1",quantile="1"}
 "#;
     assert_metrics_has_keys(expected, expected_new).await;
 

--- a/shotover-proxy/tests/runner/runner_int_tests.rs
+++ b/shotover-proxy/tests/runner/runner_int_tests.rs
@@ -103,14 +103,14 @@ Caused by:
     redis source:
       redis source chain:
         TuneableConsistencyScatter:
-          a_chain_1:
+          a_chain_1 chain:
             Terminating transform "NullSink" is not last in chain. Terminating transform must be last in chain.
             Non-terminating transform "DebugPrinter" is last in chain. Last transform must be terminating.
-          b_chain_2:
+          b_chain_2 chain:
             Terminating transform "NullSink" is not last in chain. Terminating transform must be last in chain.
-          c_chain_3:
+          c_chain_3 chain:
             TuneableConsistencyScatter:
-              sub_chain_2:
+              sub_chain_2 chain:
                 Terminating transform "NullSink" is not last in chain. Terminating transform must be last in chain.
     "#),
             EventMatcher::new().with_level(Level::Warn)

--- a/shotover/src/config/topology.rs
+++ b/shotover/src/config/topology.rs
@@ -243,7 +243,7 @@ foo source:
 foo source:
   foo source chain:
     TuneableConsistencyScatter:
-      subchain-1:
+      subchain-1 chain:
         Terminating transform "NullSink" is not last in chain. Terminating transform must be last in chain.
 "#;
 
@@ -300,7 +300,7 @@ foo source:
 foo source:
   foo source chain:
     RedisCache:
-      cache_chain:
+      cache_chain chain:
         Terminating transform "NullSink" is not last in chain. Terminating transform must be last in chain.
 "#;
 
@@ -350,7 +350,7 @@ foo source:
 foo source:
   foo source chain:
     ParallelMap:
-      parallel_map_chain:
+      parallel_map_chain chain:
         Terminating transform "NullSink" is not last in chain. Terminating transform must be last in chain.
 "#;
 
@@ -381,7 +381,7 @@ foo source:
 foo source:
   foo source chain:
     TuneableConsistencyScatter:
-      subchain-1:
+      subchain-1 chain:
         Terminating transform "NullSink" is not last in chain. Terminating transform must be last in chain.
 "#;
 
@@ -417,7 +417,7 @@ foo source:
 foo source:
   foo source chain:
     TuneableConsistencyScatter:
-      subchain-1:
+      subchain-1 chain:
         Non-terminating transform "DebugPrinter" is last in chain. Last transform must be terminating.
 "#;
 
@@ -451,7 +451,7 @@ foo source:
 foo source:
   foo source chain:
     TuneableConsistencyScatter:
-      subchain-1:
+      subchain-1 chain:
         Terminating transform "NullSink" is not last in chain. Terminating transform must be last in chain.
         Non-terminating transform "DebugPrinter" is last in chain. Last transform must be terminating.
 "#;
@@ -503,14 +503,14 @@ redis source:
 redis source:
   redis source chain:
     TuneableConsistencyScatter:
-      a_chain_1:
+      a_chain_1 chain:
         Terminating transform "NullSink" is not last in chain. Terminating transform must be last in chain.
         Non-terminating transform "DebugPrinter" is last in chain. Last transform must be terminating.
-      b_chain_2:
+      b_chain_2 chain:
         Terminating transform "NullSink" is not last in chain. Terminating transform must be last in chain.
-      c_chain_3:
+      c_chain_3 chain:
         TuneableConsistencyScatter:
-          sub_chain_2:
+          sub_chain_2 chain:
             Terminating transform "NullSink" is not last in chain. Terminating transform must be last in chain.
 "#;
 

--- a/shotover/src/server.rs
+++ b/shotover/src/server.rs
@@ -94,7 +94,7 @@ impl<C: CodecBuilder + 'static> TcpCodecListener<C> {
         available_connections_gauge.set(limit_connections.available_permits() as f64);
 
         let chain_builder = chain_config
-            .get_builder(format!("{source_name} source chain"))
+            .get_builder(format!("{source_name} source"))
             .await
             .map_err(|x| vec![format!("{x:?}")])?;
 

--- a/shotover/src/transforms/chain.rs
+++ b/shotover/src/transforms/chain.rs
@@ -231,7 +231,7 @@ impl TransformChainBuilder {
     pub fn validate(&self) -> Vec<String> {
         if self.chain.is_empty() {
             return vec![
-                format!("{}:", self.name),
+                format!("{} chain:", self.name),
                 "  Chain cannot be empty".to_string(),
             ];
         }
@@ -264,7 +264,7 @@ impl TransformChainBuilder {
             .collect::<Vec<String>>();
 
         if !errors.is_empty() {
-            errors.insert(0, format!("{}:", self.name));
+            errors.insert(0, format!("{} chain:", self.name));
         }
 
         errors
@@ -386,7 +386,7 @@ mod chain_tests {
         let chain = TransformChainBuilder::new(vec![], "test-chain".to_string());
         assert_eq!(
             chain.validate(),
-            vec!["test-chain:", "  Chain cannot be empty"]
+            vec!["test-chain chain:", "  Chain cannot be empty"]
         );
     }
 

--- a/shotover/src/transforms/distributed/tuneable_consistency_scatter.rs
+++ b/shotover/src/transforms/distributed/tuneable_consistency_scatter.rs
@@ -402,7 +402,7 @@ mod scatter_transform_tests {
             transform.validate(),
             vec![
                 "TuneableConsistencyScatter:",
-                "  test-chain-2:",
+                "  test-chain-2 chain:",
                 "    Chain cannot be empty"
             ]
         );

--- a/shotover/src/transforms/parallel_map.rs
+++ b/shotover/src/transforms/parallel_map.rs
@@ -188,7 +188,7 @@ mod parallel_map_tests {
             transform.validate(),
             vec![
                 "ParallelMap:",
-                "  test-chain-2:",
+                "  test-chain-2 chain:",
                 "    Chain cannot be empty"
             ]
         );

--- a/shotover/src/transforms/redis/cache.rs
+++ b/shotover/src/transforms/redis/cache.rs
@@ -812,7 +812,11 @@ mod test {
 
         assert_eq!(
             transform.validate(),
-            vec!["RedisCache:", "  test-chain:", "    Chain cannot be empty"]
+            vec![
+                "RedisCache:",
+                "  test-chain chain:",
+                "    Chain cannot be empty"
+            ]
         );
     }
 

--- a/shotover/src/transforms/tee.rs
+++ b/shotover/src/transforms/tee.rs
@@ -457,7 +457,7 @@ mod tests {
         let transform = config.get_builder("".to_owned()).await.unwrap();
         let result = transform.validate().join("\n");
         let expected = r#"Tee:
-  tee_chain:
+  tee_chain chain:
     Terminating transform "NullSink" is not last in chain. Terminating transform must be last in chain."#;
         assert_eq!(result, expected);
     }
@@ -505,7 +505,7 @@ mod tests {
         let transform = config.get_builder("".to_owned()).await.unwrap();
         let result = transform.validate().join("\n");
         let expected = r#"Tee:
-  mismatch_chain:
+  mismatch_chain chain:
     Terminating transform "NullSink" is not last in chain. Terminating transform must be last in chain."#;
         assert_eq!(result, expected);
     }

--- a/shotover/src/transforms/throttling.rs
+++ b/shotover/src/transforms/throttling.rs
@@ -130,7 +130,7 @@ mod test {
             assert_eq!(
                 chain.validate(),
                 vec![
-                    "test-chain:",
+                    "test-chain chain:",
                     "  RequestThrottling:",
                     "    max_requests_per_second has a minimum allowed value of 50"
                 ]


### PR DESCRIPTION
This PR tweaks chain naming so that it does not include "chain" in the name by default, allowing us to avoid including "chain" when it would be redundant.

There are two use cases of chain names:
* metrics - chain was redundant here, so this is now improved.
* topology validation - this PR alters the output of chain validation to make it clear that the chain name is referring to a chain.