### PR TITLE
Use Arc to avoid cloning PreparedMetadata

### DIFF
--- a/shotover/src/transforms/cassandra/sink_cluster/node_pool.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/node_pool.rs
@@ -47,7 +47,7 @@ pub struct KeyspaceMetadata {
 // Values in the builder are shared between transform instances that come from the same transform in the topology.yaml
 #[derive(Clone)]
 pub struct NodePoolBuilder {
-    prepared_metadata: Arc<RwLock<HashMap<CBytesShort, PreparedMetadata>>>,
+    prepared_metadata: Arc<RwLock<HashMap<CBytesShort, Arc<PreparedMetadata>>>>,
     out_of_rack_requests: Counter,
 }
 
@@ -71,7 +71,7 @@ impl NodePoolBuilder {
 }
 
 pub struct NodePool {
-    prepared_metadata: Arc<RwLock<HashMap<CBytesShort, PreparedMetadata>>>,
+    prepared_metadata: Arc<RwLock<HashMap<CBytesShort, Arc<PreparedMetadata>>>>,
     keyspace_metadata: HashMap<String, KeyspaceMetadata>,
     token_map: TokenMap,
     nodes: Vec<CassandraNode>,
@@ -125,7 +125,7 @@ impl NodePool {
 
     pub async fn add_prepared_result(&mut self, id: CBytesShort, metadata: PreparedMetadata) {
         let mut write_lock = self.prepared_metadata.write().await;
-        write_lock.insert(id, metadata);
+        write_lock.insert(id, Arc::new(metadata));
     }
 
     pub async fn get_random_node_in_dc_rack(


### PR DESCRIPTION
Looking at profiling taken before and after this change, previously we spent 5% of our time in this function within the PreparedMetadata Clone+Drop, now we spend only 0.2% of our time in the Clone+Drop.