### PR TITLE
Redesign windsock cli

### DIFF
--- a/.github/workflows/windsock_benches.yaml
+++ b/.github/workflows/windsock_benches.yaml
@@ -37,13 +37,13 @@ jobs:
         echo '1' | sudo tee /proc/sys/kernel/perf_event_paranoid
 
         # run some extra cases that arent handled by nextest
-        cargo windsock --bench-length-seconds 5 --operations-per-second 100 --profilers flamegraph --name cassandra,compression=none,connection_count=1,driver=scylla,operation=read_i64,protocol=v4,shotover=standard,topology=single
-        cargo windsock --bench-length-seconds 5 --operations-per-second 100 --profilers samply --name cassandra,compression=none,connection_count=1,driver=scylla,operation=read_i64,protocol=v4,shotover=standard,topology=single
-        cargo windsock --bench-length-seconds 5 --operations-per-second 100 --profilers sys_monitor --name kafka,shotover=standard,size=1B,topology=single
-        cargo windsock --bench-length-seconds 5 --operations-per-second 100 --profilers shotover_metrics --name redis,encryption=none,operation=get,shotover=standard,topology=single
+        cargo windsock local-run --bench-length-seconds 5 --operations-per-second 100 --profilers flamegraph name=cassandra,compression=none,connection_count=1,driver=scylla,operation=read_i64,protocol=v4,shotover=standard,topology=single
+        cargo windsock local-run --bench-length-seconds 5 --operations-per-second 100 --profilers samply name=cassandra,compression=none,connection_count=1,driver=scylla,operation=read_i64,protocol=v4,shotover=standard,topology=single
+        cargo windsock local-run --bench-length-seconds 5 --operations-per-second 100 --profilers sys_monitor name=kafka,shotover=standard,size=1B,topology=single
+        cargo windsock local-run --bench-length-seconds 5 --operations-per-second 100 --profilers shotover_metrics name=redis,encryption=none,operation=get,shotover=standard,topology=single
 
         # windsock/examples/cassandra.rs - this can stay here until windsock is moved to its own repo
-        cargo run --release --example cassandra -- --bench-length-seconds 5 --operations-per-second 100
+        cargo run --release --example cassandra -- local-run --bench-length-seconds 5 --operations-per-second 100
     - name: Ensure that tests did not create or modify any files that arent .gitignore'd
       run: |
         if [ -n "$(git status --porcelain)" ]; then

--- a/windsock/readme.md
+++ b/windsock/readme.md
@@ -102,6 +102,8 @@ impl BenchTask for BenchTaskCassandra {
 }
 ```
 
+**TODO:** document running windsock as both a standalone crate and as a cargo bench.
+
 This example is simplified for demonstration purposes, refer to `examples/cassandra.rs` for a full working example.
 
 ## Running benches
@@ -109,9 +111,9 @@ This example is simplified for demonstration purposes, refer to `examples/cassan
 Then we run our crate to run the benchmarks and view results like:
 
 ```none
-> cargo run
+> cargo windsock run-local
 ... benchmark running logs
-> cargo run -- --results-by-name "cassandra,topology=single cassandra,topology=cluster3"
+> cargo windsock results
 Results for cassandra
            topology   ──single ─cluster3
 Measurements ═══════════════════════════
@@ -142,26 +144,56 @@ and graphs: TODO
 ### Just run every bench
 
 ```shell
-> cargo run
+> cargo windsock
 ```
 
 ### Run benches with matching tags and view all the results in one table
 
 ```shell
-> cargo run -- db=kafka OPS=1000 topology=single # run benchmarks matching some tags
-> cargo run -- --results-by-tag db=kafka OPS=1000 topology=single # view the results of the benchmarks with the same tags in a single table
+> cargo windsock run-local db=kafka OPS=1000 topology=single # run benchmarks matching some tags
+> cargo windsock results # view the results of the benchmarks with the same tags in a single table
 ```
 
 ### Iteratively compare results against a previous implementation
 
 ```shell
 > git checkout main # checkout original implementation
