### PR TITLE
Update rustls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "pin-utils",
- "rustls",
+ "rustls 0.21.9",
  "tokio",
  "tracing",
 ]
@@ -1235,8 +1235,8 @@ dependencies = [
  "cassandra-protocol",
  "futures-util",
  "http",
- "rustls",
- "rustls-pemfile",
+ "rustls 0.21.9",
+ "rustls-pemfile 1.0.4",
  "tokio",
  "tokio-tungstenite 0.20.1 (git+https://github.com/shotover/tokio-tungstenite)",
 ]
@@ -1962,13 +1962,13 @@ dependencies = [
  "parking_lot",
  "rand 0.8.5",
  "redis-protocol",
- "rustls",
+ "rustls 0.21.9",
  "rustls-native-certs",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "semver",
  "socket2 0.5.5",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-stream",
  "tokio-util",
  "url",
@@ -2337,10 +2337,10 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls",
+ "rustls 0.21.9",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -4005,8 +4005,22 @@ checksum = "629648aced5775d558af50b2b4c7b02983a04b312126d45eeead26e7caa498b9"
 dependencies = [
  "log",
  "ring 0.17.6",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bc238b76c51bbc449c55ffbc39d03772a057cc8cf783c49d4af4c2537b74a8b"
+dependencies = [
+ "log",
+ "ring 0.17.6",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.0",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -4016,7 +4030,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "schannel",
  "security-framework",
 ]
@@ -4031,12 +4045,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e4980fa29e4c4b212ffb3db068a564cbf560e51d3944b7c88bd8bf5bec64f4"
+dependencies = [
+ "base64",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7673e0aa20ee4937c6aacfc12bb8341cfbf054cdd21df6bec5fd0629fe9339b"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring 0.17.6",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de2635c8bc2b88d367767c5de8ea1d8db9af3f6219eba28442242d9ab81d1b89"
+dependencies = [
+ "ring 0.17.6",
+ "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
@@ -4414,8 +4455,9 @@ dependencies = [
  "rand 0.8.5",
  "rand_distr",
  "redis-protocol",
- "rustls",
- "rustls-pemfile",
+ "rustls 0.22.0",
+ "rustls-pemfile 2.0.0",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -4423,7 +4465,7 @@ dependencies = [
  "strum_macros 0.25.3",
  "thiserror",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.25.0",
  "tokio-stream",
  "tokio-tungstenite 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-util",
@@ -4471,7 +4513,7 @@ dependencies = [
  "reqwest",
  "rstest",
  "rstest_reuse",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "scylla",
  "serde",
  "serde_json",
@@ -4967,7 +5009,18 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.9",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.0",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -5001,10 +5054,10 @@ source = "git+https://github.com/shotover/tokio-tungstenite#2f1cc11e491c2d0401d0
 dependencies = [
  "futures-util",
  "log",
- "rustls",
+ "rustls 0.21.9",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tungstenite 0.19.0",
 ]
 
@@ -5170,7 +5223,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "rustls",
+ "rustls 0.21.9",
  "sha1",
  "thiserror",
  "url",

--- a/shotover-proxy/benches/windsock/redis.rs
+++ b/shotover-proxy/benches/windsock/redis.rs
@@ -378,6 +378,8 @@ impl Bench for RedisBench {
     }
 }
 
+// TODO: when fred updates its rustls version recopy these functions from shotover/src/tls.rs
+
 fn load_certs(path: &str) -> Vec<Certificate> {
     load_certs_inner(path)
         .with_context(|| format!("Failed to read certs at {path:?}"))

--- a/shotover/Cargo.toml
+++ b/shotover/Cargo.toml
@@ -81,14 +81,10 @@ strum_macros = "0.25"
 chacha20poly1305 = { version = "0.10.0", features = ["std"] }
 generic-array = { version = "0.14", features = ["serde"] }
 kafka-protocol = "0.7.0"
-# dangerous_configuration is used to implement equivalent functionality to openssl `verify_hostname(false)`
-#
-# verify_hostname(false) like functionality can be useful when you're forced to use a particular domain name and it's impractical to generate a fresh certificate with that domain name
-# e.g. we generate a huge pool of certificates up front (to handle bursts given the Let's Encrypt rate limiting),
-# and later assign them to clusters, so the certificates have a fixed set of domains baked in.
-rustls = { version = "0.21.0", features = ["dangerous_configuration"] }
-tokio-rustls = "0.24"
-rustls-pemfile = "1.0.2"
+rustls = { version = "0.22.0" }
+tokio-rustls = "0.25"
+rustls-pemfile = "2.0.0"
+rustls-pki-types = "1.0.1"
 string = "0.3.0"
 xxhash-rust = { version = "0.8.6", features = ["xxh3"] }
 dashmap = "5.4.0"


### PR DESCRIPTION
Mostly various reshuffling of types, logic is largely the same.

* dangerous_configuration feature is no longer needed, instead rustls has chosen to convey the same idea via including `danger` in the module name and a `dangerous` method in the `ClientConfigBuilder`
* `RSAKey` was renamed to `Pkcs1Key` here: https://github.com/rustls/pemfile/commit/6f0724bfd5db1a97341218bb22ac32fbfece4a82