### PR TITLE
refactor shotover windsock cloud

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,12 +187,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-once-cell"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9338790e78aa95a416786ec8389546c4b6a1dfc3dc36071ed9518a9413a542eb"
-
-[[package]]
 name = "async-recursion"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4500,7 +4494,6 @@ name = "shotover-proxy"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "async-once-cell",
  "async-trait",
  "aws-throwaway",
  "bincode",

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -43,7 +43,6 @@ rand_distr.workspace = true
 async-trait.workspace = true
 tracing-subscriber.workspace = true
 tracing-appender.workspace = true
-async-once-cell = "0.5.2"
 fred = { version = "8.0.0", features = ["enable-rustls"] }
 tokio-bin-process.workspace = true
 rustls-pemfile = "2.0.0"

--- a/shotover-proxy/benches/windsock/cassandra.rs
+++ b/shotover-proxy/benches/windsock/cassandra.rs
@@ -1,7 +1,7 @@
 use crate::{
-    aws::{
-        cloud::{CloudResources, CloudResourcesRequired},
-        Ec2InstanceWithDocker, Ec2InstanceWithShotover, RunningShotover,
+    cloud::{
+        CloudResources, CloudResourcesRequired, Ec2InstanceWithDocker, Ec2InstanceWithShotover,
+        RunningShotover,
     },
     common::{self, Shotover},
     profilers::{self, CloudProfilerRunner, ProfilerRunner},

--- a/shotover-proxy/benches/windsock/kafka.rs
+++ b/shotover-proxy/benches/windsock/kafka.rs
@@ -1,5 +1,7 @@
-use crate::aws::cloud::{CloudResources, CloudResourcesRequired};
-use crate::aws::{Ec2InstanceWithDocker, Ec2InstanceWithShotover};
+use crate::cloud::{
+    CloudResources, CloudResourcesRequired, Ec2InstanceWithDocker, Ec2InstanceWithShotover,
+    RunningShotover,
+};
 use crate::common::{self, Shotover};
 use crate::profilers::{self, CloudProfilerRunner, ProfilerRunner};
 use crate::shotover::shotover_process_custom_topology;
@@ -157,7 +159,7 @@ impl KafkaBench {
         &self,
         shotover_instance: Option<Arc<Ec2InstanceWithShotover>>,
         kafka_instance: Arc<Ec2InstanceWithDocker>,
-    ) -> Option<crate::aws::RunningShotover> {
+    ) -> Option<RunningShotover> {
         match self.shotover {
             Shotover::Standard | Shotover::ForcedMessageParsed => {
                 let shotover_instance = shotover_instance.unwrap();
@@ -176,7 +178,7 @@ impl KafkaBench {
     async fn run_aws_shotover_colocated_with_kafka(
         &self,
         instance: Arc<Ec2InstanceWithDocker>,
-    ) -> Option<crate::aws::RunningShotover> {
+    ) -> Option<RunningShotover> {
         let ip = instance.instance.private_ip().to_string();
         match self.shotover {
             Shotover::Standard | Shotover::ForcedMessageParsed => {

--- a/shotover-proxy/benches/windsock/main.rs
+++ b/shotover-proxy/benches/windsock/main.rs
@@ -1,5 +1,5 @@
-mod aws;
 mod cassandra;
+mod cloud;
 mod common;
 #[cfg(feature = "rdkafka-driver-tests")]
 mod kafka;
@@ -12,8 +12,8 @@ use crate::common::*;
 #[cfg(feature = "rdkafka-driver-tests")]
 use crate::kafka::*;
 use crate::redis::*;
-use aws::cloud::CloudResources;
-use aws::cloud::CloudResourcesRequired;
+use cloud::CloudResources;
+use cloud::CloudResourcesRequired;
 use std::path::Path;
 use tracing_subscriber::EnvFilter;
 use windsock::{Bench, Windsock};
@@ -150,7 +150,7 @@ fn main() {
         .chain(kafka_benches)
         .chain(redis_benches)
         .collect(),
-        aws::cloud::AwsCloud::new_boxed(),
+        cloud::AwsCloud::new_boxed(),
         &["release"],
     )
     .run();

--- a/shotover-proxy/benches/windsock/redis.rs
+++ b/shotover-proxy/benches/windsock/redis.rs
@@ -1,7 +1,7 @@
 use crate::{
-    aws::{
-        cloud::{CloudResources, CloudResourcesRequired},
-        Ec2InstanceWithDocker, Ec2InstanceWithShotover, RunningShotover,
+    cloud::{
+        CloudResources, CloudResourcesRequired, Ec2InstanceWithDocker, Ec2InstanceWithShotover,
+        RunningShotover,
     },
     common::{self, Shotover},
     profilers::{self, CloudProfilerRunner, ProfilerRunner},

--- a/windsock/src/cloud.rs
+++ b/windsock/src/cloud.rs
@@ -11,20 +11,20 @@ pub trait Cloud {
 
     /// Cleanup all cloud resources created by windsock.
     /// You should destroy not just resources created during this bench run but also resources created in past bench runs that might have missed cleanup due to a panic.
-    async fn cleanup_resources(&self);
+    async fn cleanup_resources(&mut self);
 
     /// This is called once at start up before running any benches.
     /// The implementation must return an object containing all the requested cloud resources.
     /// The `required_resources` contains the `CloudResourcesRequired` returned by each bench that will be executed in this run.
     async fn create_resources(
-        &self,
+        &mut self,
         required_resources: Vec<Self::CloudResourcesRequired>,
     ) -> Self::CloudResources;
 
     /// This is called once at start up before running any benches.
     /// The returned Vec specifies the order in which to run benches.
     fn order_benches(
-        &self,
+        &mut self,
         benches: Vec<BenchInfo<Self::CloudResourcesRequired>>,
     ) -> Vec<BenchInfo<Self::CloudResourcesRequired>> {
         benches
@@ -36,7 +36,7 @@ pub trait Cloud {
     /// It is recommended to create all resources within create_resources for faster completion time, but it may be desirable in some circumstances to create some of them here.
     /// It is recommended to always destroy resources that will never be used again here.
     async fn adjust_resources(
-        &self,
+        &mut self,
         _benches: &[BenchInfo<Self::CloudResourcesRequired>],
         _bench_index: usize,
         _resources: &mut Self::CloudResources,
@@ -64,6 +64,6 @@ impl NoCloud {
 impl Cloud for NoCloud {
     type CloudResourcesRequired = ();
     type CloudResources = ();
-    async fn cleanup_resources(&self) {}
-    async fn create_resources(&self, _requests: Vec<()>) {}
+    async fn cleanup_resources(&mut self) {}
+    async fn create_resources(&mut self, _requests: Vec<()>) {}
 }


### PR DESCRIPTION
Resolves some TODO's left from the recent rework.
This PR flips the modules so now the cloud module holds the aws module which better reflects the actual dependency between AwsCloud and AwsInstances (formerly AwsWindsock).

Methods on the cloud trait were changed to use `&mut self` in order to provide more flexibility to the implementer.