### PR TITLE
make connection span debug only (optimization)

### DIFF
--- a/docs/src/user-guide/observability.md
+++ b/docs/src/user-guide/observability.md
@@ -38,5 +38,13 @@ A single value that can increment or decrement over time. Starts out with an ini
 You can configure log levels and filters at `/filter`. This can be done by a POST HTTP request to the `/filter` endpoint with the `env_filter` string set as the POST data. For example:
 
 ```shell
-curl -X PUT -d 'info,shotover_proxy=info' http://127.0.0.1:9001/filter
+curl -X PUT -d 'info, shotover_proxy=info, shotover::connection_span::info` http://127.0.0.1:9001/filter
 ```
+
+Some examples of how you can tweak this filter:
+
+* configure the first `info` to set the log level for dependencies
+* configure `shotover=info` to set the log level for shotover itself
+* set `shotover::connection_span=info` to `shotover::connection_span=debug` to attach connection info to most log events, this is disabled by default due to a minor performance hit.
+
+For more control over filtering you should understand [The tracing filter format](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives).

--- a/shotover-proxy/benches/windsock/shotover.rs
+++ b/shotover-proxy/benches/windsock/shotover.rs
@@ -10,6 +10,7 @@ pub async fn shotover_process_custom_topology(
     let topology_path = std::env::temp_dir().join(Uuid::new_v4().to_string());
     std::fs::write(&topology_path, topology_contents).unwrap();
     ShotoverProcessBuilder::new_with_topology(topology_path.to_str().unwrap())
+        .with_config("config/config.yaml")
         .with_bin(bin_path!("shotover-proxy"))
         .with_profile(profiler.shotover_profile())
         .start()

--- a/shotover-proxy/config/config.yaml
+++ b/shotover-proxy/config/config.yaml
@@ -1,3 +1,5 @@
----
-main_log_level: "info,shotover_proxy=info"
+# configure the first `info` to set the log level for dependencies
+# configure `shotover=info` to set the log level for shotover itself
+# set `shotover::connection_span=info` to `shotover::connection_span=debug` to attach connection info to most log events, this is disabled by default due to a minor performance hit.
+main_log_level: "info, shotover=info, shotover::connection_span=info"
 observability_interface: "0.0.0.0:9001"

--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -263,19 +263,19 @@ async fn cluster_multi_rack_1_per_rack(#[case] driver: CassandraDriver) {
         let shotover_rack1 =
             shotover_process("tests/test-configs/cassandra/cluster-multi-rack/topology_rack1.yaml")
                 .with_log_name("Rack1")
-                .with_observability_port(9001)
+                .with_config("tests/test-configs/shotover-config/config1.yaml")
                 .start()
                 .await;
         let shotover_rack2 =
             shotover_process("tests/test-configs/cassandra/cluster-multi-rack/topology_rack2.yaml")
                 .with_log_name("Rack2")
-                .with_observability_port(9002)
+                .with_config("tests/test-configs/shotover-config/config2.yaml")
                 .start()
                 .await;
         let shotover_rack3 =
             shotover_process("tests/test-configs/cassandra/cluster-multi-rack/topology_rack3.yaml")
                 .with_log_name("Rack3")
-                .with_observability_port(9003)
+                .with_config("tests/test-configs/shotover-config/config3.yaml")
                 .start()
                 .await;
 
@@ -318,22 +318,22 @@ async fn cluster_multi_rack_2_per_rack(#[case] driver: CassandraDriver) {
         let shotover_rack1 = shotover_process(
             "tests/test-configs/cassandra/cluster-multi-rack-2-per-rack/topology_rack1.yaml",
         )
+        .with_config("tests/test-configs/shotover-config/config1.yaml")
         .with_log_name("Rack1")
-        .with_observability_port(9001)
         .start()
         .await;
         let shotover_rack2 = shotover_process(
             "tests/test-configs/cassandra/cluster-multi-rack-2-per-rack/topology_rack2.yaml",
         )
         .with_log_name("Rack2")
-        .with_observability_port(9002)
+        .with_config("tests/test-configs/shotover-config/config2.yaml")
         .start()
         .await;
         let shotover_rack3 = shotover_process(
             "tests/test-configs/cassandra/cluster-multi-rack-2-per-rack/topology_rack3.yaml",
         )
+        .with_config("tests/test-configs/shotover-config/config3.yaml")
         .with_log_name("Rack3")
-        .with_observability_port(9003)
         .start()
         .await;
 

--- a/shotover-proxy/tests/kafka_int_tests/mod.rs
+++ b/shotover-proxy/tests/kafka_int_tests/mod.rs
@@ -77,8 +77,10 @@ async fn cluster_multi_shotover() {
             shotover_process(&format!(
                 "tests/test-configs/kafka/cluster/topology{i}.yaml"
             ))
+            .with_config(&format!(
+                "tests/test-configs/shotover-config/config{i}.yaml"
+            ))
             .with_log_name(&format!("shotover{i}"))
-            .with_observability_port(9000 + i)
             .start()
             .await,
         );

--- a/shotover-proxy/tests/lib.rs
+++ b/shotover-proxy/tests/lib.rs
@@ -13,5 +13,7 @@ mod runner;
 mod transforms;
 
 pub fn shotover_process(topology_path: &str) -> ShotoverProcessBuilder {
-    ShotoverProcessBuilder::new_with_topology(topology_path).with_bin(bin_path!("shotover-proxy"))
+    ShotoverProcessBuilder::new_with_topology(topology_path)
+        .with_bin(bin_path!("shotover-proxy"))
+        .with_config("tests/test-configs/shotover-config/config1.yaml")
 }

--- a/shotover-proxy/tests/test-configs/shotover-config/config1.yaml
+++ b/shotover-proxy/tests/test-configs/shotover-config/config1.yaml
@@ -1,0 +1,2 @@
+main_log_level: "info, shotover::connection_span=debug"
+observability_interface: "0.0.0.0:9001"

--- a/shotover-proxy/tests/test-configs/shotover-config/config2.yaml
+++ b/shotover-proxy/tests/test-configs/shotover-config/config2.yaml
@@ -1,0 +1,2 @@
+main_log_level: "info, shotover::connection_span=debug"
+observability_interface: "0.0.0.0:9002"

--- a/shotover-proxy/tests/test-configs/shotover-config/config3.yaml
+++ b/shotover-proxy/tests/test-configs/shotover-config/config3.yaml
@@ -1,0 +1,2 @@
+main_log_level: "info, shotover::connection_span=debug"
+observability_interface: "0.0.0.0:9003"

--- a/shotover/src/connection_span.rs
+++ b/shotover/src/connection_span.rs
@@ -1,0 +1,10 @@
+//! This module purposefully only contains this one function to create a span.
+//! This allows us to enable/disable just this one span via the tracing filter: `shotover::connection_span=debug`
+//!
+//! Do not add more code here!
+
+use tracing::Span;
+
+pub fn span(connection_count: u64, source: &str) -> Span {
+    tracing::debug_span!("connection", id = connection_count, source = source)
+}

--- a/shotover/src/lib.rs
+++ b/shotover/src/lib.rs
@@ -33,6 +33,7 @@
 
 pub mod codec;
 pub mod config;
+mod connection_span;
 pub mod frame;
 pub mod message;
 mod observability;

--- a/shotover/src/server.rs
+++ b/shotover/src/server.rs
@@ -169,11 +169,8 @@ impl<C: CodecBuilder + 'static> TcpCodecListener<C> {
             }
 
             self.connection_count = self.connection_count.wrapping_add(1);
-            let span = tracing::error_span!(
-                "connection",
-                id = self.connection_count,
-                source = self.source_name.as_str(),
-            );
+            let span =
+                crate::connection_span::span(self.connection_count, self.source_name.as_str());
             let transport = self.transport;
             async {
                 // Accept a new socket. This will attempt to perform error handling.


### PR DESCRIPTION
closes https://github.com/shotover/shotover-proxy/issues/1421

As written up in https://github.com/shotover/shotover-proxy/issues/1421 I've observed performance issues caused due to entering/exiting spans.

So this PR disables by default the only span created by shotover, the "connection" span, by setting the span level from error to debug.
This means the span will only be enabled when tracing level is set to debug.

This span is very useful for debugging so I:
* Made a module specifically for the span to allow enabling just the span without any other events getting enabled with it.
* Documented how to reenable it.
* Enabled it by default for integration tests (but not for benchmarks)

For reference, when the span is enabled logs look like:
```
04:26:06.269278Z  WARN connection{id=11 source="redis"}: shotover::server: failed to decode message: Error decoding redis frame
```

And when it is disabled it looks like:
```
04:26:06.269278Z  WARN shotover::server: failed to decode message: Error decoding redis frame
```

I've observed in a profiler that this PR reduces the time spent entering and exiting spans from 4% to 0.3% of total execution time.


Changing the contents of the span had no effect on performance, it is the act of entering and exiting the span that causes issues. (because it has to do this every time the tokio runtime switches context)