### PR TITLE
Use upstream nextest

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,7 +1,10 @@
 [profile.default]
 fail-fast = false
 slow-timeout = { period = '5m', terminate-after = 2 }
-archive-include = ["debug/jassets", "release/jassets"]
+archive.include = [
+    { path = "debug/jassets", relative-to = "target" },
+    { path = "release/jassets", relative-to = "target" },
+]
 
 # Overwrites profile.default when the filter matches
 [[profile.default.overrides]]

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -57,11 +57,10 @@ jobs:
         key: ubuntu-20.04-packages
     - name: Install ubuntu packages
       run: shotover-proxy/build/install_ubuntu_packages.sh
-    #- name: Install nextest
-    #  uses: taiki-e/install-action@v2
-    #  with:
-    #    tool: nextest@0.9.57
-    - run: cargo install --git https://github.com/rukai/nextest --branch archive-include-legacy cargo-nextest
+    - name: Install nextest
+      uses: taiki-e/install-action@v2
+      with:
+        tool: nextest@0.9.70
     - name: Build tests
       run: |
         cargo test --doc ${{ matrix.cargo_flags }} --all-features -- --show-output --nocapture
@@ -110,7 +109,7 @@ jobs:
     - name: Install nextest
       uses: taiki-e/install-action@v2
       with:
-        tool: nextest@0.9.57
+        tool: nextest@0.9.70
     - run: mkdir -p ~/.cargo/bin
     - name: Download archive
       uses: actions/download-artifact@v4


### PR DESCRIPTION
The latest nextest release now supports including extra files into the nextest archive: https://github.com/nextest-rs/nextest/issues/1340

Previously we were temporarily relying on a nextest fork to get this functionality but now we can swap back to upstream.