### PR TITLE
Fix Kafka java driver multi shotover tests

### DIFF
--- a/shotover-proxy/tests/kafka_int_tests/mod.rs
+++ b/shotover-proxy/tests/kafka_int_tests/mod.rs
@@ -5,6 +5,8 @@ use rstest::rstest;
 use std::time::Duration;
 use test_helpers::connection::kafka::{KafkaConnectionBuilder, KafkaDriver};
 use test_helpers::docker_compose::docker_compose;
+use test_helpers::shotover_process::{Count, EventMatcher};
+use tokio_bin_process::event::Level;
 
 #[rstest]
 #[cfg_attr(feature = "kafka-cpp-driver-tests", case::cpp(KafkaDriver::Cpp))]
@@ -239,10 +241,9 @@ async fn cluster_1_rack_single_shotover(#[case] driver: KafkaDriver) {
     .expect("Shotover did not shutdown within 10s");
 }
 
-#[cfg(feature = "kafka-cpp-driver-tests")] // temporarily needed to avoid a warning
 #[rstest]
 #[cfg_attr(feature = "kafka-cpp-driver-tests", case::cpp(KafkaDriver::Cpp))]
-//#[case::java(KafkaDriver::Java)]
+#[case::java(KafkaDriver::Java)]
 #[tokio::test(flavor = "multi_thread")] // multi_thread is needed since java driver will block when consuming, causing shotover logs to not appear
 async fn cluster_1_rack_multi_shotover(#[case] driver: KafkaDriver) {
     let _docker_compose =
@@ -263,22 +264,25 @@ async fn cluster_1_rack_multi_shotover(#[case] driver: KafkaDriver) {
     }
 
     let connection_builder = KafkaConnectionBuilder::new(driver, "127.0.0.1:9192");
-    test_cases::standard_test_suite(connection_builder).await;
+    match driver {
+        #[cfg(feature = "kafka-cpp-driver-tests")]
+        KafkaDriver::Cpp => test_cases::standard_test_suite(connection_builder).await,
+        KafkaDriver::Java => test_cases::minimal_test_suite(connection_builder).await,
+    }
 
     for shotover in shotovers {
         tokio::time::timeout(
             Duration::from_secs(10),
-            shotover.shutdown_and_then_consume_events(&[]),
+            shotover.shutdown_and_then_consume_events(&multi_shotover_events(driver)),
         )
         .await
         .expect("Shotover did not shutdown within 10s");
     }
 }
 
-#[cfg(feature = "kafka-cpp-driver-tests")] // temporarily needed to avoid a warning
 #[rstest]
 #[cfg_attr(feature = "kafka-cpp-driver-tests", case::cpp(KafkaDriver::Cpp))]
