### PR TITLE
fix kafka cluster bugs discovered by java driver

### DIFF
--- a/shotover-proxy/tests/kafka_int_tests/mod.rs
+++ b/shotover-proxy/tests/kafka_int_tests/mod.rs
@@ -154,9 +154,10 @@ async fn cluster_1_rack_single_shotover(#[case] driver: KafkaDriver) {
     .expect("Shotover did not shutdown within 10s");
 }
 
+#[cfg(feature = "rdkafka-driver-tests")] // temporarily needed to avoid a warning
 #[rstest]
 #[cfg_attr(feature = "rdkafka-driver-tests", case::cpp(KafkaDriver::Cpp))]
-#[case::java(KafkaDriver::Java)]
+//#[case::java(KafkaDriver::Java)]
 #[tokio::test(flavor = "multi_thread")] // multi_thread is needed since java driver will block when consuming, causing shotover logs to not appear
 async fn cluster_1_rack_multi_shotover(#[case] driver: KafkaDriver) {
     let _docker_compose =
@@ -189,9 +190,10 @@ async fn cluster_1_rack_multi_shotover(#[case] driver: KafkaDriver) {
     }
 }
 
+#[cfg(feature = "rdkafka-driver-tests")] // temporarily needed to avoid a warning
 #[rstest]
 #[cfg_attr(feature = "rdkafka-driver-tests", case::cpp(KafkaDriver::Cpp))]
-#[case::java(KafkaDriver::Java)]
+//#[case::java(KafkaDriver::Java)]
 #[tokio::test(flavor = "multi_thread")] // multi_thread is needed since java driver will block when consuming, causing shotover logs to not appear
 async fn cluster_2_racks_multi_shotover(#[case] driver: KafkaDriver) {
     let _docker_compose =
@@ -226,7 +228,6 @@ async fn cluster_2_racks_multi_shotover(#[case] driver: KafkaDriver) {
     }
 }
 
-#[cfg(feature = "rdkafka-driver-tests")]
 #[rstest]
 #[cfg_attr(feature = "rdkafka-driver-tests", case::cpp(KafkaDriver::Cpp))]
 #[case::java(KafkaDriver::Java)]
@@ -251,10 +252,10 @@ async fn cluster_sasl_single_shotover(#[case] driver: KafkaDriver) {
     .expect("Shotover did not shutdown within 10s");
 }
 
-#[cfg(feature = "rdkafka-driver-tests")]
+#[cfg(feature = "rdkafka-driver-tests")] // temporarily needed to avoid a warning
 #[rstest]
 #[cfg_attr(feature = "rdkafka-driver-tests", case::cpp(KafkaDriver::Cpp))]
