### PR TITLE
Remove chain name from wrapper

### DIFF
--- a/shotover/src/transforms/chain.rs
+++ b/shotover/src/transforms/chain.rs
@@ -162,7 +162,6 @@ impl BufferedChain {
 
 impl TransformChain {
     pub async fn process_request(&mut self, mut wrapper: Wrapper<'_>) -> Result<Messages> {
-        wrapper.chain_name = self.name;
         let start = Instant::now();
         wrapper.reset(&mut self.chain);
 

--- a/shotover/src/transforms/redis/sink_cluster.rs
+++ b/shotover/src/transforms/redis/sink_cluster.rs
@@ -9,7 +9,6 @@ use crate::transforms::util::cluster_connection_pool::{Authenticator, Connection
 use crate::transforms::util::{Request, Response};
 use crate::transforms::{
     ResponseFuture, Transform, TransformBuilder, TransformConfig, Transforms, Wrapper,
-    CONTEXT_CHAIN_NAME,
 };
 use anyhow::{anyhow, bail, ensure, Context, Result};
 use async_trait::async_trait;
@@ -31,7 +30,7 @@ use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::{oneshot, RwLock};
 use tokio::time::{timeout, Duration};
-use tracing::{debug, error, trace, warn};
+use tracing::{debug, trace, warn};
 
 const SLOT_SIZE: usize = 16384;
 
@@ -115,6 +114,7 @@ impl Topology {
 
 #[derive(Debug)]
 pub struct RedisSinkCluster {
+    chain_name: String,
     has_run_init: bool,
     topology: Topology,
     shared_topology: Arc<RwLock<Topology>>,
@@ -144,6 +144,7 @@ impl RedisSinkCluster {
         >,
     ) -> Self {
         let sink_cluster = RedisSinkCluster {
+            chain_name: chain_name.clone(),
             has_run_init: false,
             first_contact_points,
             direct_destination,
@@ -597,11 +598,7 @@ impl RedisSinkCluster {
 
     #[inline(always)]
     fn send_error_response(&self, message: &str) -> Result<ResponseFuture> {
-        if let Err(e) = CONTEXT_CHAIN_NAME.try_with(|chain_name| {
-        counter!("shotover_failed_requests_count", 1, "chain" => chain_name.to_string(), "transform" => self.get_name());
-    }) {
-        error!("failed to count failed request - missing chain name: {:?}", e);
-    }
+        counter!("shotover_failed_requests_count", 1, "chain" => self.chain_name.clone(), "transform" => self.get_name());
         short_circuit(RedisFrame::Error(message.into()))
     }
 


### PR DESCRIPTION
There is no need to pass in the chain name in this way.
We already give access to the chain name via passing it to the transform builders: https://github.com/shotover/shotover-proxy/blob/df6e283ebf9accb2756252872a6634b77e1de789/shotover/src/transforms/mod.rs#L247 So passing it to the transforms via `CONTEXT_CHAIN_NAME` is just redundant.

Removing the `CONTEXT_CHAIN_NAME.scope(..)` gives us a 7% win to the loopback bench on top of the changes in https://github.com/shotover/shotover-proxy/pull/1405
![image](https://github.com/shotover/shotover-proxy/assets/5120858/720af462-c5b6-47e5-b352-2f998fa9ef66)
