### PR TITLE
Rename Connection -> ConnectionSink

### DIFF
--- a/shotover/src/server.rs
+++ b/shotover/src/server.rs
@@ -435,7 +435,6 @@ pub fn spawn_read_write_tasks<
     in_tx: mpsc::Sender<Messages>,
     mut out_rx: UnboundedReceiver<Messages>,
     out_tx: UnboundedSender<Messages>,
-    force_run_chain: Option<Arc<Notify>>,
 ) {
     let (decoder, encoder) = codec.build();
     let mut reader = FramedRead::new(rx, decoder);
@@ -467,9 +466,6 @@ pub fn spawn_read_write_tasks<
                                     if in_tx.send(messages).await.is_err() {
                                         // main task has shutdown, this task is no longer needed
                                         return;
-                                    }
-                                    if let Some(force_run_chain) = force_run_chain.as_ref() {
-                                        force_run_chain.notify_one();
                                     }
                                 }
                                 Err(CodecReadError::RespondAndThenCloseConnection(messages)) => {
@@ -618,7 +614,6 @@ impl<C: CodecBuilder + 'static> Handler<C> {
                         in_tx,
                         out_rx,
                         out_tx.clone(),
-                        None,
                     );
                 } else {
                     let (rx, tx) = stream.into_split();
@@ -629,7 +624,6 @@ impl<C: CodecBuilder + 'static> Handler<C> {
                         in_tx,
                         out_rx,
                         out_tx.clone(),
-                        None,
                     );
                 };
             }

--- a/shotover/src/transforms/cassandra/sink_single.rs
+++ b/shotover/src/transforms/cassandra/sink_single.rs
@@ -1,5 +1,5 @@
 use crate::codec::{cassandra::CassandraCodecBuilder, CodecBuilder, Direction};
-use crate::connection::Connection;
+use crate::connection::SinkConnection;
 use crate::frame::cassandra::CassandraMetadata;
 use crate::message::{Messages, Metadata};
 use crate::tls::{TlsConnector, TlsConnectorConfig};
@@ -111,7 +111,7 @@ impl TransformBuilder for CassandraSinkSingleBuilder {
 pub struct CassandraSinkSingle {
     version: Option<Version>,
     address: String,
-    connection: Option<Connection>,
+    connection: Option<SinkConnection>,
     failed_requests: Counter,
     tls: Option<TlsConnector>,
     connect_timeout: Duration,
@@ -144,13 +144,12 @@ impl CassandraSinkSingle {
         if self.connection.is_none() {
             trace!("creating outbound connection {:?}", self.address);
             self.connection = Some(
-                Connection::new(
+                SinkConnection::new(
                     self.address.clone(),
                     self.codec_builder.clone(),
                     &self.tls,
                     self.connect_timeout,
-                    Some(self.force_run_chain.clone()),
-                    Direction::Sink,
+                    self.force_run_chain.clone(),
                 )
                 .await?,
             );

--- a/shotover/src/transforms/kafka/sink_cluster/mod.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/mod.rs
@@ -1,4 +1,4 @@
-use crate::connection::Connection;
+use crate::connection::SinkConnection;
 use crate::frame::kafka::{KafkaFrame, RequestBody, ResponseBody};
 use crate::frame::Frame;
 use crate::message::{Message, MessageIdMap, Messages};
@@ -251,7 +251,7 @@ pub struct KafkaSinkCluster {
     sasl_status: SaslStatus,
     connection_factory: ConnectionFactory,
     first_contact_node: Option<KafkaAddress>,
-    control_connection: Option<Connection>,
+    control_connection: Option<SinkConnection>,
     // its not clear from the docs if this cache needs to be accessed cross connection:
     // https://cwiki.apache.org/confluence/display/KAFKA/KIP-227%3A+Introduce+Incremental+FetchRequests+to+Increase+Partition+Scalability
     fetch_session_id_to_broker: HashMap<i32, BrokerId>,

--- a/shotover/src/transforms/kafka/sink_single.rs
+++ b/shotover/src/transforms/kafka/sink_single.rs
@@ -1,5 +1,5 @@
 use crate::codec::{kafka::KafkaCodecBuilder, CodecBuilder, Direction};
-use crate::connection::Connection;
+use crate::connection::SinkConnection;
 use crate::frame::kafka::{KafkaFrame, RequestBody, ResponseBody};
 use crate::frame::Frame;
 use crate::message::Messages;
@@ -96,7 +96,7 @@ impl TransformBuilder for KafkaSinkSingleBuilder {
 
 pub struct KafkaSinkSingle {
     address_port: u16,
-    connection: Option<Connection>,
+    connection: Option<SinkConnection>,
     connect_timeout: Duration,
     read_timeout: Option<Duration>,
     tls: Option<TlsConnector>,
@@ -114,13 +114,12 @@ impl Transform for KafkaSinkSingle {
             let codec = KafkaCodecBuilder::new(Direction::Sink, "KafkaSinkSingle".to_owned());
             let address = (requests_wrapper.local_addr.ip(), self.address_port);
             self.connection = Some(
-                Connection::new(
+                SinkConnection::new(
                     address,
                     codec,
                     &self.tls,
                     self.connect_timeout,
-                    Some(self.force_run_chain.clone()),
-                    Direction::Sink,
+                    self.force_run_chain.clone(),
                 )
                 .await?,
             );

--- a/shotover/src/transforms/redis/sink_single.rs
+++ b/shotover/src/transforms/redis/sink_single.rs
@@ -1,5 +1,5 @@
 use crate::codec::{CodecBuilder, Direction};
-use crate::connection::Connection;
+use crate::connection::SinkConnection;
 use crate::frame::{Frame, RedisFrame};
 use crate::message::Messages;
 use crate::tls::{TlsConnector, TlsConnectorConfig};
@@ -94,7 +94,7 @@ impl TransformBuilder for RedisSinkSingleBuilder {
 pub struct RedisSinkSingle {
     address: String,
     tls: Option<TlsConnector>,
-    connection: Option<Connection>,
+    connection: Option<SinkConnection>,
     failed_requests: Counter,
     connect_timeout: Duration,
     force_run_chain: Arc<Notify>,
@@ -110,13 +110,12 @@ impl Transform for RedisSinkSingle {
         if self.connection.is_none() {
             let codec = RedisCodecBuilder::new(Direction::Sink, "RedisSinkSingle".to_owned());
             self.connection = Some(
-                Connection::new(
+                SinkConnection::new(
                     &self.address,
                     codec,
                     &self.tls,
                     self.connect_timeout,
-                    Some(self.force_run_chain.clone()),
-                    Direction::Sink,
+                    self.force_run_chain.clone(),
                 )
                 .await?,
             );


### PR DESCRIPTION
Originally I wanted server.rs to make use of the new Connection abstraction: https://github.com/shotover/shotover-proxy/pull/1551

But at this point I think that sink transforms and server.rs have very different needs so its better to just make Connection a sink specific abstraction.
This includes renaming to ConnectionSink and removing all attempts at compatibility with server.rs