### PR TITLE
Add MessageId (progress towards cleaning up transform invariants)

### DIFF
--- a/shotover/src/message/mod.rs
+++ b/shotover/src/message/mod.rs
@@ -226,6 +226,17 @@ impl Message {
         self.request_id = Some(request_id);
     }
 
+    pub fn clone_with_new_id(&self) -> Self {
+        Message {
+            inner: self.inner.clone(),
+            meta_timestamp: self.meta_timestamp,
+            received_from_source_or_sink_at: None,
+            codec_state: self.codec_state,
+            id: rand::random(),
+            request_id: self.request_id,
+        }
+    }
+
     pub fn ensure_message_type(&self, expected_message_type: MessageType) -> Result<()> {
         match self.inner.as_ref().unwrap() {
             MessageInner::RawBytes { message_type, .. } => {

--- a/shotover/src/transforms/redis/cluster_ports_rewrite.rs
+++ b/shotover/src/transforms/redis/cluster_ports_rewrite.rs
@@ -287,7 +287,7 @@ mod test {
     #[test]
     fn test_rewrite_port_slots() {
         let slots_pcap: &[u8] = b"*3\r\n*4\r\n:10923\r\n:16383\r\n*3\r\n$12\r\n192.168.80.6\r\n:6379\r\n$40\r\n3a7c357ed75d2aa01fca1e14ef3735a2b2b8ffac\r\n*3\r\n$12\r\n192.168.80.3\r\n:6379\r\n$40\r\n77c01b0ddd8668fff05e3f6a8aaf5f3ccd454a79\r\n*4\r\n:5461\r\n:10922\r\n*3\r\n$12\r\n192.168.80.5\r\n:6379\r\n$40\r\n969c6215d064e68593d384541ceeb57e9520dbed\r\n*3\r\n$12\r\n192.168.80.2\r\n:6379\r\n$40\r\n3929f69990a75be7b2d49594c57fe620862e6fd6\r\n*4\r\n:0\r\n:5460\r\n*3\r\n$12\r\n192.168.80.7\r\n:6379\r\n$40\r\n15d52a65d1fc7a53e34bf9193415aa39136882b2\r\n*3\r\n$12\r\n192.168.80.4\r\n:6379\r\n$40\r\ncd023916a3528fae7e606a10d8289a665d6c47b0\r\n";
-        let mut codec = RedisDecoder::new(Direction::Sink);
+        let mut codec = RedisDecoder::new(None, Direction::Sink);
         let mut message = codec
             .decode(&mut slots_pcap.into())
             .unwrap()

--- a/shotover/src/transforms/redis/sink_cluster.rs
+++ b/shotover/src/transforms/redis/sink_cluster.rs
@@ -1145,7 +1145,7 @@ mod test {
         // Wireshark capture from a Redis cluster with 3 masters and 3 replicas.
         let slots_pcap: &[u8] = b"*3\r\n*4\r\n:10923\r\n:16383\r\n*3\r\n$12\r\n192.168.80.6\r\n:6379\r\n$40\r\n3a7c357ed75d2aa01fca1e14ef3735a2b2b8ffac\r\n*3\r\n$12\r\n192.168.80.3\r\n:6379\r\n$40\r\n77c01b0ddd8668fff05e3f6a8aaf5f3ccd454a79\r\n*4\r\n:5461\r\n:10922\r\n*3\r\n$12\r\n192.168.80.5\r\n:6379\r\n$40\r\n969c6215d064e68593d384541ceeb57e9520dbed\r\n*3\r\n$12\r\n192.168.80.2\r\n:6379\r\n$40\r\n3929f69990a75be7b2d49594c57fe620862e6fd6\r\n*4\r\n:0\r\n:5460\r\n*3\r\n$12\r\n192.168.80.7\r\n:6379\r\n$40\r\n15d52a65d1fc7a53e34bf9193415aa39136882b2\r\n*3\r\n$12\r\n192.168.80.4\r\n:6379\r\n$40\r\ncd023916a3528fae7e606a10d8289a665d6c47b0\r\n";
 
-        let mut codec = RedisDecoder::new(Direction::Sink);
+        let mut codec = RedisDecoder::new(None, Direction::Sink);
 
         let mut message = codec
             .decode(&mut slots_pcap.into())


### PR DESCRIPTION
This PR introduces a `MessageId` type and assigns a unique `MessageId` to every message that goes through shotover.
Additionally responses now hold the MessageId of their corresponding request.

The API for this is exposed as methods on the `Message` type:
```rust
impl Message {
    /// Return the shotover assigned MessageId
    pub fn id(&self) -> MessageId {
        self.id
    }

    /// Return the MessageId of the request that resulted in this message
    /// Returns None when:
    /// * The message is a request
    /// * The message is a response but was not created in response to a request. e.g. Cassandra events and redis pubsub
    pub fn request_id(&self) -> Option<MessageId> {
        self.request_id
    }
}
```

This will eventually replace the "requests are in the same order as responses" invariant but for now it is just in addition to it.

I updated the `Transform::transform` docs where we document such invariants and it is rendered below.
The important sections are "Request/Response invariants" and "Deprecated invariants".

![image](https://github.com/shotover/shotover-proxy/assets/5120858/8980a1ca-a12b-42ed-b6a4-a2d070045e69)


I have not observed any regressions in benchmark results with this PR and the call to rand doesnt even show up when profiling.

## Benefits

* Improves correctness - Gives us a path forward to resolve some old invariant violations in a performant way https://github.com/shotover/shotover-proxy/issues/499
* Allows future performance improvements:
    + We can return some responses before all of them have been returned.
    + We can start sending a new batch of requests before we have any responses back.
    + Better handle out of order protocols (currently only cassandra)
* Will allow us to simplify handling of pubsub/event messages which are currently special cased via `transform_pushed`
* will allow us to simplify cassandra connection logic, a lot of complexity in there to pretend cassandra is not an out of order protocol
* will allow us to simplify redis pubsub implementation

## Downsides
* The filter transform is now very awkward to implement, we'll have to keep track of the message id of the previous message in order to know where to insert the error message.
    + Maybe in the future we should clean up the filter transform by having relaxed invariants in subchains. Filter is only useful in a subchain anyway and we could make it much more efficient this way by skipping the generation of dummy error messages.
    + Or another possible solution, replace "to be deleted" messages with a dummy frame. That way the codec can just respond with a dummy response and we have a dummy response that we can replace with the error. This would actually be quite efficient as we dont need to insert or remove from the vec of messages.
* for some other transforms a hashmap of message ids is slightly more complicated than a zip with requests
* hashmap look ups are slightly more expensive than a zip with requests - But I believe the other performance wins will largely outweigh this.

## Review
I've included a port of the `protect` and `CassandraSinkCluster` transforms to the message id approach, but I've left other ports out of the PR to keep scope down.
I am fairly confident that this approach will work well for all of our transforms.
But if you have a specific transform you would like me to include in the PR to see how it fares, just let me know.

With "hide whitespace" enabled the protect transform has a very small diff, so for the typical user implemented rewrite transform not much has changed.