### PR TITLE
fix CassandraSinkCluster rewrite logic

### DIFF
--- a/shotover/src/transforms/cassandra/sink_cluster/rewrite.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/rewrite.rs
@@ -237,11 +237,10 @@ impl MessageRewriter {
         }
 
         for message_or_id in table.collected_messages.iter_mut() {
-            let MessageOrId::Id(id) = message_or_id else {
-                break;
-            };
-            if let Some(i) = responses.iter().position(|x| x.request_id() == Some(*id)) {
-                *message_or_id = MessageOrId::Message(responses.swap_remove(i));
+            if let MessageOrId::Id(id) = message_or_id {
+                if let Some(i) = responses.iter().position(|x| x.request_id() == Some(*id)) {
+                    *message_or_id = MessageOrId::Message(responses.swap_remove(i));
+                }
             }
         }
 


### PR DESCRIPTION
Currently CassandraSinkCluster rewrite logic relies on the responses arriving in order but https://github.com/shotover/shotover-proxy/pull/1567 will change them to be out of order.

This PR fixes the rewrite logic so it no longer gives up if it encounters an out of order message.