### PR TITLE
Transform metrics use handles

### DIFF
--- a/shotover-proxy/tests/runner/observability_int_tests.rs
+++ b/shotover-proxy/tests/runner/observability_int_tests.rs
@@ -18,6 +18,9 @@ async fn test_metrics() {
 # TYPE shotover_query_count counter
 # TYPE shotover_transform_failures_count counter
 # TYPE shotover_transform_latency_seconds summary
+# TYPE shotover_transform_pushed_failures_count counter
+# TYPE shotover_transform_pushed_latency_seconds summary
+# TYPE shotover_transform_pushed_total_count counter
 # TYPE shotover_transform_total_count counter
 shotover_available_connections_count{source="redis"}
 shotover_chain_failures_count{chain="redis source"}
@@ -52,9 +55,30 @@ shotover_transform_latency_seconds{transform="QueryCounter",quantile="0.95"}
 shotover_transform_latency_seconds{transform="QueryCounter",quantile="0.99"}
 shotover_transform_latency_seconds{transform="QueryCounter",quantile="0.999"}
 shotover_transform_latency_seconds{transform="QueryCounter",quantile="1"}
+shotover_transform_pushed_failures_count{transform="NullSink"}
+shotover_transform_pushed_failures_count{transform="QueryCounter"}
+shotover_transform_pushed_latency_seconds_count{transform="NullSink"}
+shotover_transform_pushed_latency_seconds_count{transform="QueryCounter"}
+shotover_transform_pushed_latency_seconds_sum{transform="NullSink"}
+shotover_transform_pushed_latency_seconds_sum{transform="QueryCounter"}
+shotover_transform_pushed_latency_seconds{transform="NullSink",quantile="0"}
+shotover_transform_pushed_latency_seconds{transform="NullSink",quantile="0.5"}
+shotover_transform_pushed_latency_seconds{transform="NullSink",quantile="0.9"}
+shotover_transform_pushed_latency_seconds{transform="NullSink",quantile="0.95"}
+shotover_transform_pushed_latency_seconds{transform="NullSink",quantile="0.99"}
+shotover_transform_pushed_latency_seconds{transform="NullSink",quantile="0.999"}
+shotover_transform_pushed_latency_seconds{transform="NullSink",quantile="1"}
+shotover_transform_pushed_latency_seconds{transform="QueryCounter",quantile="0"}
+shotover_transform_pushed_latency_seconds{transform="QueryCounter",quantile="0.5"}
+shotover_transform_pushed_latency_seconds{transform="QueryCounter",quantile="0.9"}
+shotover_transform_pushed_latency_seconds{transform="QueryCounter",quantile="0.95"}
+shotover_transform_pushed_latency_seconds{transform="QueryCounter",quantile="0.99"}
+shotover_transform_pushed_latency_seconds{transform="QueryCounter",quantile="0.999"}
+shotover_transform_pushed_latency_seconds{transform="QueryCounter",quantile="1"}
+shotover_transform_pushed_total_count{transform="NullSink"}
+shotover_transform_pushed_total_count{transform="QueryCounter"}
 shotover_transform_total_count{transform="NullSink"}
 shotover_transform_total_count{transform="QueryCounter"}
-
 "#;
     assert_metrics_has_keys("", expected).await;
 
@@ -81,7 +105,6 @@ shotover_transform_total_count{transform="QueryCounter"}
 
     let expected_new = r#"
 # TYPE shotover_chain_latency_seconds summary
-# TYPE shotover_transform_total counter
 shotover_chain_latency_seconds_count{chain="redis source",client_details="127.0.0.1"}
 shotover_chain_latency_seconds_sum{chain="redis source",client_details="127.0.0.1"}
 shotover_chain_latency_seconds{chain="redis source",client_details="127.0.0.1",quantile="0"}
@@ -93,9 +116,6 @@ shotover_chain_latency_seconds{chain="redis source",client_details="127.0.0.1",q
 shotover_chain_latency_seconds{chain="redis source",client_details="127.0.0.1",quantile="1"}
 shotover_query_count{name="redis-chain",query="GET",type="redis"}
 shotover_query_count{name="redis-chain",query="SET",type="redis"}
-shotover_transform_total{transform="NullSink"}
-shotover_transform_total{transform="QueryCounter"}
-
 "#;
     assert_metrics_has_keys(expected, expected_new).await;
 

--- a/shotover/src/transforms/chain.rs
+++ b/shotover/src/transforms/chain.rs
@@ -9,7 +9,7 @@ use tokio::sync::{mpsc, oneshot};
 use tokio::time::{Duration, Instant};
 use tracing::{debug, error, info, trace, Instrument};
 
-type InnerChain = Vec<Transforms>;
+type InnerChain = Vec<TransformAndMetrics>;
 
 #[derive(Debug)]
 pub struct BufferedChainMessages {
@@ -202,9 +202,74 @@ impl TransformChain {
 
 #[derive(Derivative)]
 #[derivative(Debug)]
+pub struct TransformAndMetrics {
+    pub transform: Transforms,
+    #[derivative(Debug = "ignore")]
+    pub transform_total: Counter,
+    #[derivative(Debug = "ignore")]
+    pub transform_failures: Counter,
+    #[derivative(Debug = "ignore")]
+    pub transform_latency: Histogram,
+    #[derivative(Debug = "ignore")]
+    pub transform_pushed_total: Counter,
+    #[derivative(Debug = "ignore")]
+    pub transform_pushed_failures: Counter,
+    #[derivative(Debug = "ignore")]
+    pub transform_pushed_latency: Histogram,
+}
+
+impl TransformAndMetrics {
+    #[cfg(test)]
+    pub fn new(transform: Transforms) -> Self {
+        TransformAndMetrics {
+            transform,
+            transform_total: Counter::noop(),
+            transform_failures: Counter::noop(),
+            transform_latency: Histogram::noop(),
+            transform_pushed_total: Counter::noop(),
+            transform_pushed_failures: Counter::noop(),
+            transform_pushed_latency: Histogram::noop(),
+        }
+    }
+}
+
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub struct TransformBuilderAndMetrics {
+    pub builder: Box<dyn TransformBuilder>,
+    #[derivative(Debug = "ignore")]
+    transform_total: Counter,
+    #[derivative(Debug = "ignore")]
+    transform_failures: Counter,
+    #[derivative(Debug = "ignore")]
+    transform_latency: Histogram,
+    #[derivative(Debug = "ignore")]
+    transform_pushed_total: Counter,
+    #[derivative(Debug = "ignore")]
+    transform_pushed_failures: Counter,
+    #[derivative(Debug = "ignore")]
+    transform_pushed_latency: Histogram,
+}
+
+impl TransformBuilderAndMetrics {
+    fn build(&self) -> TransformAndMetrics {
+        TransformAndMetrics {
+            transform: self.builder.build(),
+            transform_total: self.transform_total.clone(),
+            transform_failures: self.transform_failures.clone(),
+            transform_latency: self.transform_latency.clone(),
+            transform_pushed_total: self.transform_pushed_total.clone(),
+            transform_pushed_failures: self.transform_pushed_failures.clone(),
+            transform_pushed_latency: self.transform_pushed_latency.clone(),
+        }
+    }
+}
+
+#[derive(Derivative)]
+#[derivative(Debug)]
 pub struct TransformChainBuilder {
     pub name: String,
-    pub chain: Vec<Box<dyn TransformBuilder>>,
+    pub chain: Vec<TransformBuilderAndMetrics>,
 
     #[derivative(Debug = "ignore")]
     chain_total: Counter,
@@ -216,11 +281,17 @@ pub struct TransformChainBuilder {
 
 impl TransformChainBuilder {
     pub fn new(chain: Vec<Box<dyn TransformBuilder>>, name: String) -> Self {
-        for transform in &chain {
-            register_counter!("shotover_transform_total_count", "transform" => transform.get_name());
-            register_counter!("shotover_transform_failures_count", "transform" => transform.get_name());
-            register_histogram!("shotover_transform_latency_seconds", "transform" => transform.get_name());
-        }
+        let chain = chain.into_iter().map(|builder|
+            TransformBuilderAndMetrics {
+                transform_total: register_counter!("shotover_transform_total_count", "transform" => builder.get_name()),
+                transform_failures: register_counter!("shotover_transform_failures_count", "transform" => builder.get_name()),
+                transform_latency: register_histogram!("shotover_transform_latency_seconds", "transform" => builder.get_name()),
+                transform_pushed_total: register_counter!("shotover_transform_pushed_total_count", "transform" => builder.get_name()),
+                transform_pushed_failures: register_counter!("shotover_transform_pushed_failures_count", "transform" => builder.get_name()),
+                transform_pushed_latency: register_histogram!("shotover_transform_pushed_latency_seconds", "transform" => builder.get_name()),
+                builder,
+            }
+        ).collect();
 
         let chain_batch_size =
             register_histogram!("shotover_chain_messages_per_batch_count", "chain" => name.clone());
@@ -255,19 +326,19 @@ impl TransformChainBuilder {
             .flat_map(|(i, transform)| {
                 let mut errors = vec![];
 
-                if i == last_index && !transform.is_terminating() {
+                if i == last_index && !transform.builder.is_terminating() {
                     errors.push(format!(
                         "  Non-terminating transform {:?} is last in chain. Last transform must be terminating.",
-                        transform.get_name()
+                        transform.builder.get_name()
                     ));
-                } else if i != last_index && transform.is_terminating() {
+                } else if i != last_index && transform.builder.is_terminating() {
                     errors.push(format!(
                         "  Terminating transform {:?} is not last in chain. Terminating transform must be last in chain.",
-                        transform.get_name()
+                        transform.builder.get_name()
                     ));
                 }
 
-                errors.extend(transform.validate().iter().map(|x| format!("  {x}")));
+                errors.extend(transform.builder.validate().iter().map(|x| format!("  {x}")));
 
                 errors
             })
@@ -372,7 +443,9 @@ impl TransformChainBuilder {
             .iter()
             .map(|x| {
                 let mut transform = x.build();
-                transform.set_pushed_messages_tx(pushed_messages_tx.clone());
+                transform
+                    .transform
+                    .set_pushed_messages_tx(pushed_messages_tx.clone());
                 transform
             })
             .collect();

--- a/shotover/src/transforms/coalesce.rs
+++ b/shotover/src/transforms/coalesce.rs
@@ -93,6 +93,7 @@ impl Transform for Coalesce {
 mod test {
     use crate::frame::{Frame, RedisFrame};
     use crate::message::Message;
+    use crate::transforms::chain::TransformAndMetrics;
     use crate::transforms::coalesce::Coalesce;
     use crate::transforms::loopback::Loopback;
     use crate::transforms::{Transform, Transforms, Wrapper};
@@ -107,7 +108,9 @@ mod test {
             last_write: Instant::now(),
         };
 
-        let mut chain = vec![Transforms::Loopback(Loopback::default())];
+        let mut chain = vec![TransformAndMetrics::new(Transforms::Loopback(
+            Loopback::default(),
+        ))];
 
         let messages: Vec<_> = (0..25)
             .map(|_| Message::from_frame(Frame::Redis(RedisFrame::Null)))
@@ -146,7 +149,9 @@ mod test {
             last_write: Instant::now(),
         };
 
-        let mut chain = vec![Transforms::Loopback(Loopback::default())];
+        let mut chain = vec![TransformAndMetrics::new(Transforms::Loopback(
+            Loopback::default(),
+        ))];
 
         let messages: Vec<_> = (0..25)
             .map(|_| Message::from_frame(Frame::Redis(RedisFrame::Null)))
@@ -185,7 +190,9 @@ mod test {
             last_write: Instant::now(),
         };
 
-        let mut chain = vec![Transforms::Loopback(Loopback::default())];
+        let mut chain = vec![TransformAndMetrics::new(Transforms::Loopback(
+            Loopback::default(),
+        ))];
 
         let messages: Vec<_> = (0..25)
             .map(|_| Message::from_frame(Frame::Redis(RedisFrame::Null)))

--- a/shotover/src/transforms/filter.rs
+++ b/shotover/src/transforms/filter.rs
@@ -114,6 +114,7 @@ mod test {
     use crate::frame::Frame;
     use crate::frame::RedisFrame;
     use crate::message::{Message, QueryType};
+    use crate::transforms::chain::TransformAndMetrics;
     use crate::transforms::filter::QueryTypeFilter;
     use crate::transforms::loopback::Loopback;
     use crate::transforms::{Transform, Transforms, Wrapper};
@@ -124,7 +125,9 @@ mod test {
             filter: Filter::DenyList(vec![QueryType::Read]),
         };
 
-        let mut chain = vec![Transforms::Loopback(Loopback::default())];
+        let mut chain = vec![TransformAndMetrics::new(Transforms::Loopback(
+            Loopback::default(),
+        ))];
 
         let messages: Vec<_> = (0..26)
             .map(|i| {
@@ -178,7 +181,9 @@ mod test {
             filter: Filter::AllowList(vec![QueryType::Write]),
         };
 
-        let mut chain = vec![Transforms::Loopback(Loopback::default())];
+        let mut chain = vec![TransformAndMetrics::new(Transforms::Loopback(
+            Loopback::default(),
+        ))];
 
         let messages: Vec<_> = (0..26)
             .map(|i| {

--- a/shotover/src/transforms/load_balance.rs
+++ b/shotover/src/transforms/load_balance.rs
@@ -124,7 +124,7 @@ mod test {
                 .unwrap();
         }
 
-        match chain.chain[0].build() {
+        match chain.chain[0].builder.build() {
             Transforms::PoolConnections(p) => {
                 let all_connections = p.all_connections.lock().await;
                 assert_eq!(all_connections.len(), 3);


### PR DESCRIPTION
Currently the chain registers metrics for all its transforms but then throws away the handles, requiring the transforms to access the metrics without the handles.
This currently works fine however there are two issues with this:
* its a lot slower to access metrics without the handle, it was showing up in a profiler.
* Its easy to forget to register the metric in the first place when working without handles. In fact thats exactly what had happened to the `transform_pushed_*` metrics.

This PR fixes those two issues by holding onto the handles and then using them later on for recording metrics.

After the change I can now see:
* that we are spending less time in metrics code in the windsock samply profiler
* A roughly 25% improvement in our `transform/loopback` micro benchmark introduced by https://github.com/shotover/shotover-proxy/pull/1402 (I had to alter it slightly to enable metrics otherwise the difference wont show up)


![image](https://github.com/shotover/shotover-proxy/assets/5120858/e1740ae5-d379-498f-900f-7dfb33705bcd)
