### PR TITLE
KafkaSinkCluster accept shotover addresses as domain names

### DIFF
--- a/shotover-proxy/tests/test-configs/kafka/cluster-2-racks/topology-rack1.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-2-racks/topology-rack1.yaml
@@ -6,10 +6,10 @@ sources:
       chain:
         - KafkaSinkCluster:
             shotover_nodes:
-              - address: "127.0.0.1:9191"
+              - address: "localhost:9191"
                 rack: "rack1"
                 broker_id: 0
-              - address: "127.0.0.1:9192"
+              - address: "localhost:9192"
                 rack: "rack2"
                 broker_id: 1
             first_contact_points: ["172.16.1.2:9092"]

--- a/shotover-proxy/tests/test-configs/kafka/cluster-2-racks/topology-rack2.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-2-racks/topology-rack2.yaml
@@ -6,10 +6,10 @@ sources:
       chain:
         - KafkaSinkCluster:
             shotover_nodes:
-              - address: "127.0.0.1:9191"
+              - address: "localhost:9191"
                 rack: "rack1"
                 broker_id: 0
-              - address: "127.0.0.1:9192"
+              - address: "localhost:9192"
                 rack: "rack2"
                 broker_id: 1
             first_contact_points: ["172.16.1.5:9092"]

--- a/test-helpers/src/connection/kafka/cpp.rs
+++ b/test-helpers/src/connection/kafka/cpp.rs
@@ -25,6 +25,7 @@ impl KafkaConnectionBuilderCpp {
         let mut client = ClientConfig::new();
         client
             .set("bootstrap.servers", address)
+            .set("broker.address.family", "v4")
             // internal driver debug logs are emitted to tokio tracing, assuming the appropriate filter is used by the tracing subscriber
             .set("debug", "all");
         KafkaConnectionBuilderCpp { client }


### PR DESCRIPTION
We should be able to specify the addresses of shotover nodes as a domain name.
This PR makes that possible by allowing the host name to be an arbitrary string.