### PR TITLE
Introduce TransformContextConfig

### DIFF
--- a/custom-transforms-example/src/redis_get_rewrite.rs
+++ b/custom-transforms-example/src/redis_get_rewrite.rs
@@ -3,7 +3,9 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use shotover::frame::{Frame, RedisFrame};
 use shotover::message::{MessageIdSet, Messages};
-use shotover::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
+use shotover::transforms::{
+    Transform, TransformBuilder, TransformConfig, TransformContextConfig, Wrapper,
+};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
@@ -15,7 +17,10 @@ const NAME: &str = "RedisGetRewrite";
 #[typetag::serde(name = "RedisGetRewrite")]
 #[async_trait(?Send)]
 impl TransformConfig for RedisGetRewriteConfig {
-    async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
+    async fn get_builder(
+        &self,
+        _transform_context: TransformContextConfig,
+    ) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(RedisGetRewriteBuilder {
             result: self.result.clone(),
         }))

--- a/shotover/benches/benches/chain.rs
+++ b/shotover/benches/benches/chain.rs
@@ -5,8 +5,8 @@ use criterion::{criterion_group, BatchSize, Criterion};
 use hex_literal::hex;
 use shotover::codec::CodecState;
 use shotover::frame::cassandra::{parse_statement_single, Tracing};
-use shotover::frame::RedisFrame;
 use shotover::frame::{CassandraFrame, CassandraOperation, Frame};
+use shotover::frame::{MessageType, RedisFrame};
 use shotover::message::{Message, MessageIdMap, QueryType};
 use shotover::transforms::cassandra::peers_rewrite::CassandraPeersRewrite;
 use shotover::transforms::chain::{TransformChain, TransformChainBuilder};
@@ -19,7 +19,7 @@ use shotover::transforms::protect::{KeyManagerConfig, ProtectConfig};
 use shotover::transforms::redis::cluster_ports_rewrite::RedisClusterPortsRewrite;
 use shotover::transforms::redis::timestamp_tagging::RedisTimestampTagger;
 use shotover::transforms::throttling::RequestThrottlingConfig;
-use shotover::transforms::{TransformConfig, Wrapper};
+use shotover::transforms::{TransformConfig, TransformContextConfig, Wrapper};
 
 fn criterion_benchmark(c: &mut Criterion) {
     crate::init();
@@ -194,7 +194,10 @@ fn criterion_benchmark(c: &mut Criterion) {
                         // an absurdly large value is given so that all messages will pass through
                         max_requests_per_second: std::num::NonZeroU32::new(100_000_000).unwrap(),
                     }
-                    .get_builder("".to_owned()),
+                    .get_builder(TransformContextConfig {
+                        chain_name: "".into(),
+                        protocol: MessageType::Redis,
+                    }),
                 )
                 .unwrap(),
                 Box::<NullSink>::default(),
@@ -303,7 +306,10 @@ fn criterion_benchmark(c: &mut Criterion) {
                             kek_id: "".to_string(),
                         },
                     }
-                    .get_builder("".to_owned()),
+                    .get_builder(TransformContextConfig {
+                        chain_name: "".into(),
+                        protocol: MessageType::Redis,
+                    }),
                 )
                 .unwrap(),
                 Box::<NullSink>::default(),

--- a/shotover/src/config/chain.rs
+++ b/shotover/src/config/chain.rs
@@ -1,5 +1,5 @@
 use crate::transforms::chain::TransformChainBuilder;
-use crate::transforms::{TransformBuilder, TransformConfig};
+use crate::transforms::{TransformBuilder, TransformConfig, TransformContextConfig};
 use anyhow::Result;
 use serde::de::{DeserializeSeed, Deserializer, MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Serialize};
