### PR TITLE
Rename feature `rdkafka-driver-tests` -> `kafka-cpp-driver-tests`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,12 +9,12 @@ linker = "aarch64-linux-gnu-gcc"
 
 [alias]
 # Can run every benchmark
-windsock = "test --release --bench windsock --features kafka,alpha-transforms,rdkafka-driver-tests,cassandra,redis --"
-windsock-debug = "test --bench windsock --features kafka,alpha-transforms,rdkafka-driver-tests,cassandra,redis --"
+windsock = "test --release --bench windsock --features kafka,alpha-transforms,kafka-cpp-driver-tests,cassandra,redis --"
+windsock-debug = "test --bench windsock --features kafka,alpha-transforms,kafka-cpp-driver-tests,cassandra,redis --"
 
 # Can only run benchmarks specific to the protocol but compiles a lot faster
 windsock-redis = "test --release --bench windsock --no-default-features --features redis,alpha-transforms --"
-windsock-kafka = "test --release --bench windsock --no-default-features --features kafka,alpha-transforms,rdkafka-driver-tests --"
+windsock-kafka = "test --release --bench windsock --no-default-features --features kafka,alpha-transforms,kafka-cpp-driver-tests --"
 windsock-cassandra = "test --release --bench windsock --no-default-features --features cassandra,alpha-transforms --"
 
 # Compile benches in docker to ensure compiled libc version is compatible with the EC2 instances libc

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -63,7 +63,7 @@ kafka = ["shotover/kafka"]
 redis = ["shotover/redis"]
 opensearch = ["shotover/opensearch"]
 cassandra-cpp-driver-tests = ["test-helpers/cassandra-cpp-driver-tests"]
-rdkafka-driver-tests = ["test-helpers/rdkafka-driver-tests"]
+kafka-cpp-driver-tests = ["test-helpers/kafka-cpp-driver-tests"]
 default = ["cassandra", "kafka", "redis", "opensearch"]
 
 [[bench]]

--- a/shotover-proxy/benches/windsock/cloud/aws.rs
+++ b/shotover-proxy/benches/windsock/cloud/aws.rs
@@ -267,7 +267,7 @@ sudo docker system prune -af"#,
         }
     }
 
-    #[cfg(all(feature = "rdkafka-driver-tests", feature = "kafka"))]
+    #[cfg(all(feature = "kafka-cpp-driver-tests", feature = "kafka"))]
     pub async fn run_shotover(self: Arc<Self>, topology: &str) -> RunningShotover {
         self.instance
             .ssh()

--- a/shotover-proxy/benches/windsock/main.rs
+++ b/shotover-proxy/benches/windsock/main.rs
@@ -3,7 +3,7 @@
     any(
         not(feature = "cassandra"),
         not(feature = "redis"),
-        not(all(feature = "rdkafka-driver-tests", feature = "kafka"))
+        not(all(feature = "kafka-cpp-driver-tests", feature = "kafka"))
     ),
     allow(dead_code, unused_imports, unused_variables, unused_mut)
 )]
@@ -12,7 +12,7 @@
 mod cassandra;
 mod cloud;
 mod common;
-#[cfg(all(feature = "rdkafka-driver-tests", feature = "kafka"))]
+#[cfg(all(feature = "kafka-cpp-driver-tests", feature = "kafka"))]
 mod kafka;
 mod profilers;
 #[cfg(feature = "redis")]
