### PR TITLE
Update cassandra-cpp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,10 +814,11 @@ dependencies = [
 
 [[package]]
 name = "cassandra-cpp"
-version = "2.0.1"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2fbdfbcd8d1b9554fb3fcfe00dc729346f853ac2f984d227936ed2e4abf28dd"
+checksum = "c9ed77e0aea6277ef2b625559fb2b89ce58ab5dd4565fa00309b903e20c05894"
 dependencies = [
+ "bigdecimal",
  "cassandra-cpp-sys",
  "error-chain",
  "libc",

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -20,7 +20,7 @@ tracing.workspace = true
 clap.workspace = true
 rstest = "0.18.0"
 rstest_reuse = "0.6.0"
-cassandra-cpp = { version = "2.0.0", default-features = false }
+cassandra-cpp = { version = "3.0.0", default-features = false }
 test-helpers = { path = "../test-helpers" }
 redis.workspace = true
 chacha20poly1305.workspace = true

--- a/test-helpers/Cargo.toml
+++ b/test-helpers/Cargo.toml
@@ -16,7 +16,7 @@ subprocess.workspace = true
 tokio-bin-process.workspace = true
 cdrs-tokio.workspace = true
 cassandra-protocol.workspace = true
-cassandra-cpp = { version = "2.0.0", default-features = false, features = ["log"], optional = true }
+cassandra-cpp = { version = "3.0.0", default-features = false, features = ["log"], optional = true }
 scylla.workspace = true
 openssl.workspace = true
 bytes.workspace = true


### PR DESCRIPTION
Version 0.3 of cassandra-cpp alters the iterator API as the API used in 0.2 was unsound: https://github.com/Metaswitch/cassandra-rs/security/advisories/GHSA-x9xc-63hg-vcfq