### PR TITLE
windsock: fix cdrs connection count

### DIFF
--- a/shotover-proxy/benches/windsock/cassandra/bench.rs
+++ b/shotover-proxy/benches/windsock/cassandra/bench.rs
@@ -11,6 +11,7 @@ use async_trait::async_trait;
 use aws_throwaway::Ec2Instance;
 use cdrs_tokio::{
     cluster::{
+        connection_pool::ConnectionPoolConfigBuilder,
         session::{
             Session as CdrsTokioSession, SessionBuilder as CdrsTokioSessionBuilder,
             TcpSessionBuilder,
@@ -735,6 +736,12 @@ impl Bench for CassandraBench {
                             Compression::None => CdrsCompression::None,
                             Compression::Lz4 => CdrsCompression::Lz4,
                         })
+                        .with_connection_pool_config(
+                            ConnectionPoolConfigBuilder::new()
+                                .with_local_size(self.connection_count)
+                                .with_remote_size(self.connection_count)
+                                .build(),
+                        )
                         .build()
                         .await
                         .unwrap(),


### PR DESCRIPTION
I can tell it works because throughput increases x3 for connection_count=10 and connection_count=100
![image](https://github.com/shotover/shotover-proxy/assets/5120858/8baf5bf7-a22d-4214-8ca3-bfacd339faf5)

Not sure what the difference is between with_local_size and with_remote_size so I just set both.