### PR TITLE
Escape ec2-cargo args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -795,6 +795,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c48f0051a4b4c5e0b6d365cd04af53aeaa209e3cc15ec2cdb69e73cc87fbd0dc"
+dependencies = [
+ "memchr",
+ "regex-automata 0.4.4",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1703,6 +1714,7 @@ dependencies = [
  "aws-throwaway",
  "cargo_metadata",
  "clap",
+ "shell-quote",
  "shellfish",
  "tokio",
  "tracing-appender",
@@ -4408,6 +4420,9 @@ name = "shell-quote"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a09e78d1f98bc5db3fa689ae39f90c0b9af72fe83b0bb4a13b9636edad92fcbd"
+dependencies = [
+ "bstr",
+]
 
 [[package]]
 name = "shellfish"

--- a/ec2-cargo/Cargo.toml
+++ b/ec2-cargo/Cargo.toml
@@ -15,3 +15,4 @@ aws-throwaway.workspace = true
 tracing-appender.workspace = true
 shellfish = { version = "0.9.0", features = ["async"] }
 cargo_metadata = "0.18.0"
+shell-quote = "0.5.0"

--- a/ec2-cargo/src/main.rs
+++ b/ec2-cargo/src/main.rs
@@ -130,10 +130,9 @@ fi
     println!("All AWS throwaway resources have been deleted")
 }
 
-async fn test(state: &mut State, mut args: Vec<String>) -> Result<(), Box<dyn Error>> {
+async fn test(state: &mut State, args: Vec<String>) -> Result<(), Box<dyn Error>> {
     rsync_push_shotover(state).await;
-    args.remove(0);
-    let args = args.join(" ");
+    let args = process_args(args);
     let mut receiver = state
         .instance
         .ssh()
@@ -156,10 +155,9 @@ cargo nextest run {} 2>&1
     Ok(())
 }
 
-async fn windsock(state: &mut State, mut args: Vec<String>) -> Result<(), Box<dyn Error>> {
+async fn windsock(state: &mut State, args: Vec<String>) -> Result<(), Box<dyn Error>> {
     rsync_push_shotover(state).await;
-    args.remove(0);
-    let args = args.join(" ");
+    let args = process_args(args);
     let mut receiver = state
         .instance
         .ssh()
@@ -184,6 +182,14 @@ cargo windsock {} 2>&1
     rsync_fetch_windsock_results(state).await;
 
     Ok(())
+}
+
+fn process_args(mut args: Vec<String>) -> String {
+    args.remove(0);
+    args.iter()
+        .map(|x| String::from_utf8(shell_quote::Bash::quote(x)).unwrap())
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 async fn rsync_push_shotover(state: &State) {


### PR DESCRIPTION
Previously commands like `windsock "foo=1 bar=2"` would have the `"` lost along the way which result in a invalid windsock cli arguments.
This PR fixes the issue by escaping the arguments.