### PR TITLE
Update redis-protocol 0.4 to 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1926,7 +1926,7 @@ dependencies = [
  "log",
  "parking_lot",
  "rand 0.8.5",
- "redis-protocol",
+ "redis-protocol 4.1.0",
  "rustls 0.22.2",
  "rustls-native-certs 0.7.0",
  "rustls-webpki 0.102.2",
@@ -3788,6 +3788,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "redis-protocol"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d30496c7ef712556a132b322c57239bea229c76d8508b1794da879888ac93ee"
+dependencies = [
+ "bytes",
+ "bytes-utils",
+ "cookie-factory",
+ "crc16",
+ "log",
+ "nom",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4581,7 +4595,6 @@ dependencies = [
  "bigdecimal",
  "bincode",
  "bytes",
- "bytes-utils",
  "cached",
  "cassandra-protocol",
  "chacha20poly1305",
@@ -4612,7 +4625,7 @@ dependencies = [
  "pretty-hex",
  "rand 0.8.5",
  "rand_distr",
- "redis-protocol",
+ "redis-protocol 5.0.0",
  "rustls 0.22.2",
  "rustls-pemfile 2.1.1",
  "rustls-pki-types",
@@ -4661,7 +4674,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_distr",
  "redis",
- "redis-protocol",
+ "redis-protocol 5.0.0",
  "regex",
  "reqwest 0.12.0",
  "rstest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ rcgen = "0.12.0"
 subprocess = "0.2.7"
 chacha20poly1305 = { version = "0.10.0", features = ["std"] }
 csv = "1.2.0"
-redis-protocol = { version = "4.0.1", features = ["decode-mut"] }
+redis-protocol = { version = "5.0.0", features = ["bytes"] }
 bincode = "1.3.1"
 futures = "0.3"
 hex = "0.4.3"

--- a/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
+++ b/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
@@ -1309,7 +1309,7 @@ async fn read_redis_message(connection: &mut TcpStream) -> RedisFrame {
     let mut buffer = BytesMut::new();
     loop {
         if let Ok(Some((result, len))) =
-            redis_protocol::resp2::decode::decode(&buffer.clone().freeze())
+            redis_protocol::resp2::decode::decode_bytes(&buffer.clone().freeze())
         {
             let _ = buffer.split_to(len);
             return result;

--- a/shotover/Cargo.toml
+++ b/shotover/Cargo.toml
@@ -38,7 +38,6 @@ redis = [
     "dep:redis-protocol",
     "dep:csv",
     "dep:crc16",
-    "dep:bytes-utils"
 ]
 opensearch = [
     "dep:atoi",
@@ -52,7 +51,6 @@ atomic_enum = "0.3.0"
 axum = { version = "0.7", default-features = false, features = ["tokio", "tracing", "http1"] }
 pretty-hex = "0.4.0"
 tokio-stream = "0.1.2"
-bytes-utils = { version = "0.1.1", optional = true }
 derivative = "2.1.1"
 cached = { version = "0.49", features = ["async"], optional = true }
 governor = { version = "0.6", default-features = false, features = ["std", "jitter", "quanta"] }

--- a/shotover/src/frame/mod.rs
+++ b/shotover/src/frame/mod.rs
@@ -12,7 +12,7 @@ use kafka::KafkaFrame;
 #[cfg(feature = "opensearch")]
 pub use opensearch::OpenSearchFrame;
 #[cfg(feature = "redis")]
-pub use redis_protocol::resp2::types::Frame as RedisFrame;
+pub use redis_protocol::resp2::types::BytesFrame as RedisFrame;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 #[cfg(feature = "cassandra")]
@@ -131,7 +131,7 @@ impl Frame {
                 CassandraFrame::from_bytes(bytes, codec_state.as_cassandra()).map(Frame::Cassandra)
             }
             #[cfg(feature = "redis")]
-            MessageType::Redis => redis_protocol::resp2::decode::decode(&bytes)
+            MessageType::Redis => redis_protocol::resp2::decode::decode_bytes(&bytes)
                 .map(|x| Frame::Redis(x.unwrap().0))
                 .map_err(|e| anyhow!("{e:?}")),
             #[cfg(feature = "kafka")]


### PR DESCRIPTION
* The "decode-mut" feature is now under the "bytes" feature
* A bunch of methods and types were renamed
* the Redirection type + to_redirection method were removed, they are quite simple so I just reimplemented them in RedisSinkCluster.
* bytes-utils is now reexported within redis-protocol, since we only use that for interacting with redis-protocol, we now use the reexport instead of bytes-utils directly.