### PR TITLE
Remove ProtocolType

### DIFF
--- a/shotover/benches/benches/chain.rs
+++ b/shotover/benches/benches/chain.rs
@@ -3,10 +3,11 @@ use cassandra_protocol::compression::Compression;
 use cassandra_protocol::{consistency::Consistency, frame::Version, query::QueryParams};
 use criterion::{criterion_group, BatchSize, Criterion};
 use hex_literal::hex;
+use shotover::codec::CodecState;
 use shotover::frame::cassandra::{parse_statement_single, Tracing};
 use shotover::frame::RedisFrame;
 use shotover::frame::{CassandraFrame, CassandraOperation, Frame};
-use shotover::message::{Message, MessageIdMap, ProtocolType, QueryType};
+use shotover::message::{Message, MessageIdMap, QueryType};
 use shotover::transforms::cassandra::peers_rewrite::CassandraPeersRewrite;
 use shotover::transforms::chain::{TransformChain, TransformChainBuilder};
 use shotover::transforms::debug::returner::{DebugReturner, Response};
@@ -210,7 +211,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     )
                     .to_vec(),
                 ),
-                ProtocolType::Cassandra {
+                CodecState::Cassandra {
                     compression: Compression::None,
                 },
             )],
@@ -264,7 +265,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 }
                 .encode(Compression::None)
                 .into(),
-                ProtocolType::Cassandra {
+                CodecState::Cassandra {
                     compression: Compression::None,
                 },
             )],

--- a/shotover/benches/benches/codec/kafka.rs
+++ b/shotover/benches/benches/codec/kafka.rs
@@ -1,8 +1,8 @@
 use bytes::{Bytes, BytesMut};
 use criterion::{black_box, criterion_group, BatchSize, Criterion};
 use shotover::codec::kafka::KafkaCodecBuilder;
-use shotover::codec::{CodecBuilder, Direction};
-use shotover::message::{Message, ProtocolType};
+use shotover::codec::{CodecBuilder, CodecState, Direction};
+use shotover::message::Message;
 use tokio_util::codec::{Decoder, Encoder};
 
 const KAFKA_REQUESTS: &[(&[u8], &str)] = &[
@@ -76,7 +76,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         {
             let mut message = Message::from_bytes(
                 Bytes::from(message.to_vec()),
-                ProtocolType::Kafka {
+                CodecState::Kafka {
                     request_header: None,
                 },
             );
@@ -112,7 +112,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         for (message, _) in KAFKA_REQUESTS {
             let mut message = Message::from_bytes(
                 Bytes::from(message.to_vec()),
-                ProtocolType::Kafka {
+                CodecState::Kafka {
                     request_header: None,
                 },
             );

--- a/shotover/src/codec/cassandra.rs
+++ b/shotover/src/codec/cassandra.rs
@@ -1,4 +1,5 @@
 use super::{CodecBuilder, CodecReadError, CodecWriteError, Direction};
+use crate::codec::CodecState;
 use crate::frame::cassandra::{CassandraMetadata, CassandraOperation, Tracing};
 use crate::frame::{CassandraFrame, Frame, MessageType};
 use crate::message::{Encodable, Message, Messages, Metadata};
@@ -358,7 +359,7 @@ impl CassandraDecoder {
 
                 let message = Message::from_bytes_at_instant(
                     bytes.freeze(),
-                    crate::message::ProtocolType::Cassandra {
+                    CodecState::Cassandra {
                         compression: if compressed {
                             compression
                         } else {
@@ -510,7 +511,7 @@ impl CassandraDecoder {
 
             envelopes.push(Message::from_bytes_at_instant(
                 envelope,
-                crate::message::ProtocolType::Cassandra {
+                CodecState::Cassandra {
                     compression: Compression::None,
                 },
                 Some(received_at),

--- a/shotover/src/codec/kafka.rs
+++ b/shotover/src/codec/kafka.rs
@@ -1,7 +1,7 @@
 use super::{message_latency, CodecWriteError, Direction};
-use crate::codec::{CodecBuilder, CodecReadError};
+use crate::codec::{CodecBuilder, CodecReadError, CodecState};
 use crate::frame::MessageType;
-use crate::message::{Encodable, Message, MessageId, Messages, ProtocolType};
+use crate::message::{Encodable, Message, MessageId, Messages};
 use anyhow::{anyhow, Result};
 use bytes::BytesMut;
 use kafka_protocol::messages::ApiKey;
@@ -112,7 +112,7 @@ impl Decoder for KafkaDecoder {
                     .map_err(|_| CodecReadError::Parser(anyhow!("kafka encoder half was lost")))?;
                 let mut message = Message::from_bytes_at_instant(
                     bytes.freeze(),
-                    ProtocolType::Kafka {
+                    CodecState::Kafka {
                         request_header: Some(header),
                     },
                     Some(received_at),
@@ -122,7 +122,7 @@ impl Decoder for KafkaDecoder {
             } else {
                 Message::from_bytes_at_instant(
                     bytes.freeze(),
-                    ProtocolType::Kafka {
+                    CodecState::Kafka {
                         request_header: None,
                     },
                     Some(received_at),

--- a/shotover/src/frame/mod.rs
+++ b/shotover/src/frame/mod.rs
@@ -1,6 +1,6 @@
 //! parsed AST-like representations of messages
 
-use crate::{codec::CodecState, message::ProtocolType};
+use crate::codec::CodecState;
 use anyhow::{anyhow, Result};
 use bytes::Bytes;
 #[cfg(feature = "cassandra")]
@@ -33,9 +33,9 @@ pub enum MessageType {
     Cassandra,
     #[cfg(feature = "kafka")]
     Kafka,
-    Dummy,
     #[cfg(feature = "opensearch")]
     OpenSearch,
+    Dummy,
 }
 
 impl MessageType {
@@ -68,17 +68,18 @@ impl MessageType {
     }
 }
 
-impl From<&ProtocolType> for MessageType {
-    fn from(value: &ProtocolType) -> Self {
+impl From<&CodecState> for MessageType {
+    fn from(value: &CodecState) -> Self {
         match value {
             #[cfg(feature = "cassandra")]
-            ProtocolType::Cassandra { .. } => Self::Cassandra,
+            CodecState::Cassandra { .. } => Self::Cassandra,
             #[cfg(feature = "redis")]
-            ProtocolType::Redis => Self::Redis,
+            CodecState::Redis => Self::Redis,
             #[cfg(feature = "kafka")]
-            ProtocolType::Kafka { .. } => Self::Kafka,
+            CodecState::Kafka { .. } => Self::Kafka,
             #[cfg(feature = "opensearch")]
-            ProtocolType::OpenSearch => Self::OpenSearch,
+            CodecState::OpenSearch => Self::OpenSearch,
+            CodecState::Dummy => Self::Dummy,
         }
     }
 }


### PR DESCRIPTION
This PR swaps all usages of `ProtocolType` to `CodecState`, since they are completely identical.
It then removes `ProtocolType` entirely.
For all the usecases I think the name `CodecState` makes the most sense so that is the name I am keeping.