### PR TITLE
Kafka: end to end TLS integration test

### DIFF
--- a/shotover-proxy/tests/kafka_int_tests/mod.rs
+++ b/shotover-proxy/tests/kafka_int_tests/mod.rs
@@ -53,7 +53,6 @@ async fn passthrough_tls(#[case] driver: KafkaDriver) {
 }
 
 #[rstest]
-#[cfg_attr(feature = "rdkafka-driver-tests", case::cpp(KafkaDriver::Cpp))]
 #[case::java(KafkaDriver::Java)]
 #[tokio::test(flavor = "multi_thread")] // multi_thread is needed since java driver will block when consuming, causing shotover logs to not appear
 async fn cluster_tls(#[case] driver: KafkaDriver) {
@@ -65,7 +64,8 @@ async fn cluster_tls(#[case] driver: KafkaDriver) {
         .start()
         .await;
 
-    let connection_builder = KafkaConnectionBuilder::new(driver, "127.0.0.1:9192");
+    let connection_builder = KafkaConnectionBuilder::new(driver, "127.0.0.1:9192")
+        .use_tls("tests/test-configs/kafka/tls/certs/kafka.keystore.jks");
     test_cases::cluster_test_suite(connection_builder).await;
 
     tokio::time::timeout(

--- a/shotover-proxy/tests/test-configs/kafka/cluster-tls/topology.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-tls/topology.yaml
@@ -3,6 +3,9 @@ sources:
   - Kafka:
       name: "kafka"
       listen_addr: "127.0.0.1:9192"
+      tls:
+        certificate_path: "tests/test-configs/kafka/tls/certs/localhost.crt"
+        private_key_path: "tests/test-configs/kafka/tls/certs/localhost.key"
       chain:
         - KafkaSinkCluster:
             shotover_nodes:

--- a/test-helpers/src/connection/kafka/java.rs
+++ b/test-helpers/src/connection/kafka/java.rs
@@ -46,6 +46,15 @@ impl KafkaConnectionBuilderJava {
         KafkaConnectionBuilderJava { jvm, base_config }
     }
 
+    pub fn use_tls(mut self, truststore: &str) -> Self {
+        let conf = &mut self.base_config;
+        conf.insert("ssl.truststore.location".to_owned(), truststore.to_owned());
+        conf.insert("ssl.truststore.password".to_owned(), "password".to_owned());
+        conf.insert("security.protocol".to_owned(), "SSL".to_owned());
+
+        self
+    }
+
     pub fn use_sasl(mut self, user: &str, pass: &str) -> Self {
         let conf = &mut self.base_config;
         conf.insert("sasl.mechanism".to_owned(), "PLAIN".to_owned());

--- a/test-helpers/src/connection/kafka/mod.rs
+++ b/test-helpers/src/connection/kafka/mod.rs
@@ -27,6 +27,14 @@ impl KafkaConnectionBuilder {
         }
     }
 
+    pub fn use_tls(self, truststore: &str) -> Self {
+        match self {
+            #[cfg(feature = "rdkafka-driver-tests")]
+            Self::Cpp(_) => todo!("TLS not implemented for cpp driver"),
+            Self::Java(java) => Self::Java(java.use_tls(truststore)),
+        }
+    }
+
     pub fn use_sasl(self, user: &str, pass: &str) -> Self {
         match self {
             #[cfg(feature = "rdkafka-driver-tests")]


### PR DESCRIPTION
I've skipped support for the CPP driver for now, it should be possible ( https://github.com/fede1024/rust-rdkafka/issues/657 and https://github.com/confluentinc/librdkafka/wiki/Using-SSL-with-librdkafka ) but will require use of pem certs, so we'll need to do something like `use_tls(truststore: &str, ca_cert: &str)` to support both.

This PR extends `kafka_int_tests::cluster_tls` to cover both source and sink TLS.
In follow up PRs individual tests will be added for the source and sink as part of the SCRAM implementation.