### PR TITLE
Fix running multiple lint GA workflows

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,7 +8,7 @@ on:
 
 # Cancel already running jobs
 concurrency:
-  group: lints
+  group: lints_${{ github.head_ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
Only just noticed this issue with all the concurrent PRs.
All the other workflows include `_${{ github.head_ref }}` to ensure that we dont cancel workflows from other PRs, but that was missing for the link workflow.
This PR fixes that.