### PR TITLE
KafkaSinkCluster TLS support

### DIFF
--- a/docs/src/sources.md
+++ b/docs/src/sources.md
@@ -105,6 +105,17 @@ Kafka:
   # If not provided defaults to false
   hard_connection_limit: false
 
+  # When this field is provided TLS is used when the client connects to Shotover.
+  # Removing this field will disable TLS.
+  #tls:
+  #  # Path to the certificate file, typically named with a .crt extension.
+  #  certificate_path: "tls/localhost.crt"
+  #  # Path to the private key file, typically named with a .key extension.
+  #  private_key_path: "tls/localhost.key"
+  #  # Path to the certificate authority file, typically named with a .crt extension.
+  #  # When this field is provided client authentication will be enabled.
+  #  #certificate_authority_path: "tls/localhost_CA.crt"
+
   # Timeout in seconds after which to terminate an idle connection. This field is optional, if not provided, idle connections will never be terminated.
   # timeout: 60
 

--- a/docs/src/transforms.md
+++ b/docs/src/transforms.md
@@ -308,6 +308,18 @@ This is achieved by rewriting the FindCoordinator, Metadata and DescribeCluster 
     # This field is optional, if not provided, timeout will never occur.
     # When a timeout occurs the connection to the client is immediately closed.
     # read_timeout: 60
+
+    # When this field is provided TLS is used when connecting to the remote address.
+    # Removing this field will disable TLS.
+    #tls:
+    #  # Path to the certificate authority file, typically named with a .crt extension.
+    #  certificate_authority_path: "tls/localhost_CA.crt"
+    #  # Path to the certificate file, typically named with a .crt extension.
+    #  certificate_path: "tls/localhost.crt"
+    #  # Path to the private key file, typically named with a .key extension.
+    #  private_key_path: "tls/localhost.key"
+    #  # Enable/disable verifying the hostname of the certificate provided by the destination.
+    #  #verify_hostname: true
 ```
 
 ### KafkaSinkSingle
@@ -332,6 +344,18 @@ In order to force clients to connect through shotover the FindCoordinator, Metad
     # This field is optional, if not provided, timeout will never occur.
     # When a timeout occurs the connection to the client is immediately closed.
     # read_timeout: 60
+
+    # When this field is provided TLS is used when connecting to the remote address.
+    # Removing this field will disable TLS.
+    #tls:
+    #  # Path to the certificate authority file, typically named with a .crt extension.
+    #  certificate_authority_path: "tls/localhost_CA.crt"
+    #  # Path to the certificate file, typically named with a .crt extension.
+    #  certificate_path: "tls/localhost.crt"
+    #  # Path to the private key file, typically named with a .key extension.
+    #  private_key_path: "tls/localhost.key"
+    #  # Enable/disable verifying the hostname of the certificate provided by the destination.
+    #  #verify_hostname: true
 ```
 
 This transfrom emits a metrics [counter](user-guide/observability.md#counter) named `failed_requests` and the labels `transform` defined as `CassandraSinkSingle` and `chain` as the name of the chain that this transform is in.

--- a/shotover-proxy/benches/windsock/kafka/bench.rs
+++ b/shotover-proxy/benches/windsock/kafka/bench.rs
@@ -93,6 +93,7 @@ impl KafkaBench {
                 read_timeout: None,
                 first_contact_points: vec![kafka_address],
                 shotover_nodes: vec![host_address.clone()],
+                tls: None,
             }),
         });
         common::generate_topology(SourceConfig::Kafka(shotover::sources::kafka::KafkaConfig {

--- a/shotover-proxy/tests/test-configs/kafka/cluster-tls/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-tls/docker-compose.yaml
@@ -1,0 +1,54 @@
+version: "3"
+networks:
+  cluster_subnet:
+    name: cluster_subnet
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.16.1.0/24
+          gateway: 172.16.1.1
+services:
+  kafka0:
+    image: &image 'bitnami/kafka:3.6.1-debian-11-r24'
+    networks:
+      cluster_subnet:
+        ipv4_address: 172.16.1.2
+    environment: &environment
+      KAFKA_CFG_LISTENERS: "BROKER://:9092,CONTROLLER://:9093"
+      KAFKA_CFG_ADVERTISED_LISTENERS: "BROKER://172.16.1.2:9092"
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: "CONTROLLER:PLAINTEXT,BROKER:SSL"
+      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: "BROKER"
+      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: "CONTROLLER"
+      KAFKA_CFG_PROCESS_ROLES: "controller,broker"
+      KAFKA_KRAFT_CLUSTER_ID: "abcdefghijklmnopqrstuv"
+      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: "0@kafka0:9093,1@kafka1:9093,2@kafka2:9093"
+      KAFKA_CFG_NODE_ID: 0
+      KAFKA_CERTIFICATE_PASSWORD: password
+      KAFKA_TLS_CLIENT_AUTH: none
+    volumes: &volumes
+      - type: tmpfs
+        target: /bitnami/kafka
+      - type: bind
+        source: "../tls/certs"
+        target: "/opt/bitnami/kafka/config/certs"
+  kafka1:
+    image: *image
+    networks:
+      cluster_subnet:
+        ipv4_address: 172.16.1.3
+    environment:
+      <<: *environment
+      KAFKA_CFG_ADVERTISED_LISTENERS: "BROKER://172.16.1.3:9092"
+      KAFKA_CFG_NODE_ID: 1
+    volumes: *volumes
+  kafka2:
+    image: *image
+    networks:
+      cluster_subnet:
+        ipv4_address: 172.16.1.4
+    environment:
+      <<: *environment
+      KAFKA_CFG_ADVERTISED_LISTENERS: "BROKER://172.16.1.4:9092"
+      KAFKA_CFG_NODE_ID: 2
+    volumes: *volumes

--- a/shotover-proxy/tests/test-configs/kafka/cluster-tls/topology.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-tls/topology.yaml
@@ -1,0 +1,13 @@
+---
+sources:
+  - Kafka:
+      name: "kafka"
+      listen_addr: "127.0.0.1:9192"
+      chain:
+        - KafkaSinkCluster:
+            shotover_nodes: ["127.0.0.1:9192"]
+            first_contact_points: ["172.16.1.2:9092"]
+            connect_timeout_ms: 3000
+            tls:
+              certificate_authority_path: "tests/test-configs/kafka/tls/certs/localhost_CA.crt"
+              verify_hostname: true

--- a/shotover-proxy/tests/test-configs/kafka/passthrough-tls/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/passthrough-tls/docker-compose.yaml
@@ -13,7 +13,6 @@ services:
       - KAFKA_CFG_PROCESS_ROLES=controller,broker
       - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka0:9093
       - KAFKA_CFG_NODE_ID=0
-      - ALLOW_PLAINTEXT_LISTENER=yes
       - KAFKA_CERTIFICATE_PASSWORD=password
       - KAFKA_TLS_CLIENT_AUTH=none
     volumes:


### PR DESCRIPTION
Adds TLS support for KafkaSinkCluster.

Additionally documents the TLS support KafkaSinkCluster, KafkaSinkSingle and KafkaSource.
The other 2 were already implemented but not documented.
The documentation is copied from redis/cassandra which have identical configuration options for TLS.