### PR TITLE
Windsock kafka fix routing

### DIFF
--- a/shotover-proxy/benches/windsock/kafka/bench.rs
+++ b/shotover-proxy/benches/windsock/kafka/bench.rs
@@ -19,6 +19,8 @@ use shotover::transforms::TransformConfig;
 use std::sync::Arc;
 use std::{collections::HashMap, time::Duration};
 use test_helpers::docker_compose::docker_compose;
+use test_helpers::rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
+use test_helpers::rdkafka::client::DefaultClientContext;
 use test_helpers::rdkafka::config::ClientConfig;
 use test_helpers::rdkafka::consumer::{Consumer, StreamConsumer};
 use test_helpers::rdkafka::producer::{FutureProducer, FutureRecord};
@@ -401,8 +403,11 @@ impl Bench for KafkaBench {
         // only one string field so we just directly store the value in resources
         let broker_address = resources;
 
+        setup_topic(broker_address).await;
+
         let producer: FutureProducer = ClientConfig::new()
             .set("bootstrap.servers", broker_address)
+            .set("debug", "all")
             .set("message.timeout.ms", "5000")
             .create()
             .unwrap();
@@ -467,13 +472,10 @@ struct BenchTaskProducerKafka {
 #[async_trait]
 impl BenchTaskProducer for BenchTaskProducerKafka {
     async fn produce_one(&self) -> Result<(), String> {
+        // key is set to None which will result in round robin routing between all brokers
+        let record: FutureRecord<(), _> = FutureRecord::to("topic_foo").payload(&self.message);
         self.producer
-            .send(
-                FutureRecord::to("topic_foo")
-                    .payload(&self.message)
-                    .key("Key"),
-                Timeout::Never,
-            )
+            .send(record, Timeout::Never)
             .await
             // Take just the error, ignoring the message contents because large messages result in unreadable noise in the logs.
             .map_err(|e| format!("{:?}", e.0))
@@ -567,4 +569,29 @@ pub trait BenchTaskProducer: Clone + Send + Sync + 'static {
 
         tasks
     }
+}
+
+async fn setup_topic(broker_address: &str) {
+    let admin: AdminClient<DefaultClientContext> = ClientConfig::new()
+        .set("bootstrap.servers", broker_address)
+        .create()
+        .unwrap();
+    for topic in admin
+        .create_topics(
+            &[NewTopic {
+                name: "topic_foo",
+                num_partitions: 3,
+                replication: TopicReplication::Fixed(1),
+                config: vec![],
+            }],
+            &AdminOptions::new().operation_timeout(Some(Timeout::After(Duration::from_secs(60)))),
+        )
+        .await
+        .unwrap()
+    {
+        assert_eq!("topic_foo", topic.unwrap());
+    }
+
+    // Need to delay starting bench to avoid UnknownPartition errors
+    tokio::time::sleep(Duration::from_secs(5)).await;
 }


### PR DESCRIPTION
Blocked on https://github.com/shotover/shotover-proxy/pull/1419

Need to use unique keys to ensure spread across topology3 cluster, otherwise it all gets routed to a single node

Strangely the bug that I was previously also able to reproduce in https://github.com/shotover/shotover-proxy/pull/1427 is now only reproducible in the topology=3 benches with this PR.
However I've now tracked down the cause of the issue and fixed it here.
I was indexing into a vector that wasnt actually sorted.
Sorting the vector at time of creation allows us to continue indexing into as we were before but its actually guaranteed to work now. The sort only occurs when processing metadata messages so it should be fine performance wise.

The windsock results clearly show an improvement for benches with and without shotover:
![image](https://github.com/shotover/shotover-proxy/assets/5120858/ac8f2c38-1e61-4850-9d26-b963ec7f526e)

Unfortunately the shotover benches are now growing a backlog:
![image](https://github.com/shotover/shotover-proxy/assets/5120858/0a4a4342-6e69-40d5-baf7-72a94c470098)

This represents an improvement to the way we bench shotover, so no need to block on the backlog increase.
I should investigate it in the future though.