### PR TITLE
Fix client timeout

### DIFF
--- a/shotover/src/sources/cassandra.rs
+++ b/shotover/src/sources/cassandra.rs
@@ -7,6 +7,7 @@ use crate::tls::{TlsAcceptor, TlsAcceptorConfig};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::{watch, Semaphore};
 use tokio::task::JoinHandle;
 use tracing::{error, info};
@@ -75,7 +76,7 @@ impl CassandraSource {
             Arc::new(Semaphore::new(connection_limit.unwrap_or(512))),
             trigger_shutdown_rx.clone(),
             tls.map(TlsAcceptor::new).transpose()?,
-            timeout,
+            timeout.map(Duration::from_secs),
             transport.unwrap_or(Transport::Tcp),
         )
         .await?;

--- a/shotover/src/sources/kafka.rs
+++ b/shotover/src/sources/kafka.rs
@@ -6,6 +6,7 @@ use crate::tls::{TlsAcceptor, TlsAcceptorConfig};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::{watch, Semaphore};
 use tokio::task::JoinHandle;
 use tracing::{error, info};
@@ -71,7 +72,7 @@ impl KafkaSource {
             Arc::new(Semaphore::new(connection_limit.unwrap_or(512))),
             trigger_shutdown_rx.clone(),
             tls.map(TlsAcceptor::new).transpose()?,
-            timeout,
+            timeout.map(Duration::from_secs),
             Transport::Tcp,
         )
         .await?;

--- a/shotover/src/sources/opensearch.rs
+++ b/shotover/src/sources/opensearch.rs
@@ -5,6 +5,7 @@ use crate::sources::{Source, Transport};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::{watch, Semaphore};
 use tokio::task::JoinHandle;
 use tracing::{error, info};
@@ -65,7 +66,7 @@ impl OpenSearchSource {
             Arc::new(Semaphore::new(connection_limit.unwrap_or(512))),
             trigger_shutdown_rx.clone(),
             None,
-            timeout,
+            timeout.map(Duration::from_secs),
             Transport::Tcp,
         )
         .await?;

--- a/shotover/src/sources/redis.rs
+++ b/shotover/src/sources/redis.rs
@@ -6,6 +6,7 @@ use crate::tls::{TlsAcceptor, TlsAcceptorConfig};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::{watch, Semaphore};
 use tokio::task::JoinHandle;
 use tracing::{error, info};
@@ -71,7 +72,7 @@ impl RedisSource {
             Arc::new(Semaphore::new(connection_limit.unwrap_or(512))),
             trigger_shutdown_rx.clone(),
             tls.map(TlsAcceptor::new).transpose()?,
-            timeout,
+            timeout.map(Duration::from_secs),
             Transport::Tcp,
         )
         .await?;


### PR DESCRIPTION
This code has always been weird.
There have been previous PRs to clean it up:
* https://github.com/shotover/shotover-proxy/pull/140
* https://github.com/shotover/shotover-proxy/pull/644

But they both avoided touching the actual logic to keep the PR scope down.

This PR completely replaces the timeout logic:
* fixes the timeout to actually timeout after specified seconds
    + Currently the logic will timeout after around `log2(seconds)`, I dont think there is any good reason for this old behavior.
* Should improve performance a little:
    + This function showed up in the profiler, which is why I started working on this in the first place.
    + Avoiding using the timeout when we dont need it should help a bit
    + Avoiding breaking out of the await every second should also help a bit.
* I think the logic is easier to follow now
* We convert the config u64 to a Duration earlier, stronger typing is good