### PR TITLE
windsock: Rename "name" tag to "db"

### DIFF
--- a/.github/workflows/windsock_benches.yaml
+++ b/.github/workflows/windsock_benches.yaml
@@ -37,10 +37,10 @@ jobs:
         echo '1' | sudo tee /proc/sys/kernel/perf_event_paranoid
 
         # run some extra cases that arent handled by nextest
-        cargo windsock local-run --bench-length-seconds 5 --operations-per-second 100 --profilers flamegraph name=cassandra,compression=none,connection_count=1,driver=scylla,operation=read_i64,protocol=v4,shotover=standard,topology=single
-        cargo windsock local-run --bench-length-seconds 5 --operations-per-second 100 --profilers samply name=cassandra,compression=none,connection_count=1,driver=scylla,operation=read_i64,protocol=v4,shotover=standard,topology=single
-        cargo windsock local-run --bench-length-seconds 5 --operations-per-second 100 --profilers sys_monitor name=kafka,shotover=standard,size=1B,topology=single
-        cargo windsock local-run --bench-length-seconds 5 --operations-per-second 100 --profilers shotover_metrics name=redis,encryption=none,operation=get,shotover=standard,topology=single
+        cargo windsock local-run --bench-length-seconds 5 --operations-per-second 100 --profilers flamegraph db=cassandra,compression=none,connection_count=1,driver=scylla,operation=read_i64,protocol=v4,shotover=standard,topology=single
+        cargo windsock local-run --bench-length-seconds 5 --operations-per-second 100 --profilers samply db=cassandra,compression=none,connection_count=1,driver=scylla,operation=read_i64,protocol=v4,shotover=standard,topology=single
+        cargo windsock local-run --bench-length-seconds 5 --operations-per-second 100 --profilers sys_monitor db=kafka,shotover=standard,size=1B,topology=single
+        cargo windsock local-run --bench-length-seconds 5 --operations-per-second 100 --profilers shotover_metrics db=redis,encryption=none,operation=get,shotover=standard,topology=single
     - name: Ensure that tests did not create or modify any files that arent .gitignore'd
       run: |
         if [ -n "$(git status --porcelain)" ]; then

--- a/shotover-proxy/benches/windsock/cassandra/bench.rs
+++ b/shotover-proxy/benches/windsock/cassandra/bench.rs
@@ -473,7 +473,7 @@ impl Bench for CassandraBench {
     fn tags(&self) -> HashMap<String, String> {
         [
             (
-                "name".to_owned(),
+                "db".to_owned(),
                 match &self.db {
                     CassandraDb::Cassandra => "cassandra".to_owned(),
                     CassandraDb::Mocked => "cassandra-mocked".to_owned(),

--- a/shotover-proxy/benches/windsock/kafka/bench.rs
+++ b/shotover-proxy/benches/windsock/kafka/bench.rs
@@ -246,7 +246,7 @@ impl Bench for KafkaBench {
 
     fn tags(&self) -> HashMap<String, String> {
         [
-            ("name".to_owned(), "kafka".to_owned()),
+            ("db".to_owned(), "kafka".to_owned()),
             self.topology.to_tag(),
             self.shotover.to_tag(),
             match self.message_size {

--- a/shotover-proxy/benches/windsock/redis/bench.rs
+++ b/shotover-proxy/benches/windsock/redis/bench.rs
@@ -163,7 +163,7 @@ impl Bench for RedisBench {
 
     fn tags(&self) -> HashMap<String, String> {
         [
-            ("name".to_owned(), "redis".to_owned()),
+            ("db".to_owned(), "redis".to_owned()),
             (
                 "topology".to_owned(),
                 match &self.topology {


### PR DESCRIPTION
Windsock used to special case the "name" tag such that the  `name=` prefix was removed.
To reduce complexity for the user by making tags more predictable that functionality was removed.
However we are still left with tags named "name" when we would be better off calling this tag "db".