### PR TITLE
Remove pushed_messages mpsc from kafka transforms

### DIFF
--- a/shotover/src/transforms/kafka/sink_cluster/mod.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/mod.rs
@@ -28,7 +28,7 @@ use std::net::SocketAddr;
 use std::sync::atomic::AtomicI64;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::{mpsc, oneshot, RwLock};
+use tokio::sync::{oneshot, RwLock};
 use tokio::time::timeout;
 use uuid::Uuid;
 
@@ -147,7 +147,6 @@ impl TransformBuilder for KafkaSinkClusterBuilder {
         Box::new(KafkaSinkCluster {
             first_contact_points: self.first_contact_points.clone(),
             shotover_nodes: self.shotover_nodes.clone(),
-            pushed_messages_tx: None,
             read_timeout: self.read_timeout,
             nodes: vec![],
             nodes_shared: self.nodes_shared.clone(),
@@ -222,7 +221,6 @@ impl SaslStatus {
 pub struct KafkaSinkCluster {
     first_contact_points: Vec<String>,
     shotover_nodes: Vec<ShotoverNode>,
-    pushed_messages_tx: Option<mpsc::UnboundedSender<Messages>>,
     read_timeout: Option<Duration>,
     nodes: Vec<KafkaNode>,
     nodes_shared: Arc<RwLock<Vec<KafkaNode>>>,
@@ -281,10 +279,6 @@ impl Transform for KafkaSinkCluster {
         let responses = self.send_requests(requests_wrapper.requests).await?;
         self.receive_responses(&find_coordinator_requests, responses)
             .await
-    }
-
-    fn set_pushed_messages_tx(&mut self, pushed_messages_tx: mpsc::UnboundedSender<Messages>) {
-        self.pushed_messages_tx = Some(pushed_messages_tx);
     }
 }
 

--- a/shotover/src/transforms/kafka/sink_single.rs
+++ b/shotover/src/transforms/kafka/sink_single.rs
@@ -15,7 +15,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use tokio::io::split;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::oneshot;
 use tokio::time::timeout;
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -82,7 +82,6 @@ impl TransformBuilder for KafkaSinkSingleBuilder {
         Box::new(KafkaSinkSingle {
             outbound: None,
             address_port: self.address_port,
-            pushed_messages_tx: None,
             connect_timeout: self.connect_timeout,
             tls: self.tls.clone(),
             read_timeout: self.read_timeout,
@@ -101,7 +100,6 @@ impl TransformBuilder for KafkaSinkSingleBuilder {
 pub struct KafkaSinkSingle {
     address_port: u16,
     outbound: Option<Connection>,
-    pushed_messages_tx: Option<mpsc::UnboundedSender<Messages>>,
     connect_timeout: Duration,
     read_timeout: Option<Duration>,
     tls: Option<TlsConnector>,
@@ -192,10 +190,6 @@ impl Transform for KafkaSinkSingle {
         }
 
         Ok(responses)
-    }
-
-    fn set_pushed_messages_tx(&mut self, pushed_messages_tx: mpsc::UnboundedSender<Messages>) {
-        self.pushed_messages_tx = Some(pushed_messages_tx);
     }
 }
 


### PR DESCRIPTION
While kafka sounds like it would make use of pushed messages due to its pubsub model, responses are never sent without a corresponding request.
A fetch request is resent everytime the client wants another fetch response.

So these pushed messages senders can be just removed, I assume they were originally added due to copy/pasting from another transform as a base and it was just assumed that kafka would need push messages.