### PR TITLE
Remove "source" suffix from source chain names

### DIFF
--- a/shotover-proxy/tests/cassandra_int_tests/cluster/multi_rack.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cluster/multi_rack.rs
@@ -156,7 +156,7 @@ pub async fn test(connection: &CassandraConnection) {
     test_rewrite_system_peers_v2(connection).await;
 
     let out_of_rack_request = get_metrics_value(
-        "shotover_out_of_rack_requests_count{chain=\"cassandra source\",transform=\"CassandraSinkCluster\"}",
+        "shotover_out_of_rack_requests_count{chain=\"cassandra\",transform=\"CassandraSinkCluster\"}",
     )
     .await;
     assert_eq!(out_of_rack_request, "0");

--- a/shotover-proxy/tests/runner/observability_int_tests.rs
+++ b/shotover-proxy/tests/runner/observability_int_tests.rs
@@ -23,17 +23,17 @@ async fn test_metrics() {
 # TYPE shotover_transform_pushed_total_count counter
 # TYPE shotover_transform_total_count counter
 shotover_available_connections_count{source="redis"}
-shotover_chain_failures_count{chain="redis source"}
-shotover_chain_messages_per_batch_count_count{chain="redis source"}
-shotover_chain_messages_per_batch_count_sum{chain="redis source"}
-shotover_chain_messages_per_batch_count{chain="redis source",quantile="0"}
-shotover_chain_messages_per_batch_count{chain="redis source",quantile="0.5"}
-shotover_chain_messages_per_batch_count{chain="redis source",quantile="0.9"}
-shotover_chain_messages_per_batch_count{chain="redis source",quantile="0.95"}
-shotover_chain_messages_per_batch_count{chain="redis source",quantile="0.99"}
-shotover_chain_messages_per_batch_count{chain="redis source",quantile="0.999"}
-shotover_chain_messages_per_batch_count{chain="redis source",quantile="1"}
-shotover_chain_total_count{chain="redis source"}
+shotover_chain_failures_count{chain="redis"}
+shotover_chain_messages_per_batch_count_count{chain="redis"}
+shotover_chain_messages_per_batch_count_sum{chain="redis"}
+shotover_chain_messages_per_batch_count{chain="redis",quantile="0"}
+shotover_chain_messages_per_batch_count{chain="redis",quantile="0.5"}
+shotover_chain_messages_per_batch_count{chain="redis",quantile="0.9"}
+shotover_chain_messages_per_batch_count{chain="redis",quantile="0.95"}
+shotover_chain_messages_per_batch_count{chain="redis",quantile="0.99"}
+shotover_chain_messages_per_batch_count{chain="redis",quantile="0.999"}
+shotover_chain_messages_per_batch_count{chain="redis",quantile="1"}
+shotover_chain_total_count{chain="redis"}
 shotover_query_count{name="redis-chain"}
 shotover_transform_failures_count{transform="NullSink"}
 shotover_transform_failures_count{transform="QueryCounter"}
@@ -105,15 +105,15 @@ shotover_transform_total_count{transform="QueryCounter"}
 
     let expected_new = r#"
 # TYPE shotover_chain_latency_seconds summary
-shotover_chain_latency_seconds_count{chain="redis source",client_details="127.0.0.1"}
-shotover_chain_latency_seconds_sum{chain="redis source",client_details="127.0.0.1"}
-shotover_chain_latency_seconds{chain="redis source",client_details="127.0.0.1",quantile="0"}
-shotover_chain_latency_seconds{chain="redis source",client_details="127.0.0.1",quantile="0.5"}
-shotover_chain_latency_seconds{chain="redis source",client_details="127.0.0.1",quantile="0.9"}
-shotover_chain_latency_seconds{chain="redis source",client_details="127.0.0.1",quantile="0.95"}
-shotover_chain_latency_seconds{chain="redis source",client_details="127.0.0.1",quantile="0.99"}
-shotover_chain_latency_seconds{chain="redis source",client_details="127.0.0.1",quantile="0.999"}
-shotover_chain_latency_seconds{chain="redis source",client_details="127.0.0.1",quantile="1"}
+shotover_chain_latency_seconds_count{chain="redis",client_details="127.0.0.1"}
+shotover_chain_latency_seconds_sum{chain="redis",client_details="127.0.0.1"}
+shotover_chain_latency_seconds{chain="redis",client_details="127.0.0.1",quantile="0"}
+shotover_chain_latency_seconds{chain="redis",client_details="127.0.0.1",quantile="0.5"}
+shotover_chain_latency_seconds{chain="redis",client_details="127.0.0.1",quantile="0.9"}
+shotover_chain_latency_seconds{chain="redis",client_details="127.0.0.1",quantile="0.95"}
+shotover_chain_latency_seconds{chain="redis",client_details="127.0.0.1",quantile="0.99"}
+shotover_chain_latency_seconds{chain="redis",client_details="127.0.0.1",quantile="0.999"}
+shotover_chain_latency_seconds{chain="redis",client_details="127.0.0.1",quantile="1"}
 shotover_query_count{name="redis-chain",query="GET",type="redis"}
 shotover_query_count{name="redis-chain",query="SET",type="redis"}
 "#;

--- a/shotover-proxy/tests/runner/runner_int_tests.rs
+++ b/shotover-proxy/tests/runner/runner_int_tests.rs
@@ -58,7 +58,7 @@ async fn test_shotover_shutdown_when_invalid_topology_non_terminating_last() {
 Caused by:
     Topology errors
     redis source:
-      redis source chain:
+      redis chain:
         Non-terminating transform \"DebugPrinter\" is last in chain. Last transform must be terminating.
     ")])
     .await;
@@ -77,7 +77,7 @@ async fn test_shotover_shutdown_when_invalid_topology_terminating_not_last() {
 Caused by:
     Topology errors
     redis source:
-      redis source chain:
+      redis chain:
         Terminating transform \"NullSink\" is not last in chain. Terminating transform must be last in chain.
     ")])
     .await;
@@ -96,12 +96,12 @@ async fn test_shotover_shutdown_when_topology_invalid_topology_subchains() {
 Caused by:
     Topology errors
     redis source:
-      redis source chain:
+      redis chain:
         Terminating transform "NullSink" is not last in chain. Terminating transform must be last in chain.
         Terminating transform "NullSink" is not last in chain. Terminating transform must be last in chain.
         Non-terminating transform "DebugPrinter" is last in chain. Last transform must be terminating.
     redis source:
-      redis source chain:
+      redis chain:
         TuneableConsistencyScatter:
           a_chain_1 chain:
             Terminating transform "NullSink" is not last in chain. Terminating transform must be last in chain.

--- a/shotover/src/config/topology.rs
+++ b/shotover/src/config/topology.rs
@@ -108,7 +108,7 @@ mod topology_tests {
     async fn test_validate_chain_empty_chain() {
         let expected = r#"Topology errors
 foo source:
-  foo source chain:
+  foo chain:
     Chain cannot be empty
 "#;
 
@@ -127,7 +127,7 @@ foo source:
     async fn test_validate_coalesce() {
         let expected = r#"Topology errors
 foo source:
-  foo source chain:
+  foo chain:
     Coalesce:
       Need to provide at least one of these fields:
       * flush_when_buffered_message_count
@@ -155,7 +155,7 @@ foo source:
     async fn test_validate_chain_terminating_in_middle() {
         let expected = r#"Topology errors
 foo source:
-  foo source chain:
+  foo chain:
     Terminating transform "NullSink" is not last in chain. Terminating transform must be last in chain.
 "#;
 
@@ -175,7 +175,7 @@ foo source:
     async fn test_validate_chain_non_terminating_at_end() {
         let expected = r#"Topology errors
 foo source:
-  foo source chain:
+  foo chain:
     Non-terminating transform "DebugPrinter" is last in chain. Last transform must be terminating.
 "#;
 
@@ -195,7 +195,7 @@ foo source:
     async fn test_validate_chain_terminating_middle_non_terminating_at_end() {
         let expected = r#"Topology errors
 foo source:
-  foo source chain:
+  foo chain:
     Terminating transform "NullSink" is not last in chain. Terminating transform must be last in chain.
     Non-terminating transform "DebugPrinter" is last in chain. Last transform must be terminating.
 "#;
@@ -241,7 +241,7 @@ foo source:
     async fn test_validate_chain_invalid_subchain_scatter() {
         let expected = r#"Topology errors
 foo source:
-  foo source chain:
+  foo chain:
     TuneableConsistencyScatter:
       subchain-1 chain:
         Terminating transform "NullSink" is not last in chain. Terminating transform must be last in chain.
@@ -298,7 +298,7 @@ foo source:
     async fn test_validate_chain_invalid_subchain_redis_cache() {
         let expected = r#"Topology errors
 foo source:
-  foo source chain:
+  foo chain:
     RedisCache:
       cache_chain chain:
         Terminating transform "NullSink" is not last in chain. Terminating transform must be last in chain.
@@ -348,7 +348,7 @@ foo source:
     async fn test_validate_chain_invalid_subchain_parallel_map() {
         let expected = r#"Topology errors
 foo source:
-  foo source chain:
+  foo chain:
     ParallelMap:
       parallel_map_chain chain:
         Terminating transform "NullSink" is not last in chain. Terminating transform must be last in chain.
@@ -379,7 +379,7 @@ foo source:
     async fn test_validate_chain_subchain_terminating_in_middle() {
         let expected = r#"Topology errors
 foo source:
-  foo source chain:
+  foo chain:
     TuneableConsistencyScatter:
       subchain-1 chain:
         Terminating transform "NullSink" is not last in chain. Terminating transform must be last in chain.
@@ -415,7 +415,7 @@ foo source:
     async fn test_validate_chain_subchain_non_terminating_at_end() {
         let expected = r#"Topology errors
 foo source:
-  foo source chain:
+  foo chain:
     TuneableConsistencyScatter:
       subchain-1 chain:
         Non-terminating transform "DebugPrinter" is last in chain. Last transform must be terminating.
@@ -449,7 +449,7 @@ foo source:
     async fn test_validate_chain_subchain_terminating_middle_non_terminating_at_end() {
         let expected = r#"Topology errors
 foo source:
-  foo source chain:
+  foo chain:
     TuneableConsistencyScatter:
       subchain-1 chain:
         Terminating transform "NullSink" is not last in chain. Terminating transform must be last in chain.
@@ -496,12 +496,12 @@ foo source:
 
         let expected = r#"Topology errors
 redis source:
-  redis source chain:
+  redis chain:
     Terminating transform "NullSink" is not last in chain. Terminating transform must be last in chain.
     Terminating transform "NullSink" is not last in chain. Terminating transform must be last in chain.
     Non-terminating transform "DebugPrinter" is last in chain. Last transform must be terminating.
 redis source:
-  redis source chain:
+  redis chain:
     TuneableConsistencyScatter:
       a_chain_1 chain:
         Terminating transform "NullSink" is not last in chain. Terminating transform must be last in chain.

--- a/shotover/src/server.rs
+++ b/shotover/src/server.rs
@@ -92,7 +92,7 @@ impl<C: CodecBuilder + 'static> TcpCodecListener<C> {
         available_connections_gauge.set(limit_connections.available_permits() as f64);
 
         let chain_builder = chain_config
-            .get_builder(format!("{source_name} source"))
+            .get_builder(source_name.clone())
             .await
             .map_err(|x| vec![format!("{x:?}")])?;
 


### PR DESCRIPTION
Progress towards the second design in https://github.com/shotover/shotover-proxy/issues/337
But immediately rollsback a breaking change to our public facing API.