### PR TITLE
Avoid cloning client_details

### DIFF
--- a/shotover/benches/benches/chain.rs
+++ b/shotover/benches/benches/chain.rs
@@ -40,7 +40,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("loopback", |b| {
             b.to_async(&rt).iter_batched(
                 || BenchInput {
-                    chain: chain.build(TransformContextBuilder::new()),
+                    chain: chain.build(TransformContextBuilder::new_test()),
                     wrapper: wrapper.clone(),
                 },
                 BenchInput::bench,
@@ -59,7 +59,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("nullsink", |b| {
             b.to_async(&rt).iter_batched(
                 || BenchInput {
-                    chain: chain.build(TransformContextBuilder::new()),
+                    chain: chain.build(TransformContextBuilder::new_test()),
                     wrapper: wrapper.clone(),
                 },
                 BenchInput::bench,
@@ -97,7 +97,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("redis_filter", |b| {
             b.to_async(&rt).iter_batched(
                 || BenchInput {
-                    chain: chain.build(TransformContextBuilder::new()),
+                    chain: chain.build(TransformContextBuilder::new_test()),
                     wrapper: wrapper.clone(),
                 },
                 BenchInput::bench,
@@ -131,7 +131,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("redis_timestamp_tagger_untagged", |b| {
             b.to_async(&rt).iter_batched(
                 || BenchInput {
-                    chain: chain.build(TransformContextBuilder::new()),
+                    chain: chain.build(TransformContextBuilder::new_test()),
                     wrapper: wrapper_set.clone(),
                 },
                 BenchInput::bench,
@@ -150,7 +150,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("redis_timestamp_tagger_tagged", |b| {
             b.to_async(&rt).iter_batched(
                 || BenchInput {
-                    chain: chain.build(TransformContextBuilder::new()),
+                    chain: chain.build(TransformContextBuilder::new_test()),
                     wrapper: wrapper_get.clone(),
                 },
                 BenchInput::bench,
@@ -179,7 +179,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("redis_cluster_ports_rewrite", |b| {
             b.to_async(&rt).iter_batched(
                 || BenchInput {
-                    chain: chain.build(TransformContextBuilder::new()),
+                    chain: chain.build(TransformContextBuilder::new_test()),
                     wrapper: wrapper.clone(),
                 },
                 BenchInput::bench,
@@ -226,7 +226,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("cassandra_request_throttling_unparsed", |b| {
             b.to_async(&rt).iter_batched(
                 || BenchInput {
-                    chain: chain.build(TransformContextBuilder::new()),
+                    chain: chain.build(TransformContextBuilder::new_test()),
                     wrapper: wrapper.clone(),
                 },
                 BenchInput::bench,
@@ -280,7 +280,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("cassandra_rewrite_peers_passthrough", |b| {
             b.to_async(&rt).iter_batched(
                 || BenchInput {
-                    chain: chain.build(TransformContextBuilder::new()),
+                    chain: chain.build(TransformContextBuilder::new_test()),
                     wrapper: wrapper.clone(),
                 },
                 BenchInput::bench,
@@ -326,7 +326,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("cassandra_protect_unprotected", |b| {
             b.to_async(&rt).iter_batched(
                 || BenchInput {
-                    chain: chain.build(TransformContextBuilder::new()),
+                    chain: chain.build(TransformContextBuilder::new_test()),
                     wrapper: wrapper.clone(),
                 },
                 BenchInput::bench,
@@ -341,7 +341,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("cassandra_protect_protected", |b| {
             b.to_async(&rt).iter_batched(
                 || BenchInput {
-                    chain: chain.build(TransformContextBuilder::new()),
+                    chain: chain.build(TransformContextBuilder::new_test()),
                     wrapper: wrapper.clone(),
                 },
                 BenchInput::bench,

--- a/shotover/src/transforms/distributed/tuneable_consistency_scatter.rs
+++ b/shotover/src/transforms/distributed/tuneable_consistency_scatter.rs
@@ -319,7 +319,7 @@ mod scatter_transform_tests {
     }
 
     fn build_chains(route_map: HashMap<String, TransformChainBuilder>) -> Vec<BufferedChain> {
-        let context = TransformContextBuilder::new();
+        let context = TransformContextBuilder::new_test();
         route_map
             .into_values()
             .map(|x| x.build_buffered(10, context.clone()))

--- a/shotover/src/transforms/mod.rs
+++ b/shotover/src/transforms/mod.rs
@@ -54,13 +54,15 @@ pub struct TransformContextBuilder {
     /// * This must be used when a sink transform has asynchronously received responses in the background
     /// * This should be used when a transform needs to generate or flush messages after some kind of timeout or background process completes.
     pub force_run_chain: Arc<Notify>,
+    pub client_details: String,
 }
 
 #[allow(clippy::new_without_default)]
 impl TransformContextBuilder {
-    pub fn new() -> Self {
+    pub fn new_test() -> Self {
         TransformContextBuilder {
             force_run_chain: Arc::new(Notify::new()),
+            client_details: String::new(),
         }
     }
 }
@@ -107,7 +109,6 @@ pub struct TransformContextConfig {
 pub struct Wrapper<'a> {
     pub requests: Messages,
     transforms: TransformIter<'a>,
-    pub client_details: String,
     /// Contains the shotover source's ip address and port which the message was received on
     pub local_addr: SocketAddr,
     /// When true transforms must flush any buffered messages into the messages field.
@@ -150,7 +151,6 @@ impl<'a> Clone for Wrapper<'a> {
         Wrapper {
             requests: self.requests.clone(),
             transforms: TransformIter::new_forwards(&mut []),
-            client_details: self.client_details.clone(),
             local_addr: self.local_addr,
             flush: self.flush,
         }
@@ -231,7 +231,6 @@ impl<'a> Wrapper<'a> {
         Wrapper {
             requests,
             transforms: TransformIter::new_forwards(&mut []),
-            client_details: "".to_owned(),
             local_addr: "127.0.0.1:8000".parse().unwrap(),
             flush: false,
         }
@@ -241,7 +240,6 @@ impl<'a> Wrapper<'a> {
         Wrapper {
             requests,
             transforms: TransformIter::new_forwards(&mut []),
-            client_details: "".to_owned(),
             local_addr,
             flush: false,
         }
@@ -251,24 +249,9 @@ impl<'a> Wrapper<'a> {
         Wrapper {
             requests: vec![],
             transforms: TransformIter::new_forwards(&mut []),
-            client_details: "".to_owned(),
             // The connection is closed so we need to just fake an address here
             local_addr: "127.0.0.1:10000".parse().unwrap(),
             flush: true,
-        }
-    }
-
-    pub fn new_with_client_details(
-        requests: Messages,
-        client_details: String,
-        local_addr: SocketAddr,
-    ) -> Self {
-        Wrapper {
-            requests,
-            transforms: TransformIter::new_forwards(&mut []),
-            client_details,
-            local_addr,
-            flush: false,
         }
     }
 


### PR DESCRIPTION
This PR moves client_details from being passed at chain run time to chain build time.

This improves performance in 2 ways:
* client_details string is no longer reallocated and deallocated every chain run
* shotover_chain_latency histogram is no longer recreated every chain run

This results in a very nice improvement to chain overhead, 25% faster in a chain containing just a loopback transform:
![image](https://github.com/shotover/shotover-proxy/assets/5120858/c42874e9-6811-48fe-a22f-11ce61b519fa)

In reality this is a very small win for actual workloads, I'm guessing ~0.3% from what I could see in the profiler, but since it improves performance for all protocols and workloads its very much worth doing.