### PR TITLE
KafkaSinkCluster use try_recv instead of recv

### DIFF
--- a/shotover/src/transforms/cassandra/sink_single.rs
+++ b/shotover/src/transforms/cassandra/sink_single.rs
@@ -150,6 +150,7 @@ impl CassandraSinkSingle {
                     &self.tls,
                     self.connect_timeout,
                     self.force_run_chain.clone(),
+                    self.read_timeout,
                 )
                 .await?,
             );

--- a/shotover/src/transforms/kafka/sink_cluster/mod.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/mod.rs
@@ -156,7 +156,6 @@ impl TransformBuilder for KafkaSinkClusterBuilder {
         Box::new(KafkaSinkCluster {
             first_contact_points: self.first_contact_points.clone(),
             shotover_nodes: self.shotover_nodes.clone(),
-            read_timeout: self.read_timeout,
             nodes: vec![],
             nodes_shared: self.nodes_shared.clone(),
             controller_broker: self.controller_broker.clone(),
@@ -168,6 +167,7 @@ impl TransformBuilder for KafkaSinkClusterBuilder {
             connection_factory: ConnectionFactory::new(
                 self.tls.clone(),
                 self.connect_timeout,
+                self.read_timeout,
                 transform_context.force_run_chain,
             ),
             first_contact_node: None,
@@ -240,7 +240,6 @@ impl SaslStatus {
 pub struct KafkaSinkCluster {
     first_contact_points: Vec<String>,
     shotover_nodes: Vec<ShotoverNode>,
-    read_timeout: Option<Duration>,
     nodes: Vec<KafkaNode>,
     nodes_shared: Arc<RwLock<Vec<KafkaNode>>>,
     controller_broker: Arc<AtomicBrokerId>,
@@ -306,7 +305,6 @@ impl Transform for KafkaSinkCluster {
                 .collect();
             self.nodes = nodes?;
         }
-
 
         let mut responses = if requests_wrapper.requests.is_empty() {
             // there are no requests, so no point sending any, but we should check for any responses without awaiting

--- a/shotover/src/transforms/kafka/sink_cluster/node.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/node.rs
@@ -12,6 +12,7 @@ use tokio::sync::Notify;
 pub struct ConnectionFactory {
     tls: Option<TlsConnector>,
     connect_timeout: Duration,
+    read_timeout: Option<Duration>,
     handshake_message: Option<Message>,
     auth_message: Option<Message>,
     force_run_chain: Arc<Notify>,
@@ -21,6 +22,7 @@ impl ConnectionFactory {
     pub fn new(
         tls: Option<TlsConnector>,
         connect_timeout: Duration,
+        read_timeout: Option<Duration>,
         force_run_chain: Arc<Notify>,
     ) -> Self {
         ConnectionFactory {
@@ -29,6 +31,7 @@ impl ConnectionFactory {
             handshake_message: None,
             auth_message: None,
             force_run_chain,
+            read_timeout,
         }
     }
 
@@ -49,6 +52,7 @@ impl ConnectionFactory {
             &self.tls,
             self.connect_timeout,
             self.force_run_chain.clone(),
+            self.read_timeout,
         )
         .await?;
 

--- a/shotover/src/transforms/kafka/sink_single.rs
+++ b/shotover/src/transforms/kafka/sink_single.rs
@@ -120,6 +120,7 @@ impl Transform for KafkaSinkSingle {
                     &self.tls,
                     self.connect_timeout,
                     self.force_run_chain.clone(),
+                    self.read_timeout,
                 )
                 .await?,
             );

--- a/shotover/src/transforms/redis/sink_single.rs
+++ b/shotover/src/transforms/redis/sink_single.rs
@@ -116,6 +116,7 @@ impl Transform for RedisSinkSingle {
                     &self.tls,
                     self.connect_timeout,
                     self.force_run_chain.clone(),
+                    None,
                 )
                 .await?,
             );


### PR DESCRIPTION
In this PR we finally receive some of the performance wins the recent refactors have been leading towards.

The changes to make this happen are:
* Fix coordinator logic to use message IDs instead of indexes
    + Its a prereq and I missed this in https://github.com/shotover/shotover-proxy/pull/1548
* Add timeout logic to connection.
    + Without this there is no way to maintain our read timeouts when we swap to try_recv since it is not async.
* Replace Connection::recv with Connection::try_recv
   + this is where the actual performance gains come from
   + Using try_recv means we no longer wait for all messages to arrive and can immediately return from and rerun the chain. This means the sending of more requests is no longer blocked on responses coming back.


1KB messages get +30% throughput and -15% latency :tada: (I know the screenshot gives higher results but the baseline its comparing against was a weaker result due to noise)
100KB messages are getting a far more stable throughput now as well.

![image](https://github.com/shotover/shotover-proxy/assets/5120858/8563bac2-6d76-44a9-951c-8e97f43ef390)
