### PR TITLE
Add TLS support for KafkaSinkSingle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /.vscode
 /shotover-proxy/tests/test-configs/redis/tls/certs
 /shotover-proxy/tests/test-configs/cassandra/tls/certs
+/shotover-proxy/tests/test-configs/kafka/tls/certs
 .workspace.code-workspace
 **/.DS_Store
 /.project

--- a/shotover-proxy/benches/windsock/kafka/bench.rs
+++ b/shotover-proxy/benches/windsock/kafka/bench.rs
@@ -82,6 +82,7 @@ impl KafkaBench {
                 destination_port: 9192,
                 connect_timeout_ms: 3000,
                 read_timeout: None,
+                tls: None,
             }),
             KafkaTopology::Cluster1 | KafkaTopology::Cluster3 => Box::new(KafkaSinkClusterConfig {
                 connect_timeout_ms: 3000,

--- a/shotover-proxy/tests/test-configs/kafka/passthrough-tls/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/passthrough-tls/docker-compose.yaml
@@ -1,0 +1,24 @@
+version: "3"
+services:
+  kafka0:
+    image: 'bitnami/kafka:3.6.1-debian-11-r24'
+    ports:
+      - '9092:9092'
+    environment:
+      - KAFKA_CFG_LISTENERS=BROKER://:9092,CONTROLLER://:9093
+      - KAFKA_CFG_ADVERTISED_LISTENERS=BROKER://127.0.0.1:9092
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,BROKER:SSL
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=BROKER
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_CFG_PROCESS_ROLES=controller,broker
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka0:9093
+      - KAFKA_CFG_NODE_ID=0
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CERTIFICATE_PASSWORD=password
+      - KAFKA_TLS_CLIENT_AUTH=none
+    volumes:
+      - type: tmpfs
+        target: /bitnami/kafka
+      - type: bind
+        source: "../tls/certs"
+        target: "/opt/bitnami/kafka/config/certs"

--- a/shotover-proxy/tests/test-configs/kafka/passthrough-tls/topology.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/passthrough-tls/topology.yaml
@@ -1,0 +1,12 @@
+---
+sources:
+  - Kafka:
+      name: "kafka"
+      listen_addr: "127.0.0.1:9192"
+      chain:
+        - KafkaSinkSingle:
+            destination_port: 9092
+            connect_timeout_ms: 3000
+            tls:
+              certificate_authority_path: "tests/test-configs/kafka/tls/certs/localhost_CA.crt"
+              verify_hostname: true

--- a/test-helpers/src/docker_compose.rs
+++ b/test-helpers/src/docker_compose.rs
@@ -27,7 +27,7 @@ pub fn new_moto() -> DockerCompose {
     docker_compose("tests/transforms/docker-compose-moto.yaml")
 }
 
-pub static IMAGE_WAITERS: [Image; 11] = [
+pub static IMAGE_WAITERS: [Image; 12] = [
     Image {
         name: "motoserver/moto",
         log_regex_to_wait_for: r"Press CTRL\+C to quit",
@@ -68,6 +68,11 @@ pub static IMAGE_WAITERS: [Image; 11] = [
     Image {
         name: "shotover/cassandra-test:3.11.13-r1",
         log_regex_to_wait_for: r"Startup complete",
+        timeout: Duration::from_secs(120),
+    },
+    Image {
+        name: "bitnami/kafka:3.6.1-debian-11-r24",
+        log_regex_to_wait_for: r"Kafka Server started",
         timeout: Duration::from_secs(120),
     },
     Image {


### PR DESCRIPTION
Implements TLS for KafkaSinkSingle.

KafkaSinkCluster and KafkaSource should be done in follow up PRs.