@@ -52,7 +52,7 @@ fn main() {
 
     #[cfg(feature = "cassandra")]
     benches.extend(cassandra::benches());
-    #[cfg(all(feature = "rdkafka-driver-tests", feature = "kafka"))]
+    #[cfg(all(feature = "kafka-cpp-driver-tests", feature = "kafka"))]
     benches.extend(kafka::benches());
     #[cfg(feature = "redis")]
     benches.extend(redis::benches());

--- a/shotover-proxy/tests/kafka_int_tests/mod.rs
+++ b/shotover-proxy/tests/kafka_int_tests/mod.rs
@@ -9,7 +9,7 @@ use test_helpers::shotover_process::{Count, EventMatcher};
 use tokio_bin_process::event::Level;
 
 #[rstest]
-#[cfg_attr(feature = "rdkafka-driver-tests", case::cpp(KafkaDriver::Cpp))]
+#[cfg_attr(feature = "kafka-cpp-driver-tests", case::cpp(KafkaDriver::Cpp))]
 #[case::java(KafkaDriver::Java)]
 #[tokio::test(flavor = "multi_thread")] // multi_thread is needed since java driver will block when consuming, causing shotover logs to not appear
 async fn passthrough_standard(#[case] driver: KafkaDriver) {
@@ -31,7 +31,7 @@ async fn passthrough_standard(#[case] driver: KafkaDriver) {
 }
 
 #[rstest]
-#[cfg_attr(feature = "rdkafka-driver-tests", case::cpp(KafkaDriver::Cpp))]
+#[cfg_attr(feature = "kafka-cpp-driver-tests", case::cpp(KafkaDriver::Cpp))]
 #[case::java(KafkaDriver::Java)]
 #[tokio::test(flavor = "multi_thread")] // multi_thread is needed since java driver will block when consuming, causing shotover logs to not appear
 async fn passthrough_tls(#[case] driver: KafkaDriver) {
@@ -80,7 +80,7 @@ async fn cluster_tls(#[case] driver: KafkaDriver) {
 
 #[cfg(feature = "alpha-transforms")]
 #[rstest]
-#[cfg_attr(feature = "rdkafka-driver-tests", case::cpp(KafkaDriver::Cpp))]
+#[cfg_attr(feature = "kafka-cpp-driver-tests", case::cpp(KafkaDriver::Cpp))]
 #[case::java(KafkaDriver::Java)]
 #[tokio::test(flavor = "multi_thread")] // multi_thread is needed since java driver will block when consuming, causing shotover logs to not appear
 async fn passthrough_encode(#[case] driver: KafkaDriver) {
@@ -98,7 +98,7 @@ async fn passthrough_encode(#[case] driver: KafkaDriver) {
 
 #[cfg(feature = "alpha-transforms")]
 #[rstest]
-#[cfg_attr(feature = "rdkafka-driver-tests", case::cpp(KafkaDriver::Cpp))]
+#[cfg_attr(feature = "kafka-cpp-driver-tests", case::cpp(KafkaDriver::Cpp))]
 #[case::java(KafkaDriver::Java)]
 #[tokio::test(flavor = "multi_thread")] // multi_thread is needed since java driver will block when consuming, causing shotover logs to not appear
 async fn passthrough_sasl_plain(#[case] driver: KafkaDriver) {
@@ -172,7 +172,7 @@ async fn single_sasl_scram_plaintext_source_tls_sink(#[case] driver: KafkaDriver
 }
 
 #[rstest]
-#[cfg_attr(feature = "rdkafka-driver-tests", case::cpp(KafkaDriver::Cpp))]
+#[cfg_attr(feature = "kafka-cpp-driver-tests", case::cpp(KafkaDriver::Cpp))]
 #[case::java(KafkaDriver::Java)]
 #[tokio::test(flavor = "multi_thread")] // multi_thread is needed since java driver will block when consuming, causing shotover logs to not appear
 async fn cluster_1_rack_single_shotover(#[case] driver: KafkaDriver) {
@@ -193,9 +193,9 @@ async fn cluster_1_rack_single_shotover(#[case] driver: KafkaDriver) {
     .expect("Shotover did not shutdown within 10s");
 }
 
-#[cfg(feature = "rdkafka-driver-tests")] // temporarily needed to avoid a warning
+#[cfg(feature = "kafka-cpp-driver-tests")] // temporarily needed to avoid a warning
 #[rstest]
-#[cfg_attr(feature = "rdkafka-driver-tests", case::cpp(KafkaDriver::Cpp))]
+#[cfg_attr(feature = "kafka-cpp-driver-tests", case::cpp(KafkaDriver::Cpp))]
 //#[case::java(KafkaDriver::Java)]
 #[tokio::test(flavor = "multi_thread")] // multi_thread is needed since java driver will block when consuming, causing shotover logs to not appear
 async fn cluster_1_rack_multi_shotover(#[case] driver: KafkaDriver) {
@@ -229,9 +229,9 @@ async fn cluster_1_rack_multi_shotover(#[case] driver: KafkaDriver) {
     }
 }
 
-#[cfg(feature = "rdkafka-driver-tests")] // temporarily needed to avoid a warning
+#[cfg(feature = "kafka-cpp-driver-tests")] // temporarily needed to avoid a warning
 #[rstest]
-#[cfg_attr(feature = "rdkafka-driver-tests", case::cpp(KafkaDriver::Cpp))]
+#[cfg_attr(feature = "kafka-cpp-driver-tests", case::cpp(KafkaDriver::Cpp))]
 //#[case::java(KafkaDriver::Java)]
 #[tokio::test(flavor = "multi_thread")] // multi_thread is needed since java driver will block when consuming, causing shotover logs to not appear
 async fn cluster_2_racks_multi_shotover(#[case] driver: KafkaDriver) {
@@ -268,7 +268,7 @@ async fn cluster_2_racks_multi_shotover(#[case] driver: KafkaDriver) {
 }
 
 #[rstest]
-//#[cfg_attr(feature = "rdkafka-driver-tests", case::cpp(KafkaDriver::Cpp))] // CPP driver does not support scram
+//#[cfg_attr(feature = "kafka-cpp-driver-tests", case::cpp(KafkaDriver::Cpp))] // CPP driver does not support scram
 #[case::java(KafkaDriver::Java)]
 #[tokio::test(flavor = "multi_thread")] // multi_thread is needed since java driver will block when consuming, causing shotover logs to not appear
 async fn cluster_sasl_scram_single_shotover(#[case] driver: KafkaDriver) {
@@ -307,9 +307,9 @@ Caused by:
     .expect("Shotover did not shutdown within 10s");
 }
 
-#[cfg(feature = "rdkafka-driver-tests")] // temporarily needed to avoid a warning
+#[cfg(feature = "kafka-cpp-driver-tests")] // temporarily needed to avoid a warning
 #[rstest]
-#[cfg_attr(feature = "rdkafka-driver-tests", case::cpp(KafkaDriver::Cpp))]
+#[cfg_attr(feature = "kafka-cpp-driver-tests", case::cpp(KafkaDriver::Cpp))]
 //#[case::java(KafkaDriver::Java)]
 #[tokio::test(flavor = "multi_thread")] // multi_thread is needed since java driver will block when consuming, causing shotover logs to not appear
 async fn cluster_sasl_plain_multi_shotover(#[case] driver: KafkaDriver) {
@@ -342,7 +342,7 @@ async fn cluster_sasl_plain_multi_shotover(#[case] driver: KafkaDriver) {
     assert_eq!(
         connection_builder.assert_admin_error().await.to_string(),
         match driver {
-            #[cfg(feature = "rdkafka-driver-tests")]
+            #[cfg(feature = "kafka-cpp-driver-tests")]
             KafkaDriver::Cpp => "Admin operation error: OperationTimedOut (Local: Timed out)",
             KafkaDriver::Java => "org.apache.kafka.common.errors.SaslAuthenticationException: Authentication failed: Invalid username or password\n"
         }

--- a/test-helpers/Cargo.toml
+++ b/test-helpers/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 
 [features]
 cassandra-cpp-driver-tests = ["cassandra-cpp"]
-rdkafka-driver-tests = ["rdkafka"]
+kafka-cpp-driver-tests = ["rdkafka"]
 
 [dependencies]
 tracing.workspace = true

--- a/test-helpers/src/connection/kafka/mod.rs
+++ b/test-helpers/src/connection/kafka/mod.rs
@@ -1,21 +1,21 @@
-#[cfg(feature = "rdkafka-driver-tests")]
+#[cfg(feature = "kafka-cpp-driver-tests")]
 pub mod cpp;
 pub mod java;
 
 use anyhow::Result;
-#[cfg(feature = "rdkafka-driver-tests")]
+#[cfg(feature = "kafka-cpp-driver-tests")]
 use cpp::*;
 use java::*;
 
 #[derive(Clone, Copy)]
 pub enum KafkaDriver {
-    #[cfg(feature = "rdkafka-driver-tests")]
+    #[cfg(feature = "kafka-cpp-driver-tests")]
     Cpp,
     Java,
 }
 
 pub enum KafkaConnectionBuilder {
-    #[cfg(feature = "rdkafka-driver-tests")]
+    #[cfg(feature = "kafka-cpp-driver-tests")]
     Cpp(KafkaConnectionBuilderCpp),
     Java(KafkaConnectionBuilderJava),
 }
@@ -23,7 +23,7 @@ pub enum KafkaConnectionBuilder {
 impl KafkaConnectionBuilder {
     pub fn new(driver: KafkaDriver, address: &str) -> Self {
         match driver {
-            #[cfg(feature = "rdkafka-driver-tests")]
+            #[cfg(feature = "kafka-cpp-driver-tests")]
             KafkaDriver::Cpp => Self::Cpp(KafkaConnectionBuilderCpp::new(address)),
             KafkaDriver::Java => Self::Java(KafkaConnectionBuilderJava::new(address)),
         }
@@ -31,7 +31,7 @@ impl KafkaConnectionBuilder {
 
     pub fn use_tls(self, truststore: &str) -> Self {
         match self {
-            #[cfg(feature = "rdkafka-driver-tests")]
+            #[cfg(feature = "kafka-cpp-driver-tests")]
             Self::Cpp(_) => todo!("TLS not implemented for cpp driver"),
             Self::Java(java) => Self::Java(java.use_tls(truststore)),
         }
@@ -39,7 +39,7 @@ impl KafkaConnectionBuilder {
 
     pub fn use_sasl_scram(self, user: &str, pass: &str) -> Self {
         match self {
-            #[cfg(feature = "rdkafka-driver-tests")]
+            #[cfg(feature = "kafka-cpp-driver-tests")]
             Self::Cpp(cpp) => Self::Cpp(cpp.use_sasl_scram(user, pass)),
             Self::Java(java) => Self::Java(java.use_sasl_scram(user, pass)),
         }
@@ -47,7 +47,7 @@ impl KafkaConnectionBuilder {
 
     pub fn use_sasl_plain(self, user: &str, pass: &str) -> Self {
         match self {
-            #[cfg(feature = "rdkafka-driver-tests")]
+            #[cfg(feature = "kafka-cpp-driver-tests")]
             Self::Cpp(cpp) => Self::Cpp(cpp.use_sasl_plain(user, pass)),
             Self::Java(java) => Self::Java(java.use_sasl_plain(user, pass)),
         }
@@ -55,7 +55,7 @@ impl KafkaConnectionBuilder {
 
     pub async fn connect_producer(&self, acks: i32) -> KafkaProducer {
         match self {
-            #[cfg(feature = "rdkafka-driver-tests")]
+            #[cfg(feature = "kafka-cpp-driver-tests")]
             Self::Cpp(cpp) => KafkaProducer::Cpp(cpp.connect_producer(acks).await),
             Self::Java(java) => KafkaProducer::Java(java.connect_producer(acks).await),
         }
@@ -63,7 +63,7 @@ impl KafkaConnectionBuilder {
 
     pub async fn connect_consumer(&self, topic_name: &str) -> KafkaConsumer {
         match self {
-            #[cfg(feature = "rdkafka-driver-tests")]
+            #[cfg(feature = "kafka-cpp-driver-tests")]
             Self::Cpp(cpp) => KafkaConsumer::Cpp(cpp.connect_consumer(topic_name).await),
             Self::Java(java) => KafkaConsumer::Java(java.connect_consumer(topic_name).await),
         }
@@ -71,7 +71,7 @@ impl KafkaConnectionBuilder {
 
     pub async fn connect_admin(&self) -> KafkaAdmin {
         match self {
-            #[cfg(feature = "rdkafka-driver-tests")]
+            #[cfg(feature = "kafka-cpp-driver-tests")]
             Self::Cpp(cpp) => KafkaAdmin::Cpp(cpp.connect_admin().await),
             Self::Java(java) => KafkaAdmin::Java(java.connect_admin().await),
         }
@@ -92,7 +92,7 @@ impl KafkaConnectionBuilder {
 
     pub async fn admin_cleanup(&self) {
         match self {
-            #[cfg(feature = "rdkafka-driver-tests")]
+            #[cfg(feature = "kafka-cpp-driver-tests")]
             Self::Cpp(cpp) => cpp.admin_cleanup().await,
             Self::Java(_) => {}
         }
@@ -100,7 +100,7 @@ impl KafkaConnectionBuilder {
 }
 
 pub enum KafkaProducer {
-    #[cfg(feature = "rdkafka-driver-tests")]
+    #[cfg(feature = "kafka-cpp-driver-tests")]
     Cpp(KafkaProducerCpp),
     Java(KafkaProducerJava),
 }
@@ -108,7 +108,7 @@ pub enum KafkaProducer {
 impl KafkaProducer {
     pub async fn assert_produce(&self, record: Record<'_>, expected_offset: Option<i64>) {
         match self {
-            #[cfg(feature = "rdkafka-driver-tests")]
+            #[cfg(feature = "kafka-cpp-driver-tests")]
             Self::Cpp(cpp) => cpp.assert_produce(record, expected_offset).await,
             Self::Java(java) => java.assert_produce(record, expected_offset).await,
         }
@@ -122,7 +122,7 @@ pub struct Record<'a> {
 }
 
 pub enum KafkaConsumer {
-    #[cfg(feature = "rdkafka-driver-tests")]
+    #[cfg(feature = "kafka-cpp-driver-tests")]
     Cpp(KafkaConsumerCpp),
     Java(KafkaConsumerJava),
 }
@@ -130,7 +130,7 @@ pub enum KafkaConsumer {
 impl KafkaConsumer {
     pub async fn assert_consume(&mut self, expected_response: ExpectedResponse) {
         let response = match self {
-            #[cfg(feature = "rdkafka-driver-tests")]
+            #[cfg(feature = "kafka-cpp-driver-tests")]
             Self::Cpp(cpp) => cpp.consume().await,
             Self::Java(java) => java.consume().await,
         };
@@ -144,7 +144,7 @@ impl KafkaConsumer {
         let mut responses = vec![];
         while responses.len() < expected_responses.len() {
             match self {
-                #[cfg(feature = "rdkafka-driver-tests")]
+                #[cfg(feature = "kafka-cpp-driver-tests")]
                 Self::Cpp(cpp) => responses.push(cpp.consume().await),
                 Self::Java(java) => responses.push(java.consume().await),
             }
@@ -188,7 +188,7 @@ impl PartialEq for ExpectedResponse {
 }
 
 pub enum KafkaAdmin {
-    #[cfg(feature = "rdkafka-driver-tests")]
+    #[cfg(feature = "kafka-cpp-driver-tests")]
     Cpp(KafkaAdminCpp),
     Java(KafkaAdminJava),
 }
@@ -196,7 +196,7 @@ pub enum KafkaAdmin {
 impl KafkaAdmin {
     pub async fn create_topics_fallible(&self, topics: &[NewTopic<'_>]) -> Result<()> {
         match self {
-            #[cfg(feature = "rdkafka-driver-tests")]
+            #[cfg(feature = "kafka-cpp-driver-tests")]
             KafkaAdmin::Cpp(cpp) => cpp.create_topics_fallible(topics).await,
             KafkaAdmin::Java(java) => java.create_topics_fallible(topics).await,
         }
@@ -204,7 +204,7 @@ impl KafkaAdmin {
 
     pub async fn create_topics(&self, topics: &[NewTopic<'_>]) {
         match self {
-            #[cfg(feature = "rdkafka-driver-tests")]
+            #[cfg(feature = "kafka-cpp-driver-tests")]
             KafkaAdmin::Cpp(cpp) => cpp.create_topics(topics).await,
             KafkaAdmin::Java(java) => java.create_topics(topics).await,
         }
@@ -212,7 +212,7 @@ impl KafkaAdmin {
 
     pub async fn delete_topics(&self, to_delete: &[&str]) {
         match self {
-            #[cfg(feature = "rdkafka-driver-tests")]
+            #[cfg(feature = "kafka-cpp-driver-tests")]
             Self::Cpp(cpp) => cpp.delete_topics(to_delete).await,
             Self::Java(java) => java.delete_topics(to_delete).await,
         }
@@ -220,7 +220,7 @@ impl KafkaAdmin {
 
     pub async fn create_partitions(&self, partitions: &[NewPartition<'_>]) {
         match self {
-            #[cfg(feature = "rdkafka-driver-tests")]
+            #[cfg(feature = "kafka-cpp-driver-tests")]
             KafkaAdmin::Cpp(cpp) => cpp.create_partitions(partitions).await,
             KafkaAdmin::Java(java) => java.create_partitions(partitions).await,
         }
@@ -228,7 +228,7 @@ impl KafkaAdmin {
 
     pub async fn describe_configs(&self, resources: &[ResourceSpecifier<'_>]) {
         match self {
-            #[cfg(feature = "rdkafka-driver-tests")]
+            #[cfg(feature = "kafka-cpp-driver-tests")]
             KafkaAdmin::Cpp(cpp) => cpp.describe_configs(resources).await,
             KafkaAdmin::Java(java) => java.describe_configs(resources).await,
         }
@@ -236,7 +236,7 @@ impl KafkaAdmin {
 
     pub async fn alter_configs(&self, alter_configs: &[AlterConfig<'_>]) {
         match self {
-            #[cfg(feature = "rdkafka-driver-tests")]
+            #[cfg(feature = "kafka-cpp-driver-tests")]
             KafkaAdmin::Cpp(cpp) => cpp.alter_configs(alter_configs).await,
             KafkaAdmin::Java(java) => java.alter_configs(alter_configs).await,
         }

--- a/windsock-cloud-docker/src/container.rs
+++ b/windsock-cloud-docker/src/container.rs
@@ -92,7 +92,7 @@ export RUST_LOG={rust_log}
 export AWS_ACCESS_KEY_ID={access_key_id}
 export AWS_SECRET_ACCESS_KEY={secret_access_key}
 export CARGO_TERM_COLOR=always
-cargo test --target-dir /target --release --bench windsock --no-default-features --features alpha-transforms,rdkafka-driver-tests,{features} -- {args}"#
+cargo test --target-dir /target --release --bench windsock --no-default-features --features alpha-transforms,kafka-cpp-driver-tests,{features} -- {args}"#
     )).await;
 
         // extract windsock results


### PR DESCRIPTION
I'm proposing that rdkafka-driver-tests should be renamed to `kafka-cpp-driver-tests`, since its not obvious that rdkafka is the name of the cpp driver for kafka. 

This is more consistent with:
* the driver test abstractions which always refer to rdkafka as just `cpp`
* other similar features, we already have `cassandra-cpp-driver-tests`