### PR TITLE
Add batch size metric + rename existing metrics

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,27 @@
 Any breaking changes to the `topology.yaml` or `shotover` rust API should be documented here.
 This assists us in knowing when to make the next release a breaking release and assists users with making upgrades to new breaking releases.
 
+## 0.3.0
+
+### metrics
+
+The prometheus metrics were renamed to better follow the official reccomended naming scheme: <https://prometheus.io/docs/practices/naming/>
+This included ensuring all meterics were prefixed with `shotover_` and all metrics were suffixed with an appropriate `_unit`.
+This includes:
+
+* `shotover_transform_total` -> `shotover_transform_total_count`
+* `shotover_transform_failures` -> `shotover_transform_failures_count`
+* `shotover_transform_latency`  -> `shotover_transform_latency_seconds`
+* `shotover_chain_total` -> `shotover_chain_total_count`
+* `shotover_chain_failures`  -> `shotover_chain_failures_count`
+* `shotover_chain_latency`  -> `shotover_chain_latency_seconds`
+* `shotover_available_connections` -> `shotover_available_connections_count`
+* `shotover_chain_failures` -> `shotover_chain_failures_count`
+* `out_of_rack_requests`  -> `shotover_out_of_rack_requests_count`
+* `client_protocol_version` -> `shotover_client_protocol_version_count`
+* `failed_requests` -> `shotover_failed_requests_count`
+* `query_count` -> `shotover_query_count`
+
 ## 0.2.0
 
 ### topology.yaml
