### PR TITLE
Update GA deps

### DIFF
--- a/.github/workflows/bench_run.yaml
+++ b/.github/workflows/bench_run.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-20.04
     name: Benchmarks
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
       with:
         # PRs do not share caches, instead each PR initially pulls from the cache of the main branch for the first run.
@@ -27,7 +27,7 @@ jobs:
         shared-key: "ubuntu-20.04 - --release-build_check_and_upload"
         save-if: false
     - name: cache custom ubuntu packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: shotover-proxy/build/packages
         key: ubuntu-20.04-packages
@@ -36,7 +36,7 @@ jobs:
     - name: Run benchmarks
       run: shotover-proxy/tests/scripts/bench_against_master.sh ${{ github.event.number }}
     - name: Upload comment artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: comment_info
         path: comment_info/

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,11 +30,11 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: cache custom ubuntu packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: shotover-proxy/build/packages
           key: ubuntu-22.04-packages
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         # We purposefully dont cache here as build_and_test will always be the bottleneck
         # so we should leave the cache alone so build_and_test can make more use of it.
       - name: Install ubuntu packages

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -34,7 +34,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
       with:
         # rust-cache already handles all the sane defaults for caching rust builds.
@@ -51,7 +51,7 @@ jobs:
         # * PRs that update rust version or changes deps will be slow to iterate on due to changes not being cached.
         save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: cache custom ubuntu packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: shotover-proxy/build/packages
         key: ubuntu-20.04-packages
@@ -66,7 +66,7 @@ jobs:
         cargo test --doc ${{ matrix.cargo_flags }} --all-features -- --show-output --nocapture
         cargo nextest archive --archive-file nextest-${{ matrix.profile }}.tar.zst ${{ matrix.cargo_flags }} --all-features --all-targets
     - name: Upload built tests to workflow
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: nextest-${{ matrix.profile }}
         path: nextest-${{ matrix.profile }}.tar.zst
@@ -98,9 +98,9 @@ jobs:
     runs-on: ubuntu-20.04
     needs: build_check_and_upload
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: cache custom ubuntu packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: shotover-proxy/build/packages
         key: ubuntu-20.04-packages
@@ -112,7 +112,7 @@ jobs:
         tool: nextest@0.9.57
     - run: mkdir -p ~/.cargo/bin
     - name: Download archive
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: nextest-${{ matrix.profile }}
     - name: Run tests

--- a/.github/workflows/create_comment.yaml
+++ b/.github/workflows/create_comment.yaml
@@ -30,33 +30,14 @@ jobs:
       github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: 'Download results'
-        uses: actions/github-script@v3.1.0
+        uses: actions/download-artifact@v4
         with:
-          # This script is copy pasted from https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
-          # Waiting on this issue to be able to just use download-artifacts https://github.com/actions/download-artifact/issues/60
-          script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: ${{github.event.workflow_run.id }},
-            });
-            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "comment_info"
-            })[0];
-            if (!matchArtifact) {
-              throw 'comment_info artifact was not produced by the previous workflow';
-            }
-            var download = await github.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
-            });
-            var fs = require('fs');
-            fs.writeFileSync('${{github.workspace}}/comment_info.zip', Buffer.from(download.data));
+          name: 'comment-info'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
       - run: unzip comment_info.zip
       - name: 'Comment on PR'
-        uses: actions/github-script@v3
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -17,7 +17,7 @@ jobs:
     name: "Build docker image and run smoke test"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Push image
         run: |
           # build image

--- a/.github/workflows/license_check.yaml
+++ b/.github/workflows/license_check.yaml
@@ -20,6 +20,6 @@ jobs:
     runs-on: ubuntu-22.04
     name: License Check
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: cargo install --locked cargo-deny
       - run: cargo deny check licenses

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,7 +20,7 @@ jobs:
     name: Formatting and lints
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
       with:
         # this line means that only the main branch writes to the cache
@@ -31,7 +31,7 @@ jobs:
         # * PRs that update rust version or changes deps will be slow to iterate on due to changes not being cached.
         save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: cache custom ubuntu packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: shotover-proxy/build/packages
         key: ubuntu-20.04-packages

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
     name: "Check that the project is releaseable"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install ubuntu packages
         run: shotover-proxy/build/install_ubuntu_packages.sh
       - name: Run checks
@@ -27,7 +27,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Push image
         run: |
           docker build -t shotover/shotover-proxy:latest -t shotover/shotover-proxy:${GITHUB_REF/refs\/tags\//} .
@@ -39,7 +39,7 @@ jobs:
     needs: prepublish-check
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install ubuntu packages
         run: shotover-proxy/build/install_ubuntu_packages.sh
       - name: Build & test
@@ -57,7 +57,7 @@ jobs:
     needs: prepublish-check
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install ubuntu packages
         run: shotover-proxy/build/install_ubuntu_packages.sh
       - name: Publish

--- a/.github/workflows/windsock_benches.yaml
+++ b/.github/workflows/windsock_benches.yaml
@@ -20,7 +20,7 @@ jobs:
     name: "Windsock benches"
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
       with:
         # this line means that only the main branch writes to the cache


### PR DESCRIPTION
A bunch of the GA actions we use are now deprecated and will be removed soon:
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20

Its hard to verify that the change to create_comment.yaml will still work since its not run until checked in, but I've examined the node APIs used and they should be unchanged from node 16 to node 20. Worst case I just have to fix it in a follow up PR.

As a bonus upload-artifact@v4 claims to have much faster upload speeds.
edit: Oh wow, they werent kidding.
Before:
![image](https://github.com/shotover/shotover-proxy/assets/5120858/d4022232-df33-44d6-86db-46b15106da76)

After:
![image](https://github.com/shotover/shotover-proxy/assets/5120858/0839350d-45f8-4e7f-878d-c8fa38cf6f8c)
