### PR TITLE
Add useful panic message when required_cloud_resources is unimplemented

### DIFF
--- a/windsock/src/bench.rs
+++ b/windsock/src/bench.rs
@@ -128,7 +128,7 @@ pub trait Bench {
 
     /// Specifies the cloud resources that should be provided to this bench
     fn required_cloud_resources(&self) -> Self::CloudResourcesRequired {
-        unimplemented!();
+        unimplemented!("To support running in cloud this bench needs to implement `Bench::required_cloud_resources`");
     }
 
     /// How many cores to assign the async runtime in which the bench runs.


### PR DESCRIPTION
We intentionally provide a default implementation here so that users not using cloud functionality dont need to worry about it.
But we can and should provide a better error message for cloud users that hit this panic.