### PR TITLE
Release shotover 0.3.1 (fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4358,7 +4358,7 @@ dependencies = [
 
 [[package]]
 name = "shotover-proxy"
-version = "0.2.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shotover-proxy"
-version = "0.2.0"
+version = "0.3.1"
 authors = ["Ben <ben@instaclustr.com>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
We failed to properly release both 0.3.0 and 0.3.1 and completely failed to notice.
This is definitely pushing forward a move to https://github.com/axodotdev/cargo-dist for me.

This PR fixes the release.
I'll retag this commit as the true 0.3.1.