### PR TITLE
Port CassandraSinkSingle to Connection + remove transform_pushed impementation

### DIFF
--- a/shotover/src/codec/cassandra.rs
+++ b/shotover/src/codec/cassandra.rs
@@ -825,7 +825,7 @@ impl CassandraEncoder {
 
         if let Some(tx) = &self.stream_id_to_request_id_tx {
             let Ok(Metadata::Cassandra(meta)) = m.metadata() else {
-                unreachable!("Gauranteed to be cassandra")
+                unreachable!("Guaranteed to be cassandra")
             };
             tx.send(StreamIdToRequestId {
                 stream_id: meta.stream_id,

--- a/shotover/src/frame/cassandra.rs
+++ b/shotover/src/frame/cassandra.rs
@@ -944,8 +944,8 @@ impl Display for CassandraFrame {
                     }
                     Ok(())
                 }
-                CassandraResult::Void => write!(f, "Result Void"),
-                _ => write!(f, "Result {:?}", result),
+                CassandraResult::Void => write!(f, " Result Void"),
+                _ => write!(f, " Result {:?}", result),
             },
             CassandraOperation::Ready(_) => write!(f, " Ready"),
             _ => write!(f, " {:?}", self.operation),

--- a/shotover/src/message/mod.rs
+++ b/shotover/src/message/mod.rs
@@ -473,7 +473,7 @@ impl Message {
     // TODO: We will have a better idea of how to make this generic once we have multiple out of order protocols
     //       For now its just written to match cassandra's stream_id field
     // TODO: deprecated, just call `metadata()` instead
-    pub fn stream_id(&self) -> Option<i16> {
+    pub(crate) fn stream_id(&self) -> Option<i16> {
         match &self.inner {
             #[cfg(feature = "cassandra")]
             Some(MessageInner::RawBytes {

--- a/shotover/src/server.rs
+++ b/shotover/src/server.rs
@@ -721,11 +721,13 @@ impl<C: CodecBuilder + 'static> Handler<C> {
                 },
             };
 
-            debug!("sending response to client: {:?}", responses);
             // send the result of the process up stream
-            if out_tx.send(responses).is_err() {
-                // the client has disconnected so we should terminate this connection
-                return Ok(());
+            if !responses.is_empty() {
+                debug!("sending response to client: {:?}", responses);
+                if out_tx.send(responses).is_err() {
+                    // the client has disconnected so we should terminate this connection
+                    return Ok(());
+                }
             }
         }
 

--- a/shotover/src/server.rs
+++ b/shotover/src/server.rs
@@ -754,7 +754,7 @@ impl<C: CodecBuilder + 'static> Handler<C> {
             Ok(x) => Ok(x),
             Err(err) => {
                 // An internal error occured and we need to terminate the connection because we can no
-                // longer make any gaurantees about the state its in.
+                // longer make any guarantees about the state its in.
                 // However before we do that we need to return errors for all the messages in this batch for two reasons:
                 // * Poorly programmed clients may hang forever waiting for a response
                 // * We want to give the user a hint as to what went wrong

--- a/shotover/src/transforms/kafka/sink_single.rs
+++ b/shotover/src/transforms/kafka/sink_single.rs
@@ -117,7 +117,7 @@ impl Transform for KafkaSinkSingle {
                 Connection::new(
                     address,
                     codec,
-                    &mut self.tls,
+                    &self.tls,
                     self.connect_timeout,
                     Some(self.force_run_chain.clone()),
                     Direction::Sink,

--- a/shotover/src/transforms/redis/sink_single.rs
+++ b/shotover/src/transforms/redis/sink_single.rs
@@ -113,7 +113,7 @@ impl Transform for RedisSinkSingle {
                 Connection::new(
                     &self.address,
                     codec,
-                    &mut self.tls,
+                    &self.tls,
                     self.connect_timeout,
                     Some(self.force_run_chain.clone()),
                     Direction::Sink,

--- a/test-helpers/src/connection/cassandra.rs
+++ b/test-helpers/src/connection/cassandra.rs
@@ -697,7 +697,7 @@ impl CassandraConnection {
             .build()
     }
 
-    // TODO: lets return Vec<CqlValue> instead, as it provides better gaurantees for correctness
+    // TODO: lets return Vec<CqlValue> instead, as it provides better guarantees for correctness
     fn build_values_scylla(values: &[ResultValue]) -> Vec<Box<dyn SerializeCql + '_>> {
         values
             .iter()


### PR DESCRIPTION
This PR includes two changes that needed to be included in a single PR as they are dependent on each other:
* CassandraSinkSingle uses the new Connection type instead of the old Cassandra specific CassandraConnection.
* CassandraSinkSingle and CassandraPeersRewrite no longer use `Transform::transform_pushed` and instead expect cassandra events to come through the regular `Transform::transform` chain.
    + CassandraPeersRewrite only works with CassandraSinkSingle so they had to be done together but I see no issue with leaving CassandraSinkCluster for another PR.

Additionally this PR adds logic to the cassandra codec to assign request_id's to incoming responses.
This could technically be in a prereq, but its fairly straightforward so I'm including it here.
It follows the exact same logic as the kafka and redis codecs.