-//#[case::java(KafkaDriver::Java)]
+#[case::java(KafkaDriver::Java)]
 #[tokio::test(flavor = "multi_thread")] // multi_thread is needed since java driver will block when consuming, causing shotover logs to not appear
 async fn cluster_2_racks_multi_shotover(#[case] driver: KafkaDriver) {
     let _docker_compose =
@@ -301,12 +305,16 @@ async fn cluster_2_racks_multi_shotover(#[case] driver: KafkaDriver) {
     }
 
     let connection_builder = KafkaConnectionBuilder::new(driver, "127.0.0.1:9192");
-    test_cases::standard_test_suite(connection_builder).await;
+    match driver {
+        #[cfg(feature = "kafka-cpp-driver-tests")]
+        KafkaDriver::Cpp => test_cases::standard_test_suite(connection_builder).await,
+        KafkaDriver::Java => test_cases::minimal_test_suite(connection_builder).await,
+    }
 
     for shotover in shotovers {
         tokio::time::timeout(
             Duration::from_secs(10),
-            shotover.shutdown_and_then_consume_events(&[]),
+            shotover.shutdown_and_then_consume_events(&multi_shotover_events(driver)),
         )
         .await
         .expect("Shotover did not shutdown within 10s");
@@ -374,10 +382,9 @@ async fn cluster_sasl_scram_over_mtls_single_shotover(#[case] driver: KafkaDrive
     .expect("Shotover did not shutdown within 10s");
 }
 
-#[cfg(feature = "kafka-cpp-driver-tests")] // temporarily needed to avoid a warning
 #[rstest]
 #[cfg_attr(feature = "kafka-cpp-driver-tests", case::cpp(KafkaDriver::Cpp))]
-//#[case::java(KafkaDriver::Java)]
+#[case::java(KafkaDriver::Java)]
 #[tokio::test(flavor = "multi_thread")] // multi_thread is needed since java driver will block when consuming, causing shotover logs to not appear
 async fn cluster_sasl_plain_multi_shotover(#[case] driver: KafkaDriver) {
     let _docker_compose =
@@ -399,7 +406,11 @@ async fn cluster_sasl_plain_multi_shotover(#[case] driver: KafkaDriver) {
 
     let connection_builder =
         KafkaConnectionBuilder::new(driver, "127.0.0.1:9192").use_sasl_plain("user", "password");
-    test_cases::standard_test_suite(connection_builder).await;
+    match driver {
+        #[cfg(feature = "kafka-cpp-driver-tests")]
+        KafkaDriver::Cpp => test_cases::standard_test_suite(connection_builder).await,
+        KafkaDriver::Java => test_cases::minimal_test_suite(connection_builder).await,
+    }
 
     // Test invalid credentials
     // We perform the regular test suite first in an attempt to catch a scenario
@@ -418,9 +429,29 @@ async fn cluster_sasl_plain_multi_shotover(#[case] driver: KafkaDriver) {
     for shotover in shotovers {
         tokio::time::timeout(
             Duration::from_secs(10),
-            shotover.shutdown_and_then_consume_events(&[]),
+            shotover.shutdown_and_then_consume_events(&multi_shotover_events(driver)),
         )
         .await
         .expect("Shotover did not shutdown within 10s");
+    }
+}
+
+fn multi_shotover_events(driver: KafkaDriver) -> Vec<EventMatcher> {
+    #[allow(irrefutable_let_patterns)]
+    if let KafkaDriver::Java = driver {
+        // The java driver manages to send requests fast enough that shotover's find_coordinator_of_group method
+        // gets a COORDINATOR_NOT_AVAILABLE response from kafka.
+        // If the client were connecting directly to kafka it would get this same error, so it doesnt make sense for us to retry on error.
+        // Instead we just let shotover pass on the NOT_COORDINATOR error to the client which triggers this warning in the process.
+        // So we ignore the warning in this case.
+        vec![EventMatcher::new()
+            .with_level(Level::Warn)
+            .with_target("shotover::transforms::kafka::sink_cluster")
+            .with_message(
+                r#"no known coordinator for GroupId("some_group"), routing message to a random node so that a NOT_COORDINATOR or similar error is returned to the client"#,
+            )
+            .with_count(Count::Any)]
+    } else {
+        vec![]
     }
 }

--- a/shotover-proxy/tests/kafka_int_tests/test_cases.rs
+++ b/shotover-proxy/tests/kafka_int_tests/test_cases.rs
@@ -243,3 +243,16 @@ pub async fn standard_test_suite(connection_builder: KafkaConnectionBuilder) {
     produce_consume_acks0(&connection_builder).await;
     connection_builder.admin_cleanup().await;
 }
+
+// TODO: get all tests passing on the standard_test_suite and then delete this function
+pub async fn minimal_test_suite(connection_builder: KafkaConnectionBuilder) {
+    admin_setup(&connection_builder).await;
+    produce_consume_partitions1(&connection_builder, "partitions1").await;
+    // fails due to missing metadata on the unknown_topic (out of bounds error)
+    //produce_consume_partitions1(&connection_builder, "unknown_topic").await;
+    // Failed to decode kafka_protocol::messages::produce_response::ProduceResponse v9
+    //produce_consume_partitions3(&connection_builder).await;
+    // Failed to decode kafka_protocol::messages::produce_response::ProduceResponse v9
+    //produce_consume_acks0(&connection_builder).await;
+    connection_builder.admin_cleanup().await;
+}


### PR DESCRIPTION
This PR brings us closer to full support for the java driver.
The java driver integration tests that are currently disabled are now enabled but some of the test cases within those integration tests are still disabled.
This is done by calling a `minimal_test_suite` function and calling it when running the java driver.

The fixes to shotover was to handle prefetching topic metadata for fetches using the newer protocol version used by the java driver.
The new protocol specifies topics by their id instead of their name.
Previously we were only prefetching topic metadata by name but now we also do it by topic id.
This involved:
1. finding a list of all topic id's in the current message batch. (route_requests method)
2. Including these topic id's in the metadata request (get_metadata_of_topics method)
   + I chose to revert to a lower api_version when not dealing with topic id's, this isnt required but I figured we may as well support the older kafka versions since it doesn't add much complexity.