@@ -14,12 +14,18 @@ pub struct TransformChainConfig(
 );
 
 impl TransformChainConfig {
-    pub async fn get_builder(&self, name: String) -> Result<TransformChainBuilder> {
+    pub async fn get_builder(
+        &self,
+        transform_context: TransformContextConfig,
+    ) -> Result<TransformChainBuilder> {
         let mut transforms: Vec<Box<dyn TransformBuilder>> = Vec::new();
         for tc in &self.0 {
-            transforms.push(tc.get_builder(name.clone()).await?)
+            transforms.push(tc.get_builder(transform_context.clone()).await?)
         }
-        Ok(TransformChainBuilder::new(transforms, name.leak()))
+        Ok(TransformChainBuilder::new(
+            transforms,
+            transform_context.chain_name.leak(),
+        ))
     }
 }
 

--- a/shotover/src/server.rs
+++ b/shotover/src/server.rs
@@ -4,7 +4,7 @@ use crate::message::{Message, Messages};
 use crate::sources::Transport;
 use crate::tls::{AcceptError, TlsAcceptor};
 use crate::transforms::chain::{TransformChain, TransformChainBuilder};
-use crate::transforms::Wrapper;
+use crate::transforms::{TransformContextConfig, Wrapper};
 use anyhow::{anyhow, Context, Result};
 use bytes::BytesMut;
 use futures::future::join_all;
@@ -92,8 +92,12 @@ impl<C: CodecBuilder + 'static> TcpCodecListener<C> {
             gauge!("shotover_available_connections_count", "source" => source_name.clone());
         available_connections_gauge.set(limit_connections.available_permits() as f64);
 
+        let chain_usage_config = TransformContextConfig {
+            chain_name: source_name.clone(),
+            protocol: codec.protocol(),
+        };
         let chain_builder = chain_config
-            .get_builder(source_name.clone())
+            .get_builder(chain_usage_config)
             .await
             .map_err(|x| vec![format!("{x:?}")])?;
 

--- a/shotover/src/transforms/cassandra/peers_rewrite.rs
+++ b/shotover/src/transforms/cassandra/peers_rewrite.rs
@@ -1,10 +1,13 @@
-use crate::frame::{
-    value::{GenericValue, IntSize},
-    CassandraOperation, CassandraResult, Frame,
-};
 use crate::message::{Message, Messages};
 use crate::transforms::cassandra::peers_rewrite::CassandraOperation::Event;
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
+use crate::{
+    frame::{
+        value::{GenericValue, IntSize},
+        CassandraOperation, CassandraResult, Frame,
+    },
+    transforms::TransformContextConfig,
+};
 use anyhow::Result;
 use async_trait::async_trait;
 use cassandra_protocol::frame::events::{ServerEvent, StatusChange};
@@ -23,7 +26,10 @@ const NAME: &str = "CassandraPeersRewrite";
 #[typetag::serde(name = "CassandraPeersRewrite")]
 #[async_trait(?Send)]
 impl TransformConfig for CassandraPeersRewriteConfig {
-    async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
+    async fn get_builder(
+        &self,
+        _transform_context: TransformContextConfig,
+    ) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(CassandraPeersRewrite::new(self.port)))
     }
 }

--- a/shotover/src/transforms/cassandra/sink_single.rs
+++ b/shotover/src/transforms/cassandra/sink_single.rs
@@ -4,7 +4,9 @@ use crate::frame::cassandra::CassandraMetadata;
 use crate::message::{Messages, Metadata};
 use crate::tls::{TlsConnector, TlsConnectorConfig};
 use crate::transforms::cassandra::connection::Response;
