### PR TITLE
valkey passthrough test

### DIFF
--- a/shotover-proxy/tests/test-configs/redis/passthrough-valkey/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/redis/passthrough-valkey/docker-compose.yaml
@@ -1,0 +1,6 @@
+services:
+  valkey-one:
+    image: chainguard/valkey:latest
+    ports:
+      - "1111:6379"
+

--- a/shotover-proxy/tests/test-configs/redis/passthrough-valkey/topology.yaml
+++ b/shotover-proxy/tests/test-configs/redis/passthrough-valkey/topology.yaml
@@ -1,0 +1,9 @@
+---
+sources:
+  - Redis:
+      name: "redis"
+      listen_addr: "127.0.0.1:6379"
+      chain:
+        - RedisSinkSingle:
+            remote_address: "127.0.0.1:1111"
+            connect_timeout_ms: 3000

--- a/test-helpers/src/docker_compose.rs
+++ b/test-helpers/src/docker_compose.rs
@@ -20,7 +20,7 @@ pub fn new_moto() -> DockerCompose {
     docker_compose("tests/transforms/docker-compose-moto.yaml")
 }
 
-pub static IMAGE_WAITERS: [Image; 11] = [
+pub static IMAGE_WAITERS: [Image; 12] = [
     Image {
         name: "motoserver/moto",
         log_regex_to_wait_for: r"Press CTRL\+C to quit",
@@ -33,6 +33,11 @@ pub static IMAGE_WAITERS: [Image; 11] = [
     },
     Image {
         name: "library/redis:6.2.5",
+        log_regex_to_wait_for: r"Ready to accept connections",
+        timeout: Duration::from_secs(120),
+    },
+    Image {
+        name: "chainguard/valkey:latest",
         log_regex_to_wait_for: r"Ready to accept connections",
         timeout: Duration::from_secs(120),
     },


### PR DESCRIPTION
Valkey is looking to be the dominant open source fork for Redis, makes sense to run this smoke against it. There hasn't been an official release so I've pinned to latest. This would work to our advantage because it will notify us immediately if anything changes that breaks Shotover compatibility.