### PR TITLE
move into protocol specific modules for message module

### DIFF
--- a/shotover/src/frame/cassandra.rs
+++ b/shotover/src/frame/cassandra.rs
@@ -99,6 +99,36 @@ pub struct CassandraMetadata {
     pub opcode: Opcode,
 }
 
+impl CassandraMetadata {
+    pub fn backpressure_response(&self) -> CassandraFrame {
+        let body = CassandraOperation::Error(ErrorBody {
+            message: "Server overloaded".into(),
+            ty: ErrorType::Overloaded,
+        });
+
+        CassandraFrame {
+            version: self.version,
+            stream_id: self.stream_id,
+            tracing: Tracing::Response(None),
+            warnings: vec![],
+            operation: body,
+        }
+    }
+
+    pub fn to_error_response(&self, error: String) -> CassandraFrame {
+        CassandraFrame {
+            version: self.version,
+            stream_id: self.stream_id,
+            operation: CassandraOperation::Error(ErrorBody {
+                message: error,
+                ty: ErrorType::Server,
+            }),
+            tracing: Tracing::Response(None),
+            warnings: vec![],
+        }
+    }
+}
+
 #[derive(PartialEq, Debug, Clone, Copy)]
 pub enum Tracing {
     Request(bool),


### PR DESCRIPTION
This is in preparation for https://github.com/shotover/shotover-proxy/pull/1441 where this refactor will slightly reduce complexity due to added `cfg(feature = "..")`s