-> cargo run # run all benchmarks
-> cargo run -- --set-baseline # set the last benchmark run as the baseline
+> cargo windsock run-local # run all benchmarks
+> cargo windsock baseline-set # set the last benchmark run as the baseline
 > vim src/main.rs # modify implementation
-> cargo run # run all benchmarks, every result is compared against the baseline
+> cargo windsock run-local # run all benchmarks, every result is compared against the baseline
+> cargo windsock results # view those results in a nice table
 > vim src/main.rs # modify implementation again
-> cargo run # run all benchmarks, every result is compared against the baseline
+> cargo windsock run-local # run all benchmarks, every result is compared against the baseline
+```
+
+### Run benchmarks in the cloud (simple)
+
+```shell
+# create cloud resources, run benchmarks and then cleanup - all in one command
+> cargo windsock cloud-setup-run-cleanup
+```
+
+### Iteratively compare results against a previous implementation (running in a remote cloud)
+
+```shell
+# Setup the cloud resources and then form a baseline
+> git checkout main # checkout original implementation
+> cargo windsock cloud-setup db=kafka # setup the cloud resources required to run all kafka benchmarks
+> cargo windsock cloud-run db=kafka # run all the kafka benchmarks in the cloud
+> cargo windsock baseline-set # set the last benchmark run as the baseline
+
+# Make a change and and measure the effect
+> vim src/main.rs # modify implementation
+> cargo windsock cloud-run db=kafka # run all benchmarks, every result is compared against the baseline
+> cargo windsock results # view those results in a nice table, compared against the baseline
+
+# And again
+> vim src/main.rs # modify implementation again
+> cargo windsock cloud-run db=kafka # run all benchmarks, every result is compared against the baseline
+
+# And finally...
+> cargo windsock cloud-cleanup # Terminate all the cloud resources now that we are done
 ```
 
 ### Generate graph webpage
@@ -169,6 +201,6 @@ and graphs: TODO
 TODO: not yet implemented
 
 ```shell
