### PR TITLE
Swap release build from fat LTO to thin LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ resolver = "2"
 
 # https://deterministic.space/high-performance-rust.html
 [profile.release]
-lto = "fat"
+lto = "thin"
 codegen-units = 1
 
 [profile.bench]
-lto = "fat"
+lto = "thin"
 codegen-units = 1
 
 # used for e.g. generating flamegraphs


### PR DESCRIPTION
Supersedes https://github.com/shotover/shotover-proxy/pull/1437

Previously in https://github.com/shotover/shotover-proxy/pull/1437 I was considering removing the shotover library dependency (as opposed to the binary) from our integration tests (and then in a follow up PR remove it from our windsock benches)

However I've now discovered that that same win can be achieved by disabling LTO or most of the win by setting LTO to thin.
Here are recorded times to compile the integration test binary with various LTO settings and with the dependency on shotover included/removed:
```
no shotover dep - no   LTO = 58s
no shotover dep - thin LTO = 1min 17s
no shotover dep - fat  LTO = 2min 8s
   shotover dep - no   LTO = 59s
   shotover dep - thin LTO = 1min 22s
   shotover dep - fat  LTO = 3min 6s (main branch)
```

So in this PR I propose we set our LTO to thin instead of fat.

## Performance Regressions

The microbenchmarks appear largely unaffected but some kafka benchmarks seem to have regressed by 5%.

## Compile time benefits
* reduced CI runtime
   + we are bottlenecked by the time it takes to perform a release build and this PR should cut out multiple minutes once the new build configuration is cached.
   + This is not super important though, the 20 minute CI runtime is quite livable.
* Reduced local time to run windsock benchmarks.
   + This PR reduces incremental compile time of `cargo windsock`  by:
       - changes to just windsock benches now compile in 1 min 13s (this is 2 mins faster)
       - changes to shotover, which also triggers a windsock recompile, now compile in 2min 10s (this is 2 mins faster)
   + This is a huge win as it will allow much faster iteration of performance experiments.

I think that the compile time benefits will outweigh the performance regressions by allowing us to more efficiently maintain and improve the performance of shotover.

# Alternatives
## 1
It would be possible to introduce a new profile used for producing final binaries that does have "fat" LTO enabled but I dont like the idea of that as I think we should be testing in CI and running benchmarks on the final binary that we ship.
Optimizations can behave unexpectedly so unless we are actually benching on "fat" its possible it could regress the performance that we observe on "thin".
Additionally the countless CI runs of shotover as we develop helps catch intermittent issues which could be specific to the compilation settings that we use. Having that change only for the final build is risky even if we do run all the tests with that config just before release.
Further down the line we could consider such an approach if we combine "fat" LTO with some kind of profile guided optimization to get some wins that are actually worth the difference between what we develop on.

## 2
We could remove the dependency on shotover to achieve a similar win or we could disable LTO for just windsock binary (with some nasty cargo workarounds).
The issue with both of these is:
The shotover binary itself is also dependent on the LTO setting so assuming windsock and shotover are compiled concurrently shotover will bottleneck windsock compilation when a change to shotover occurs.

## 3
Or we could just do nothing, and accept the long compile times.