-use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
+use crate::transforms::{
+    Transform, TransformBuilder, TransformConfig, TransformContextConfig, Wrapper,
+};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use cassandra_protocol::frame::Version;
@@ -29,11 +31,14 @@ const NAME: &str = "CassandraSinkSingle";
 #[typetag::serde(name = "CassandraSinkSingle")]
 #[async_trait(?Send)]
 impl TransformConfig for CassandraSinkSingleConfig {
-    async fn get_builder(&self, chain_name: String) -> Result<Box<dyn TransformBuilder>> {
+    async fn get_builder(
+        &self,
+        transform_context: TransformContextConfig,
+    ) -> Result<Box<dyn TransformBuilder>> {
         let tls = self.tls.clone().map(TlsConnector::new).transpose()?;
         Ok(Box::new(CassandraSinkSingleBuilder::new(
             self.address.clone(),
-            chain_name,
+            transform_context.chain_name,
             tls,
             self.connect_timeout_ms,
             self.read_timeout,

--- a/shotover/src/transforms/coalesce.rs
+++ b/shotover/src/transforms/coalesce.rs
@@ -1,3 +1,4 @@
+use super::TransformContextConfig;
 use crate::message::Messages;
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
 use anyhow::Result;
@@ -24,7 +25,10 @@ const NAME: &str = "Coalesce";
 #[typetag::serde(name = "Coalesce")]
 #[async_trait(?Send)]
 impl TransformConfig for CoalesceConfig {
-    async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
+    async fn get_builder(
+        &self,
+        _transform_context: TransformContextConfig,
+    ) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(Coalesce {
             buffer: Vec::with_capacity(self.flush_when_buffered_message_count.unwrap_or(0)),
             flush_when_buffered_message_count: self.flush_when_buffered_message_count,

--- a/shotover/src/transforms/debug/force_parse.rs
+++ b/shotover/src/transforms/debug/force_parse.rs
@@ -7,6 +7,8 @@ use crate::message::Messages;
 /// It could also be used to ensure that messages round trip correctly when parsed.
 #[cfg(feature = "alpha-transforms")]
 use crate::transforms::TransformConfig;
+#[cfg(feature = "alpha-transforms")]
+use crate::transforms::TransformContextConfig;
 use crate::transforms::{Transform, TransformBuilder, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -25,7 +27,10 @@ pub struct DebugForceParseConfig {
 #[typetag::serde(name = "DebugForceParse")]
 #[async_trait(?Send)]
 impl TransformConfig for DebugForceParseConfig {
-    async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
+    async fn get_builder(
+        &self,
+        _transform_context: TransformContextConfig,
+    ) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(DebugForceParse {
             parse_requests: self.parse_requests,
             parse_responses: self.parse_responses,
@@ -49,7 +54,10 @@ const NAME: &str = "DebugForceEncode";
 #[typetag::serde(name = "DebugForceEncode")]
 #[async_trait(?Send)]
 impl TransformConfig for DebugForceEncodeConfig {
-    async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
+    async fn get_builder(
+        &self,
+        _transform_context: TransformContextConfig,
+    ) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(DebugForceParse {
             parse_requests: self.encode_requests,
             parse_responses: self.encode_responses,

--- a/shotover/src/transforms/debug/log_to_file.rs
+++ b/shotover/src/transforms/debug/log_to_file.rs
@@ -17,7 +17,10 @@ const NAME: &str = "DebugLogToFile";
 #[typetag::serde(name = "DebugLogToFile")]
 #[async_trait(?Send)]
 impl crate::transforms::TransformConfig for DebugLogToFileConfig {
-    async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
+    async fn get_builder(
+        &self,
+        _transform_context: crate::transforms::TransformContextConfig,
+    ) -> Result<Box<dyn TransformBuilder>> {
         // This transform is used for debugging a specific run, so we clean out any logs left over from the previous run
         std::fs::remove_dir_all("message-log").ok();
 

--- a/shotover/src/transforms/debug/printer.rs
+++ b/shotover/src/transforms/debug/printer.rs
@@ -1,5 +1,7 @@
 use crate::message::Messages;
-use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
+use crate::transforms::{
+    Transform, TransformBuilder, TransformConfig, TransformContextConfig, Wrapper,
+};
 use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -13,7 +15,10 @@ const NAME: &str = "DebugPrinter";
 #[typetag::serde(name = "DebugPrinter")]
 #[async_trait(?Send)]
 impl TransformConfig for DebugPrinterConfig {
-    async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
+    async fn get_builder(
+        &self,
+        _transform_context: TransformContextConfig,
+    ) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(DebugPrinter::new()))
     }
 }

--- a/shotover/src/transforms/debug/returner.rs
+++ b/shotover/src/transforms/debug/returner.rs
@@ -1,5 +1,7 @@
 use crate::message::{Message, Messages};
-use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
+use crate::transforms::{
+    Transform, TransformBuilder, TransformConfig, TransformContextConfig, Wrapper,
+};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -15,7 +17,10 @@ const NAME: &str = "DebugReturner";
 #[typetag::serde(name = "DebugReturner")]
 #[async_trait(?Send)]
 impl TransformConfig for DebugReturnerConfig {
-    async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
+    async fn get_builder(
+        &self,
+        _transform_context: TransformContextConfig,
+    ) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(DebugReturner::new(self.response.clone())))
     }
 }

--- a/shotover/src/transforms/filter.rs
+++ b/shotover/src/transforms/filter.rs
@@ -1,3 +1,4 @@
+use super::TransformContextConfig;
 use crate::message::{Message, MessageIdMap, Messages, QueryType};
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
 use anyhow::Result;
@@ -28,7 +29,10 @@ const NAME: &str = "QueryTypeFilter";
 #[typetag::serde(name = "QueryTypeFilter")]
 #[async_trait(?Send)]
 impl TransformConfig for QueryTypeFilterConfig {
-    async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
+    async fn get_builder(
+        &self,
+        _transform_context: TransformContextConfig,
+    ) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(QueryTypeFilter {
             filter: self.filter.clone(),
             filtered_requests: MessageIdMap::default(),

--- a/shotover/src/transforms/kafka/sink_cluster.rs
+++ b/shotover/src/transforms/kafka/sink_cluster.rs
@@ -6,8 +6,8 @@ use crate::message::{Message, Messages};
 use crate::tcp;
 use crate::transforms::util::cluster_connection_pool::{spawn_read_write_tasks, Connection};
 use crate::transforms::util::{Request, Response};
-use crate::transforms::TransformConfig;
 use crate::transforms::{Transform, TransformBuilder, Wrapper};
+use crate::transforms::{TransformConfig, TransformContextConfig};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use dashmap::DashMap;
@@ -45,11 +45,14 @@ const NAME: &str = "KafkaSinkCluster";
 #[typetag::serde(name = "KafkaSinkCluster")]
 #[async_trait(?Send)]
 impl TransformConfig for KafkaSinkClusterConfig {
-    async fn get_builder(&self, chain_name: String) -> Result<Box<dyn TransformBuilder>> {
+    async fn get_builder(
+        &self,
+        transform_context: TransformContextConfig,
+    ) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(KafkaSinkClusterBuilder::new(
             self.first_contact_points.clone(),
             self.shotover_nodes.clone(),
-            chain_name,
+            transform_context.chain_name,
             self.connect_timeout_ms,
             self.read_timeout,
         )))

--- a/shotover/src/transforms/kafka/sink_single.rs
+++ b/shotover/src/transforms/kafka/sink_single.rs
@@ -7,7 +7,7 @@ use crate::tls::{TlsConnector, TlsConnectorConfig};
 use crate::transforms::kafka::common::produce_channel;
 use crate::transforms::util::cluster_connection_pool::{spawn_read_write_tasks, Connection};
 use crate::transforms::util::{Request, Response};
-use crate::transforms::{Transform, TransformBuilder, Wrapper};
+use crate::transforms::{Transform, TransformBuilder, TransformContextConfig, Wrapper};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -33,11 +33,14 @@ const NAME: &str = "KafkaSinkSingle";
 #[typetag::serde(name = "KafkaSinkSingle")]
 #[async_trait(?Send)]
 impl TransformConfig for KafkaSinkSingleConfig {
-    async fn get_builder(&self, chain_name: String) -> Result<Box<dyn TransformBuilder>> {
+    async fn get_builder(
+        &self,
+        transform_context: TransformContextConfig,
+    ) -> Result<Box<dyn TransformBuilder>> {
         let tls = self.tls.clone().map(TlsConnector::new).transpose()?;
         Ok(Box::new(KafkaSinkSingleBuilder::new(
             self.destination_port,
-            chain_name,
+            transform_context.chain_name,
             self.connect_timeout_ms,
             self.read_timeout,
             tls,

--- a/shotover/src/transforms/load_balance.rs
+++ b/shotover/src/transforms/load_balance.rs
@@ -1,3 +1,4 @@
+use super::TransformContextConfig;
 use crate::config::chain::TransformChainConfig;
 use crate::message::Messages;
 use crate::transforms::chain::{BufferedChain, TransformChainBuilder};
@@ -20,8 +21,11 @@ const NAME: &str = "ConnectionBalanceAndPool";
 #[typetag::serde(name = "ConnectionBalanceAndPool")]
 #[async_trait(?Send)]
 impl TransformConfig for ConnectionBalanceAndPoolConfig {
-    async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
-        let chain = Arc::new(self.chain.get_builder(self.name.clone()).await?);
+    async fn get_builder(
+        &self,
+        transform_context: TransformContextConfig,
+    ) -> Result<Box<dyn TransformBuilder>> {
+        let chain = Arc::new(self.chain.get_builder(transform_context).await?);
 
         Ok(Box::new(ConnectionBalanceAndPoolBuilder {
             max_connections: self.max_connections,

--- a/shotover/src/transforms/mod.rs
+++ b/shotover/src/transforms/mod.rs
@@ -1,6 +1,7 @@
 //! Various types required for defining a transform
 
 use self::chain::TransformAndMetrics;
+use crate::frame::MessageType;
 use crate::message::{Message, MessageIdMap, Messages};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -64,7 +65,17 @@ impl Debug for dyn TransformBuilder {
 #[typetag::serde]
 #[async_trait(?Send)]
 pub trait TransformConfig: Debug {
-    async fn get_builder(&self, chain_name: String) -> Result<Box<dyn TransformBuilder>>;
+    async fn get_builder(
+        &self,
+        transform_context: TransformContextConfig,
+    ) -> Result<Box<dyn TransformBuilder>>;
+}
+
+/// Provides extra context that may be needed when creating a TransformBuilder
+#[derive(Clone)]
+pub struct TransformContextConfig {
+    pub chain_name: String,
+    pub protocol: MessageType,
 }
 
 /// The [`Wrapper`] struct is passed into each transform and contains a list of mutable references to the

--- a/shotover/src/transforms/null.rs
+++ b/shotover/src/transforms/null.rs
@@ -1,3 +1,4 @@
+use super::TransformContextConfig;
 use crate::message::Messages;
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
 use anyhow::Result;
@@ -12,7 +13,10 @@ const NAME: &str = "NullSink";
 #[typetag::serde(name = "NullSink")]
 #[async_trait(?Send)]
 impl TransformConfig for NullSinkConfig {
-    async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
+    async fn get_builder(
+        &self,
+        _transform_context: TransformContextConfig,
+    ) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(NullSink {}))
     }
 }

--- a/shotover/src/transforms/opensearch/mod.rs
+++ b/shotover/src/transforms/opensearch/mod.rs
@@ -1,3 +1,4 @@
+use super::TransformContextConfig;
 use crate::tcp;
 use crate::transforms::{Messages, Transform, TransformBuilder, TransformConfig, Wrapper};
 use crate::{
@@ -25,10 +26,13 @@ const NAME: &str = "OpenSearchSinkSingle";
 #[typetag::serde(name = "OpenSearchSinkSingle")]
 #[async_trait(?Send)]
 impl TransformConfig for OpenSearchSinkSingleConfig {
-    async fn get_builder(&self, chain_name: String) -> Result<Box<dyn TransformBuilder>> {
+    async fn get_builder(
+        &self,
+        transform_context: TransformContextConfig,
+    ) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(OpenSearchSinkSingleBuilder::new(
             self.address.clone(),
-            chain_name,
+            transform_context.chain_name,
             self.connect_timeout_ms,
         )))
     }

--- a/shotover/src/transforms/protect/mod.rs
+++ b/shotover/src/transforms/protect/mod.rs
@@ -27,15 +27,15 @@ pub struct ProtectConfig {
     pub key_manager: KeyManagerConfig,
 }
 
-#[cfg(feature = "alpha-transforms")]
-use crate::transforms::TransformConfig;
-
 const NAME: &str = "Protect";
 #[cfg(feature = "alpha-transforms")]
 #[typetag::serde(name = "Protect")]
 #[async_trait(?Send)]
-impl TransformConfig for ProtectConfig {
-    async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
+impl crate::transforms::TransformConfig for ProtectConfig {
+    async fn get_builder(
+        &self,
+        _transform_context: crate::transforms::TransformContextConfig,
+    ) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(Protect {
             keyspace_table_columns: self
                 .keyspace_table_columns

--- a/shotover/src/transforms/query_counter.rs
+++ b/shotover/src/transforms/query_counter.rs
@@ -8,6 +8,8 @@ use metrics::counter;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::TransformContextConfig;
+
 #[derive(Debug, Clone)]
 pub struct QueryCounter {
     counter_name: String,
@@ -85,7 +87,10 @@ const NAME: &str = "QueryCounter";
 #[typetag::serde(name = "QueryCounter")]
 #[async_trait(?Send)]
 impl TransformConfig for QueryCounterConfig {
-    async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
+    async fn get_builder(
+        &self,
+        _transform_context: TransformContextConfig,
+    ) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(QueryCounter::new(self.name.clone())))
     }
 }

--- a/shotover/src/transforms/redis/cluster_ports_rewrite.rs
+++ b/shotover/src/transforms/redis/cluster_ports_rewrite.rs
@@ -1,6 +1,7 @@
 use crate::frame::Frame;
 use crate::frame::RedisFrame;
 use crate::message::{MessageIdMap, Messages};
+use crate::transforms::TransformContextConfig;
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
 use anyhow::{anyhow, bail, Context, Result};
 use async_trait::async_trait;
@@ -18,7 +19,10 @@ const NAME: &str = "RedisClusterPortsRewrite";
 #[typetag::serde(name = "RedisClusterPortsRewrite")]
 #[async_trait(?Send)]
 impl TransformConfig for RedisClusterPortsRewriteConfig {
-    async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
+    async fn get_builder(
+        &self,
+        _transform_context: TransformContextConfig,
+    ) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(RedisClusterPortsRewrite::new(self.new_port)))
     }
 }

--- a/shotover/src/transforms/redis/timestamp_tagging.rs
+++ b/shotover/src/transforms/redis/timestamp_tagging.rs
@@ -1,7 +1,9 @@
 use crate::frame::redis::redis_query_type;
 use crate::frame::{Frame, RedisFrame};
 use crate::message::{Message, Messages, QueryType};
-use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
+use crate::transforms::{
+    Transform, TransformBuilder, TransformConfig, TransformContextConfig, Wrapper,
+};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -19,7 +21,10 @@ const NAME: &str = "RedisTimestampTagger";
 #[typetag::serde(name = "RedisTimestampTagger")]
 #[async_trait(?Send)]
 impl TransformConfig for RedisTimestampTaggerConfig {
-    async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
+    async fn get_builder(
+        &self,
+        _transform_context: TransformContextConfig,
+    ) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(RedisTimestampTagger {}))
     }
 }

--- a/shotover/src/transforms/throttling.rs
+++ b/shotover/src/transforms/throttling.rs
@@ -1,3 +1,4 @@
+use super::TransformContextConfig;
 use crate::message::{Message, MessageIdMap, Messages};
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
 use anyhow::Result;
@@ -23,7 +24,10 @@ const NAME: &str = "RequestThrottling";
 #[typetag::serde(name = "RequestThrottling")]
 #[async_trait(?Send)]
 impl TransformConfig for RequestThrottlingConfig {
-    async fn get_builder(&self, _chain_name: String) -> Result<Box<dyn TransformBuilder>> {
+    async fn get_builder(
+        &self,
+        _transform_context: TransformContextConfig,
+    ) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(RequestThrottling {
             limiter: Arc::new(RateLimiter::direct(Quota::per_second(
                 self.max_requests_per_second,


### PR DESCRIPTION
This PR introduces the `TransformContextConfig` struct which is passed to each transform at the point where the `TransformConfig` is converted to a `TransformBuilder`. i.e. during shotover initialization

This enables a whole bunch of potential optimizations where we pass in some extra information about the context the transform is in. i.e. the chain its in and what other transforms are in its chain.
A potential future optimization would be detecting if the next transform is going to discard any responses passed to it.
This would allow for a nice optimization to the Filter transform where we skip error generation if its in a Tee subchain configured to discard responses.

However right now, `TransformContextConfig` just contains:
* the name of the chain which we currently use in various diagnostics.
* The protocol that the transform will be processing, currently there is no usages of this information but I plan to use it as part of the port of the Tee transform to use MessageId.

~~Additionally the `CodecBuilder::websocket_subprotocol` is turned into a `CodecBuilder::protocol` so that we can obtain the protocol to insert into the `TransformContextConfig`.~~