### PR TITLE
Transforms use dynamic dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4362,7 +4362,6 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "string",
- "strum_macros 0.26.1",
  "thiserror",
  "tokio",
  "tokio-rustls 0.25.0",

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,29 @@ This assists us in knowing when to make the next release a breaking release and 
 
 ## 0.3.0
 
+## shotover rust API
+
+`TransformBuilder::build` now returns `Box<dyn Transform>` instead of `Transforms`.
+This means that custom transforms should implement the builder as:
+
+```rust
+impl TransformBuilder for CustomBuilder {
+  fn build(&self) -> Box<dyn Transform> {
+    Box::new(CustomTransform::new())
+  }
+}
+```
+
+Instead of:
+
+```rust
+impl TransformBuilder for CustomBuilder {
+  fn build(&self) -> Transforms {
+    Transforms::Custom(CustomTransform::new())
+  }
+}
+```
+
 ### metrics
 
 The prometheus metrics were renamed to better follow the official reccomended naming scheme: <https://prometheus.io/docs/practices/naming/>

--- a/custom-transforms-example/src/redis_get_rewrite.rs
+++ b/custom-transforms-example/src/redis_get_rewrite.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use shotover::frame::{Frame, RedisFrame};
 use shotover::message::Messages;
-use shotover::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
+use shotover::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
@@ -11,6 +11,7 @@ pub struct RedisGetRewriteConfig {
     pub result: String,
 }
 
