### PR TITLE
KafkaSinkCluster: support topics with multiple partitions

### DIFF
--- a/shotover-proxy/tests/kafka_int_tests/mod.rs
+++ b/shotover-proxy/tests/kafka_int_tests/mod.rs
@@ -66,7 +66,7 @@ async fn cluster_tls(#[case] driver: KafkaDriver) {
 
     let connection_builder = KafkaConnectionBuilder::new(driver, "127.0.0.1:9192")
         .use_tls("tests/test-configs/kafka/tls/certs/kafka.keystore.jks");
-    test_cases::cluster_test_suite(connection_builder).await;
+    test_cases::standard_test_suite(connection_builder).await;
 
     tokio::time::timeout(
         Duration::from_secs(10),
@@ -144,7 +144,7 @@ async fn cluster_1_rack_single_shotover(#[case] driver: KafkaDriver) {
         .await;
 
     let connection_builder = KafkaConnectionBuilder::new(driver, "127.0.0.1:9192");
-    test_cases::cluster_test_suite(connection_builder).await;
+    test_cases::standard_test_suite(connection_builder).await;
 
     tokio::time::timeout(
         Duration::from_secs(10),
@@ -178,7 +178,7 @@ async fn cluster_1_rack_multi_shotover(#[case] driver: KafkaDriver) {
     }
 
     let connection_builder = KafkaConnectionBuilder::new(driver, "127.0.0.1:9192");
-    test_cases::cluster_test_suite(connection_builder).await;
+    test_cases::standard_test_suite(connection_builder).await;
 
     for shotover in shotovers {
         tokio::time::timeout(
@@ -216,7 +216,7 @@ async fn cluster_2_racks_multi_shotover(#[case] driver: KafkaDriver) {
     }
 
     let connection_builder = KafkaConnectionBuilder::new(driver, "127.0.0.1:9192");
-    test_cases::cluster_test_suite(connection_builder).await;
+    test_cases::standard_test_suite(connection_builder).await;
 
     for shotover in shotovers {
         tokio::time::timeout(
@@ -242,7 +242,7 @@ async fn cluster_sasl_single_shotover(#[case] driver: KafkaDriver) {
 
     let connection_builder =
         KafkaConnectionBuilder::new(driver, "127.0.0.1:9192").use_sasl("user", "password");
-    test_cases::cluster_test_suite(connection_builder).await;
+    test_cases::standard_test_suite(connection_builder).await;
 
     tokio::time::timeout(
         Duration::from_secs(10),
@@ -277,7 +277,7 @@ async fn cluster_sasl_multi_shotover(#[case] driver: KafkaDriver) {
 
     let connection_builder =
         KafkaConnectionBuilder::new(driver, "127.0.0.1:9192").use_sasl("user", "password");
-    test_cases::cluster_test_suite(connection_builder).await;
+    test_cases::standard_test_suite(connection_builder).await;
 
     for shotover in shotovers {
         tokio::time::timeout(

--- a/shotover-proxy/tests/kafka_int_tests/test_cases.rs
+++ b/shotover-proxy/tests/kafka_int_tests/test_cases.rs
@@ -243,12 +243,3 @@ pub async fn standard_test_suite(connection_builder: KafkaConnectionBuilder) {
     produce_consume_acks0(&connection_builder).await;
     connection_builder.admin_cleanup().await;
 }
-
-// TODO: make cluster's run standard_test_suite instead
-pub async fn cluster_test_suite(connection_builder: KafkaConnectionBuilder) {
-    admin_setup(&connection_builder).await;
-    produce_consume_partitions1(&connection_builder, "partitions1").await;
-    produce_consume_partitions1(&connection_builder, "unknown_topic").await;
-    produce_consume_acks0(&connection_builder).await;
-    connection_builder.admin_cleanup().await;
-}


### PR DESCRIPTION
Completes phase 0 of https://github.com/shotover/shotover-proxy/issues/1585

Our previous half-working implementation of session_id handling has been removed, it will be reintroduced in phases 1 and 2. Instead we just set session_id in fetch responses to 0 so the client will always send full requests starting a new session from scratch.

This PR introduces a system of splitting requests and merging their responses.
This is done by changing `PendingRequest` -> `PendingRequestTy` and making it a field of the new `PendingRequest` type.
This then allow us to add a `PendingRequest.combine_responses` field where a value of 1 indicates no responses to be combined and a higher value indicates how many responses should be combined into a single response.

Then we define the logic for splitting fetches via `split_fetch_request_by_destination` and the logic for combining them again via `combine_fetch_responses`.