### PR TITLE
Enable LTO when profiling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,16 +15,10 @@ resolver = "2"
 lto = "fat"
 codegen-units = 1
 
-[profile.bench]
-lto = "fat"
-codegen-units = 1
-
 # used for e.g. generating flamegraphs
 [profile.profiling]
 inherits = "release"
-lto = false
 debug = true
-codegen-units = 1
 
 [workspace.dependencies]
 scylla = { version = "0.12.0", features = ["ssl"] }


### PR DESCRIPTION
The bench profile is a default profile that already exists that gets used when running benches.
It inherits from release and all the config that we set for it is already set by release.
So I just deleted it.

The profiling profile is a profile derived from release that windsock uses to recompile shotover to ensure that it has debuginfo enabled so that profiling it will give useful results.
The magic line that enables this is `debug = true` but previously I also thought that we needed to disable LTO.
However it turns out that it works just fine with LTO enabled.
So this PR enables lto by removing the `lto = false` line and letting it fall back to the release profiles `lto = fat`
This is very useful as it ensures that we are profiling a binary that is a lot closer to what we release.

I also removed the `codegen-units = 1` line since that is already set in the release profile that we derive from.

I did attempt to combine the profiling and release profiles, so that we are profiling the same binary we release.
However with `debug = true` the binary increases to 186MB from 20MB, this is way too big.
If I then enable [split-debuginfo](https://doc.rust-lang.org/cargo/reference/profiles.html#split-debuginfo) it reduces to 40MB but that is still too large.
So with the current state of things I dont we think we should combine them.