### PR TITLE
write ssh instructions to stdout when creating cloud resources

### DIFF
--- a/shotover-proxy/benches/windsock/cloud/mod.rs
+++ b/shotover-proxy/benches/windsock/cloud/mod.rs
@@ -67,6 +67,22 @@ impl Cloud for AwsCloud {
             aws.create_bencher_instances(benches_will_run, 1),
             aws.create_shotover_instances(benches_will_run, required.shotover_instance_count)
         );
+
+        println!();
+        println!("In order to investigate bench failures you may want to ssh into the instances:");
+        for (i, docker) in docker.iter().enumerate() {
+            println!("Docker instance #{i}");
+            println!("{}\n", docker.instance.ssh_instructions());
+        }
+        for (i, shotover) in shotover.iter().enumerate() {
+            println!("Shotover instance #{i}");
+            println!("{}\n", shotover.instance.ssh_instructions());
+        }
+        for (i, bencher) in bencher.iter().enumerate() {
+            println!("Bencher instance #{i}");
+            println!("{}\n", bencher.instance.ssh_instructions());
+        }
+
         let bencher = bencher.pop();
         CloudResources {
             shotover,


### PR DESCRIPTION
Originally I avoided printing these out and instead manually added printlns when I really needed to debug something.
But since we now have cloud creation as a previous step I'm not so worried about the extra noise of printing these.
And the ability to ssh into the machines when something goes wrong is invaluable.