### PR TITLE
Add feature flags for each protocol in shotover

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,6 +8,17 @@ rustflags = [
 linker = "aarch64-linux-gnu-gcc"
 
 [alias]
-windsock = "test --release --bench windsock --features alpha-transforms,rdkafka-driver-tests --"
-windsock-debug = "test --bench windsock --features alpha-transforms,rdkafka-driver-tests --"
-windsock-cloud-docker = "run --package windsock-cloud-docker --"
+# Can run every benchmark
+windsock = "test --release --bench windsock --features kafka,alpha-transforms,rdkafka-driver-tests,cassandra,redis --"
+windsock-debug = "test --bench windsock --features kafka,alpha-transforms,rdkafka-driver-tests,cassandra,redis --"
+
+# Can only run benchmarks specific to the protocol but compiles a lot faster
+windsock-redis = "test --release --bench windsock --no-default-features --features redis,alpha-transforms --"
+windsock-kafka = "test --release --bench windsock --no-default-features --features kafka,alpha-transforms,rdkafka-driver-tests --"
+windsock-cassandra = "test --release --bench windsock --no-default-features --features cassandra,alpha-transforms --"
+
+# Compile benches in docker to ensure compiled libc version is compatible with the EC2 instances libc
+windsock-cloud-docker = "run --package windsock-cloud-docker -- redis,cassandra,kafka"
+windsock-cloud-docker-redis = "run --package windsock-cloud-docker -- redis"
+windsock-cloud-docker-kafka = "run --package windsock-cloud-docker -- kafka"
+windsock-cloud-docker-cassandra = "run --package windsock-cloud-docker -- cassandra"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,11 +40,13 @@ jobs:
       - name: Install ubuntu packages
         run: shotover-proxy/build/install_ubuntu_packages.sh
       - name: Install cargo-hack
-        run: cargo install cargo-hack --version 0.5.8
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hack@0.6.16
       - name: Ensure that dev tools compiles and has no warnings with no features enabled
         run: cargo clippy --locked ${{ matrix.cargo_flags }} --all-targets -- -D warnings
       - name: Ensure that shotover-proxy compiles and has no warnings under every possible combination of features
         # some things to explicitly point out:
         # * clippy also reports rustc warnings and errors
         # * clippy --all-targets is not run so we only build the shotover_proxy executable without the tests/benches
-        run: cargo hack --feature-powerset clippy --locked ${{ matrix.cargo_flags }} --package shotover-proxy -- -D warnings
+        run: cargo hack --feature-powerset --at-least-one-of redis,cassandra,kafka,opensearch clippy --locked ${{ matrix.cargo_flags }} --package shotover-proxy -- -D warnings

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -40,14 +40,14 @@ jobs:
     - name: Install cargo-hack
       uses: taiki-e/install-action@v2
       with:
-        tool: cargo-hack@0.6.4
+        tool: cargo-hack@0.6.16
     - name: Ensure `cargo fmt --all` was run
       run: cargo fmt --all -- --check
     - name: Ensure that all crates compile and have no warnings under every possible combination of features
       # some things to explicitly point out:
       # * clippy also reports rustc warnings and errors
       # * clippy --all-targets causes clippy to run against tests and examples which it doesnt do by default.
-      run: cargo hack --feature-powerset clippy --all-targets --locked -- -D warnings
+      run: cargo hack --feature-powerset --at-least-one-of redis,cassandra,kafka,opensearch clippy --all-targets --locked -- -D warnings
     - name: Report disk usage
       run: |
         df -h

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ codegen-units = 1
 scylla = { version = "0.11.0", features = ["ssl"] }
 bytes = { version = "1.0.0", features = ["serde"] }
 tokio = { version = "1.25.0", features = ["full", "macros"] }
-tokio-util = { version = "0.7.7" }
+tokio-util = { version = "0.7.7", features = ["codec"] }
 tokio-openssl = "0.6.2"
 itertools = "0.12.0"
 openssl = { version = "0.10.36", features = ["vendored"] }

--- a/custom-transforms-example/Cargo.toml
+++ b/custom-transforms-example/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-shotover = { path = "../shotover" }
+shotover = { path = "../shotover", default-features = false}
 anyhow.workspace = true
 serde.workspace = true
 async-trait.workspace = true
@@ -20,3 +20,11 @@ typetag.workspace = true
 test-helpers = {path = "../test-helpers"}
 tokio.workspace = true
 redis.workspace = true
+
+[features]
+redis = ["shotover/redis"]
+default = ["redis"]
+
+[[test]]
+name = "test"
+required-features = ["redis"]

--- a/custom-transforms-example/src/main.rs
+++ b/custom-transforms-example/src/main.rs
@@ -1,6 +1,8 @@
 use shotover::runner::Shotover;
 
+#[cfg(feature = "redis")]
 mod redis_get_rewrite;
+#[cfg(feature = "redis")]
 shotover::import_transform!(redis_get_rewrite::RedisGetRewriteConfig);
 
 fn main() {

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-shotover = { path = "../shotover" }
+shotover = { path = "../shotover", default-features = false}
 
 [dev-dependencies]
 prometheus-parse = "0.2.4"
@@ -60,8 +60,13 @@ shell-quote.workspace = true
 [features]
 # Include WIP alpha transforms in the public API
 alpha-transforms = ["shotover/alpha-transforms"]
+cassandra = ["shotover/cassandra"]
+kafka = ["shotover/kafka"]
+redis = ["shotover/redis"]
+opensearch = ["shotover/opensearch"]
 cassandra-cpp-driver-tests = ["test-helpers/cassandra-cpp-driver-tests"]
 rdkafka-driver-tests = ["test-helpers/rdkafka-driver-tests"]
+default = ["cassandra", "kafka", "redis", "opensearch"]
 
 [[bench]]
 name = "windsock"

--- a/shotover-proxy/benches/windsock/cloud/aws.rs
+++ b/shotover-proxy/benches/windsock/cloud/aws.rs
@@ -255,7 +255,7 @@ sudo docker system prune -af"#,
         }
     }
 
