### PR TITLE
Fix cloud shotover metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,13 +527,14 @@ dependencies = [
 
 [[package]]
 name = "aws-throwaway"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0da812cb994ccf68233bb00551df33d55b6841f83ab35f98095316be82133c"
+checksum = "3d5955140d4b11b9e3cb8c21546885b68472a3f20f6d8af58f4fbea8747f2e5b"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64",
+ "futures",
  "russh",
  "russh-keys",
  "serde",
@@ -2232,7 +2233,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.5",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",

--- a/shotover-proxy/benches/windsock/cassandra/bench.rs
+++ b/shotover-proxy/benches/windsock/cassandra/bench.rs
@@ -559,6 +559,9 @@ impl Bench for CassandraBench {
         let shotover_ip = shotover_instance
             .as_ref()
             .map(|x| x.instance.private_ip().to_string());
+        let shotover_connect_ip = shotover_instance
+            .as_ref()
+            .map(|x| x.instance.connect_ip().to_string());
 
         let mut profiler_instances: HashMap<String, &Ec2Instance> =
             [("bencher".to_owned(), &bench_instance.instance)].into();
@@ -581,9 +584,13 @@ impl Bench for CassandraBench {
                 profiler_instances.insert("cassandra".to_owned(), &cassandra_instances[0].instance);
             }
         }
-        let mut profiler =
-            CloudProfilerRunner::new(self.name(), profiling, profiler_instances, &shotover_ip)
-                .await;
+        let mut profiler = CloudProfilerRunner::new(
+            self.name(),
+            profiling,
+            profiler_instances,
+            &shotover_connect_ip,
+        )
+        .await;
 
         let cassandra_nodes = vec![
             AwsNodeInfo {

--- a/shotover-proxy/benches/windsock/cloud/aws.rs
+++ b/shotover-proxy/benches/windsock/cloud/aws.rs
@@ -22,6 +22,8 @@ impl AwsInstances {
     pub async fn new() -> Self {
         AwsInstances {
             aws: Aws::builder(CleanupResources::WithAppTag(AWS_THROWAWAY_TAG.to_owned()))
+                // shotover metrics port
+                .expose_ports_to_internet(vec![9001])
                 .build()
                 .await,
         }

--- a/shotover-proxy/benches/windsock/profilers.rs
+++ b/shotover-proxy/benches/windsock/profilers.rs
@@ -104,7 +104,7 @@ impl CloudProfilerRunner {
         bench_name: String,
         profiling: Profiling,
         instances: HashMap<String, &Ec2Instance>,
-        shotover_ip: &Option<String>,
+        shotover_connect_ip: &Option<String>,
     ) -> Self {
         let run_sys_monitor = profiling
             .profilers_to_use
@@ -124,7 +124,7 @@ impl CloudProfilerRunner {
         let shotover_metrics = if run_shotover_metrics {
             Some(ShotoverMetrics::new(
                 bench_name.clone(),
-                shotover_ip.as_ref().unwrap(),
+                shotover_connect_ip.as_ref().unwrap(),
             ))
         } else {
             None


### PR DESCRIPTION
I needed to fix two things to get shotover_metrics working on cloud benches:
* Use the connect_ip to fetch the metrics from instead of the private ip. connect_ip will automatically select the private or public ip depending on how aws-throwaway was configured. Public is used when the bencher is on your local machine private is used when the bencher is within EC2.
* expose port 9001 to the internet via `expose_ports_to_internet` builder method.