### PR TITLE
Fix running integration tests without --features alpha-transforms

### DIFF
--- a/shotover-proxy/tests/kafka_int_tests/mod.rs
+++ b/shotover-proxy/tests/kafka_int_tests/mod.rs
@@ -76,6 +76,7 @@ async fn cluster_tls(#[case] driver: KafkaDriver) {
     .expect("Shotover did not shutdown within 10s");
 }
 
+#[cfg(feature = "alpha-transforms")]
 #[rstest]
 #[cfg_attr(feature = "rdkafka-driver-tests", case::cpp(KafkaDriver::Cpp))]
 #[case::java(KafkaDriver::Java)]
@@ -111,6 +112,7 @@ async fn passthrough_sasl(#[case] driver: KafkaDriver) {
     shotover.shutdown_and_then_consume_events(&[]).await;
 }
 
+#[cfg(feature = "alpha-transforms")]
 #[rstest]
 #[cfg_attr(feature = "rdkafka-driver-tests", case::cpp(KafkaDriver::Cpp))]
 #[case::java(KafkaDriver::Java)]


### PR DESCRIPTION
Issue introduced by https://github.com/shotover/shotover-proxy/pull/1509

All tests that setup shotover to use an alpha-transform should have `#[cfg(feature = "alpha-transforms")]` so that they dont show up as test failures when running without alpha-transforms enabled.