### PR TITLE
CassandraSinkCluster rewrite.rs fix

### DIFF
--- a/shotover/src/transforms/cassandra/sink_cluster/rewrite.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/rewrite.rs
@@ -70,14 +70,14 @@ impl MessageRewriter {
         pool: &mut NodePool,
         version: Version,
     ) -> Result<()> {
-        for (i, message) in messages.iter_mut().enumerate() {
-            if let Some(rewrite) = self.get_rewrite_table(i, message) {
-                self.to_rewrite.push(rewrite);
-            }
-        }
+        let mut new_rewrites: Vec<_> = messages
+            .iter_mut()
+            .enumerate()
+            .filter_map(|(i, message)| self.get_rewrite_table(i, message))
+            .collect();
 
         // Insert the extra messages required by table rewrites.
-        for table_to_rewrite in &mut self.to_rewrite {
+        for table_to_rewrite in &mut new_rewrites {
             match &table_to_rewrite.ty {
                 RewriteTableTy::Local => {
                     let query = "SELECT rack, data_center, schema_version, tokens, release_version FROM system.peers";
@@ -138,6 +138,7 @@ impl MessageRewriter {
                 }
             }
         }
+        self.to_rewrite.extend(new_rewrites);
 
         Ok(())
     }


### PR DESCRIPTION
Previously we were modifying `self.to_rewrite` assuming that it only contained `TableToRewrite`s from the current request batch but it may actually contain `TableToRewrite`s from previous request batches as well.

This happens to work currently since we complete rewriting within a single request batch, but as of https://github.com/shotover/shotover-proxy/pull/1553 that will no longer be the case.