### PR TITLE
Remove version field from all docker-compose.yaml

### DIFF
--- a/custom-transforms-example/config/docker-compose.yaml
+++ b/custom-transforms-example/config/docker-compose.yaml
@@ -1,9 +1,8 @@
-version: "3.3"
 services:
   redis-one:
     image: library/redis:5.0.9
     ports:
       - "1111:6379"
     volumes:
-    - ./redis.conf:/usr/local/etc/redis/redis.conf
-    command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
+      - ./redis.conf:/usr/local/etc/redis/redis.conf
+    command: [ "redis-server", "/usr/local/etc/redis/redis.conf" ]

--- a/docs/src/examples/redis-clustering-unaware.md
+++ b/docs/src/examples/redis-clustering-unaware.md
@@ -20,7 +20,6 @@ This more accurately reflects a real production use but will take a bit more set
 And reduce the docker-compose.yaml to just the shotover part
 
 ```yaml
-version: '3.3'
 services:
   shotover-0:
     networks:

--- a/shotover-proxy/tests/test-configs/cassandra/cassandra-5/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra/cassandra-5/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   cassandra-one:
     image: shotover/cassandra-test:5.0-beta1-r2

--- a/shotover-proxy/tests/test-configs/cassandra/cluster-multi-rack-2-per-rack/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra/cluster-multi-rack-2-per-rack/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 networks:
   cluster_subnet:
     name: cluster_subnet

--- a/shotover-proxy/tests/test-configs/cassandra/cluster-multi-rack/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra/cluster-multi-rack/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 networks:
   cluster_subnet:
     name: cluster_subnet

--- a/shotover-proxy/tests/test-configs/cassandra/cluster-tls/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra/cluster-tls/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 networks:
   cluster_subnet:
     name: cluster_subnet

--- a/shotover-proxy/tests/test-configs/cassandra/cluster-v3/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra/cluster-v3/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 networks:
   cluster_subnet:
     name: cluster_subnet

--- a/shotover-proxy/tests/test-configs/cassandra/cluster-v4/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra/cluster-v4/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 networks:
   cluster_subnet:
     name: cluster_subnet

--- a/shotover-proxy/tests/test-configs/cassandra/cluster-v5/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra/cluster-v5/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 networks:
   cluster_subnet:
     name: cluster_subnet

--- a/shotover-proxy/tests/test-configs/cassandra/passthrough-parse-request/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra/passthrough-parse-request/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   cassandra-one:
     image: shotover/cassandra-test:4.0.6-r1

--- a/shotover-proxy/tests/test-configs/cassandra/passthrough-parse-response/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra/passthrough-parse-response/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   cassandra-one:
     image: shotover/cassandra-test:4.0.6-r1

--- a/shotover-proxy/tests/test-configs/cassandra/passthrough-websocket-tls/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra/passthrough-websocket-tls/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   cassandra-one:
     image: shotover/cassandra-test:4.0.6-r1

--- a/shotover-proxy/tests/test-configs/cassandra/passthrough-websocket/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra/passthrough-websocket/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   cassandra-one:
     image: shotover/cassandra-test:4.0.6-r1

--- a/shotover-proxy/tests/test-configs/cassandra/passthrough/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra/passthrough/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   cassandra-one:
     image: shotover/cassandra-test:4.0.6-r1

--- a/shotover-proxy/tests/test-configs/cassandra/peers-rewrite/docker-compose-3.11-cassandra.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra/peers-rewrite/docker-compose-3.11-cassandra.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 networks:
   cluster_subnet:
     name: cluster_subnet

--- a/shotover-proxy/tests/test-configs/cassandra/peers-rewrite/docker-compose-4.0-cassandra.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra/peers-rewrite/docker-compose-4.0-cassandra.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 networks:
   cluster_subnet:
     name: cluster_subnet

--- a/shotover-proxy/tests/test-configs/cassandra/protect-aws/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra/protect-aws/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   cassandra-one:
     image: shotover/cassandra-test:4.0.6-r1

--- a/shotover-proxy/tests/test-configs/cassandra/protect-local/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra/protect-local/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   cassandra-one:
     image: shotover/cassandra-test:4.0.6-r1

--- a/shotover-proxy/tests/test-configs/cassandra/redis-cache/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra/redis-cache/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   redis-one:
     image: library/redis:5.0.9

--- a/shotover-proxy/tests/test-configs/cassandra/request-throttling/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra/request-throttling/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   cassandra-one:
     image: shotover/cassandra-test:4.0.6-r1

--- a/shotover-proxy/tests/test-configs/cassandra/tls/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra/tls/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   cassandra-one:
     image: shotover/cassandra-test:4.0.6-r1

--- a/shotover-proxy/tests/test-configs/kafka/bench/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/bench/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   kafka0:
     image: 'bitnami/kafka:3.6.1-debian-11-r24'

--- a/shotover-proxy/tests/test-configs/kafka/cluster-1-rack/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-1-rack/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 networks:
   cluster_subnet:
     name: cluster_subnet

--- a/shotover-proxy/tests/test-configs/kafka/cluster-2-racks/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-2-racks/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 networks:
   cluster_subnet:
     name: cluster_subnet

--- a/shotover-proxy/tests/test-configs/kafka/cluster-sasl/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-sasl/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3'
-
 networks:
   cluster_subnet:
     name: cluster_subnet

--- a/shotover-proxy/tests/test-configs/kafka/cluster-tls/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-tls/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 networks:
   cluster_subnet:
     name: cluster_subnet

--- a/shotover-proxy/tests/test-configs/kafka/passthrough-sasl/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/passthrough-sasl/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   kafka:
     image: 'bitnami/kafka:3.6.1-debian-11-r24'
@@ -23,4 +21,3 @@ services:
       - KAFKA_CFG_SASL_MECHANISM_INTER_BROKER_PROTOCOL=PLAIN
       - KAFKA_INTER_BROKER_USER=controller_user
       - KAFKA_INTER_BROKER_PASSWORD=controller_password
-

--- a/shotover-proxy/tests/test-configs/kafka/passthrough-tls/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/passthrough-tls/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   kafka0:
     image: 'bitnami/kafka:3.6.1-debian-11-r24'

--- a/shotover-proxy/tests/test-configs/kafka/passthrough/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/passthrough/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   kafka0:
     image: 'bitnami/kafka:3.6.1-debian-11-r24'

--- a/shotover-proxy/tests/test-configs/log-to-file/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/log-to-file/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   redis-one:
     image: library/redis:5.0.9

--- a/shotover-proxy/tests/test-configs/opensearch-passthrough/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/opensearch-passthrough/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   opensearch-node1:
     image: opensearchproject/opensearch:2.9.0
@@ -23,4 +22,3 @@ services:
     ports:
       - 9200:9200
       - 9600:9600
-

--- a/shotover-proxy/tests/test-configs/redis/cluster-auth/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/redis/cluster-auth/docker-compose.yaml
@@ -1,11 +1,9 @@
-version: '3.3'
 services:
   redis-node-0:
     image: &image bitnami/redis-cluster:6.2.12-debian-11-r26
     ports:
       - "2230:6379"
-    environment:
-      &environment
+    environment: &environment
       - 'REDIS_PASSWORD=shotover'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
 

--- a/shotover-proxy/tests/test-configs/redis/cluster-dr/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/redis/cluster-dr/docker-compose.yaml
@@ -1,11 +1,9 @@
-version: '3.3'
 services:
   redis-node-0:
     image: &image bitnami/redis-cluster:6.2.12-debian-11-r26
     ports:
       - "2220:6379"
-    environment:
-      &node-environment
+    environment: &node-environment
       - 'REDIS_PASSWORD=shotover'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
 
@@ -59,8 +57,7 @@ services:
     image: *image
     ports:
       - "2120:6379"
-    environment:
-      &dr-environment
+    environment: &dr-environment
       - 'REDIS_PASSWORD=shotover'
       - 'REDIS_NODES=redis-node-0-dr redis-node-1-dr redis-node-2-dr redis-node-3-dr redis-node-4-dr redis-node-5-dr'
 

--- a/shotover-proxy/tests/test-configs/redis/cluster-handling/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/redis/cluster-handling/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.3'
 networks:
   cluster_subnet:
     name: cluster_subnet
@@ -14,8 +13,7 @@ services:
       cluster_subnet:
         ipv4_address: 172.16.1.2
     image: &image bitnami/redis-cluster:6.2.12-debian-11-r26
-    environment:
-      &environment
+    environment: &environment
       - 'ALLOW_EMPTY_PASSWORD=yes'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
 

--- a/shotover-proxy/tests/test-configs/redis/cluster-hiding/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/redis/cluster-hiding/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.3'
 networks:
   cluster_subnet:
     name: cluster_subnet
@@ -14,8 +13,7 @@ services:
       cluster_subnet:
         ipv4_address: 172.16.1.2
     image: &image bitnami/redis-cluster:6.2.12-debian-11-r26
-    environment:
-      &environment
+    environment: &environment
       - 'ALLOW_EMPTY_PASSWORD=yes'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
 

--- a/shotover-proxy/tests/test-configs/redis/cluster-ports-rewrite/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/redis/cluster-ports-rewrite/docker-compose.yaml
@@ -1,11 +1,9 @@
-version: '3.3'
 services:
   redis-node-0:
     image: &image bitnami/redis-cluster:6.2.12-debian-11-r26
     ports:
       - "2220:6379"
-    environment:
-      &environment
+    environment: &environment
       - 'ALLOW_EMPTY_PASSWORD=yes'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
 

--- a/shotover-proxy/tests/test-configs/redis/cluster-tls/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/redis/cluster-tls/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.3'
 networks:
   cluster_subnet:
     name: cluster_subnet
@@ -18,8 +17,7 @@ services:
     volumes:
       - &keys ../tls/certs:/usr/local/etc/redis/certs
 
-    environment:
-      &node_environment
+    environment: &node_environment
       - 'ALLOW_EMPTY_PASSWORD=yes'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
       - 'REDIS_TLS_PORT=6379'

--- a/shotover-proxy/tests/test-configs/redis/multi/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/redis/multi/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   redis-one:
     image: &image library/redis:5.0.9

--- a/shotover-proxy/tests/test-configs/redis/passthrough/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/redis/passthrough/docker-compose.yaml
@@ -1,9 +1,8 @@
-version: "3.3"
 services:
   redis-one:
     image: library/redis:5.0.9
     ports:
       - "1111:6379"
     volumes:
-    - ./redis.conf:/usr/local/etc/redis/redis.conf
-    command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
+      - ./redis.conf:/usr/local/etc/redis/redis.conf
+    command: [ "redis-server", "/usr/local/etc/redis/redis.conf" ]

--- a/shotover-proxy/tests/test-configs/redis/tls-no-client-auth/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/redis/tls-no-client-auth/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   redis-one:
     image: bitnami/redis:6.2.13-debian-11-r73

--- a/shotover-proxy/tests/test-configs/redis/tls-no-verify-hostname/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/redis/tls-no-verify-hostname/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   redis-one:
     image: bitnami/redis:6.2.13-debian-11-r73

--- a/shotover-proxy/tests/test-configs/redis/tls/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/redis/tls/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   redis-one:
     image: bitnami/redis:6.2.13-debian-11-r73

--- a/shotover-proxy/tests/transforms/docker-compose-moto.yaml
+++ b/shotover-proxy/tests/transforms/docker-compose-moto.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   moto:
     image: "motoserver/moto"


### PR DESCRIPTION
This field has been deprecated in the latest release of docker-compose which I am running on my machine.
As a result a warning message is emitted before the actual output of commands such as `docker compose ps`. This breaks our parsing of the output causing our integration tests to fail on my machine.

I've raised https://github.com/shotover/docker-compose-runner/issues/17 to properly fix the parsing issue.
For now this PR resolves the issue by removing the use of the deprecated field.