### PR TITLE
Call setup_tracing_subscriber_for_test from shotover_process as well.

### DIFF
--- a/test-helpers/src/docker_compose.rs
+++ b/test-helpers/src/docker_compose.rs
@@ -1,19 +1,12 @@
 use docker_compose_runner::*;
 use std::{env, time::Duration};
-use tracing_subscriber::fmt::TestWriter;
 
 pub use docker_compose_runner::DockerCompose;
 
-fn setup_tracing_subscriber_for_test_logic() {
-    tracing_subscriber::fmt()
-        .with_writer(TestWriter::new())
-        .with_env_filter("warn")
-        .try_init()
-        .ok();
-}
-
 pub fn docker_compose(file_path: &str) -> DockerCompose {
-    setup_tracing_subscriber_for_test_logic();
+    // Run setup here to ensure any test that calls this gets tracing
+    crate::test_tracing::setup_tracing_subscriber_for_test();
+
     DockerCompose::new(&IMAGE_WAITERS, |_| {}, file_path)
 }
 

--- a/test-helpers/src/lib.rs
+++ b/test-helpers/src/lib.rs
@@ -4,6 +4,7 @@ pub mod docker_compose;
 pub mod metrics;
 pub mod mock_cassandra;
 pub mod shotover_process;
+mod test_tracing;
 
 use anyhow::{anyhow, Result};
 use subprocess::{Exec, Redirection};

--- a/test-helpers/src/shotover_process.rs
+++ b/test-helpers/src/shotover_process.rs
@@ -18,6 +18,9 @@ pub struct ShotoverProcessBuilder {
 
 impl ShotoverProcessBuilder {
     pub fn new_with_topology(topology_path: &str) -> Self {
+        // Run setup here to ensure any test that calls this gets tracing
+        crate::test_tracing::setup_tracing_subscriber_for_test();
+
         Self {
             topology_path: topology_path.to_owned(),
             config_path: None,

--- a/test-helpers/src/test_tracing.rs
+++ b/test-helpers/src/test_tracing.rs
@@ -1,0 +1,14 @@
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::EnvFilter;
+
+pub fn setup_tracing_subscriber_for_test() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::WARN.into())
+                .from_env()
+                .unwrap(),
+        )
+        .try_init()
+        .ok();
+}


### PR DESCRIPTION
This is useful for tests that run shotover but no database behind it.

Additionally this PR enables `RUST_LOG` env var to control the log level