-> cargo run # run all benches
-> cargo run -- --generate_webpage # generate a webpage from the results
+> cargo windsock local-run # run all benches
+> cargo windsock generate-webpage # generate a webpage from the results
 ```

--- a/windsock/src/lib.rs
+++ b/windsock/src/lib.rs
@@ -17,11 +17,11 @@ pub use tables::Goal;
 
 use anyhow::{anyhow, Result};
 use bench::BenchState;
-use clap::Parser;
-use cli::{Args, Command};
+use clap::{CommandFactory, Parser};
+use cli::{Command, RunArgs, WindsockArgs};
 use cloud::{BenchInfo, Cloud};
 use filter::Filter;
-use std::{path::Path, process::exit};
+use std::process::exit;
 use tokio::runtime::Runtime;
 
 pub struct Windsock<ResourcesRequired, Resources> {
@@ -70,7 +70,7 @@ impl<ResourcesRequired: Clone, Resources: Clone> Windsock<ResourcesRequired, Res
     }
 
     fn run_inner(mut self) -> Result<()> {
-        let args = cli::Args::parse();
+        let args = WindsockArgs::parse();
 
         let running_in_release = self.running_in_release;
         if let Some(command) = args.command {
@@ -90,43 +90,73 @@ impl<ResourcesRequired: Clone, Resources: Clone> Windsock<ResourcesRequired, Res
                 Command::Results {
                     ignore_baseline,
                     filter,
-                } => tables::results(ignore_baseline, filter.as_deref().unwrap_or(""))?,
+                } => tables::results(
+                    ignore_baseline,
+                    &filter.unwrap_or_default().replace(',', " "),
+                )?,
                 Command::CompareByName { filter } => tables::compare_by_name(&filter)?,
                 Command::CompareByTags { filter } => tables::compare_by_tags(&filter)?,
+                Command::CloudSetup { filter } => {
+                    create_runtime(None).block_on(self.cloud_setup(filter))?
+                }
+                Command::CloudRun(args) => {
+                    create_runtime(None).block_on(self.cloud_run(args, running_in_release))?;
+                }
+                Command::CloudCleanup => {
+                    create_runtime(None).block_on(self.cloud_cleanup());
+                }
+                Command::CloudSetupRunCleanup(args) => {
+                    create_runtime(None)
+                        .block_on(self.cloud_setup_run_cleanup(args, running_in_release))?;
+                }
+                Command::LocalRun(args) => {
+                    create_runtime(None).block_on(self.local_run(args, running_in_release))?;
+                }
+                Command::InternalRun(args) => self.internal_run(&args, running_in_release)?,
             }
-            return Ok(());
-        }
-        if args.cleanup_cloud_resources {
-            let rt = create_runtime(None);
-            rt.block_on(self.cloud.cleanup_resources());
         } else if args.nextest_list() {
             list::nextest_list(&args, &self.benches);
-        } else if args.nextest_run_by_name() {
-            create_runtime(None).block_on(self.run_nextest(args, running_in_release))?;
+        } else if let Some(name) = args.nextest_run_by_name() {
+            create_runtime(None).block_on(self.run_nextest(name, running_in_release))?;
         } else if let Some(err) = args.nextest_invalid_args() {
             return Err(err);
-        } else if let Some(internal_run) = &args.internal_run {
-            self.internal_run(&args, internal_run, running_in_release)?;
-        } else if let Some(name) = args.name.clone() {
-            create_runtime(None).block_on(self.run_named_bench(args, name, running_in_release))?;
-        } else if args.cloud {
-            create_runtime(None)
-                .block_on(self.run_filtered_benches_cloud(args, running_in_release))?;
         } else {
-            create_runtime(None)
-                .block_on(self.run_filtered_benches_local(args, running_in_release))?;
+            WindsockArgs::command().print_help().unwrap();
         }
 
         Ok(())
     }
 
-    fn internal_run(
+    async fn cloud_run(&mut self, args: RunArgs, running_in_release: bool) -> Result<()> {
+        let bench_infos = self.bench_infos(&args.filter(), &args.profilers)?;
+        let resources = self.load_cloud_from_disk(&bench_infos).await?;
+        self.run_filtered_benches_cloud(args, running_in_release, bench_infos, resources)
+            .await?;
+        println!("Cloud resources have not been cleaned up.");
+        println!("Make sure to use `cloud-cleanup` when you are finished with them.");
+        Ok(())
+    }
+
+    async fn cloud_setup_run_cleanup(
         &mut self,
-        args: &Args,
-        internal_run: &str,
+        args: RunArgs,
         running_in_release: bool,
     ) -> Result<()> {
-        let (name, resources) = internal_run.split_at(internal_run.find(' ').unwrap() + 1);
+        let bench_infos = self.bench_infos(&args.filter(), &args.profilers)?;
+        let resources = self.temp_setup_cloud(&bench_infos).await?;
+        self.run_filtered_benches_cloud(args, running_in_release, bench_infos, resources)
+            .await?;
+        self.cloud_cleanup().await;
+        Ok(())
+    }
+
+    fn internal_run(&mut self, args: &RunArgs, running_in_release: bool) -> Result<()> {
+        let name_and_resources = args
+            .filter
+            .as_ref()
+            .expect("Filter arg must be provided for internal-run");
+        let (name, resources) =
+            name_and_resources.split_at(name_and_resources.find(' ').unwrap() + 1);
         let name = name.trim();
         match self.benches.iter_mut().find(|x| x.tags.get_name() == name) {
             Some(bench) => {
@@ -147,94 +177,32 @@ impl<ResourcesRequired: Clone, Resources: Clone> Windsock<ResourcesRequired, Res
         }
     }
 
-    async fn run_nextest(&mut self, mut args: Args, running_in_release: bool) -> Result<()> {
-        // This is not a real bench we are just testing that it works,
-        // so set some really minimal runtime values
-        args.bench_length_seconds = Some(2);
-        args.operations_per_second = Some(100);
-
-        let name = args.filter.as_ref().unwrap().clone();
-        self.run_named_bench(args, name, running_in_release).await
-    }
-
-    async fn run_named_bench(
-        &mut self,
-        args: Args,
-        name: String,
-        running_in_release: bool,
-    ) -> Result<()> {
-        ReportArchive::clear_last_run();
-        let resources_path = cloud_resources_path();
-
-        let bench = match self.benches.iter_mut().find(|x| x.tags.get_name() == name) {
-            Some(bench) => {
-                if args
-                    .profilers
-                    .iter()
-                    .all(|x| bench.supported_profilers.contains(x))
-                {
-                    bench
-                } else {
-                    return Err(anyhow!("Specified bench {name:?} was requested to run with the profilers {:?} but it only supports the profilers {:?}", args.profilers, bench.supported_profilers));
-                }
-            }
-            None => return Err(anyhow!("Specified bench {name:?} does not exist.")),
+    async fn run_nextest(&mut self, name: &str, running_in_release: bool) -> Result<()> {
+        let args = RunArgs {
+            profilers: vec![],
+            // This is not a real bench we are just testing that it works,
+            // so set some really minimal runtime values
+            bench_length_seconds: Some(2),
+            operations_per_second: Some(100),
+            filter: Some(name.to_string()),
         };
 
-        let resources = if args.cloud {
-            let resources = vec![bench.required_cloud_resources()];
-            Some(if args.load_cloud_resources_file {
-                self.cloud
-                    .load_resources_file(&resources_path, resources)
-                    .await
-            } else {
-                self.cloud
-                    .create_resources(resources, !args.store_cloud_resources_file)
-                    .await
-            })
-        } else {
-            None
-        };
-
-        if args.store_cloud_resources_file {
-            println!(
-                "Cloud resources have been created in preparation for running the bench:\n  {name}"
-            );
-            println!("Make sure to use `--cleanup-cloud-resources` when you are finished with these resources.");
-        } else {
-            bench
-                .orchestrate(&args, running_in_release, resources.clone())
-                .await;
-        }
-
-        if args.cloud {
-            self.cleanup_cloud_resources(resources, &args, &resources_path)
-                .await;
-        }
-        Ok(())
+        self.local_run(args, running_in_release).await
     }
 
-    async fn run_filtered_benches_cloud(
+    fn bench_infos(
         &mut self,
-        args: Args,
-        running_in_release: bool,
-    ) -> Result<()> {
-        ReportArchive::clear_last_run();
-        let filter = parse_filter(&args)?;
-        let resources_path = cloud_resources_path();
-
+        filter: &str,
+        profilers_enabled: &[String],
+    ) -> Result<Vec<BenchInfo<ResourcesRequired>>> {
+        let filter = Filter::from_query(filter)
+            .map_err(|err| anyhow!("Failed to parse FILTER {filter:?}\n{err}"))?;
         let mut bench_infos = vec![];
         for bench in &mut self.benches {
-            if filter
-                .as_ref()
-                .map(|x| {
-                    x.matches(&bench.tags)
-                        && args
-                            .profilers
-                            .iter()
-                            .all(|x| bench.supported_profilers.contains(x))
-                })
-                .unwrap_or(true)
+            if filter.matches(&bench.tags)
+                && profilers_enabled
+                    .iter()
+                    .all(|x| bench.supported_profilers.contains(x))
             {
                 bench_infos.push(BenchInfo {
                     resources: bench.required_cloud_resources(),
@@ -242,110 +210,112 @@ impl<ResourcesRequired: Clone, Resources: Clone> Windsock<ResourcesRequired, Res
                 });
             }
         }
-        bench_infos = self.cloud.order_benches(bench_infos);
+        Ok(self.cloud.order_benches(bench_infos))
+    }
 
-        let mut resources = if !bench_infos.is_empty() {
+    async fn load_cloud_from_disk(
+        &mut self,
+        bench_infos: &[BenchInfo<ResourcesRequired>],
+    ) -> Result<Resources> {
+        if !bench_infos.is_empty() {
             let resources = bench_infos.iter().map(|x| x.resources.clone()).collect();
-            Some(if args.load_cloud_resources_file {
-                self.cloud
-                    .load_resources_file(&resources_path, resources)
-                    .await
-            } else {
-                self.cloud
-                    .create_resources(resources, !args.store_cloud_resources_file)
-                    .await
-            })
+            Ok(self
+                .cloud
+                .load_resources_file(&cloud_resources_path(), resources)
+                .await)
         } else {
-            None
+            Err(anyhow!("No benches found with the specified filter"))
+        }
+    }
+
+    async fn cloud_setup(&mut self, filter: String) -> Result<()> {
+        let bench_infos = self.bench_infos(&filter, &[])?;
+
+        let resources = if !bench_infos.is_empty() {
+            let resources = bench_infos.iter().map(|x| x.resources.clone()).collect();
+            self.cloud.create_resources(resources, false).await
+        } else {
+            return Err(anyhow!("No benches found with the specified filter"));
         };
 
-        if args.store_cloud_resources_file {
-            println!("Cloud resources have been created in preparation for running the following benches:");
-            for bench in bench_infos {
-                println!("  {}", bench.name);
-            }
-            println!("Make sure to use `--cleanup-cloud-resources` when you are finished with these resources");
-        } else {
-            for (i, bench_info) in bench_infos.iter().enumerate() {
-                for bench in &mut self.benches {
-                    if bench.tags.get_name() == bench_info.name {
-                        if let Some(resources) = &mut resources {
-                            self.cloud
-                                .adjust_resources(&bench_infos, i, resources)
-                                .await;
-                        }
-                        bench
-                            .orchestrate(&args, running_in_release, resources.clone())
-                            .await;
-                        break;
-                    }
-                }
-            }
-        }
-
-        self.cleanup_cloud_resources(resources, &args, &resources_path)
+        self.cloud
+            .store_resources_file(&cloud_resources_path(), resources)
             .await;
+
+        println!(
+            "Cloud resources have been created in preparation for running the following benches:"
+        );
+        for bench in bench_infos {
+            println!("  {}", bench.name);
+        }
+        println!("Make sure to use `cloud-cleanup` when you are finished with these resources");
 
         Ok(())
     }
 
-    async fn cleanup_cloud_resources(
+    async fn temp_setup_cloud(
         &mut self,
-        resources: Option<Resources>,
-        args: &Args,
-        resources_path: &Path,
-    ) {
-        if args.store_cloud_resources_file {
-            if let Some(resources) = resources {
-                self.cloud
-                    .store_resources_file(resources_path, resources)
-                    .await;
-            }
-        } else if args.load_cloud_resources_file {
-            println!("Cloud resources have not been cleaned up.");
-            println!(
-                "Make sure to use `--cleanup-cloud-resources` when you are finished with them."
-            );
+        bench_infos: &[BenchInfo<ResourcesRequired>],
+    ) -> Result<Resources> {
+        let resources = if !bench_infos.is_empty() {
+            let resources = bench_infos.iter().map(|x| x.resources.clone()).collect();
+            self.cloud.create_resources(resources, true).await
         } else {
-            std::fs::remove_file(resources_path).ok();
-            self.cloud.cleanup_resources().await;
-        }
+            return Err(anyhow!("No benches found with the specified filter"));
+        };
+
+        Ok(resources)
     }
 
-    async fn run_filtered_benches_local(
+    async fn run_filtered_benches_cloud(
         &mut self,
-        args: Args,
+        args: RunArgs,
         running_in_release: bool,
+        bench_infos: Vec<BenchInfo<ResourcesRequired>>,
+        mut resources: Resources,
     ) -> Result<()> {
         ReportArchive::clear_last_run();
-        let filter = parse_filter(&args)?;
+
+        for (i, bench_info) in bench_infos.iter().enumerate() {
+            for bench in &mut self.benches {
+                if bench.tags.get_name() == bench_info.name {
+                    self.cloud
+                        .adjust_resources(&bench_infos, i, &mut resources)
+                        .await;
+                    bench
+                        .orchestrate(&args, running_in_release, Some(resources.clone()))
+                        .await;
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn cloud_cleanup(&mut self) {
+        std::fs::remove_file(cloud_resources_path()).ok();
+        self.cloud.cleanup_resources().await;
+    }
+
+    async fn local_run(&mut self, args: RunArgs, running_in_release: bool) -> Result<()> {
+        ReportArchive::clear_last_run();
+        let filter = args.filter();
+        let filter = Filter::from_query(&filter)
+            .map_err(|err| anyhow!("Failed to parse FILTER {:?}\n{err}", filter))?;
+
         for bench in &mut self.benches {
-            if filter
-                .as_ref()
-                .map(|x| {
-                    x.matches(&bench.tags)
-                        && args
-                            .profilers
-                            .iter()
-                            .all(|x| bench.supported_profilers.contains(x))
-                })
-                .unwrap_or(true)
+            if filter.matches(&bench.tags)
+                && args
+                    .profilers
+                    .iter()
+                    .all(|x| bench.supported_profilers.contains(x))
             {
                 bench.orchestrate(&args, running_in_release, None).await;
             }
         }
         Ok(())
     }
-}
-
-fn parse_filter(args: &Args) -> Result<Option<Filter>> {
-    args.filter
-        .as_ref()
-        .map(|filter| {
-            Filter::from_query(filter.as_ref())
-                .map_err(|err| anyhow!("Failed to parse FILTER {filter:?}\n{err}"))
-        })
-        .transpose()
 }
 
 fn create_runtime(worker_threads: Option<usize>) -> Runtime {

--- a/windsock/src/list.rs
+++ b/windsock/src/list.rs
@@ -1,4 +1,4 @@
-use crate::{bench::BenchState, cli::Args};
+use crate::{bench::BenchState, cli::WindsockArgs};
 
 pub fn list<ResourcesRequired, Resources>(benches: &[BenchState<ResourcesRequired, Resources>]) {
     // regular usage
@@ -9,7 +9,7 @@ pub fn list<ResourcesRequired, Resources>(benches: &[BenchState<ResourcesRequire
 }
 
 pub fn nextest_list<ResourcesRequired, Resources>(
-    args: &Args,
+    args: &WindsockArgs,
     benches: &[BenchState<ResourcesRequired, Resources>],
 ) {
     if args.nextest_list_all() {

--- a/windsock/src/list.rs
+++ b/windsock/src/list.rs
@@ -1,6 +1,14 @@
 use crate::{bench::BenchState, cli::Args};
 
-pub fn list<ResourcesRequired, Resources>(
+pub fn list<ResourcesRequired, Resources>(benches: &[BenchState<ResourcesRequired, Resources>]) {
+    // regular usage
+    println!("Benches:");
+    for bench in benches {
+        println!("{}", bench.tags.get_name());
+    }
+}
+
+pub fn nextest_list<ResourcesRequired, Resources>(
     args: &Args,
     benches: &[BenchState<ResourcesRequired, Resources>],
 ) {
@@ -12,10 +20,7 @@ pub fn list<ResourcesRequired, Resources>(
     } else if args.nextest_list_ignored() {
         // windsock does not support ignored tests
     } else {
-        // regular usage
-        println!("Benches:");
-        for bench in benches {
-            println!("{}", bench.tags.get_name());
-        }
+        // in case the user accidentally runs `--list` just give them the regular `list` output.
+        list(benches);
     }
 }

--- a/windsock/src/tables.rs
+++ b/windsock/src/tables.rs
@@ -45,26 +45,6 @@ pub fn compare_by_name(names: &str) -> Result<()> {
     Ok(())
 }
 
-pub fn results_by_name(names: &str) -> Result<()> {
-    let archives: Result<Vec<ReportColumn>> =
-        names.split_whitespace().map(ReportColumn::load).collect();
-    display_results_table(&archives?);
-    Ok(())
-}
-
-pub fn baseline_compare_by_tags(arg: &str) -> Result<()> {
-    let filter = Filter::from_query(arg)
-        .with_context(|| format!("Failed to parse tag filter from {:?}", arg))?;
-    let archives: Result<Vec<ReportColumn>> = ReportArchive::reports_in_last_run()
-        .iter()
-        .filter(|name| filter.matches(&Tags::from_name(name)))
-        .map(|x| ReportColumn::load_with_baseline(x))
-        .collect();
-    display_baseline_compare_table(&archives?);
-
-    Ok(())
-}
-
 pub fn compare_by_tags(arg: &str) -> Result<()> {
     let mut split = arg.split_whitespace();
     let base_name = split.next().unwrap().to_owned();
@@ -100,15 +80,28 @@ pub fn compare_by_tags(arg: &str) -> Result<()> {
     Ok(())
 }
 
-pub fn results_by_tags(arg: &str) -> Result<()> {
+pub fn results(ignore_baseline: bool, arg: &str) -> Result<()> {
     let filter = Filter::from_query(arg)
         .with_context(|| format!("Failed to parse tag filter from {:?}", arg))?;
     let archives: Result<Vec<ReportColumn>> = ReportArchive::reports_in_last_run()
         .iter()
         .filter(|name| filter.matches(&Tags::from_name(name)))
-        .map(|x| ReportColumn::load(x))
+        .map(|x| {
+            if ignore_baseline {
+                ReportColumn::load(x)
+            } else {
+                ReportColumn::load_with_baseline(x)
+            }
+        })
         .collect();
-    display_results_table(&archives?);
+    let archives = archives?;
+    if archives.iter().any(|x| x.baseline.is_some()) {
+        // If there any baselines then compare against baselines
+        display_baseline_compare_table(&archives);
+    } else {
+        // Otherwise display just results without any comparison
+        display_results_table(&archives);
+    }
 
     Ok(())
 }

--- a/windsock/src/tables.rs
+++ b/windsock/src/tables.rs
@@ -80,9 +80,9 @@ pub fn compare_by_tags(arg: &str) -> Result<()> {
     Ok(())
 }
 
-pub fn results(ignore_baseline: bool, arg: &str) -> Result<()> {
-    let filter = Filter::from_query(arg)
-        .with_context(|| format!("Failed to parse tag filter from {:?}", arg))?;
+pub fn results(ignore_baseline: bool, filter: &str) -> Result<()> {
+    let filter = Filter::from_query(filter)
+        .with_context(|| format!("Failed to parse tag filter from {:?}", filter))?;
     let archives: Result<Vec<ReportColumn>> = ReportArchive::reports_in_last_run()
         .iter()
         .filter(|name| filter.matches(&Tags::from_name(name)))
@@ -96,7 +96,7 @@ pub fn results(ignore_baseline: bool, arg: &str) -> Result<()> {
         .collect();
     let archives = archives?;
     if archives.iter().any(|x| x.baseline.is_some()) {
-        // If there any baselines then compare against baselines
+        // If there are any baselines then compare against baselines
         display_baseline_compare_table(&archives);
     } else {
         // Otherwise display just results without any comparison


### PR DESCRIPTION
closes https://github.com/shotover/shotover-proxy/issues/1480

This PR cleans up the windsock CLI.
We have accrued a large number of flags at this point and its time we turned them all into proper subcommands to simplify usage of the CLI.

Consider the new `cargo windsock help`:
![image](https://github.com/shotover/shotover-proxy/assets/5120858/8538875b-1aa3-45e0-b108-c1a1ecd543c3)

compared to the old:
![image](https://github.com/shotover/shotover-proxy/assets/5120858/ebf55499-3902-4616-8337-112b5b4a5d2a)

The relevant commands for a task are now a lot clearer, no longer lost among the sea of flags.

To achieve this reduction of the number of flags/subcommand the following was done:
* many flags turned into subcommands
* previously we split flags up as `name`/`by-tags`. But I've now altered names such that they are valid tags, so we no longer need the distinction.
* previously we had a separate flag for comparing against baselines. Now we compare against baselines automatically when they are available, with a `--disable-baseline` flag hidden within the `results` flag for the rare case that its ever needed.

To see the help of a particular subcommand, we can run help on that subcommand, for example here we can see all the flags specific to configuring a run are now within the run subcommands:
![image](https://github.com/shotover/shotover-proxy/assets/5120858/d710912d-d49f-4dfb-9683-8f92824636c6)

A particular improvement i'm quite happy with is:
Previously I had to recall do I want to run `cargo windsock --result-by-tags ""` or `cargo windsock --baseline-compare-by-tags ""`.
However now it is correct to just run `cargo windsock results` in both situations.
So much simpler!

The changes to the readme give a good overview of how to use the new CLI.