-#[case::java(KafkaDriver::Java)]
+//#[case::java(KafkaDriver::Java)]
 #[tokio::test(flavor = "multi_thread")] // multi_thread is needed since java driver will block when consuming, causing shotover logs to not appear
 async fn cluster_sasl_multi_shotover(#[case] driver: KafkaDriver) {
     let _docker_compose =

--- a/shotover-proxy/tests/kafka_int_tests/mod.rs
+++ b/shotover-proxy/tests/kafka_int_tests/mod.rs
@@ -52,10 +52,9 @@ async fn passthrough_tls(#[case] driver: KafkaDriver) {
     .expect("Shotover did not shutdown within 10s");
 }
 
-#[cfg(feature = "rdkafka-driver-tests")] // temporarily needed to avoid a warning
 #[rstest]
 #[cfg_attr(feature = "rdkafka-driver-tests", case::cpp(KafkaDriver::Cpp))]
-// #[case::java(KafkaDriver::Java)]
+#[case::java(KafkaDriver::Java)]
 #[tokio::test(flavor = "multi_thread")] // multi_thread is needed since java driver will block when consuming, causing shotover logs to not appear
 async fn cluster_tls(#[case] driver: KafkaDriver) {
     test_helpers::cert::generate_kafka_test_certs();
@@ -133,10 +132,9 @@ async fn passthrough_sasl_encode(#[case] driver: KafkaDriver) {
     shotover.shutdown_and_then_consume_events(&[]).await;
 }
 
-#[cfg(feature = "rdkafka-driver-tests")] // temporarily needed to avoid a warning
 #[rstest]
 #[cfg_attr(feature = "rdkafka-driver-tests", case::cpp(KafkaDriver::Cpp))]
-// #[case::java(KafkaDriver::Java)]
+#[case::java(KafkaDriver::Java)]
 #[tokio::test(flavor = "multi_thread")] // multi_thread is needed since java driver will block when consuming, causing shotover logs to not appear
 async fn cluster_1_rack_single_shotover(#[case] driver: KafkaDriver) {
     let _docker_compose =
@@ -156,11 +154,10 @@ async fn cluster_1_rack_single_shotover(#[case] driver: KafkaDriver) {
     .expect("Shotover did not shutdown within 10s");
 }
 
-#[cfg(feature = "rdkafka-driver-tests")] // temporarily needed to avoid a warning
 #[rstest]
 #[cfg_attr(feature = "rdkafka-driver-tests", case::cpp(KafkaDriver::Cpp))]
-// #[case::java(KafkaDriver::Java)]
-#[tokio::test(flavor = "multi_thread")]
+#[case::java(KafkaDriver::Java)]
+#[tokio::test(flavor = "multi_thread")] // multi_thread is needed since java driver will block when consuming, causing shotover logs to not appear
 async fn cluster_1_rack_multi_shotover(#[case] driver: KafkaDriver) {
     let _docker_compose =
         docker_compose("tests/test-configs/kafka/cluster-1-rack/docker-compose.yaml");
@@ -192,10 +189,9 @@ async fn cluster_1_rack_multi_shotover(#[case] driver: KafkaDriver) {
     }
 }
 
-#[cfg(feature = "rdkafka-driver-tests")] // temporarily needed to avoid a warning
 #[rstest]
 #[cfg_attr(feature = "rdkafka-driver-tests", case::cpp(KafkaDriver::Cpp))]
-//#[case::java(KafkaDriver::Java)]
+#[case::java(KafkaDriver::Java)]
 #[tokio::test(flavor = "multi_thread")] // multi_thread is needed since java driver will block when consuming, causing shotover logs to not appear
 async fn cluster_2_racks_multi_shotover(#[case] driver: KafkaDriver) {
     let _docker_compose =
@@ -233,8 +229,8 @@ async fn cluster_2_racks_multi_shotover(#[case] driver: KafkaDriver) {
 #[cfg(feature = "rdkafka-driver-tests")]
 #[rstest]
 #[cfg_attr(feature = "rdkafka-driver-tests", case::cpp(KafkaDriver::Cpp))]
-// #[case::java(KafkaDriver::Java)]
-#[tokio::test]
+#[case::java(KafkaDriver::Java)]
+#[tokio::test(flavor = "multi_thread")] // multi_thread is needed since java driver will block when consuming, causing shotover logs to not appear
 async fn cluster_sasl_single_shotover(#[case] driver: KafkaDriver) {
     let _docker_compose =
         docker_compose("tests/test-configs/kafka/cluster-sasl/docker-compose.yaml");
@@ -258,8 +254,8 @@ async fn cluster_sasl_single_shotover(#[case] driver: KafkaDriver) {
 #[cfg(feature = "rdkafka-driver-tests")]
 #[rstest]
 #[cfg_attr(feature = "rdkafka-driver-tests", case::cpp(KafkaDriver::Cpp))]
-// #[case::java(KafkaDriver::Java)]
-#[tokio::test]
+#[case::java(KafkaDriver::Java)]
+#[tokio::test(flavor = "multi_thread")] // multi_thread is needed since java driver will block when consuming, causing shotover logs to not appear
 async fn cluster_sasl_multi_shotover(#[case] driver: KafkaDriver) {
     let _docker_compose =
         docker_compose("tests/test-configs/kafka/cluster-sasl/docker-compose.yaml");

--- a/shotover/src/transforms/kafka/sink_cluster/mod.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/mod.rs
@@ -247,7 +247,7 @@ pub struct KafkaSinkCluster {
     rng: SmallRng,
     sasl_status: SaslStatus,
     connection_factory: ConnectionFactory,
-    first_contact_node: Option<BrokerId>,
+    first_contact_node: Option<KafkaAddress>,
     // its not clear from the docs if this cache needs to be accessed cross connection:
     // https://cwiki.apache.org/confluence/display/KAFKA/KIP-227%3A+Introduce+Incremental+FetchRequests+to+Increase+Partition+Scalability
     fetch_session_id_to_broker: HashMap<i32, BrokerId>,
@@ -661,14 +661,14 @@ impl KafkaSinkCluster {
         message: Message,
         return_chan: Option<oneshot::Sender<Response>>,
     ) -> Result<()> {
-        let node = if let Some(first_contact_node) = self.first_contact_node {
+        let node = if let Some(first_contact_node) = &self.first_contact_node {
             self.nodes
                 .iter_mut()
-                .find(|node| node.broker_id == first_contact_node)
+                .find(|node| node.kafka_address == *first_contact_node)
                 .unwrap()
         } else {
             let node = self.nodes.get_mut(0).unwrap();
-            self.first_contact_node = Some(node.broker_id);
+            self.first_contact_node = Some(node.kafka_address.clone());
             node
         };
 

--- a/shotover/src/transforms/kafka/sink_cluster/mod.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/mod.rs
@@ -1,7 +1,7 @@
 use super::common::produce_channel;
 use crate::frame::kafka::{KafkaFrame, RequestBody, ResponseBody};
 use crate::frame::Frame;
-use crate::message::{Message, Messages};
+use crate::message::{Message, MessageIdMap, Messages};
 use crate::tls::{TlsConnector, TlsConnectorConfig};
 use crate::transforms::util::{Request, Response};
 use crate::transforms::{Transform, TransformBuilder, TransformContextBuilder, Wrapper};
@@ -23,6 +23,7 @@ use rand::rngs::SmallRng;
 use rand::seq::{IteratorRandom, SliceRandom};
 use rand::SeedableRng;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::hash::Hasher;
 use std::net::SocketAddr;
 use std::sync::atomic::AtomicI64;
@@ -31,6 +32,14 @@ use std::time::Duration;
 use tokio::sync::{mpsc, oneshot, RwLock};
 use tokio::time::timeout;
 use uuid::Uuid;
+
+#[derive(thiserror::Error, Debug)]
+enum FindCoordinatorError {
+    #[error("Coordinator not available")]
+    CoordinatorNotAvailable,
+    #[error("{0:?}")]
+    Unrecoverable(#[from] anyhow::Error),
+}
 
 mod node;
 
@@ -158,6 +167,8 @@ impl TransformBuilder for KafkaSinkClusterBuilder {
             sasl_status: SaslStatus::new(self.sasl_enabled),
             connection_factory: ConnectionFactory::new(self.tls.clone(), self.connect_timeout),
             first_contact_node: None,
+            fetch_session_id_to_broker: HashMap::new(),
+            fetch_request_destinations: Default::default(),
         })
     }
 
@@ -233,6 +244,11 @@ pub struct KafkaSinkCluster {
     sasl_status: SaslStatus,
     connection_factory: ConnectionFactory,
     first_contact_node: Option<BrokerId>,
+    // its not clear from the docs if this cache needs to be accessed cross connection:
+    // https://cwiki.apache.org/confluence/display/KAFKA/KIP-227%3A+Introduce+Incremental+FetchRequests+to+Increase+Partition+Scalability
+    fetch_session_id_to_broker: HashMap<i32, BrokerId>,
+    // for use with fetch_session_id_to_broker
+    fetch_request_destinations: MessageIdMap<BrokerId>,
 }
 
 #[async_trait]
@@ -357,10 +373,20 @@ impl KafkaSinkCluster {
         }
 
         for group in groups {
-            let node = self.find_coordinator_of_group(group.clone()).await?;
-            self.group_to_coordinator_broker
-                .insert(group, node.broker_id);
-            self.add_node_if_new(node).await;
+            match self.find_coordinator_of_group(group.clone()).await {
+                Ok(node) => {
+                    self.group_to_coordinator_broker
+                        .insert(group, node.broker_id);
+                    self.add_node_if_new(node).await;
+                }
+                Err(FindCoordinatorError::CoordinatorNotAvailable) => {
+                    // We cant find the coordinator so do nothing so that the request will be routed to a random node:
+                    // * If it happens to be the coordinator all is well
+                    // * If its not the coordinator then it will return a COORDINATOR_NOT_AVAILABLE message to
+                    //   the client prompting it to retry the whole process again.
+                }
+                Err(FindCoordinatorError::Unrecoverable(err)) => Err(err)?,
+            }
         }
 
         // request and process metadata if we are missing topics or the controller broker id
@@ -441,37 +467,55 @@ impl KafkaSinkCluster {
                     body: RequestBody::Fetch(fetch),
                     ..
                 })) => {
-                    // assume that all topics in this message have the same routing requirements
-                    let topic = fetch
-                        .topics
-                        .first()
-                        .ok_or_else(|| anyhow!("No topics in produce message"))?;
-                    let connection = if let Some(topic_meta) = self.topics.get(&topic.topic.0) {
-                        // assume that all partitions in this topic have the same routing requirements
-                        let partition = &topic_meta.partitions[topic
-                            .partitions
+                    let node = if fetch.session_id == 0 {
+                        // assume that all topics in this message have the same routing requirements
+                        let topic = fetch
+                            .topics
                             .first()
-                            .ok_or_else(|| anyhow!("No partitions in topic"))?
-                            .partition
-                            as usize];
-                        self.nodes
-                            .iter_mut()
-                            .filter(|node| partition.replica_nodes.contains(&node.broker_id))
-                            .choose(&mut self.rng)
-                            .unwrap()
-                            .get_connection(&self.connection_factory)
-                            .await?
-                            .clone()
+                            .ok_or_else(|| anyhow!("No topics in fetch message"))?;
+                        let topic_name = &topic.topic;
+                        let node = if let Some(topic_meta) = self.topics.get(topic_name) {
+                            let partition_index = topic
+                                .partitions
+                                .first()
+                                .ok_or_else(|| anyhow!("No partitions in topic"))?
+                                .partition
+                                as usize;
+                            // assume that all partitions in this topic have the same routing requirements
+                            if let Some(partition) = topic_meta.partitions.get(partition_index) {
+                                self.nodes
+                                    .iter_mut()
+                                    .filter(|node| {
+                                        partition.replica_nodes.contains(&node.broker_id)
+                                    })
+                                    .choose(&mut self.rng)
+                                    .unwrap()
+                            } else {
+                                let partition_len = topic_meta.partitions.len();
+                                tracing::warn!("no known partition replica for {topic_name:?} at partition index {partition_index} out of {partition_len} partitions, routing message to a random node so that a NOT_LEADER_OR_FOLLOWER or similar error is returned to the client");
+                                self.nodes.choose_mut(&mut self.rng).unwrap()
+                            }
+                        } else {
+                            tracing::warn!("no known partition replica for {topic_name:?}, routing message to a random node so that a NOT_LEADER_OR_FOLLOWER or similar error is returned to the client");
+                            self.nodes.choose_mut(&mut self.rng).unwrap()
+                        };
+                        self.fetch_request_destinations
+                            .insert(message.id(), node.broker_id);
+                        node
                     } else {
-                        let topic = &topic.topic;
-                        tracing::warn!("no known partition replica for {topic:?}, routing message to a random node so that a NOT_LEADER_OR_FOLLOWER or similar error is returned to the client");
-                        self.nodes
-                            .choose_mut(&mut self.rng)
-                            .unwrap()
-                            .get_connection(&self.connection_factory)
-                            .await?
-                            .clone()
+                        // route via session id
+                        if let Some(destination) =
+                            self.fetch_session_id_to_broker.get(&fetch.session_id)
+                        {
+                            self.nodes
+                                .iter_mut()
+                                .find(|x| &x.broker_id == destination)
+                                .unwrap()
+                        } else {
+                            todo!()
+                        }
                     };
+                    let connection = node.get_connection(&self.connection_factory).await?.clone();
 
                     let (tx, rx) = oneshot::channel();
                     connection
@@ -500,9 +544,19 @@ impl KafkaSinkCluster {
                 }
                 Some(Frame::Kafka(KafkaFrame::Request {
                     body: RequestBody::OffsetFetch(offset_fetch),
-                    ..
+                    header,
                 })) => {
-                    let group_id = offset_fetch.group_id.clone();
+                    let group_id = if header.request_api_version <= 7 {
+                        offset_fetch.group_id.clone()
+                    } else {
+                        // This is possibly dangerous.
+                        // The client could construct a message which is valid for a specific shotover node, but not for any single kafka broker.
+                        // We may need to add some logic to split the request into multiple messages going to different destinations,
+                        // and then reconstruct the response back into a single response
+                        //
+                        // For now just pick the first group as that is sufficient for the simple cases.
+                        offset_fetch.groups.first().unwrap().group_id.clone()
+                    };
                     results.push(self.route_to_coordinator(message, group_id).await?);
                 }
                 Some(Frame::Kafka(KafkaFrame::Request {
@@ -612,7 +666,10 @@ impl KafkaSinkCluster {
         Ok(())
     }
 
-    async fn find_coordinator_of_group(&mut self, group: GroupId) -> Result<KafkaNode> {
+    async fn find_coordinator_of_group(
+        &mut self,
+        group: GroupId,
+    ) -> Result<KafkaNode, FindCoordinatorError> {
         let request = Message::from_frame(Frame::Kafka(KafkaFrame::Request {
             header: RequestHeader::builder()
                 .request_api_key(ApiKey::FindCoordinatorKey as i16)
@@ -647,14 +704,20 @@ impl KafkaSinkCluster {
             Some(Frame::Kafka(KafkaFrame::Response {
                 body: ResponseBody::FindCoordinator(coordinator),
                 ..
-            })) => Ok(KafkaNode::new(
-                coordinator.node_id,
-                KafkaAddress::new(coordinator.host.clone(), coordinator.port),
-                None,
-            )),
+            })) => {
+                if coordinator.error_code == 0 {
+                    Ok(KafkaNode::new(
+                        coordinator.node_id,
+                        KafkaAddress::new(coordinator.host.clone(), coordinator.port),
+                        None,
+                    ))
+                } else {
+                    Err(FindCoordinatorError::CoordinatorNotAvailable)
+                }
+            }
             other => Err(anyhow!(
                 "Unexpected message returned to findcoordinator request {other:?}"
-            )),
+            ))?,
         }
     }
 
@@ -714,8 +777,8 @@ impl KafkaSinkCluster {
 
         // TODO: Handle errors like NOT_COORDINATOR by removing element from self.topics and self.coordinator_broker_id
 
-        // Rewrite responses to ensure clients only see the shotover cluster and hide the existence of the real kafka cluster
         for (i, response) in responses.iter_mut().enumerate() {
+            let request_id = response.request_id();
             match response.frame() {
                 Some(Frame::Kafka(KafkaFrame::Response {
                     body: ResponseBody::FindCoordinator(find_coordinator),
@@ -738,6 +801,17 @@ impl KafkaSinkCluster {
                     self.process_metadata_response(metadata).await;
                     self.rewrite_metadata_response(metadata)?;
                     response.invalidate_cache();
+                }
+                Some(Frame::Kafka(KafkaFrame::Response {
+                    body: ResponseBody::Fetch(fetch),
+                    ..
+                })) => {
+                    let destination = self
+                        .fetch_request_destinations
+                        .remove(&request_id.unwrap())
+                        .unwrap();
+                    self.fetch_session_id_to_broker
+                        .insert(fetch.session_id, destination);
                 }
                 Some(Frame::Kafka(KafkaFrame::Response {
                     body: ResponseBody::DescribeCluster(_),
@@ -796,6 +870,7 @@ impl KafkaSinkCluster {
             if let Some(broker_id) = self.group_to_coordinator_broker.get(&group_id) {
                 if node.broker_id == *broker_id {
                     connection = Some(node.get_connection(&self.connection_factory).await?.clone());
+                    break;
                 }
             }
         }
@@ -857,12 +932,16 @@ impl KafkaSinkCluster {
     ) {
         if request.key_type == 0 {
             if version <= 3 {
-                self.group_to_coordinator_broker
-                    .insert(GroupId(request.key.clone()), find_coordinator.node_id);
+                if find_coordinator.error_code == 0 {
+                    self.group_to_coordinator_broker
+                        .insert(GroupId(request.key.clone()), find_coordinator.node_id);
+                }
             } else {
                 for coordinator in &find_coordinator.coordinators {
-                    self.group_to_coordinator_broker
-                        .insert(GroupId(coordinator.key.clone()), find_coordinator.node_id);
+                    if coordinator.error_code == 0 {
+                        self.group_to_coordinator_broker
+                            .insert(GroupId(coordinator.key.clone()), coordinator.node_id);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR has a few bug fixes included in one PR, since they are all needed to get the java driver working on kafka cluster + single shotover tests.
kafka cluster + multi shotover are still broken and will be investigated + fixed in a follow up.

A lot of the differences in the drivers stem from the cpp driver using an older version of the protocol.
So all of the codepaths for the new protocol were previously untested.

## Bug 1
fetch sessions were previously unhandled.
https://cwiki.apache.org/confluence/display/KAFKA/KIP-227%3A+Introduce+Incremental+FetchRequests+to+Increase+Partition+Scalability
We need to detect when the server has setup a fetch session (when a fetch response includes a non-zero fetch_session) and then ensure that all fetch requests that specify that fetch_session are routed back to the original broker.

## Bug 2

Some clients only use the topic ID while some only use the topic name.
We need to fallback to the other, if one of them isnt set.

## Bug 3
newer version of OffsetFetch wasnt supported, we were reading invalid group_id's out of a no longer used field.

## Bug 4

simple copy paste error in `process_find_coordinator_response`: `find_coordinator.node_id` -> `coordinator.node_id`

## Bug 5

we were processing the contents of FindCoordinator responses even when the server reported them as errored via the error_code field.
The other fields are invalid when the message contains an error and should never be used for anything.
This issue applied to both `process_find_coordinator_response` and `find_coordinator_of_group`

## Bug 6

route_to_first_contact_node was using BrokerId to keep track of the first node but the first node actually changes its BrokerId since it starts at -1 and is later updated to the real value when its discovered.
Instead lets use the address to keep track of which node is the first one to contact.