### PR TITLE
KafkaSinkCluster disable SCRAM

### DIFF
--- a/docs/src/transforms.md
+++ b/docs/src/transforms.md
@@ -254,6 +254,8 @@ Instead Shotover will pretend to be either a single Kafka node or part of a clus
 
 This is achieved by rewriting the FindCoordinator, Metadata and DescribeCluster messages to contain the nodes in the shotover cluster instead of the kafka cluster.
 
+KafkaSinkCluster does not support SASL SCRAM authentication, if a client attempts to use SCRAM it will appear as if its not enabled in the server.
+
 ```yaml
 - KafkaSinkCluster:
     # Addresses of the initial kafka brokers to connect to.


### PR DESCRIPTION
closes https://github.com/shotover/shotover-proxy/issues/1575

We recently concluded that SCRAM support is not feasible for KafkaSinkCluster.
The only way to achieve it would be to include username/password pairs within shotovers config, however that is very undesirable and largely defeats the purpose of SCRAM anyway.

As such I think the best way forward is to handle clients attempting to use SCRAM by telling them SCRAM is not enabled so that they may attempt to use another authentication method if it is enabled.
This PR does so and also performs some minor cleanup on general SASL handling.

If we do find a way to support SCRAM in the future I think this logic would still be useful to have as a fallback when the user has not configured passwords to enable SCRAM.