### PR TITLE
SinkConnection improvements

### DIFF
--- a/shotover/src/transforms/cassandra/sink_cluster/topology.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/topology.rs
@@ -102,8 +102,8 @@ async fn topology_task_process(
             // Wait for events to come in from the cassandra node.
             // If all the nodes receivers are closed then immediately stop listening and shutdown the task
             tokio::select! {
-                responses = connection.recv() => match responses {
-                    Ok(responses) => events.extend(responses),
+                responses = connection.recv_into(&mut events) => match responses {
+                    Ok(()) => {}
                     Err(err) => return Err(anyhow!(err).context("topology control connection was closed")),
                 },
                 _ = nodes_tx.closed() => return Ok(())

--- a/shotover/src/transforms/kafka/sink_cluster/mod.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/mod.rs
@@ -785,7 +785,8 @@ impl KafkaSinkCluster {
     fn recv_responses(&mut self) -> Result<Vec<Message>> {
         for node in &mut self.nodes {
             if let Some(connection) = node.get_connection_if_open() {
-                if let Ok(responses) = connection.try_recv() {
+                let mut responses = vec![];
+                if let Ok(()) = connection.try_recv_into(&mut responses) {
                     for response in responses {
                         let mut response = Some(response);
                         for pending_request in &mut self.pending_requests {


### PR DESCRIPTION
This PR improves SinkConnection to be more robust and efficient. https://github.com/shotover/shotover-proxy/pull/1565 started on this work but I didnt realize how deep the issue went.

1. First I realized that the fix in #1565 only fixed try_recv. recv had the same issue and that was unfixed. So this PR adds the fix to `recv` as well.
2. I realized that fixing #1565 introduced a bunch of needless allocations. The fix to this is to have the user pass in the `&mut Vec<Message>` that they will be adding to. This is a fairly ergonomic solution since sinks often directly append the result to another vec anyway.
    + In doing this I renamed `recv` -> `recv_into` and `try_recv` -> `try_recv_into` to better suit the new functionality.
    + Additionally I had to port all the transforms to use this new API.
    