### PR TITLE
Fix GA comment creation

### DIFF
--- a/.github/workflows/create_comment.yaml
+++ b/.github/workflows/create_comment.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: 'Download results'
         uses: actions/download-artifact@v4
         with:
-          name: 'comment-info'
+          name: 'comment_info'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
       - run: unzip comment_info.zip


### PR DESCRIPTION
This was broken in https://github.com/shotover/shotover-proxy/pull/1493
no real way to test this without actually checking in, so lets see how this goes.