### PR TITLE
Cleanup client_details

### DIFF
--- a/shotover/benches/benches/chain.rs
+++ b/shotover/benches/benches/chain.rs
@@ -38,7 +38,6 @@ fn criterion_benchmark(c: &mut Criterion) {
                 || BenchInput {
                     chain: chain.build(),
                     wrapper: wrapper.clone(),
-                    client_details: "".into(),
                 },
                 BenchInput::bench,
                 BatchSize::SmallInput,
@@ -77,7 +76,6 @@ fn criterion_benchmark(c: &mut Criterion) {
                 || BenchInput {
                     chain: chain.build(),
                     wrapper: wrapper.clone(),
-                    client_details: "".into(),
                 },
                 BenchInput::bench,
                 BatchSize::SmallInput,
@@ -113,7 +111,6 @@ fn criterion_benchmark(c: &mut Criterion) {
                 || BenchInput {
                     chain: chain.build(),
                     wrapper: wrapper_set.clone(),
-                    client_details: "".into(),
                 },
                 BenchInput::bench,
                 BatchSize::SmallInput,
@@ -134,7 +131,6 @@ fn criterion_benchmark(c: &mut Criterion) {
                 || BenchInput {
                     chain: chain.build(),
                     wrapper: wrapper_get.clone(),
-                    client_details: "".into(),
                 },
                 BenchInput::bench,
                 BatchSize::SmallInput,
@@ -165,7 +161,6 @@ fn criterion_benchmark(c: &mut Criterion) {
                 || BenchInput {
                     chain: chain.build(),
                     wrapper: wrapper.clone(),
-                    client_details: "".into(),
                 },
                 BenchInput::bench,
                 BatchSize::SmallInput,
@@ -211,7 +206,6 @@ fn criterion_benchmark(c: &mut Criterion) {
                 || BenchInput {
                     chain: chain.build(),
                     wrapper: wrapper.clone(),
-                    client_details: "".into(),
                 },
                 BenchInput::bench,
                 BatchSize::SmallInput,
@@ -267,7 +261,6 @@ fn criterion_benchmark(c: &mut Criterion) {
                 || BenchInput {
                     chain: chain.build(),
                     wrapper: wrapper.clone(),
-                    client_details: "".into(),
                 },
                 BenchInput::bench,
                 BatchSize::SmallInput,
@@ -311,7 +304,6 @@ fn criterion_benchmark(c: &mut Criterion) {
                 || BenchInput {
                     chain: chain.build(),
                     wrapper: wrapper.clone(),
-                    client_details: "".into(),
                 },
                 BenchInput::bench,
                 BatchSize::SmallInput,
@@ -327,7 +319,6 @@ fn criterion_benchmark(c: &mut Criterion) {
                 || BenchInput {
                     chain: chain.build(),
                     wrapper: wrapper.clone(),
-                    client_details: "".into(),
                 },
                 BenchInput::bench,
                 BatchSize::SmallInput,
@@ -367,15 +358,11 @@ fn cassandra_parsed_query(query: &str) -> Wrapper {
 struct BenchInput<'a> {
     chain: TransformChain,
     wrapper: Wrapper<'a>,
-    client_details: String,
 }
 
 impl<'a> BenchInput<'a> {
     async fn bench(mut self) {
-        self.chain
-            .process_request(self.wrapper, self.client_details)
-            .await
-            .unwrap();
+        self.chain.process_request(self.wrapper).await.unwrap();
     }
 }
 

--- a/shotover/src/server.rs
+++ b/shotover/src/server.rs
@@ -659,10 +659,7 @@ impl<C: CodecBuilder + 'static> Handler<C> {
         // Flush messages regardless of if we are shutting down due to a failure or due to application shutdown
         match self
             .chain
-            .process_request(
-                Wrapper::flush_with_chain_name(self.chain.name.clone()),
-                client_details,
-            )
+            .process_request(Wrapper::flush_with_chain_name(self.chain.name.clone()))
             .await
         {
             Ok(_) => {}
@@ -749,13 +746,13 @@ impl<C: CodecBuilder + 'static> Handler<C> {
 
             let modified_messages = if reverse_chain {
                 self.chain
-                    .process_request_rev(wrapper, client_details.to_owned())
+                    .process_request_rev(wrapper)
                     .await
                     .context("Chain failed to receive pushed messages/events, the connection will now be closed.")?
             } else {
                 match self
                     .chain
-                    .process_request(wrapper, client_details.to_owned())
+                    .process_request(wrapper)
                     .await
                     .context("Chain failed to send and/or receive messages, the connection will now be closed.")
                 {

--- a/shotover/src/transforms/chain.rs
+++ b/shotover/src/transforms/chain.rs
@@ -161,15 +161,12 @@ impl BufferedChain {
 }
 
 impl TransformChain {
-    pub async fn process_request(
-        &mut self,
-        mut wrapper: Wrapper<'_>,
-        client_details: String,
-    ) -> Result<Messages> {
+    pub async fn process_request(&mut self, mut wrapper: Wrapper<'_>) -> Result<Messages> {
         let start = Instant::now();
         wrapper.reset(&mut self.chain);
 
         self.chain_batch_size.record(wrapper.requests.len() as f64);
+        let client_details = wrapper.client_details.to_owned();
         let result = wrapper.call_next_transform().await;
         self.chain_total.increment(1);
         if result.is_err() {
@@ -180,15 +177,12 @@ impl TransformChain {
         result
     }
 
-    pub async fn process_request_rev(
-        &mut self,
-        mut wrapper: Wrapper<'_>,
-        client_details: String,
-    ) -> Result<Messages> {
+    pub async fn process_request_rev(&mut self, mut wrapper: Wrapper<'_>) -> Result<Messages> {
         let start = Instant::now();
         wrapper.reset_rev(&mut self.chain);
 
         self.chain_batch_size.record(wrapper.requests.len() as f64);
+        let client_details = wrapper.client_details.to_owned();
         let result = wrapper.call_next_transform_pushed().await;
         self.chain_total.increment(1);
         if result.is_err() {
@@ -307,7 +301,7 @@ impl TransformChainBuilder {
 
                     let mut wrapper = Wrapper::new_with_chain_name(messages, chain.name.clone(), local_addr);
                     wrapper.flush = flush;
-                    let chain_response = chain.process_request(wrapper, chain.name.clone()).await;
+                    let chain_response = chain.process_request(wrapper).await;
 
                     if let Err(e) = &chain_response {
                         error!("Internal error in buffered chain: {e:?}");
@@ -326,10 +320,7 @@ impl TransformChainBuilder {
                 debug!("buffered chain processing thread exiting, stopping chain loop and dropping");
 
                 match chain
-                    .process_request(
-                        Wrapper::flush_with_chain_name(chain.name.clone()),
-                        "".into(),
-                    )
+                    .process_request(Wrapper::flush_with_chain_name(chain.name.clone()))
                     .await
                 {
                     Ok(_) => info!("Buffered chain {} was shutdown", chain.name),

--- a/shotover/src/transforms/load_balance.rs
+++ b/shotover/src/transforms/load_balance.rs
@@ -119,7 +119,7 @@ mod test {
         for _ in 0..90 {
             chain
                 .build()
-                .process_request(Wrapper::new(Messages::new()), "test_client".to_string())
+                .process_request(Wrapper::new(Messages::new()))
                 .await
                 .unwrap();
         }

--- a/shotover/src/transforms/mod.rs
+++ b/shotover/src/transforms/mod.rs
@@ -367,7 +367,7 @@ impl<'a> Wrapper<'a> {
         Wrapper {
             requests,
             transforms: TransformIter::new_forwards(&mut []),
-            client_details: "".to_string(),
+            client_details: "".to_owned(),
             local_addr: "127.0.0.1:8000".parse().unwrap(),
             chain_name: "".to_string(),
             flush: false,
@@ -382,7 +382,7 @@ impl<'a> Wrapper<'a> {
         Wrapper {
             requests,
             transforms: TransformIter::new_forwards(&mut []),
-            client_details: "".to_string(),
+            client_details: "".to_owned(),
             local_addr,
             chain_name,
             flush: false,
@@ -393,7 +393,7 @@ impl<'a> Wrapper<'a> {
         Wrapper {
             requests: vec![],
             transforms: TransformIter::new_forwards(&mut []),
-            client_details: "".into(),
+            client_details: "".to_owned(),
             // The connection is closed so we need to just fake an address here
             local_addr: "127.0.0.1:10000".parse().unwrap(),
             chain_name,

--- a/shotover/src/transforms/parallel_map.rs
+++ b/shotover/src/transforms/parallel_map.rs
@@ -96,14 +96,11 @@ impl Transform for ParallelMap {
             let mut future = UOFutures::new(self.ordered);
             for chain in self.chains.iter_mut() {
                 if let Some(message) = message_iter.next() {
-                    future.push(chain.process_request(
-                        Wrapper::new_with_chain_name(
-                            vec![message],
-                            chain.name.clone(),
-                            requests_wrapper.local_addr,
-                        ),
-                        "Parallel".to_string(),
-                    ));
+                    future.push(chain.process_request(Wrapper::new_with_chain_name(
+                        vec![message],
+                        chain.name.clone(),
+                        requests_wrapper.local_addr,
+                    )));
                 }
             }
             // We do this gnarly functional chain to unwrap each individual result and pop an error on the first one

--- a/shotover/src/transforms/redis/cache.rs
+++ b/shotover/src/transforms/redis/cache.rs
@@ -250,14 +250,11 @@ impl SimpleRedisCache {
 
         let redis_responses = self
             .cache_chain
-            .process_request(
-                Wrapper::new_with_chain_name(
-                    redis_requests,
-                    self.cache_chain.name.clone(),
-                    local_addr,
-                ),
-                "clientdetailstodo".to_string(),
-            )
+            .process_request(Wrapper::new_with_chain_name(
+                redis_requests,
+                self.cache_chain.name.clone(),
+                local_addr,
+            ))
             .await?;
 
         Ok(self.unwrap_cache_response(redis_responses, redis_indices, cassandra_requests))
@@ -363,14 +360,11 @@ impl SimpleRedisCache {
         if !cache_messages.is_empty() {
             let result = self
                 .cache_chain
-                .process_request(
-                    Wrapper::new_with_chain_name(
-                        cache_messages,
-                        self.cache_chain.name.clone(),
-                        local_addr,
-                    ),
-                    "clientdetailstodo".to_string(),
-                )
+                .process_request(Wrapper::new_with_chain_name(
+                    cache_messages,
+                    self.cache_chain.name.clone(),
+                    local_addr,
+                ))
                 .await;
             if let Err(err) = result {
                 warn!("Cache error: {err}");

--- a/shotover/src/transforms/sampler.rs
+++ b/shotover/src/transforms/sampler.rs
@@ -36,12 +36,6 @@ pub struct Sampler {
     sample_chain: TransformChain,
 }
 
-impl Sampler {
-    fn get_name(&self) -> &'static str {
-        "Sampler"
-    }
-}
-
 #[async_trait]
 impl Transform for Sampler {
     async fn transform<'a>(&'a mut self, requests_wrapper: Wrapper<'a>) -> Result<Messages> {
@@ -49,8 +43,7 @@ impl Transform for Sampler {
         if chance < self.numerator {
             let sample = requests_wrapper.clone();
             let (sample, downstream) = tokio::join!(
-                self.sample_chain
-                    .process_request(sample, self.get_name().to_string()),
+                self.sample_chain.process_request(sample),
                 requests_wrapper.call_next_transform()
             );
             if sample.is_err() {


### PR DESCRIPTION
Previously we were duplicating client_details state and often setting it to invalid values.
This PR fixes that by avoiding passing as a separate parameter and instead always using the value from Wrapper.