### PR TITLE
Release shotover 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4288,7 +4288,7 @@ dependencies = [
 
 [[package]]
 name = "shotover"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/shotover/Cargo.toml
+++ b/shotover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shotover"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Ben <ben@instaclustr.com>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
We should get the important performance improvements from https://github.com/shotover/shotover-proxy/pull/1459 out the door.

We can make a patch release since we havent had any breaking changes to shotover since 0.3.0