### PR TITLE
Port KafkaSinkSingle to Connection

### DIFF
--- a/shotover/src/transforms/redis/sink_single.rs
+++ b/shotover/src/transforms/redis/sink_single.rs
@@ -116,6 +116,7 @@ impl Transform for RedisSinkSingle {
                     &mut self.tls,
                     self.connect_timeout,
                     Some(self.force_run_chain.clone()),
+                    Direction::Sink,
                 )
                 .await?,
             );


### PR DESCRIPTION
This ended up a bit involved since I needed to add dummy response generation to the Connection type in order to get kafka working.
The connection logic used by cluster_connection_pool.rs already has this implemented https://github.com/shotover/shotover-proxy/blob/main/shotover/src/transforms/util/cluster_connection_pool.rs#L290 and many transforms rely on this.
The new implementation in Connection is more robust though, the one in cluster_connection_pool.rs has issues with cancel safety and a possible race condition.

The actual porting of KafkaSinkSingle to Connection is pretty straightforward, is very similar to RedisSinkSingle

windsock benchmarks show no regressions.