@@ -56,15 +77,7 @@ The usage of the Filter transform has been changed to use either an allow list o
         DenyList: [Read]
 ```
 
-
-
-### shotover rust api
-
 ## 0.1.11
-
-### topology.yaml
-
-* No recorded changes
 
 ### shotover rust api
 

--- a/docs/src/user-guide/observability.md
+++ b/docs/src/user-guide/observability.md
@@ -2,15 +2,17 @@
 
 This interface will serve Prometheus metrics from `/metrics`. The following metrics are included by default, others are transform specific.
 
-| Name                             | Labels      | Data type               | Description                                               |
-|----------------------------------|-------------|-------------------------|-----------------------------------------------------------|
-| `shotover_transform_total`       | `transform` | [counter](#counter)     | Counts the amount of times the `transform` is used        |
-| `shotover_transform_failures`    | `transform` | [counter](#counter)     | Counts the amount of times the `transform` fails          |
-| `shotover_transform_latency`     | `transform` | [histogram](#histogram) | The latency for running `transform`                       |
-| `shotover_chain_total`           | `chain`     | [counter](#counter)     | Counts the amount of times `chain` is used                |
-| `shotover_chain_failures`        | `chain`     | [counter](#counter)     | Counts the amount of times `chain` fails                  |
-| `shotover_chain_latency`         | `chain`     | [histogram](#histogram) | The latency for running `chain`                           |
-| `shotover_available_connections` | `source`    | [gauge](#gauge)         | The number of connections currently connected to `source` |
+| Name                                       | Labels      | Data type               | Description                                                               |
+|--------------------------------------------|-------------|-------------------------|---------------------------------------------------------------------------|
+| `shotover_transform_total_count`           | `transform` | [counter](#counter)     | Counts the amount of times the `transform` is used                        |
+| `shotover_transform_failures_count`        | `transform` | [counter](#counter)     | Counts the amount of times the `transform` fails                          |
+| `shotover_transform_latency_seconds`       | `transform` | [histogram](#histogram) | The latency for a message batch to go through the `transform`             |
+| `shotover_transform_pushed_latency_seconds`| `transform` | [histogram](#histogram) | The latency for a pushed message from the DB to go through the `transform`|
+| `shotover_chain_total_count`               | `chain`     | [counter](#counter)     | Counts the amount of times `chain` is used                                |
+| `shotover_chain_failures_count`            | `chain`     | [counter](#counter)     | Counts the amount of times `chain` fails                                  |
+| `shotover_chain_latency_seconds`           | `chain`     | [histogram](#histogram) | The latency for running `chain`                                           |
+| `shotover_chain_messages_per_batch_count`  | `chain`     | [histogram](#histogram) | The number of messages in each batch passing through `chain`.             |
+| `shotover_available_connections_count`     | `source`    | [gauge](#gauge)         | The number of connections currently connected to `source`                 |
 
 ## Metric data types
 
@@ -26,7 +28,7 @@ Measures the distribution of values for a set of measurements and starts with no
 
 A single value that can increment or decrement over time. Starts out with an initial value of zero.
 
-# Log levels and filters
+## Log levels and filters
 
 You can configure log levels and filters at `/filter`. This can be done by a POST HTTP request to the `/filter` endpoint with the `env_filter` string set as the POST data. For example:
 

--- a/shotover-proxy/tests/cassandra_int_tests/cache/assert.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cache/assert.rs
@@ -5,7 +5,7 @@ use test_helpers::metrics::get_metrics_value;
 
 /// gets the current miss count from the cache instrumentation.
 async fn get_cache_miss_value() -> u64 {
-    let value = get_metrics_value("cache_miss").await;
+    let value = get_metrics_value("shotover_cache_miss_count").await;
     value
         .parse()
         .map_err(|_| format!("Failed to parse {value} to integer"))

--- a/shotover-proxy/tests/cassandra_int_tests/cluster/multi_rack.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cluster/multi_rack.rs
@@ -156,7 +156,7 @@ pub async fn test(connection: &CassandraConnection) {
     test_rewrite_system_peers_v2(connection).await;
 
     let out_of_rack_request = get_metrics_value(
-        "out_of_rack_requests{chain=\"cassandra source\",transform=\"CassandraSinkCluster\"}",
+        "shotover_out_of_rack_requests_count{chain=\"cassandra source\",transform=\"CassandraSinkCluster\"}",
     )
     .await;
     assert_eq!(out_of_rack_request, "0");

--- a/shotover-proxy/tests/runner/observability_int_tests.rs
+++ b/shotover-proxy/tests/runner/observability_int_tests.rs
@@ -11,39 +11,50 @@ async fn test_metrics() {
 
     // Expected string looks unnatural because it is sorted in alphabetical order to make it match the sorted error output
     let expected = r#"
-# TYPE query_count counter
-# TYPE shotover_available_connections gauge
-# TYPE shotover_chain_failures counter
-# TYPE shotover_chain_total counter
-# TYPE shotover_transform_failures counter
-# TYPE shotover_transform_latency summary
-# TYPE shotover_transform_total counter
-query_count{name="redis-chain"}
-shotover_available_connections{source="redis"}
-shotover_chain_failures{chain="redis source"}
-shotover_chain_total{chain="redis source"}
-shotover_transform_failures{transform="NullSink"}
-shotover_transform_failures{transform="QueryCounter"}
-shotover_transform_latency_count{transform="NullSink"}
-shotover_transform_latency_count{transform="QueryCounter"}
-shotover_transform_latency_sum{transform="NullSink"}
-shotover_transform_latency_sum{transform="QueryCounter"}
-shotover_transform_latency{transform="NullSink",quantile="0"}
-shotover_transform_latency{transform="NullSink",quantile="0.5"}
-shotover_transform_latency{transform="NullSink",quantile="0.9"}
-shotover_transform_latency{transform="NullSink",quantile="0.95"}
-shotover_transform_latency{transform="NullSink",quantile="0.99"}
-shotover_transform_latency{transform="NullSink",quantile="0.999"}
-shotover_transform_latency{transform="NullSink",quantile="1"}
-shotover_transform_latency{transform="QueryCounter",quantile="0"}
-shotover_transform_latency{transform="QueryCounter",quantile="0.5"}
-shotover_transform_latency{transform="QueryCounter",quantile="0.9"}
-shotover_transform_latency{transform="QueryCounter",quantile="0.95"}
-shotover_transform_latency{transform="QueryCounter",quantile="0.99"}
-shotover_transform_latency{transform="QueryCounter",quantile="0.999"}
-shotover_transform_latency{transform="QueryCounter",quantile="1"}
-shotover_transform_total{transform="NullSink"}
-shotover_transform_total{transform="QueryCounter"}
+# TYPE shotover_available_connections_count gauge
+# TYPE shotover_chain_failures_count counter
+# TYPE shotover_chain_messages_per_batch_count summary
+# TYPE shotover_chain_total_count counter
+# TYPE shotover_query_count counter
+# TYPE shotover_transform_failures_count counter
+# TYPE shotover_transform_latency_seconds summary
+# TYPE shotover_transform_total_count counter
+shotover_available_connections_count{source="redis"}
+shotover_chain_failures_count{chain="redis source"}
+shotover_chain_messages_per_batch_count_count{chain="redis source"}
+shotover_chain_messages_per_batch_count_sum{chain="redis source"}
+shotover_chain_messages_per_batch_count{chain="redis source",quantile="0"}
+shotover_chain_messages_per_batch_count{chain="redis source",quantile="0.5"}
+shotover_chain_messages_per_batch_count{chain="redis source",quantile="0.9"}
+shotover_chain_messages_per_batch_count{chain="redis source",quantile="0.95"}
+shotover_chain_messages_per_batch_count{chain="redis source",quantile="0.99"}
+shotover_chain_messages_per_batch_count{chain="redis source",quantile="0.999"}
+shotover_chain_messages_per_batch_count{chain="redis source",quantile="1"}
+shotover_chain_total_count{chain="redis source"}
+shotover_query_count{name="redis-chain"}
+shotover_transform_failures_count{transform="NullSink"}
+shotover_transform_failures_count{transform="QueryCounter"}
+shotover_transform_latency_seconds_count{transform="NullSink"}
+shotover_transform_latency_seconds_count{transform="QueryCounter"}
+shotover_transform_latency_seconds_sum{transform="NullSink"}
+shotover_transform_latency_seconds_sum{transform="QueryCounter"}
+shotover_transform_latency_seconds{transform="NullSink",quantile="0"}
+shotover_transform_latency_seconds{transform="NullSink",quantile="0.5"}
+shotover_transform_latency_seconds{transform="NullSink",quantile="0.9"}
+shotover_transform_latency_seconds{transform="NullSink",quantile="0.95"}
+shotover_transform_latency_seconds{transform="NullSink",quantile="0.99"}
+shotover_transform_latency_seconds{transform="NullSink",quantile="0.999"}
+shotover_transform_latency_seconds{transform="NullSink",quantile="1"}
+shotover_transform_latency_seconds{transform="QueryCounter",quantile="0"}
+shotover_transform_latency_seconds{transform="QueryCounter",quantile="0.5"}
+shotover_transform_latency_seconds{transform="QueryCounter",quantile="0.9"}
+shotover_transform_latency_seconds{transform="QueryCounter",quantile="0.95"}
+shotover_transform_latency_seconds{transform="QueryCounter",quantile="0.99"}
+shotover_transform_latency_seconds{transform="QueryCounter",quantile="0.999"}
+shotover_transform_latency_seconds{transform="QueryCounter",quantile="1"}
+shotover_transform_total_count{transform="NullSink"}
+shotover_transform_total_count{transform="QueryCounter"}
+
 "#;
     assert_metrics_has_keys("", expected).await;
 
@@ -69,28 +80,32 @@ shotover_transform_total{transform="QueryCounter"}
         .unwrap_err();
 
     let expected_new = r#"
-# TYPE shotover_chain_latency summary
-query_count{name="redis-chain",query="GET",type="redis"}
-query_count{name="redis-chain",query="SET",type="redis"}
-shotover_chain_latency_count{chain="redis source",client_details="127.0.0.1"}
-shotover_chain_latency_sum{chain="redis source",client_details="127.0.0.1"}
-shotover_chain_latency{chain="redis source",client_details="127.0.0.1",quantile="0"}
-shotover_chain_latency{chain="redis source",client_details="127.0.0.1",quantile="0.5"}
-shotover_chain_latency{chain="redis source",client_details="127.0.0.1",quantile="0.9"}
-shotover_chain_latency{chain="redis source",client_details="127.0.0.1",quantile="0.95"}
-shotover_chain_latency{chain="redis source",client_details="127.0.0.1",quantile="0.99"}
-shotover_chain_latency{chain="redis source",client_details="127.0.0.1",quantile="0.999"}
-shotover_chain_latency{chain="redis source",client_details="127.0.0.1",quantile="1"}
+# TYPE shotover_chain_latency_seconds summary
+# TYPE shotover_transform_total counter
+shotover_chain_latency_seconds_count{chain="redis source",client_details="127.0.0.1"}
+shotover_chain_latency_seconds_sum{chain="redis source",client_details="127.0.0.1"}
+shotover_chain_latency_seconds{chain="redis source",client_details="127.0.0.1",quantile="0"}
+shotover_chain_latency_seconds{chain="redis source",client_details="127.0.0.1",quantile="0.5"}
+shotover_chain_latency_seconds{chain="redis source",client_details="127.0.0.1",quantile="0.9"}
+shotover_chain_latency_seconds{chain="redis source",client_details="127.0.0.1",quantile="0.95"}
+shotover_chain_latency_seconds{chain="redis source",client_details="127.0.0.1",quantile="0.99"}
+shotover_chain_latency_seconds{chain="redis source",client_details="127.0.0.1",quantile="0.999"}
+shotover_chain_latency_seconds{chain="redis source",client_details="127.0.0.1",quantile="1"}
+shotover_query_count{name="redis-chain",query="GET",type="redis"}
+shotover_query_count{name="redis-chain",query="SET",type="redis"}
+shotover_transform_total{transform="NullSink"}
+shotover_transform_total{transform="QueryCounter"}
+
 "#;
     assert_metrics_has_keys(expected, expected_new).await;
 
     assert_metrics_key_value(
-        r#"query_count{name="redis-chain",query="GET",type="redis"}"#,
+        r#"shotover_query_count{name="redis-chain",query="GET",type="redis"}"#,
         "1",
     )
     .await;
     assert_metrics_key_value(
-        r#"query_count{name="redis-chain",query="SET",type="redis"}"#,
+        r#"shotover_query_count{name="redis-chain",query="SET",type="redis"}"#,
         "2",
     )
     .await;

--- a/shotover/src/codec/cassandra.rs
+++ b/shotover/src/codec/cassandra.rs
@@ -143,9 +143,9 @@ pub struct VersionCounter {
 impl VersionCounter {
     fn new() -> Self {
         Self {
-            v3: register_counter!("client_protocol_version", "version" => "v3"),
-            v4: register_counter!("client_protocol_version", "version" => "v4"),
-            v5: register_counter!("client_protocol_version", "version" => "v5"),
+            v3: register_counter!("shotover_client_protocol_version_count", "version" => "v3"),
+            v4: register_counter!("shotover_client_protocol_version_count", "version" => "v4"),
+            v5: register_counter!("shotover_client_protocol_version_count", "version" => "v5"),
         }
     }
 

--- a/shotover/src/server.rs
+++ b/shotover/src/server.rs
@@ -89,8 +89,7 @@ impl<C: CodecBuilder + 'static> TcpCodecListener<C> {
         timeout: Option<u64>,
         transport: Transport,
     ) -> Result<Self, Vec<String>> {
-        let available_connections_gauge =
-            register_gauge!("shotover_available_connections", "source" => source_name.clone());
+        let available_connections_gauge = register_gauge!("shotover_available_connections_count", "source" => source_name.clone());
         available_connections_gauge.set(limit_connections.available_permits() as f64);
 
         let chain_builder = chain_config

--- a/shotover/src/transforms/cassandra/sink_cluster/mod.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/mod.rs
@@ -114,7 +114,7 @@ impl CassandraSinkClusterBuilder {
         connect_timeout_ms: u64,
         timeout: Option<u64>,
     ) -> Self {
-        let failed_requests = register_counter!("failed_requests", "chain" => chain_name.clone(), "transform" => "CassandraSinkCluster");
+        let failed_requests = register_counter!("shotover_failed_requests_count", "chain" => chain_name.clone(), "transform" => "CassandraSinkCluster");
         let receive_timeout = timeout.map(Duration::from_secs);
         let connect_timeout = Duration::from_millis(connect_timeout_ms);
 

--- a/shotover/src/transforms/cassandra/sink_cluster/node_pool.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/node_pool.rs
@@ -55,7 +55,7 @@ impl NodePoolBuilder {
     pub fn new(chain_name: String) -> Self {
         Self {
             prepared_metadata: Arc::new(RwLock::new(HashMap::new())),
-            out_of_rack_requests: register_counter!("out_of_rack_requests", "chain" => chain_name, "transform" => "CassandraSinkCluster"),
+            out_of_rack_requests: register_counter!("shotover_out_of_rack_requests_count", "chain" => chain_name, "transform" => "CassandraSinkCluster"),
         }
     }
 

--- a/shotover/src/transforms/cassandra/sink_single.rs
+++ b/shotover/src/transforms/cassandra/sink_single.rs
@@ -59,7 +59,7 @@ impl CassandraSinkSingleBuilder {
         connect_timeout_ms: u64,
         timeout: Option<u64>,
     ) -> CassandraSinkSingleBuilder {
-        let failed_requests = register_counter!("failed_requests", "chain" => chain_name, "transform" => "CassandraSinkSingle");
+        let failed_requests = register_counter!("shotover_failed_requests_count", "chain" => chain_name, "transform" => "CassandraSinkSingle");
         let receive_timeout = timeout.map(Duration::from_secs);
         let codec_builder = CassandraCodecBuilder::new(Direction::Sink);
 

--- a/shotover/src/transforms/mod.rs
+++ b/shotover/src/transforms/mod.rs
@@ -337,7 +337,7 @@ impl<'a> Wrapper<'a> {
         if result.is_err() {
             counter!("shotover_transform_failures", 1, "transform" => transform_name)
         }
-        histogram!("shotover_transform_latency", start.elapsed(),  "transform" => transform_name);
+        histogram!("shotover_transform_latency_seconds", start.elapsed(),  "transform" => transform_name);
         result
     }
 
@@ -358,7 +358,7 @@ impl<'a> Wrapper<'a> {
         if result.is_err() {
             counter!("shotover_transform_pushed_failures", 1, "transform" => transform_name)
         }
-        histogram!("shotover_transform_pushed_latency", start.elapsed(),  "transform" => transform_name);
+        histogram!("shotover_transform_pushed_latency_seconds", start.elapsed(),  "transform" => transform_name);
         result
     }
 

--- a/shotover/src/transforms/query_counter.rs
+++ b/shotover/src/transforms/query_counter.rs
@@ -22,7 +22,7 @@ pub struct QueryCounterConfig {
 
 impl QueryCounter {
     pub fn new(counter_name: String) -> Self {
-        register_counter!("query_count", "name" => counter_name.clone());
+        register_counter!("shotover_query_count", "name" => counter_name.clone());
 
         QueryCounter { counter_name }
     }
@@ -45,18 +45,18 @@ impl Transform for QueryCounter {
             match m.frame() {
                 Some(Frame::Cassandra(frame)) => {
                     for statement in frame.operation.queries() {
-                        counter!("query_count", 1, "name" => self.counter_name.clone(), "query" => statement.short_name(), "type" => "cassandra");
+                        counter!("shotover_query_count", 1, "name" => self.counter_name.clone(), "query" => statement.short_name(), "type" => "cassandra");
                     }
                 }
                 Some(Frame::Redis(frame)) => {
                     if let Some(query_type) = get_redis_query_type(frame) {
-                        counter!("query_count", 1, "name" => self.counter_name.clone(), "query" => query_type, "type" => "redis");
+                        counter!("shotover_query_count", 1, "name" => self.counter_name.clone(), "query" => query_type, "type" => "redis");
                     } else {
-                        counter!("query_count", 1, "name" => self.counter_name.clone(), "query" => "unknown", "type" => "redis");
+                        counter!("shotover_query_count", 1, "name" => self.counter_name.clone(), "query" => "unknown", "type" => "redis");
                     }
                 }
                 Some(Frame::Kafka(_)) => {
-                    counter!("query_count", 1, "name" => self.counter_name.clone(), "query" => "unknown", "type" => "kafka");
+                    counter!("shotover_query_count", 1, "name" => self.counter_name.clone(), "query" => "unknown", "type" => "kafka");
                 }
                 Some(Frame::Dummy) => {
                     // Dummy does not count as a message
@@ -65,7 +65,7 @@ impl Transform for QueryCounter {
                     todo!();
                 }
                 None => {
-                    counter!("query_count", 1, "name" => self.counter_name.clone(), "query" => "unknown", "type" => "none")
+                    counter!("shotover_query_count", 1, "name" => self.counter_name.clone(), "query" => "unknown", "type" => "none")
                 }
             }
         }

--- a/shotover/src/transforms/redis/cache.rs
+++ b/shotover/src/transforms/redis/cache.rs
@@ -85,7 +85,7 @@ pub struct RedisConfig {
 #[async_trait(?Send)]
 impl TransformConfig for RedisConfig {
     async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
-        let missed_requests = register_counter!("cache_miss");
+        let missed_requests = register_counter!("shotover_cache_miss_count");
 
         let caching_schema: HashMap<FQName, TableCacheSchema> = self
             .caching_schema

--- a/shotover/src/transforms/redis/sink_cluster.rs
+++ b/shotover/src/transforms/redis/sink_cluster.rs
@@ -159,7 +159,7 @@ impl RedisSinkCluster {
             token: None,
         };
 
-        register_counter!("failed_requests", "chain" => chain_name, "transform" => sink_cluster.get_name());
+        register_counter!("shotover_failed_requests_count", "chain" => chain_name, "transform" => sink_cluster.get_name());
 
         sink_cluster
     }
@@ -598,7 +598,7 @@ impl RedisSinkCluster {
     #[inline(always)]
     fn send_error_response(&self, message: &str) -> Result<ResponseFuture> {
         if let Err(e) = CONTEXT_CHAIN_NAME.try_with(|chain_name| {
-        counter!("failed_requests", 1, "chain" => chain_name.to_string(), "transform" => self.get_name());
+        counter!("shotover_failed_requests_count", 1, "chain" => chain_name.to_string(), "transform" => self.get_name());
     }) {
         error!("failed to count failed request - missing chain name: {:?}", e);
     }

--- a/shotover/src/transforms/redis/sink_single.rs
+++ b/shotover/src/transforms/redis/sink_single.rs
@@ -58,7 +58,7 @@ impl RedisSinkSingleBuilder {
         chain_name: String,
         connect_timeout_ms: u64,
     ) -> Self {
-        let failed_requests = register_counter!("failed_requests", "chain" => chain_name, "transform" => "RedisSinkSingle");
+        let failed_requests = register_counter!("shotover_failed_requests_count", "chain" => chain_name, "transform" => "RedisSinkSingle");
         let connect_timeout = Duration::from_millis(connect_timeout_ms);
 
         RedisSinkSingleBuilder {

--- a/shotover/src/transforms/tee.rs
+++ b/shotover/src/transforms/tee.rs
@@ -49,7 +49,8 @@ impl TeeBuilder {
             tokio::spawn(chain_switch_listener.async_run(result_source.clone()));
         }
 
-        let dropped_messages = register_counter!("tee_dropped_messages", "chain" => "Tee");
+        let dropped_messages =
+            register_counter!("shotover_tee_dropped_messages_count", "chain" => "Tee");
 
         TeeBuilder {
             tx,


### PR DESCRIPTION
This PR introduces a new metric batch_size that records a histogram of the batch sizes used for each chain.
However in adding this I found that shotover_metrics windsock profiler cannot properly format this new metric as it assumes that all histograms are measured in milliseconds.
This is not good so I sought a way to fix this.

As per https://prometheus.io/docs/practices/naming/ our metrics should be named such that the unit is postfixed to the metric name.
Once we do that we have a way to correctly identify the unit used by the metrics.
So I renamed all our metrics to follow this and then changed shotover_metrics profiler to make use of these to determine how to format the metrics.