### PR TITLE
Transforms declare supported protocols

### DIFF
--- a/shotover-proxy/tests/test-configs/invalid_protocol_mismatch.yaml
+++ b/shotover-proxy/tests/test-configs/invalid_protocol_mismatch.yaml
@@ -1,0 +1,11 @@
+---
+sources:
+  - Cassandra:
+      name: "cassandra"
+      listen_addr: "127.0.0.1:6379"
+      chain:
+        - QueryCounter:
+            name: cassandra
+        - RedisSinkSingle:
+            remote_address: "127.0.0.1:1111"
+            connect_timeout_ms: 3000

--- a/shotover/src/transforms/mod.rs
+++ b/shotover/src/transforms/mod.rs
@@ -92,6 +92,32 @@ pub trait TransformConfig: Debug {
         &self,
         transform_context: TransformContextConfig,
     ) -> Result<Box<dyn TransformBuilder>>;
+
+    fn up_chain_protocol(&self) -> UpChainProtocol {
+        // TODO: Remove default implementation to force transforms to make a choice.
+        UpChainProtocol::Any
+    }
+
+    fn down_chain_protocol(&self) -> DownChainProtocol {
+        // TODO: Remove default implementation to force transforms to make a choice.
+        DownChainProtocol::SameAsIncoming
+    }
+}
+
+pub enum UpChainProtocol {
+    /// This transform will only accept the specified protocols from up chain.
+    MustBeOneOf(Vec<MessageType>),
+    /// This transform will accept any protocol from up chain.
+    Any,
+}
+
+pub enum DownChainProtocol {
+    /// The protocol sent down the chain will be this protocol.
+    TransformedTo(MessageType),
+    /// The protocol sent down the chain will be the same protocol received from up chain.
+    SameAsIncoming,
+    /// The transform is a sink transform and so it does not send any messages down chain.
+    Sink,
 }
 
 /// Provides extra context that may be needed when creating a TransformBuilder

--- a/shotover/src/transforms/redis/sink_single.rs
+++ b/shotover/src/transforms/redis/sink_single.rs
@@ -1,10 +1,11 @@
 use crate::codec::{CodecBuilder, Direction};
 use crate::connection::SinkConnection;
-use crate::frame::{Frame, RedisFrame};
+use crate::frame::{Frame, MessageType, RedisFrame};
 use crate::message::Messages;
 use crate::tls::{TlsConnector, TlsConnectorConfig};
 use crate::transforms::{
-    Transform, TransformBuilder, TransformConfig, TransformContextBuilder, Wrapper,
+    DownChainProtocol, Transform, TransformBuilder, TransformConfig, TransformContextBuilder,
+    UpChainProtocol, Wrapper,
 };
 use crate::{codec::redis::RedisCodecBuilder, transforms::TransformContextConfig};
 use anyhow::Result;
@@ -40,6 +41,14 @@ impl TransformConfig for RedisSinkSingleConfig {
             transform_context.chain_name,
             self.connect_timeout_ms,
         )))
+    }
+
+    fn up_chain_protocol(&self) -> UpChainProtocol {
+        UpChainProtocol::MustBeOneOf(vec![MessageType::Redis])
+    }
+
+    fn down_chain_protocol(&self) -> DownChainProtocol {
+        DownChainProtocol::Sink
     }
 }
 


### PR DESCRIPTION
Progress towards https://github.com/shotover/shotover-proxy/issues/520

This PR improves topology validation and allows for new kinds of topologies:
* We now catch and report to the user when two protocol incompatible transforms are connected to each other. Previously this would just blow up at runtime with a confusing error.
* We now allow topologies like: `CassandraToRedisTransform` -> `Tee`
   + Previously this would have failed since Tee relies on the protocol type being correctly set in `TransformContextConfig` but the protocol was only set to the protocol of the source and any changes to the protocol via previous transforms was ignored.

Not sure if up chain and down chain are the clearest way to name these but I also cant think of anything better.
I considered incoming and outgoing but I feel that is confusing since that its not clear what perspective its coming from.
Incoming could mean coming from the client but that would only be correct from the perspective of requests, since responses are actually outgoing to the client.


Work to do in follow up PRs:
* Correctly declare protocols for all existing transforms and make `up_chain_protocol` and `down_chain_protocol` mandatory
* Improve diagnostic formatting, when compared to the existing diagnostics for `TransformBuilder::validate` and `TransformBuilder::is_terminate` the diagnostics formatting is not as good. We will need to build up similar abstractions for diagnostics on config as we have for builders.
* Remove `TransformBuilder::is_terminating`, its redundant now since `DownChainProtocol` is a superset of that information.