### PR TITLE
RedisCache: port to MessageId invariants

### DIFF
--- a/shotover/src/message/mod.rs
+++ b/shotover/src/message/mod.rs
@@ -135,6 +135,19 @@ impl Message {
         }
     }
 
+    /// This method should be called when generating a new request travelling down a seperate chain to an original request.
+    /// The generated request will share the same MessageId as the message it is diverged from.
+    pub fn from_frame_diverged(frame: Frame, diverged_from: &Message) -> Self {
+        Message {
+            codec_state: frame.as_codec_state(),
+            inner: Some(MessageInner::Modified { frame }),
+            meta_timestamp: None,
+            received_from_source_or_sink_at: diverged_from.received_from_source_or_sink_at,
+            id: diverged_from.id(),
+            request_id: None,
+        }
+    }
+
     /// Same as [`Message::from_bytes`] but `received_from_source_or_sink_at` is set to None.
     pub fn from_bytes(bytes: Bytes, codec_state: CodecState) -> Self {
         Self::from_bytes_at_instant(bytes, codec_state, None)

--- a/shotover/src/transforms/mod.rs
+++ b/shotover/src/transforms/mod.rs
@@ -323,10 +323,6 @@ pub trait Transform: Send {
     ///         - When writing protocol generic transforms: always ensure this is upheld.
     ///         - When writing a transform specific to a protocol that is out of order: you can disregard this requirement
     ///             * This is currently only cassandra
-    /// * Deprecated invariants:
-    ///     + Many transforms rely on the number of responses equalling the number of requests and that requests will be in the same order as the responses.
-    ///       Currently shotover maintains this gaurantee for backwards compatibility
-    ///       but the gaurantee will be removed as soon as the transforms have been altered to no longer rely on it.
     ///
     /// # Naming
     /// Transform also have different naming conventions.


### PR DESCRIPTION
This one was a bit tricky since the transform sends requests down a redis chain and waits for the responses before sending anything to cassandra.
So in order to fit the the new invariants we need to seperately keep track of what responses we are waiting for from both redis and cassandra.
However in the end it didnt add too much more complexity.
Once shotover reaches the point where it can send without waiting for responses, this transform will benefit from it greatly since it can respond to any cached requests immediately even if there are uncached requests in the same batch, before this PR that was impossible.

Additionally this is the final transform that required porting, so I've now removed the `Deprecated invariants` from the transform invariants documentation.
We can now proceed with making use of the lack of those invariants to improve shotover throughput.