-    #[cfg(feature = "rdkafka-driver-tests")]
+    #[cfg(all(feature = "rdkafka-driver-tests", feature = "kafka"))]
     pub async fn run_shotover(self: Arc<Self>, topology: &str) -> RunningShotover {
         self.instance
             .ssh()

--- a/shotover-proxy/benches/windsock/main.rs
+++ b/shotover-proxy/benches/windsock/main.rs
@@ -1,9 +1,21 @@
+// Allow dead code if any of the protocol features are disabled
+#![cfg_attr(
+    any(
+        not(feature = "cassandra"),
+        not(feature = "redis"),
+        not(all(feature = "rdkafka-driver-tests", feature = "kafka"))
+    ),
+    allow(dead_code, unused_imports, unused_variables, unused_mut)
+)]
+
+#[cfg(feature = "cassandra")]
 mod cassandra;
 mod cloud;
 mod common;
-#[cfg(feature = "rdkafka-driver-tests")]
+#[cfg(all(feature = "rdkafka-driver-tests", feature = "kafka"))]
 mod kafka;
 mod profilers;
+#[cfg(feature = "redis")]
 mod redis;
 mod shotover;
 
@@ -38,9 +50,11 @@ fn main() {
 
     let mut benches = vec![];
 
+    #[cfg(feature = "cassandra")]
     benches.extend(cassandra::benches());
-    #[cfg(feature = "rdkafka-driver-tests")]
+    #[cfg(all(feature = "rdkafka-driver-tests", feature = "kafka"))]
     benches.extend(kafka::benches());
+    #[cfg(feature = "redis")]
     benches.extend(redis::benches());
 
     Windsock::new(benches, cloud::AwsCloud::new_boxed(), &["release"]).run();

--- a/shotover-proxy/tests/lib.rs
+++ b/shotover-proxy/tests/lib.rs
@@ -1,15 +1,20 @@
-#[allow(clippy::single_component_path_imports)]
+#[allow(clippy::single_component_path_imports, unused_imports)]
 use rstest_reuse;
 
 use test_helpers::shotover_process::ShotoverProcessBuilder;
 use tokio_bin_process::bin_path;
 
+#[cfg(feature = "cassandra")]
 mod cassandra_int_tests;
+#[cfg(feature = "kafka")]
 mod kafka_int_tests;
-#[cfg(feature = "alpha-transforms")]
+#[cfg(all(feature = "alpha-transforms", feature = "opensearch"))]
 mod opensearch_int_tests;
+#[cfg(feature = "redis")]
 mod redis_int_tests;
+#[cfg(feature = "redis")]
 mod runner;
+#[cfg(feature = "redis")]
 mod transforms;
 
 pub fn shotover_process(topology_path: &str) -> ShotoverProcessBuilder {

--- a/shotover/Cargo.toml
+++ b/shotover/Cargo.toml
@@ -12,6 +12,39 @@ description = "Shotover API for building custom transforms"
 [features]
 # Include WIP alpha transforms in the public API
 alpha-transforms = []
+cassandra = [
+    "dep:cassandra-protocol",
+    "dep:cql3-parser",
+    "dep:lz4_flex",
+    "dep:version-compare",
+    "dep:aws-sdk-kms",
+    "dep:aws-config",
+    "dep:base64",
+    "dep:serde_json",
+    "dep:halfbrown",
+    "dep:chacha20poly1305",
+    "dep:generic-array",
+    "dep:hex",
+    "dep:bincode",
+    "dep:cached",
+]
+kafka = [
+    "dep:kafka-protocol",
+    "dep:dashmap",
+    "dep:xxhash-rust",
+    "dep:string",
+]
+redis = [
+    "dep:redis-protocol",
+    "dep:csv",
+    "dep:crc16",
+]
+opensearch = [
+    "dep:atoi",
+    "dep:http",
+    "dep:httparse",
+]
+default = ["cassandra", "redis", "kafka", "opensearch"]
 
 [dependencies]
 atomic_enum = "0.2.0"
@@ -19,12 +52,12 @@ pretty-hex = "0.4.0"
 tokio-stream = "0.1.2"
 bytes-utils = "0.1.1"
 derivative = "2.1.1"
-cached = { version = "0.48", features = ["async"] }
+cached = { version = "0.48", features = ["async"], optional = true }
 governor = { version = "0.6", default-features = false, features = ["std", "jitter", "quanta"] }
 nonzero_ext = "0.3.0"
-version-compare = "0.1"
+version-compare = { version = "0.1", optional = true }
 rand = { features = ["small_rng"], workspace = true }
-lz4_flex = "0.11.0"
+lz4_flex = { version = "0.11.0", optional = true }
 clap.workspace = true
 itertools.workspace = true
 rand_distr.workspace = true
@@ -32,9 +65,8 @@ bytes.workspace = true
 futures.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
-csv.workspace = true
-hex.workspace = true
-hex-literal.workspace = true
+csv = { workspace = true, optional = true }
+hex = { workspace = true, optional = true }
 async-trait.workspace = true
 typetag.workspace = true
 tokio-tungstenite = "0.21.0"
@@ -46,17 +78,17 @@ backtrace = "0.3.66"
 backtrace-ext = "0.2"
 
 # Parsers
-cql3-parser = "0.4.0"
+cql3-parser = { version = "0.4.0", optional = true }
 serde.workspace = true
-serde_json.workspace = true
+serde_json = { workspace = true, optional = true }
 serde_yaml.workspace = true
-bincode.workspace = true
+bincode = { workspace = true, optional = true }
 num = { version = "0.4.0", features = ["serde"] }
-uuid.workspace = true
+uuid = { workspace = true }
 bigdecimal = { version = "0.4.0", features = ["serde"] }
-base64 = "0.21.0"
-httparse = "1.8.0"
-http = "0.2.9"
+base64 = { version = "0.21.0", optional = true }
+httparse = { version = "1.8.0", optional = true }
+http = { version = "0.2.9", optional = true }
 
 #Observability
 metrics = "0.21.0"
@@ -65,32 +97,36 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 tracing-appender.workspace = true
 hyper.workspace = true
-halfbrown = "0.2.1"
+halfbrown = { version = "0.2.1", optional = true }
 
 # Transform dependencies
-redis-protocol.workspace = true
-cassandra-protocol.workspace = true
-crc16 = "0.4.0"
+redis-protocol = { workspace = true, optional = true }
+cassandra-protocol = { workspace = true, optional = true }
+crc16 = { version = "0.4.0", optional = true }
 ordered-float.workspace = true
 
 #Crypto
-aws-config = "1.0.0"
-aws-sdk-kms = "1.1.0"
-chacha20poly1305 = { version = "0.10.0", features = ["std"] }
-generic-array = { version = "0.14", features = ["serde"] }
-kafka-protocol = "0.8.0"
+aws-config = { version = "1.0.0", optional = true }
+aws-sdk-kms = { version = "1.1.0", optional = true }
+chacha20poly1305 = { version = "0.10.0", features = ["std"], optional = true }
+generic-array = { version = "0.14", features = ["serde"], optional = true }
+kafka-protocol = { version = "0.8.0", optional = true }
 rustls = { version = "0.22.0" }
 tokio-rustls = "0.25"
 rustls-pemfile = "2.0.0"
 rustls-pki-types = "1.0.1"
-string = "0.3.0"
-xxhash-rust = { version = "0.8.6", features = ["xxh3"] }
-dashmap = "5.4.0"
-atoi = "2.0.0"
+string = { version = "0.3.0", optional = true }
+xxhash-rust = { version = "0.8.6", features = ["xxh3"], optional = true }
+dashmap = { version = "5.4.0", optional = true }
+atoi = { version = "2.0.0", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5.0", features = ["async_tokio"] }
+hex-literal.workspace = true
 
+# TODO: Optionally compiling benches is quite tricky with criterion, maybe it would be easier with divan?
+#       For now just set required features
 [[bench]]
 name = "benches"
 harness = false
+required-features = ["cassandra", "redis", "kafka"]

--- a/shotover/src/codec/mod.rs
+++ b/shotover/src/codec/mod.rs
@@ -1,15 +1,21 @@
 //! Codec types to use for connecting to a DB in a sink transform
 
 use crate::message::Messages;
+#[cfg(feature = "cassandra")]
 use cassandra_protocol::compression::Compression;
 use core::fmt;
+#[cfg(feature = "kafka")]
 use kafka::RequestHeader;
 use metrics::{register_histogram, Histogram};
 use tokio_util::codec::{Decoder, Encoder};
 
+#[cfg(feature = "cassandra")]
 pub mod cassandra;
+#[cfg(feature = "kafka")]
 pub mod kafka;
+#[cfg(feature = "opensearch")]
 pub mod opensearch;
+#[cfg(feature = "redis")]
 pub mod redis;
 
 #[derive(Eq, PartialEq, Copy, Clone)]
@@ -40,18 +46,23 @@ pub fn message_latency(direction: Direction, destination_name: String) -> Histog
 
 #[derive(Debug, Clone, PartialEq, Copy)]
 pub enum CodecState {
+    #[cfg(feature = "cassandra")]
     Cassandra {
         compression: Compression,
     },
+    #[cfg(feature = "redis")]
     Redis,
+    #[cfg(feature = "kafka")]
     Kafka {
         request_header: Option<RequestHeader>,
     },
     Dummy,
+    #[cfg(feature = "opensearch")]
     OpenSearch,
 }
 
 impl CodecState {
+    #[cfg(feature = "cassandra")]
     pub fn as_cassandra(&self) -> Compression {
         match self {
             CodecState::Cassandra { compression } => *compression,
@@ -61,6 +72,7 @@ impl CodecState {
         }
     }
 
+    #[cfg(feature = "kafka")]
     pub fn as_kafka(&self) -> Option<RequestHeader> {
         match self {
             CodecState::Kafka { request_header } => *request_header,

--- a/shotover/src/config/topology.rs
+++ b/shotover/src/config/topology.rs
@@ -60,7 +60,7 @@ impl Topology {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "redis", feature = "cassandra"))]
 mod topology_tests {
     use crate::config::chain::TransformChainConfig;
     use crate::config::topology::Topology;

--- a/shotover/src/frame/mod.rs
+++ b/shotover/src/frame/mod.rs
@@ -3,34 +3,51 @@
 use crate::{codec::CodecState, message::ProtocolType};
 use anyhow::{anyhow, Result};
 use bytes::Bytes;
+#[cfg(feature = "cassandra")]
 pub use cassandra::{CassandraFrame, CassandraOperation, CassandraResult};
+#[cfg(feature = "cassandra")]
 use cassandra_protocol::compression::Compression;
+#[cfg(feature = "kafka")]
 use kafka::KafkaFrame;
+#[cfg(feature = "opensearch")]
 pub use opensearch::OpenSearchFrame;
+#[cfg(feature = "redis")]
 pub use redis_protocol::resp2::types::Frame as RedisFrame;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
+#[cfg(feature = "cassandra")]
 pub mod cassandra;
+#[cfg(feature = "kafka")]
 pub mod kafka;
+#[cfg(feature = "opensearch")]
 pub mod opensearch;
+#[cfg(feature = "redis")]
 pub mod redis;
 pub mod value;
 
 #[derive(PartialEq, Debug, Clone, Copy)]
 pub enum MessageType {
+    #[cfg(feature = "redis")]
     Redis,
+    #[cfg(feature = "cassandra")]
     Cassandra,
+    #[cfg(feature = "kafka")]
     Kafka,
     Dummy,
+    #[cfg(feature = "opensearch")]
     OpenSearch,
 }
 
 impl From<&ProtocolType> for MessageType {
     fn from(value: &ProtocolType) -> Self {
         match value {
+            #[cfg(feature = "cassandra")]
             ProtocolType::Cassandra { .. } => Self::Cassandra,
+            #[cfg(feature = "redis")]
             ProtocolType::Redis => Self::Redis,
+            #[cfg(feature = "kafka")]
             ProtocolType::Kafka { .. } => Self::Kafka,
+            #[cfg(feature = "opensearch")]
             ProtocolType::OpenSearch => Self::OpenSearch,
         }
     }
@@ -39,14 +56,18 @@ impl From<&ProtocolType> for MessageType {
 impl Frame {
     pub fn as_codec_state(&self) -> CodecState {
         match self {
+            #[cfg(feature = "cassandra")]
             Frame::Cassandra(_) => CodecState::Cassandra {
                 compression: Compression::None,
             },
+            #[cfg(feature = "redis")]
             Frame::Redis(_) => CodecState::Redis,
+            #[cfg(feature = "kafka")]
             Frame::Kafka(_) => CodecState::Kafka {
                 request_header: None,
             },
             Frame::Dummy => CodecState::Dummy,
+            #[cfg(feature = "opensearch")]
             Frame::OpenSearch(_) => CodecState::OpenSearch,
         }
     }
@@ -54,12 +75,16 @@ impl Frame {
 
 #[derive(PartialEq, Debug, Clone)]
 pub enum Frame {
+    #[cfg(feature = "cassandra")]
     Cassandra(CassandraFrame),
+    #[cfg(feature = "redis")]
     Redis(RedisFrame),
+    #[cfg(feature = "kafka")]
     Kafka(KafkaFrame),
     /// Represents a message that must exist due to shotovers requirement that every request has a corresponding response.
     /// It exists purely to keep transform invariants and codecs will completely ignore this frame when they receive it
     Dummy,
+    #[cfg(feature = "opensearch")]
     OpenSearch(OpenSearchFrame),
 }
 
@@ -70,40 +95,53 @@ impl Frame {
         codec_state: CodecState,
     ) -> Result<Self> {
         match message_type {
+            #[cfg(feature = "cassandra")]
             MessageType::Cassandra => {
                 CassandraFrame::from_bytes(bytes, codec_state.as_cassandra()).map(Frame::Cassandra)
             }
+            #[cfg(feature = "redis")]
             MessageType::Redis => redis_protocol::resp2::decode::decode(&bytes)
                 .map(|x| Frame::Redis(x.unwrap().0))
                 .map_err(|e| anyhow!("{e:?}")),
+            #[cfg(feature = "kafka")]
             MessageType::Kafka => {
                 KafkaFrame::from_bytes(bytes, codec_state.as_kafka()).map(Frame::Kafka)
             }
             MessageType::Dummy => Ok(Frame::Dummy),
+            #[cfg(feature = "opensearch")]
             MessageType::OpenSearch => Ok(Frame::OpenSearch(OpenSearchFrame::from_bytes(&bytes)?)),
         }
     }
 
     pub fn name(&self) -> &'static str {
         match self {
+            #[cfg(feature = "redis")]
             Frame::Redis(_) => "Redis",
+            #[cfg(feature = "cassandra")]
             Frame::Cassandra(_) => "Cassandra",
+            #[cfg(feature = "kafka")]
             Frame::Kafka(_) => "Kafka",
             Frame::Dummy => "Dummy",
+            #[cfg(feature = "opensearch")]
             Frame::OpenSearch(_) => "OpenSearch",
         }
     }
 
     pub fn get_type(&self) -> MessageType {
         match self {
+            #[cfg(feature = "cassandra")]
             Frame::Cassandra(_) => MessageType::Cassandra,
+            #[cfg(feature = "redis")]
             Frame::Redis(_) => MessageType::Redis,
+            #[cfg(feature = "kafka")]
             Frame::Kafka(_) => MessageType::Kafka,
             Frame::Dummy => MessageType::Dummy,
+            #[cfg(feature = "opensearch")]
             Frame::OpenSearch(_) => MessageType::OpenSearch,
         }
     }
 
+    #[cfg(feature = "redis")]
     pub fn redis(&mut self) -> Result<&mut RedisFrame> {
         match self {
             Frame::Redis(frame) => Ok(frame),
@@ -114,6 +152,7 @@ impl Frame {
         }
     }
 
+    #[cfg(feature = "kafka")]
     pub fn into_kafka(self) -> Result<KafkaFrame> {
         match self {
             Frame::Kafka(frame) => Ok(frame),
@@ -124,6 +163,7 @@ impl Frame {
         }
     }
 
+    #[cfg(feature = "redis")]
     pub fn into_redis(self) -> Result<RedisFrame> {
         match self {
             Frame::Redis(frame) => Ok(frame),
@@ -134,8 +174,10 @@ impl Frame {
         }
     }
 
+    #[cfg(feature = "cassandra")]
     pub fn into_cassandra(self) -> Result<CassandraFrame> {
         match self {
+            #[cfg(feature = "cassandra")]
             Frame::Cassandra(frame) => Ok(frame),
             frame => Err(anyhow!(
                 "Expected cassandra frame but received {} frame",
@@ -144,8 +186,10 @@ impl Frame {
         }
     }
 
+    #[cfg(feature = "opensearch")]
     pub fn into_opensearch(self) -> Result<OpenSearchFrame> {
         match self {
+            #[cfg(feature = "opensearch")]
             Frame::OpenSearch(frame) => Ok(frame),
             frame => Err(anyhow!(
                 "Expected opensearch frame but received {} frame",
@@ -158,10 +202,14 @@ impl Frame {
 impl Display for Frame {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
+            #[cfg(feature = "cassandra")]
             Frame::Cassandra(frame) => write!(f, "Cassandra {}", frame),
+            #[cfg(feature = "redis")]
             Frame::Redis(frame) => write!(f, "Redis {:?}", frame),
+            #[cfg(feature = "kafka")]
             Frame::Kafka(frame) => write!(f, "Kafka {}", frame),
             Frame::Dummy => write!(f, "Shotover internal dummy message"),
+            #[cfg(feature = "opensearch")]
             Frame::OpenSearch(frame) => write!(f, "OpenSearch: {:?}", frame),
         }
     }

--- a/shotover/src/frame/value.rs
+++ b/shotover/src/frame/value.rs
@@ -1,6 +1,7 @@
 //! Generic representations of data types that appear in messages
-//!
+#[cfg(feature = "cassandra")]
 pub mod cassandra;
+#[cfg(feature = "redis")]
 mod redis;
 
 use bigdecimal::BigDecimal;

--- a/shotover/src/lib.rs
+++ b/shotover/src/lib.rs
@@ -31,6 +31,25 @@
 #![deny(clippy::print_stderr)]
 #![allow(clippy::needless_doctest_main)]
 #![allow(clippy::box_default)]
+// Allow dead code if any of the protocol features are disabled
+#![cfg_attr(
+    any(
+        not(feature = "cassandra"),
+        not(feature = "redis"),
+        not(feature = "kafka"),
+        not(feature = "opensearch"),
+    ),
+    allow(dead_code, unused_imports, unused_variables, unused_mut)
+)]
+#[cfg(all(
+    not(feature = "cassandra"),
+    not(feature = "redis"),
+    not(feature = "kafka"),
+    not(feature = "opensearch"),
+))]
+compile_error!(
+    "At least one protocol feature must be enabled, e.g. `cassandra`, `redis`, `kafka` or `opensearch`"
+);
 
 pub mod codec;
 pub mod config;

--- a/shotover/src/sources/mod.rs
+++ b/shotover/src/sources/mod.rs
@@ -1,17 +1,25 @@
 //! Sources used to listen for connections and send/recieve with the client.
 
+#[cfg(feature = "cassandra")]
 use crate::sources::cassandra::{CassandraConfig, CassandraSource};
+#[cfg(feature = "kafka")]
 use crate::sources::kafka::{KafkaConfig, KafkaSource};
+#[cfg(feature = "opensearch")]
 use crate::sources::opensearch::{OpenSearchConfig, OpenSearchSource};
+#[cfg(feature = "redis")]
 use crate::sources::redis::{RedisConfig, RedisSource};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 
+#[cfg(feature = "cassandra")]
 pub mod cassandra;
+#[cfg(feature = "kafka")]
 pub mod kafka;
+#[cfg(feature = "opensearch")]
 pub mod opensearch;
+#[cfg(feature = "redis")]
 pub mod redis;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
@@ -23,18 +31,26 @@ pub enum Transport {
 
 #[derive(Debug)]
 pub enum Source {
+    #[cfg(feature = "cassandra")]
     Cassandra(CassandraSource),
+    #[cfg(feature = "redis")]
     Redis(RedisSource),
+    #[cfg(feature = "kafka")]
     Kafka(KafkaSource),
+    #[cfg(feature = "opensearch")]
     OpenSearch(OpenSearchSource),
 }
 
 impl Source {
     pub fn into_join_handle(self) -> JoinHandle<()> {
         match self {
+            #[cfg(feature = "cassandra")]
             Source::Cassandra(c) => c.join_handle,
+            #[cfg(feature = "redis")]
             Source::Redis(r) => r.join_handle,
+            #[cfg(feature = "kafka")]
             Source::Kafka(r) => r.join_handle,
+            #[cfg(feature = "opensearch")]
             Source::OpenSearch(o) => o.join_handle,
         }
     }
@@ -43,9 +59,13 @@ impl Source {
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub enum SourceConfig {
+    #[cfg(feature = "cassandra")]
     Cassandra(CassandraConfig),
+    #[cfg(feature = "redis")]
     Redis(RedisConfig),
+    #[cfg(feature = "kafka")]
     Kafka(KafkaConfig),
+    #[cfg(feature = "opensearch")]
     OpenSearch(OpenSearchConfig),
 }
 
@@ -55,9 +75,13 @@ impl SourceConfig {
         trigger_shutdown_rx: watch::Receiver<bool>,
     ) -> Result<Source, Vec<String>> {
         match self {
+            #[cfg(feature = "cassandra")]
             SourceConfig::Cassandra(c) => c.get_source(trigger_shutdown_rx).await,
+            #[cfg(feature = "redis")]
             SourceConfig::Redis(r) => r.get_source(trigger_shutdown_rx).await,
+            #[cfg(feature = "kafka")]
             SourceConfig::Kafka(r) => r.get_source(trigger_shutdown_rx).await,
+            #[cfg(feature = "opensearch")]
             SourceConfig::OpenSearch(r) => r.get_source(trigger_shutdown_rx).await,
         }
     }

--- a/shotover/src/transforms/coalesce.rs
+++ b/shotover/src/transforms/coalesce.rs
@@ -94,7 +94,7 @@ impl Transform for Coalesce {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "redis"))]
 mod test {
     use crate::frame::{Frame, RedisFrame};
     use crate::message::Message;

--- a/shotover/src/transforms/filter.rs
+++ b/shotover/src/transforms/filter.rs
@@ -111,7 +111,7 @@ impl Transform for QueryTypeFilter {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "redis"))]
 mod test {
     use super::Filter;
     use crate::frame::Frame;

--- a/shotover/src/transforms/mod.rs
+++ b/shotover/src/transforms/mod.rs
@@ -15,22 +15,27 @@ use tokio::time::Instant;
 
 use self::chain::TransformAndMetrics;
 
+#[cfg(feature = "cassandra")]
 pub mod cassandra;
 pub mod chain;
 pub mod coalesce;
 pub mod debug;
+#[cfg(feature = "redis")]
 pub mod distributed;
 pub mod filter;
+#[cfg(feature = "kafka")]
 pub mod kafka;
 pub mod load_balance;
 pub mod loopback;
 pub mod noop;
 pub mod null;
-#[cfg(feature = "alpha-transforms")]
+#[cfg(all(feature = "alpha-transforms", feature = "opensearch"))]
 pub mod opensearch;
 pub mod parallel_map;
+#[cfg(feature = "cassandra")]
 pub mod protect;
 pub mod query_counter;
+#[cfg(feature = "redis")]
 pub mod redis;
 pub mod sampler;
 pub mod tee;

--- a/shotover/src/transforms/redis/mod.rs
+++ b/shotover/src/transforms/redis/mod.rs
@@ -1,5 +1,6 @@
 use crate::transforms::util::ConnectionError;
 
+#[cfg(all(feature = "redis", feature = "cassandra"))]
 pub mod cache;
 pub mod cluster_ports_rewrite;
 pub mod sink_cluster;

--- a/shotover/src/transforms/util/cluster_connection_pool.rs
+++ b/shotover/src/transforms/util/cluster_connection_pool.rs
@@ -286,7 +286,7 @@ async fn rx_process<C: DecoderHalf, R: AsyncRead + Unpin + Send + 'static>(
     Ok(())
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "redis"))]
 mod test {
     use super::spawn_read_write_tasks;
     use crate::codec::redis::RedisCodecBuilder;

--- a/windsock-cloud-docker/src/container.rs
+++ b/windsock-cloud-docker/src/container.rs
@@ -68,6 +68,9 @@ unzip awscliv2.zip
         // run windsock
         let mut args = std::env::args();
         args.next(); // skip binary name
+        let features = args
+            .next()
+            .expect("The first argument must be a list of features to compile shotover with");
         let args: Vec<String> = args
             .map(|x| {
                 if x.is_empty() {
@@ -83,7 +86,7 @@ unzip awscliv2.zip
         container_bash(&format!(
         r#"cd shotover-proxy;
 source "$HOME/.cargo/env";
-AWS_ACCESS_KEY_ID={access_key_id} AWS_SECRET_ACCESS_KEY={secret_access_key} CARGO_TERM_COLOR=always cargo test --target-dir /target --release --bench windsock --features alpha-transforms --features rdkafka-driver-tests -- {args}"#
+AWS_ACCESS_KEY_ID={access_key_id} AWS_SECRET_ACCESS_KEY={secret_access_key} CARGO_TERM_COLOR=always cargo test --target-dir /target --release --bench windsock --no-default-features --features alpha-transforms,rdkafka-driver-tests,{features} -- {args}"#
     )).await;
 
         // extract windsock results


### PR DESCRIPTION
This improves compile times of windsock without compromising on performance like https://github.com/shotover/shotover-proxy/pull/1438 ended up doing.

Previously `cargo windsock` took 2m 45s to compile after a change to our windsock benches.
Now it takes:
* `cargo windsock-redis` - 1 min 32s
* `cargo windsock-kafka` - 1 min 21s
* `cargo windsock-cassandra` - 2 min 23s
* `cargo windsock` - 2m 45s

We would be getting similar improvements to our integration tests but we rarely need to run them in release so I didnt bother adding cargo aliases for them or measuring them.

Additionally, this PR improves compile times of shotover when developing custom transforms that only need to support a single protocol by allowing developers to disable unneeded dependencies within shotover, this will be quite helpful for our internal kafka project where we are also struggling with build times and have no need for any protocol other than kafka.
As a result of compiling less, the binary size with just kafka enabled is now 13.9MB, while the standard build with everything enabled is 19MB.

Additionally, additionally, this will be quite helpful for investigating the cause of build time issues in the future as we can easily eliminate certain protocols from the build.

## Updates:

### Reduced cfgs

With the help of #1442 #1443 #1444 and #1445 I have reduced the number of cfgs from 283 down to 181

### Improvements for custom transform devs
Testing on our internal kafka-specific project:
* full build times of shotover have been reduced from 8m 53s to 4m 49s
* iterative build times have been reduced from 4m 26s to 1m 57s

As a result with this PR we will cut 4 minutes off the time to run CI as we have no caching setup for our CI on that project.
We will also cut 2 mins 30s from our iterative benchmark workflow which is super important to the project as its very performance sensitive.