### PR TITLE
Remove Transform::transform_pushed

### DIFF
--- a/docs/src/user-guide/observability.md
+++ b/docs/src/user-guide/observability.md
@@ -7,7 +7,6 @@ This interface will serve Prometheus metrics from `/metrics`. The following metr
 | `shotover_transform_total_count`           | `transform` | [counter](#counter)     | Counts the amount of times the `transform` is used                        |
 | `shotover_transform_failures_count`        | `transform` | [counter](#counter)     | Counts the amount of times the `transform` fails                          |
 | `shotover_transform_latency_seconds`       | `transform` | [histogram](#histogram) | The latency for a message batch to go through the `transform`             |
-| `shotover_transform_pushed_latency_seconds`| `transform` | [histogram](#histogram) | The latency for a pushed message from the DB to go through the `transform`|
 | `shotover_chain_total_count`               | `chain`     | [counter](#counter)     | Counts the amount of times `chain` is used                                |
 | `shotover_chain_failures_count`            | `chain`     | [counter](#counter)     | Counts the amount of times `chain` fails                                  |
 | `shotover_chain_latency_seconds`           | `chain`     | [histogram](#histogram) | The latency for running `chain`                                           |

--- a/shotover-proxy/tests/runner/observability_int_tests.rs
+++ b/shotover-proxy/tests/runner/observability_int_tests.rs
@@ -18,9 +18,6 @@ async fn test_metrics() {
 # TYPE shotover_sink_to_source_latency_seconds summary
 # TYPE shotover_transform_failures_count counter
 # TYPE shotover_transform_latency_seconds summary
-# TYPE shotover_transform_pushed_failures_count counter
-# TYPE shotover_transform_pushed_latency_seconds summary
-# TYPE shotover_transform_pushed_total_count counter
 # TYPE shotover_transform_total_count counter
 shotover_available_connections_count{source="redis"}
 shotover_chain_failures_count{chain="redis"}
@@ -68,30 +65,6 @@ shotover_transform_latency_seconds{transform="QueryCounter",quantile="0.95"}
 shotover_transform_latency_seconds{transform="QueryCounter",quantile="0.99"}
 shotover_transform_latency_seconds{transform="QueryCounter",quantile="0.999"}
 shotover_transform_latency_seconds{transform="QueryCounter",quantile="1"}
-shotover_transform_pushed_failures_count{transform="NullSink"}
-shotover_transform_pushed_failures_count{transform="QueryCounter"}
-shotover_transform_pushed_latency_seconds_count{transform="NullSink"}
-shotover_transform_pushed_latency_seconds_count{transform="QueryCounter"}
-shotover_transform_pushed_latency_seconds_sum{transform="NullSink"}
-shotover_transform_pushed_latency_seconds_sum{transform="QueryCounter"}
-shotover_transform_pushed_latency_seconds{transform="NullSink",quantile="0"}
-shotover_transform_pushed_latency_seconds{transform="NullSink",quantile="0.1"}
-shotover_transform_pushed_latency_seconds{transform="NullSink",quantile="0.5"}
-shotover_transform_pushed_latency_seconds{transform="NullSink",quantile="0.9"}
-shotover_transform_pushed_latency_seconds{transform="NullSink",quantile="0.95"}
-shotover_transform_pushed_latency_seconds{transform="NullSink",quantile="0.99"}
-shotover_transform_pushed_latency_seconds{transform="NullSink",quantile="0.999"}
-shotover_transform_pushed_latency_seconds{transform="NullSink",quantile="1"}
-shotover_transform_pushed_latency_seconds{transform="QueryCounter",quantile="0"}
-shotover_transform_pushed_latency_seconds{transform="QueryCounter",quantile="0.1"}
-shotover_transform_pushed_latency_seconds{transform="QueryCounter",quantile="0.5"}
-shotover_transform_pushed_latency_seconds{transform="QueryCounter",quantile="0.9"}
-shotover_transform_pushed_latency_seconds{transform="QueryCounter",quantile="0.95"}
-shotover_transform_pushed_latency_seconds{transform="QueryCounter",quantile="0.99"}
-shotover_transform_pushed_latency_seconds{transform="QueryCounter",quantile="0.999"}
-shotover_transform_pushed_latency_seconds{transform="QueryCounter",quantile="1"}
-shotover_transform_pushed_total_count{transform="NullSink"}
-shotover_transform_pushed_total_count{transform="QueryCounter"}
 shotover_transform_total_count{transform="NullSink"}
 shotover_transform_total_count{transform="QueryCounter"}
 "#;

--- a/shotover/src/codec/redis.rs
+++ b/shotover/src/codec/redis.rs
@@ -95,9 +95,6 @@ impl Decoder for RedisDecoder {
     type Item = Messages;
     type Error = CodecReadError;
 
-    // TODO: this duplicates a bunch of logic from sink_single.rs
-    //       As soon as we remove `Transforms::transform_pushed` we can remove the duplication on the RedisSinkSingle side.
-    //       Once thats done we will have pubsub support for both RedisSinkSingle AND RedisSinkCluster. Progress!
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
         let received_at = Instant::now();
         match decode_bytes_mut(src)


### PR DESCRIPTION
Progress towards https://github.com/shotover/shotover-proxy/issues/1507

The final PR for the removal of transform_pushed.
No users of transform_pushed remain so it can be just cleanly removed.