+const NAME: &str = "RedisGetRewrite";
 #[typetag::serde(name = "RedisGetRewrite")]
 #[async_trait(?Send)]
 impl TransformConfig for RedisGetRewriteConfig {
@@ -27,14 +28,14 @@ pub struct RedisGetRewriteBuilder {
 }
 
 impl TransformBuilder for RedisGetRewriteBuilder {
-    fn build(&self) -> Transforms {
-        Transforms::Custom(Box::new(RedisGetRewrite {
+    fn build(&self) -> Box<dyn Transform> {
+        Box::new(RedisGetRewrite {
             result: self.result.clone(),
-        }))
+        })
     }
 
     fn get_name(&self) -> &'static str {
-        "RedisGetRewrite"
+        NAME
     }
 }
 
@@ -44,6 +45,10 @@ pub struct RedisGetRewrite {
 
 #[async_trait]
 impl Transform for RedisGetRewrite {
+    fn get_name(&self) -> &'static str {
+        NAME
+    }
+
     async fn transform<'a>(&'a mut self, mut requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         let mut get_indices = vec![];
         for (i, message) in requests_wrapper.requests.iter_mut().enumerate() {

--- a/shotover/Cargo.toml
+++ b/shotover/Cargo.toml
@@ -76,7 +76,6 @@ ordered-float.workspace = true
 #Crypto
 aws-config = "1.0.0"
 aws-sdk-kms = "1.1.0"
-strum_macros = "0.26"
 chacha20poly1305 = { version = "0.10.0", features = ["std"] }
 generic-array = { version = "0.14", features = ["serde"] }
 kafka-protocol = "0.8.0"

--- a/shotover/src/lib.rs
+++ b/shotover/src/lib.rs
@@ -30,6 +30,7 @@
 #![deny(clippy::print_stdout)]
 #![deny(clippy::print_stderr)]
 #![allow(clippy::needless_doctest_main)]
+#![allow(clippy::box_default)]
 
 pub mod codec;
 pub mod config;

--- a/shotover/src/runner.rs
+++ b/shotover/src/runner.rs
@@ -2,8 +2,6 @@
 use crate::config::topology::Topology;
 use crate::config::Config;
 use crate::observability::LogFilterHttpExporter;
-use crate::transforms::Transforms;
-use crate::transforms::Wrapper;
 use anyhow::Context;
 use anyhow::{anyhow, Result};
 use clap::{crate_version, Parser};
@@ -13,7 +11,7 @@ use std::net::SocketAddr;
 use tokio::runtime::{self, Runtime};
 use tokio::signal::unix::{signal, SignalKind};
 use tokio::sync::watch;
-use tracing::{debug, error, info};
+use tracing::{error, info};
 use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
 use tracing_subscriber::filter::Directive;
 use tracing_subscriber::fmt::format::DefaultFields;
@@ -301,16 +299,6 @@ async fn run(
     info!("Starting Shotover {}", crate_version!());
     info!(configuration = ?config);
     info!(topology = ?topology);
-
-    debug!(
-        "Transform overhead size on stack is {}",
-        std::mem::size_of::<Transforms>()
-    );
-
-    debug!(
-        "Wrapper overhead size on stack is {}",
-        std::mem::size_of::<Wrapper<'_>>()
-    );
 
     match topology.run_chains(trigger_shutdown_rx).await {
         Ok(sources) => {

--- a/shotover/src/transforms/cassandra/peers_rewrite.rs
+++ b/shotover/src/transforms/cassandra/peers_rewrite.rs
@@ -4,7 +4,7 @@ use crate::frame::{
 };
 use crate::message::{Message, Messages};
 use crate::transforms::cassandra::peers_rewrite::CassandraOperation::Event;
-use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
+use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
 use cassandra_protocol::frame::events::{ServerEvent, StatusChange};
@@ -19,6 +19,7 @@ pub struct CassandraPeersRewriteConfig {
     pub port: u16,
 }
 
+const NAME: &str = "CassandraPeersRewrite";
 #[typetag::serde(name = "CassandraPeersRewrite")]
 #[async_trait(?Send)]
 impl TransformConfig for CassandraPeersRewriteConfig {
@@ -43,17 +44,21 @@ impl CassandraPeersRewrite {
 }
 
 impl TransformBuilder for CassandraPeersRewrite {
-    fn build(&self) -> Transforms {
-        Transforms::CassandraPeersRewrite(self.clone())
+    fn build(&self) -> Box<dyn Transform> {
+        Box::new(self.clone())
     }
 
     fn get_name(&self) -> &'static str {
-        "CassandraPeersRewrite"
+        NAME
     }
 }
 
 #[async_trait]
 impl Transform for CassandraPeersRewrite {
+    fn get_name(&self) -> &'static str {
+        NAME
+    }
+
     async fn transform<'a>(&'a mut self, mut requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         // Find the indices of queries to system.peers & system.peers_v2
         // we need to know which columns in which CQL queries in which messages have system peers

--- a/shotover/src/transforms/cassandra/sink_single.rs
+++ b/shotover/src/transforms/cassandra/sink_single.rs
@@ -4,7 +4,7 @@ use crate::frame::cassandra::CassandraMetadata;
 use crate::message::{Messages, Metadata};
 use crate::tls::{TlsConnector, TlsConnectorConfig};
 use crate::transforms::cassandra::connection::Response;
-use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
+use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use cassandra_protocol::frame::Version;
@@ -25,6 +25,7 @@ pub struct CassandraSinkSingleConfig {
     pub read_timeout: Option<u64>,
 }
 
+const NAME: &str = "CassandraSinkSingle";
 #[typetag::serde(name = "CassandraSinkSingle")]
 #[async_trait(?Send)]
 impl TransformConfig for CassandraSinkSingleConfig {
@@ -77,8 +78,8 @@ impl CassandraSinkSingleBuilder {
 }
 
 impl TransformBuilder for CassandraSinkSingleBuilder {
-    fn build(&self) -> Transforms {
-        Transforms::CassandraSinkSingle(CassandraSinkSingle {
+    fn build(&self) -> Box<dyn Transform> {
+        Box::new(CassandraSinkSingle {
             outbound: None,
             version: self.version,
             address: self.address.clone(),
@@ -92,7 +93,7 @@ impl TransformBuilder for CassandraSinkSingleBuilder {
     }
 
     fn get_name(&self) -> &'static str {
-        "CassandraSinkSingle"
+        NAME
     }
 
     fn is_terminating(&self) -> bool {
@@ -168,6 +169,10 @@ impl CassandraSinkSingle {
 
 #[async_trait]
 impl Transform for CassandraSinkSingle {
+    fn get_name(&self) -> &'static str {
+        NAME
+    }
+
     async fn transform<'a>(&'a mut self, requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         self.send_message(requests_wrapper.requests).await
     }

--- a/shotover/src/transforms/chain.rs
+++ b/shotover/src/transforms/chain.rs
@@ -1,5 +1,5 @@
 use crate::message::Messages;
-use crate::transforms::{TransformBuilder, Transforms, Wrapper};
+use crate::transforms::{Transform, TransformBuilder, Wrapper};
 use anyhow::{anyhow, Result};
 use derivative::Derivative;
 use futures::TryFutureExt;
@@ -51,18 +51,13 @@ impl BufferedChainMessages {
 /// Transform chains can be of arbitary complexity and a transform can even have its own set of child transform chains.
 /// Transform chains are defined by the user in Shotover's configuration file and are linked to sources.
 ///
-/// The transform chain is a vector of mutable references to the enum [Transforms] (which is an enum dispatch wrapper around the various transform types).
-#[derive(Derivative)]
-#[derivative(Debug)]
+/// The transform chain is a vector of mutable references to the enum [Transform] (which is an enum dispatch wrapper around the various transform types).
 pub struct TransformChain {
     pub name: &'static str,
     pub chain: InnerChain,
 
-    #[derivative(Debug = "ignore")]
     chain_total: Counter,
-    #[derivative(Debug = "ignore")]
     chain_failures: Counter,
-    #[derivative(Debug = "ignore")]
     chain_batch_size: Histogram,
 }
 
@@ -194,27 +189,19 @@ impl TransformChain {
     }
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct TransformAndMetrics {
-    pub transform: Transforms,
-    #[derivative(Debug = "ignore")]
+    pub transform: Box<dyn Transform>,
     pub transform_total: Counter,
-    #[derivative(Debug = "ignore")]
     pub transform_failures: Counter,
-    #[derivative(Debug = "ignore")]
     pub transform_latency: Histogram,
-    #[derivative(Debug = "ignore")]
     pub transform_pushed_total: Counter,
-    #[derivative(Debug = "ignore")]
     pub transform_pushed_failures: Counter,
-    #[derivative(Debug = "ignore")]
     pub transform_pushed_latency: Histogram,
 }
 
 impl TransformAndMetrics {
     #[cfg(test)]
-    pub fn new(transform: Transforms) -> Self {
+    pub fn new(transform: Box<dyn Transform>) -> Self {
         TransformAndMetrics {
             transform,
             transform_total: Counter::noop(),

--- a/shotover/src/transforms/debug/force_parse.rs
+++ b/shotover/src/transforms/debug/force_parse.rs
@@ -7,7 +7,7 @@ use crate::message::Messages;
 /// It could also be used to ensure that messages round trip correctly when parsed.
 #[cfg(feature = "alpha-transforms")]
 use crate::transforms::TransformConfig;
-use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
+use crate::transforms::{Transform, TransformBuilder, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -44,6 +44,7 @@ pub struct DebugForceEncodeConfig {
     pub encode_responses: bool,
 }
 
+const NAME: &str = "DebugForceEncode";
 #[cfg(feature = "alpha-transforms")]
 #[typetag::serde(name = "DebugForceEncode")]
 #[async_trait(?Send)]
@@ -67,17 +68,21 @@ pub struct DebugForceParse {
 }
 
 impl TransformBuilder for DebugForceParse {
-    fn build(&self) -> Transforms {
-        Transforms::DebugForceParse(self.clone())
+    fn build(&self) -> Box<dyn Transform> {
+        Box::new(self.clone())
     }
 
     fn get_name(&self) -> &'static str {
-        "DebugForceParse"
+        NAME
     }
 }
 
 #[async_trait]
 impl Transform for DebugForceParse {
+    fn get_name(&self) -> &'static str {
+        NAME
+    }
+
     async fn transform<'a>(&'a mut self, mut requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         for message in &mut requests_wrapper.requests {
             if self.parse_requests {

--- a/shotover/src/transforms/debug/printer.rs
+++ b/shotover/src/transforms/debug/printer.rs
@@ -1,5 +1,5 @@
 use crate::message::Messages;
-use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
+use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -9,6 +9,7 @@ use tracing::info;
 #[serde(deny_unknown_fields)]
 pub struct DebugPrinterConfig;
 
+const NAME: &str = "DebugPrinter";
 #[typetag::serde(name = "DebugPrinter")]
 #[async_trait(?Send)]
 impl TransformConfig for DebugPrinterConfig {
@@ -35,17 +36,21 @@ impl DebugPrinter {
 }
 
 impl TransformBuilder for DebugPrinter {
-    fn build(&self) -> Transforms {
-        Transforms::DebugPrinter(self.clone())
+    fn build(&self) -> Box<dyn Transform> {
+        Box::new(self.clone())
     }
 
     fn get_name(&self) -> &'static str {
-        "DebugPrinter"
+        NAME
     }
 }
 
 #[async_trait]
 impl Transform for DebugPrinter {
+    fn get_name(&self) -> &'static str {
+        NAME
+    }
+
     async fn transform<'a>(&'a mut self, mut requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         for request in &mut requests_wrapper.requests {
             info!("Request: {}", request.to_high_level_string());

--- a/shotover/src/transforms/debug/random_delay.rs
+++ b/shotover/src/transforms/debug/random_delay.rs
@@ -6,6 +6,8 @@ use rand_distr::Distribution;
 use rand_distr::Normal;
 use tokio::time::Duration;
 
+const NAME: &str = "DebugRandomDelay";
+
 #[derive(Debug, Clone)]
 pub struct DebugRandomDelay {
     pub delay: u64,
@@ -14,6 +16,10 @@ pub struct DebugRandomDelay {
 
 #[async_trait]
 impl Transform for DebugRandomDelay {
+    fn get_name(&self) -> &'static str {
+        NAME
+    }
+
     async fn transform<'a>(&'a mut self, requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         let delay = if let Some(dist) = self.distribution {
             Duration::from_millis(dist.sample(&mut rand::thread_rng()) as u64 + self.delay)

--- a/shotover/src/transforms/debug/returner.rs
+++ b/shotover/src/transforms/debug/returner.rs
@@ -1,6 +1,6 @@
 use crate::frame::{Frame, RedisFrame};
 use crate::message::{Message, Messages};
-use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
+use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -12,6 +12,7 @@ pub struct DebugReturnerConfig {
     response: Response,
 }
 
+const NAME: &str = "DebugReturner";
 #[typetag::serde(name = "DebugReturner")]
 #[async_trait(?Send)]
 impl TransformConfig for DebugReturnerConfig {
@@ -41,12 +42,12 @@ impl DebugReturner {
 }
 
 impl TransformBuilder for DebugReturner {
-    fn build(&self) -> Transforms {
-        Transforms::DebugReturner(self.clone())
+    fn build(&self) -> Box<dyn Transform> {
+        Box::new(self.clone())
     }
 
     fn get_name(&self) -> &'static str {
-        "DebugReturner"
+        NAME
     }
 
     fn is_terminating(&self) -> bool {
@@ -56,6 +57,10 @@ impl TransformBuilder for DebugReturner {
 
 #[async_trait]
 impl Transform for DebugReturner {
+    fn get_name(&self) -> &'static str {
+        NAME
+    }
+
     async fn transform<'a>(&'a mut self, requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         match &self.response {
             Response::Message(message) => Ok(message.clone()),

--- a/shotover/src/transforms/loopback.rs
+++ b/shotover/src/transforms/loopback.rs
@@ -1,18 +1,20 @@
 use crate::message::Messages;
-use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
+use crate::transforms::{Transform, TransformBuilder, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
+
+const NAME: &str = "Loopback";
 
 #[derive(Debug, Clone, Default)]
 pub struct Loopback {}
 
 impl TransformBuilder for Loopback {
-    fn build(&self) -> Transforms {
-        Transforms::Loopback(self.clone())
+    fn build(&self) -> Box<dyn Transform> {
+        Box::new(self.clone())
     }
 
     fn get_name(&self) -> &'static str {
-        "Loopback"
+        NAME
     }
 
     fn is_terminating(&self) -> bool {
@@ -22,6 +24,10 @@ impl TransformBuilder for Loopback {
 
 #[async_trait]
 impl Transform for Loopback {
+    fn get_name(&self) -> &'static str {
+        NAME
+    }
+
     async fn transform<'a>(&'a mut self, requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         Ok(requests_wrapper.requests)
     }

--- a/shotover/src/transforms/noop.rs
+++ b/shotover/src/transforms/noop.rs
@@ -3,6 +3,8 @@ use crate::transforms::{Transform, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
 
+const NAME: &str = "NoOp";
+
 #[derive(Debug, Clone)]
 pub struct NoOp {}
 
@@ -20,6 +22,10 @@ impl Default for NoOp {
 
 #[async_trait]
 impl Transform for NoOp {
+    fn get_name(&self) -> &'static str {
+        NAME
+    }
+
     async fn transform<'a>(&'a mut self, requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         requests_wrapper.call_next_transform().await
     }

--- a/shotover/src/transforms/null.rs
+++ b/shotover/src/transforms/null.rs
@@ -1,5 +1,5 @@
 use crate::message::Messages;
-use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
+use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 #[serde(deny_unknown_fields)]
 pub struct NullSinkConfig;
 
+const NAME: &str = "NullSink";
 #[typetag::serde(name = "NullSink")]
 #[async_trait(?Send)]
 impl TransformConfig for NullSinkConfig {
@@ -20,12 +21,12 @@ impl TransformConfig for NullSinkConfig {
 pub struct NullSink {}
 
 impl TransformBuilder for NullSink {
-    fn build(&self) -> super::Transforms {
-        Transforms::NullSink(self.clone())
+    fn build(&self) -> Box<dyn Transform> {
+        Box::new(self.clone())
     }
 
     fn get_name(&self) -> &'static str {
-        "NullSink"
+        NAME
     }
 
     fn is_terminating(&self) -> bool {
@@ -35,6 +36,10 @@ impl TransformBuilder for NullSink {
 
 #[async_trait]
 impl Transform for NullSink {
+    fn get_name(&self) -> &'static str {
+        NAME
+    }
+
     async fn transform<'a>(&'a mut self, mut requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         for message in &mut requests_wrapper.requests {
             *message =

--- a/shotover/src/transforms/opensearch/mod.rs
+++ b/shotover/src/transforms/opensearch/mod.rs
@@ -1,7 +1,5 @@
 use crate::tcp;
-use crate::transforms::{
-    Messages, Transform, TransformBuilder, TransformConfig, Transforms, Wrapper,
-};
+use crate::transforms::{Messages, Transform, TransformBuilder, TransformConfig, Wrapper};
 use crate::{
     codec::{opensearch::OpenSearchCodecBuilder, CodecBuilder, Direction},
     transforms::util::{
@@ -23,6 +21,7 @@ pub struct OpenSearchSinkSingleConfig {
     connect_timeout_ms: u64,
 }
 
+const NAME: &str = "OpenSearchSinkSingle";
 #[typetag::serde(name = "OpenSearchSinkSingle")]
 #[async_trait(?Send)]
 impl TransformConfig for OpenSearchSinkSingleConfig {
@@ -53,8 +52,8 @@ impl OpenSearchSinkSingleBuilder {
 }
 
 impl TransformBuilder for OpenSearchSinkSingleBuilder {
-    fn build(&self) -> Transforms {
-        Transforms::OpenSearchSinkSingle(OpenSearchSinkSingle {
+    fn build(&self) -> Box<dyn Transform> {
+        Box::new(OpenSearchSinkSingle {
             address: self.address.clone(),
             connect_timeout: self.connect_timeout,
             codec_builder: OpenSearchCodecBuilder::new(Direction::Sink, self.get_name().to_owned()),
@@ -63,7 +62,7 @@ impl TransformBuilder for OpenSearchSinkSingleBuilder {
     }
 
     fn get_name(&self) -> &'static str {
-        "OpenSearchSinkSingle"
+        NAME
     }
 
     fn is_terminating(&self) -> bool {
@@ -80,6 +79,10 @@ pub struct OpenSearchSinkSingle {
 
 #[async_trait]
 impl Transform for OpenSearchSinkSingle {
+    fn get_name(&self) -> &'static str {
+        NAME
+    }
+
     async fn transform<'a>(&'a mut self, requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         // Return immediately if we have no messages.
         // If we tried to send no messages we would block forever waiting for a reply that will never come.

--- a/shotover/src/transforms/protect/mod.rs
+++ b/shotover/src/transforms/protect/mod.rs
@@ -4,7 +4,7 @@ use crate::frame::{
 use crate::message::Messages;
 use crate::transforms::protect::key_management::KeyManager;
 pub use crate::transforms::protect::key_management::KeyManagerConfig;
-use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
+use crate::transforms::{Transform, TransformBuilder, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
 use cql3_parser::cassandra_statement::CassandraStatement;
@@ -30,6 +30,7 @@ pub struct ProtectConfig {
 #[cfg(feature = "alpha-transforms")]
 use crate::transforms::TransformConfig;
 
+const NAME: &str = "Protect";
 #[cfg(feature = "alpha-transforms")]
 #[typetag::serde(name = "Protect")]
 #[async_trait(?Send)]
@@ -70,12 +71,12 @@ pub struct Protect {
 }
 
 impl TransformBuilder for Protect {
-    fn build(&self) -> Transforms {
-        Transforms::Protect(Box::new(self.clone()))
+    fn build(&self) -> Box<dyn Transform> {
+        Box::new(self.clone())
     }
 
     fn get_name(&self) -> &'static str {
-        "Protect"
+        NAME
     }
 }
 
@@ -167,6 +168,10 @@ impl Protect {
 
 #[async_trait]
 impl Transform for Protect {
+    fn get_name(&self) -> &'static str {
+        NAME
+    }
+
     async fn transform<'a>(&'a mut self, mut requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         // encrypt the values included in any INSERT or UPDATE queries
         for message in requests_wrapper.requests.iter_mut() {

--- a/shotover/src/transforms/query_counter.rs
+++ b/shotover/src/transforms/query_counter.rs
@@ -1,7 +1,7 @@
 use crate::frame::Frame;
 use crate::message::Messages;
 use crate::transforms::TransformConfig;
-use crate::transforms::{Transform, TransformBuilder, Transforms, Wrapper};
+use crate::transforms::{Transform, TransformBuilder, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
 use metrics::{counter, register_counter};
@@ -28,17 +28,21 @@ impl QueryCounter {
 }
 
 impl TransformBuilder for QueryCounter {
-    fn build(&self) -> Transforms {
-        Transforms::QueryCounter(self.clone())
+    fn build(&self) -> Box<dyn Transform> {
+        Box::new(self.clone())
     }
 
     fn get_name(&self) -> &'static str {
-        "QueryCounter"
+        NAME
     }
 }
 
 #[async_trait]
 impl Transform for QueryCounter {
+    fn get_name(&self) -> &'static str {
+        NAME
+    }
+
     async fn transform<'a>(&'a mut self, mut requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         for m in &mut requests_wrapper.requests {
             match m.frame() {
@@ -73,6 +77,7 @@ impl Transform for QueryCounter {
     }
 }
 
+const NAME: &str = "QueryCounter";
 #[typetag::serde(name = "QueryCounter")]
 #[async_trait(?Send)]
 impl TransformConfig for QueryCounterConfig {

--- a/shotover/src/transforms/redis/cluster_ports_rewrite.rs
+++ b/shotover/src/transforms/redis/cluster_ports_rewrite.rs
@@ -1,7 +1,7 @@
 use crate::frame::Frame;
 use crate::frame::RedisFrame;
 use crate::message::Messages;
-use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
+use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
 use anyhow::{anyhow, bail, Context, Result};
 use async_trait::async_trait;
 use bytes::{BufMut, Bytes, BytesMut};
@@ -14,6 +14,7 @@ pub struct RedisClusterPortsRewriteConfig {
     pub new_port: u16,
 }
 
+const NAME: &str = "RedisClusterPortsRewrite";
 #[typetag::serde(name = "RedisClusterPortsRewrite")]
 #[async_trait(?Send)]
 impl TransformConfig for RedisClusterPortsRewriteConfig {
@@ -25,12 +26,12 @@ impl TransformConfig for RedisClusterPortsRewriteConfig {
 }
 
 impl TransformBuilder for RedisClusterPortsRewrite {
-    fn build(&self) -> Transforms {
-        Transforms::RedisClusterPortsRewrite(self.clone())
+    fn build(&self) -> Box<dyn Transform> {
+        Box::new(self.clone())
     }
 
     fn get_name(&self) -> &'static str {
-        "RedisClusterPortsRewrite"
+        NAME
     }
 }
 
@@ -47,6 +48,10 @@ impl RedisClusterPortsRewrite {
 
 #[async_trait]
 impl Transform for RedisClusterPortsRewrite {
+    fn get_name(&self) -> &'static str {
+        NAME
+    }
+
     async fn transform<'a>(&'a mut self, mut requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         // Find the indices of cluster slot messages
         let mut cluster_slots_indices = vec![];

--- a/shotover/src/transforms/redis/timestamp_tagging.rs
+++ b/shotover/src/transforms/redis/timestamp_tagging.rs
@@ -1,7 +1,7 @@
 use crate::frame::redis::redis_query_type;
 use crate::frame::{Frame, RedisFrame};
 use crate::message::{Message, Messages, QueryType};
-use crate::transforms::{Transform, TransformBuilder, TransformConfig, Transforms, Wrapper};
+use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -15,6 +15,7 @@ use tracing::{debug, trace};
 #[serde(deny_unknown_fields)]
 pub struct RedisTimestampTaggerConfig;
 
+const NAME: &str = "RedisTimestampTagger";
 #[typetag::serde(name = "RedisTimestampTagger")]
 #[async_trait(?Send)]
 impl TransformConfig for RedisTimestampTaggerConfig {
@@ -33,12 +34,12 @@ impl RedisTimestampTagger {
 }
 
 impl TransformBuilder for RedisTimestampTagger {
-    fn build(&self) -> Transforms {
-        Transforms::RedisTimestampTagger(self.clone())
+    fn build(&self) -> Box<dyn Transform> {
+        Box::new(self.clone())
     }
 
     fn get_name(&self) -> &'static str {
-        "RedisTimestampTagger"
+        NAME
     }
 }
 
@@ -182,6 +183,10 @@ fn unwrap_response(message: &mut Message) -> Result<()> {
 
 #[async_trait]
 impl Transform for RedisTimestampTagger {
+    fn get_name(&self) -> &'static str {
+        NAME
+    }
+
     async fn transform<'a>(&'a mut self, mut requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         // TODO: This is wrong. We need to keep track of tagged_success per message
         let mut tagged_success = true;

--- a/shotover/src/transforms/sampler.rs
+++ b/shotover/src/transforms/sampler.rs
@@ -6,6 +6,8 @@ use async_trait::async_trait;
 use tokio::macros::support::thread_rng_n;
 use tracing::warn;
 
+const NAME: &str = "Sampler";
+
 #[derive(Debug)]
 pub struct SamplerBuilder {
     pub numerator: u32,
@@ -29,7 +31,6 @@ impl Default for SamplerBuilder {
     }
 }
 
-#[derive(Debug)]
 pub struct Sampler {
     numerator: u32,
     denominator: u32,
@@ -38,6 +39,10 @@ pub struct Sampler {
 
 #[async_trait]
 impl Transform for Sampler {
+    fn get_name(&self) -> &'static str {
+        NAME
+    }
+
     async fn transform<'a>(&'a mut self, requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         let chance = thread_rng_n(self.denominator);
         if chance < self.numerator {

--- a/shotover/src/transforms/throttling.rs
+++ b/shotover/src/transforms/throttling.rs
@@ -13,14 +13,13 @@ use serde::{Deserialize, Serialize};
 use std::num::NonZeroU32;
 use std::sync::Arc;
 
-use super::Transforms;
-
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct RequestThrottlingConfig {
     pub max_requests_per_second: NonZeroU32,
 }
 
+const NAME: &str = "RequestThrottling";
 #[typetag::serde(name = "RequestThrottling")]
 #[async_trait(?Send)]
 impl TransformConfig for RequestThrottlingConfig {
@@ -41,12 +40,12 @@ pub struct RequestThrottling {
 }
 
 impl TransformBuilder for RequestThrottling {
-    fn build(&self) -> Transforms {
-        Transforms::RequestThrottling(self.clone())
+    fn build(&self) -> Box<dyn Transform> {
+        Box::new(self.clone())
     }
 
     fn get_name(&self) -> &'static str {
-        "RequestThrottlingConfig"
+        NAME
     }
 
     fn validate(&self) -> Vec<String> {
@@ -63,6 +62,10 @@ impl TransformBuilder for RequestThrottling {
 
 #[async_trait]
 impl Transform for RequestThrottling {
+    fn get_name(&self) -> &'static str {
+        NAME
+    }
+
     async fn transform<'a>(&'a mut self, mut requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         // extract throttled messages from the requests_wrapper
         let throttled_messages: Vec<(Message, usize)> = (0..requests_wrapper.requests.len())


### PR DESCRIPTION
For a long time we have been using static dispatch for our transforms.
This was done for performance reasons at the cost of manually implementing dispatch via enum matching.

However, motivated by a desire to reduce the need for `cfg(feature = "..")` in the codebase I investigated whether this was truly necessary.
From microbenchmark and windsock results I can not observe any regression in performance from using dynamic dispatch instead.
So this PR refactors transforms to use trait objects / dynamic dispatch.

## Benefits:
* Technically speeds up custom transforms
    + Previously custom transforms were using both dynamic dispatch and enum dispatch, the worst of both worlds. Now its just dynamic dispatch.
* Removes the only difference between internal and custom transforms - this could allow us to break shotover up into multiple crates in the future.
* No longer need to manually implement enum dispatch
* Fixes names for custom transforms
    + previously the name used for diagnostics for custom transforms would always just be "Custom" instead of the actual name of the transform.

## Negatives:
* A unit test for the `ConnectionBalanceAndPool` transform had to be deleted as it was inspecting the state of the transform and there is no way to achieve that with a trait object.
   + If we end up using ConnectionBalanceAndPool some day then we should write a proper integration test for the transform that does not rely on transform internals for testing.
   + However considering the transform is currently unused, we shouldnt let this PR be blocked on such a test.