### PR TITLE
Redo internal error response generation

### DIFF
--- a/shotover-proxy/tests/redis_int_tests/mod.rs
+++ b/shotover-proxy/tests/redis_int_tests/mod.rs
@@ -76,7 +76,10 @@ Caused by:
     3: Connection refused (os error 111)"#,
                 )
                 .with_count(Count::Times(2)),
-            // When the chain is flushed on client connection close we hit the same error again
+            // This error occurs due to `test_invalid_frame`, it opens a connection, sends an invalid frame which
+            // fails at the codec stage and never reaches the transform.
+            // Since the transform has never been reached, the chain/transform does not fail and
+            // chain flush is reached when the connection is closed by the client.
             EventMatcher::new()
                 .with_level(Level::Error)
                 .with_target("shotover::server")
@@ -88,7 +91,7 @@ Caused by:
     1: Failed to connect to destination 127.0.0.1:1111
     2: Connection refused (os error 111)"#,
                 )
-                .with_count(Count::Times(3)),
+                .with_count(Count::Times(1)),
             invalid_frame_event(),
         ])
         .await;

--- a/shotover/src/transforms/cassandra/sink_cluster/rewrite.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/rewrite.rs
@@ -305,7 +305,7 @@ impl MessageRewriter {
                         Ok(x) => x,
                         Err(MessageParseError::CassandraError(err)) => {
                             client_peers_response = client_peers_response
-                                        .to_error_response(format!("{:?}", err.context("Shotover failed to generate system.peers, an error occured when an internal system.peers query was run.")))
+                                        .from_response_to_error_response(format!("{:?}", err.context("Shotover failed to generate system.peers, an error occured when an internal system.peers query was run.")))
                                         .expect("This must succeed because it is a cassandra message and we already know it to be parseable");
                             responses.push(client_peers_response);
                             return Ok(true);
@@ -316,7 +316,7 @@ impl MessageRewriter {
                         Ok(x) => nodes.extend(x),
                         Err(MessageParseError::CassandraError(err)) => {
                             client_peers_response = client_peers_response
-                                        .to_error_response(format!("{:?}", err.context("Shotover failed to generate system.peers, an error occured when an internal system.local query was run.")))
+                                        .from_response_to_error_response(format!("{:?}", err.context("Shotover failed to generate system.peers, an error occured when an internal system.local query was run.")))
                                         .expect("This must succeed because it is a cassandra message and we already know it to be parseable");
                             responses.push(client_peers_response);
                             return Ok(true);
@@ -554,7 +554,7 @@ impl MessageRewriter {
         let mut peers = match parse_system_nodes(peers_response) {
             Ok(x) => x,
             Err(MessageParseError::CassandraError(err)) => {
-                *local_response = local_response.to_error_response(format!("{:?}", err.context("Shotover failed to generate system.local, an error occured when an internal system.peers query was run.")))
+                *local_response = local_response.from_response_to_error_response(format!("{:?}", err.context("Shotover failed to generate system.local, an error occured when an internal system.peers query was run.")))
                     .expect("This must succeed because it is a cassandra message and we already know it to be parseable");
                 return Ok(());
             }

--- a/shotover/src/transforms/filter.rs
+++ b/shotover/src/transforms/filter.rs
@@ -67,7 +67,9 @@ impl Transform for QueryTypeFilter {
                 self.filtered_requests.insert(
                     request.id(),
                     request
-                        .to_error_response("Message was filtered out by shotover".to_owned())
+                        .from_request_to_error_response(
+                            "Message was filtered out by shotover".to_owned(),
+                        )
                         .map_err(|e| e.context("Failed to filter message"))?,
                 );
                 request.replace_with_dummy();

--- a/shotover/src/transforms/mod.rs
+++ b/shotover/src/transforms/mod.rs
@@ -301,6 +301,11 @@ pub trait Transform: Send {
     ///         - When writing a transform specific to a protocol that is out of order: you can disregard this requirement
     ///             * This is currently only cassandra
     ///
+    /// * Err response:
+    ///     + When [`Transform::transform`] returns `Err`, shotover will never call [`Transform::transform`] on this transform instance again
+    ///       and will close the connection with the client after attempting to generate error responses for any pending requests.
+    ///       So it is ok to leave the transform in an invalid state when returning `Err`.
+    ///
     /// # Naming
     /// Transform also have different naming conventions.
     /// * Transform that interact with an external system are called Sinks.

--- a/shotover/src/transforms/null.rs
+++ b/shotover/src/transforms/null.rs
@@ -45,15 +45,10 @@ impl Transform for NullSink {
     }
 
     async fn transform<'a>(&'a mut self, mut requests_wrapper: Wrapper<'a>) -> Result<Messages> {
-        for message in &mut requests_wrapper.requests {
-            let request_id = message.id();
-
+        for request in &mut requests_wrapper.requests {
             // reuse the requests to hold the responses to avoid an allocation
-            *message =
-                message.to_error_response("Handled by shotover null transform".to_string())?;
-
-            // set the response to point to its corresponding request
-            message.set_request_id(request_id)
+            *request = request
+                .from_request_to_error_response("Handled by shotover null transform".to_string())?;
         }
         Ok(requests_wrapper.requests)
     }

--- a/shotover/src/transforms/tee.rs
+++ b/shotover/src/transforms/tee.rs
@@ -258,7 +258,7 @@ impl Transform for Tee {
                             keep_message.to_high_level_string(),
                             other_message.to_high_level_string()
                         );
-                        *keep_message = keep_message.to_error_response(
+                        *keep_message = keep_message.from_response_to_error_response(
                             "ERR The responses from the Tee subchain and down-chain did not match and behavior is set to fail on mismatch".into()
                         ).unwrap();
                     },


### PR DESCRIPTION
This PR addresses a few issues:
* internal error response generation has been broken since the recent transform invariant refactorings.
   + To resolve this, internal error response generation is completely redone. A `PendingRequests` type is introduced to keep track of pending requests. It uses a different method for tracking depending on the protocol.
* flushing was triggering after internal error generation, this is bad since transforms do not attempt to maintain their internal invariants when returning an error.
   + To resolve this, I changed shotover to skip flushing if the chain was closed due to a transform error and additionally documented shotover's behavior here as a transform invariant.
* We were cloning entire messages which is a performance concern since, while its true that newly created messages should have no allocations:
    + They still take up a lot of stack space, its currently like ~400bytes per message.
    + I think some codecs DO parse messages if they really need to in order to handle weird edge cases. .e.g cassandra batch messages.
    + This PR resolves the issue by storing the request as a `Metadata` instead of a `Message`, just 4 bytes of stack space.
* to_error_responses was leaving the responses without the appropriate request_id set. In order to correctly set the id its required to know if the message is a request or a response so I split the method into `from_request_to_error_response` and `from_response_to_error_response`