### PR TITLE
Remove dummy message insertion

### DIFF
--- a/shotover/src/transforms/mod.rs
+++ b/shotover/src/transforms/mod.rs
@@ -316,7 +316,7 @@ pub trait Transform: Send {
     ///     + This type of transform is called a Terminating transform (as no subsequent transforms in the chain will be called).
     ///
     /// * Request/Response invariants:
-    ///     + Transforms must ensure that each request that passes through the transform has a corresponding response returned for it.
+    ///     + Transforms must ensure that each request that passes through the transform has a corresponding response returned for it if and only if [`Message::has_response`] is true for the request.
     ///         - A response/request pair can be identified by calling `request_id()` on a response and matching that to the `id()` of a previous request.
     ///         - The response does not need to be returned within the same call to [`Transform::transform`] that the request was encountered.
     ///           But it must be returned eventually over the lifetime of the transform.


### PR DESCRIPTION
Some protocols, so far only kafka, have some requests which do not trigger a response.
This is forbidden by our transform invariants, so to handle this we have logic in SinkConnection to insert dummy responses that correspond to those requests.
This works but I've done some thinking and I am proposing that we throw this away and instead have the user just call the new `respondable_id()` method when they need to wait for a response on a protocol which may not send a response:
* The dummy insertion logic is very complicated, I'd rather not have to maintain it. For example I think its causing mysterious problems with https://github.com/shotover/shotover-proxy/pull/1569
* It should be a performance improvement for cases with many responseless requests, for example a kafka client configured with `acks = 0`:
   + In SinkConnection, avoids bookkeeping vec allocations, message vec insertions.
   + In certain transforms, responseless requests do not need to have their ID's inserted and removed from hashmaps to correlate to a response that is in reality only a dummy response to be ignored.
* We are swapping around complexity, hard to say which is better.
   + Previously, transforms for certain protocols need to handle the possibility of some responses containing Dummy frames instead of the frame of the protocol.
   + With this PR, transforms for certain protocols need to call `respondable_id()` instead of `id()` when correlating responses to requests, currently none of our transforms actually need to do this.
