### PR TITLE
Cassandra optimize ring walking

### DIFF
--- a/shotover/src/transforms/cassandra/sink_cluster/mod.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/mod.rs
@@ -36,7 +36,7 @@ mod rewrite;
 mod routing_key;
 #[cfg(test)]
 mod test_router;
-mod token_map;
+mod token_ring;
 pub mod topology;
 
 pub type KeyspaceChanTx = watch::Sender<HashMap<String, KeyspaceMetadata>>;

--- a/shotover/src/transforms/cassandra/sink_cluster/node_pool.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/node_pool.rs
@@ -1,6 +1,6 @@
 use super::node::{CassandraNode, ConnectionFactory};
 use super::routing_key::calculate_routing_key;
-use super::token_map::TokenMap;
+use super::token_ring::TokenRing;
 use super::KeyspaceChanRx;
 use crate::transforms::cassandra::connection::CassandraConnection;
 use anyhow::{anyhow, Context, Error, Result};
@@ -60,7 +60,7 @@ impl NodePoolBuilder {
         NodePool {
             prepared_metadata: self.prepared_metadata.clone(),
             keyspace_metadata: HashMap::new(),
-            token_map: TokenMap::new(&[]),
+            token_map: TokenRing::new(&[]),
             nodes: vec![],
             out_of_rack_requests: self.out_of_rack_requests.clone(),
         }
@@ -70,7 +70,7 @@ impl NodePoolBuilder {
 pub struct NodePool {
     prepared_metadata: Arc<RwLock<HashMap<CBytesShort, Arc<PreparedMetadata>>>>,
     keyspace_metadata: HashMap<String, KeyspaceMetadata>,
-    token_map: TokenMap,
+    token_map: TokenRing,
     nodes: Vec<CassandraNode>,
     out_of_rack_requests: Counter,
 }
@@ -99,7 +99,7 @@ impl NodePool {
             }
         }
         self.nodes = new_nodes;
-        self.token_map = TokenMap::new(self.nodes.as_slice());
+        self.token_map = TokenRing::new(self.nodes.as_slice());
         tracing::debug!(
             "nodes updated, nodes={:#?}\ntokens={:#?}",
             self.nodes,


### PR DESCRIPTION
I came up with an implementation that is faster than iterating over a BTreeMap.
It wasnt as fast as I hoped it would be but its still a 0.4% win when profiling `cassandra,compression=none,connection_count=100,driver=scylla,operation=read_i64,protocol=v4,shotover=standard,topology=cluster3` so I think its still worth it, so lets land it unless there are objections due to extra complexity.
BTreeMap and binary search are both average and worse case `O(log(n))` so they should be no issue when cassandra is configured with more tokens. I believe our benchmarks use 255 tokens.

Originally based on the scylla implementation from https://github.com/scylladb/scylla-rust-driver/blob/main/scylla/src/transport/locator/token_ring.rs
Using exactly their implementation gave the same or very slightly worse performance to our existing implementation.