### PR TITLE
Make up_chain_protocol/down_chain_protocol mandatory

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,11 @@ For full details refer to the [documentation of the invariants](https://github.c
 The `transform_pushed` method has been removed.
 The messages that were previously sent through that method will now go through the regular `transform` method.
 
+#### TransformConfig trait
+
+Mandatory methods `TransformConfig::up_chain_protocol` and `TransformConfig::down_chain_protocol` are added.
+Implement these to define what protocols your transform requires and outputs.
+
 ## 0.3.0
 
 ### shotover rust API

--- a/custom-transforms-example/src/redis_get_rewrite.rs
+++ b/custom-transforms-example/src/redis_get_rewrite.rs
@@ -1,9 +1,9 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use shotover::frame::{Frame, RedisFrame};
+use shotover::frame::{Frame, MessageType, RedisFrame};
 use shotover::message::{MessageIdSet, Messages};
-use shotover::transforms::TransformContextBuilder;
+use shotover::transforms::{DownChainProtocol, TransformContextBuilder, UpChainProtocol};
 use shotover::transforms::{
     Transform, TransformBuilder, TransformConfig, TransformContextConfig, Wrapper,
 };
@@ -25,6 +25,14 @@ impl TransformConfig for RedisGetRewriteConfig {
         Ok(Box::new(RedisGetRewriteBuilder {
             result: self.result.clone(),
         }))
+    }
+
+    fn up_chain_protocol(&self) -> UpChainProtocol {
+        UpChainProtocol::MustBeOneOf(vec![MessageType::Redis])
+    }
+
+    fn down_chain_protocol(&self) -> DownChainProtocol {
+        DownChainProtocol::SameAsUpChain
     }
 }
 

--- a/shotover/src/config/chain.rs
+++ b/shotover/src/config/chain.rs
@@ -39,8 +39,8 @@ impl TransformChainConfig {
 
             upchain_protocol = match tc.down_chain_protocol() {
                 DownChainProtocol::TransformedTo(new) => new,
-                DownChainProtocol::SameAsIncoming => upchain_protocol,
-                DownChainProtocol::Sink => {
+                DownChainProtocol::SameAsUpChain => upchain_protocol,
+                DownChainProtocol::Terminating => {
                     if i + 1 != self.0.len() {
                         // TODO: Move bad sink reporting to here
                         upchain_protocol

--- a/shotover/src/config/topology.rs
+++ b/shotover/src/config/topology.rs
@@ -81,6 +81,7 @@ impl Topology {
 mod topology_tests {
     use crate::config::chain::TransformChainConfig;
     use crate::config::topology::Topology;
+    use crate::sources::cassandra::CassandraConfig;
     use crate::transforms::coalesce::CoalesceConfig;
     use crate::transforms::debug::printer::DebugPrinterConfig;
     use crate::transforms::null::NullSinkConfig;
@@ -94,8 +95,8 @@ mod topology_tests {
     use std::collections::HashMap;
     use tokio::sync::watch;
 
-    fn create_source_from_chain(chain: Vec<Box<dyn TransformConfig>>) -> Vec<SourceConfig> {
-        let redis_source = SourceConfig::Redis(RedisConfig {
+    fn create_source_from_chain_redis(chain: Vec<Box<dyn TransformConfig>>) -> Vec<SourceConfig> {
+        vec![SourceConfig::Redis(RedisConfig {
             name: "foo".to_string(),
             listen_addr: "127.0.0.1:0".to_string(),
             connection_limit: None,
@@ -103,15 +104,40 @@ mod topology_tests {
             tls: None,
             timeout: None,
             chain: TransformChainConfig(chain),
-        });
-
-        vec![redis_source]
+        })]
     }
 
-    async fn run_test_topology(
+    fn create_source_from_chain_cassandra(
+        chain: Vec<Box<dyn TransformConfig>>,
+    ) -> Vec<SourceConfig> {
+        vec![SourceConfig::Cassandra(CassandraConfig {
+            name: "foo".to_string(),
+            listen_addr: "127.0.0.1:0".to_string(),
+            connection_limit: None,
+            hard_connection_limit: None,
+            tls: None,
+            timeout: None,
+            chain: TransformChainConfig(chain),
+            transport: None,
+        })]
+    }
+
+    async fn run_test_topology_redis(
         chain: Vec<Box<dyn TransformConfig>>,
     ) -> anyhow::Result<Vec<Source>> {
-        let sources = create_source_from_chain(chain);
+        let sources = create_source_from_chain_redis(chain);
+
+        let topology = Topology { sources };
+
+        let (_sender, trigger_shutdown_rx) = watch::channel::<bool>(false);
+
+        topology.run_chains(trigger_shutdown_rx).await
+    }
+
+    async fn run_test_topology_cassandra(
+        chain: Vec<Box<dyn TransformConfig>>,
+    ) -> anyhow::Result<Vec<Source>> {
+        let sources = create_source_from_chain_cassandra(chain);
 
         let topology = Topology { sources };
 
@@ -128,13 +154,16 @@ foo source:
     Chain cannot be empty
 "#;
 
-        let error = run_test_topology(vec![]).await.unwrap_err().to_string();
+        let error = run_test_topology_redis(vec![])
+            .await
+            .unwrap_err()
+            .to_string();
         assert_eq!(error, expected);
     }
 
     #[tokio::test]
     async fn test_validate_chain_valid_chain() {
-        run_test_topology(vec![Box::new(DebugPrinterConfig), Box::new(NullSinkConfig)])
+        run_test_topology_redis(vec![Box::new(DebugPrinterConfig), Box::new(NullSinkConfig)])
             .await
             .unwrap();
     }
@@ -153,7 +182,7 @@ foo source:
       Check https://docs.shotover.io/transforms.html#coalesce for more information.
 "#;
 
-        let error = run_test_topology(vec![
+        let error = run_test_topology_redis(vec![
             Box::new(CoalesceConfig {
                 flush_when_buffered_message_count: None,
                 flush_when_millis_since_last_flush: None,
@@ -175,7 +204,7 @@ foo source:
     Terminating transform "NullSink" is not last in chain. Terminating transform must be last in chain.
 "#;
 
-        let error = run_test_topology(vec![
+        let error = run_test_topology_redis(vec![
             Box::new(DebugPrinterConfig),
             Box::new(NullSinkConfig),
             Box::new(NullSinkConfig),
@@ -195,7 +224,7 @@ foo source:
     Non-terminating transform "DebugPrinter" is last in chain. Last transform must be terminating.
 "#;
 
-        let error = run_test_topology(vec![
+        let error = run_test_topology_redis(vec![
             Box::new(DebugPrinterConfig),
             Box::new(DebugPrinterConfig),
             Box::new(DebugPrinterConfig),
@@ -216,7 +245,7 @@ foo source:
     Non-terminating transform "DebugPrinter" is last in chain. Last transform must be terminating.
 "#;
 
-        let error = run_test_topology(vec![
+        let error = run_test_topology_redis(vec![
             Box::new(DebugPrinterConfig),
             Box::new(DebugPrinterConfig),
             Box::new(NullSinkConfig),
@@ -230,10 +259,10 @@ foo source:
     }
 
     #[tokio::test]
-    async fn test_validate_chain_valid_subchain_redis_cache() {
+    async fn test_validate_chain_valid_subchain_cassandra_redis_cache() {
         let caching_schema = HashMap::new();
 
-        run_test_topology(vec![
+        run_test_topology_cassandra(vec![
             Box::new(DebugPrinterConfig),
             Box::new(DebugPrinterConfig),
             Box::new(RedisCacheConfig {
@@ -251,7 +280,7 @@ foo source:
     }
 
     #[tokio::test]
-    async fn test_validate_chain_invalid_subchain_redis_cache() {
+    async fn test_validate_chain_invalid_subchain_cassandra_redis_cache() {
         let expected = r#"Topology errors
 foo source:
   foo chain:
@@ -260,7 +289,7 @@ foo source:
         Terminating transform "NullSink" is not last in chain. Terminating transform must be last in chain.
 "#;
 
-        let error = run_test_topology(vec![
+        let error = run_test_topology_cassandra(vec![
             Box::new(DebugPrinterConfig),
             Box::new(DebugPrinterConfig),
             Box::new(RedisCacheConfig {
@@ -283,7 +312,7 @@ foo source:
 
     #[tokio::test]
     async fn test_validate_chain_valid_subchain_parallel_map() {
-        run_test_topology(vec![
+        run_test_topology_redis(vec![
             Box::new(DebugPrinterConfig),
             Box::new(DebugPrinterConfig),
             Box::new(ParallelMapConfig {
@@ -310,7 +339,7 @@ foo source:
         Terminating transform "NullSink" is not last in chain. Terminating transform must be last in chain.
 "#;
 
-        let error = run_test_topology(vec![
+        let error = run_test_topology_redis(vec![
             Box::new(DebugPrinterConfig),
             Box::new(DebugPrinterConfig),
             Box::new(ParallelMapConfig {
@@ -348,7 +377,7 @@ foo source:
             Box::new(NullSinkConfig),
         ]);
 
-        let error = run_test_topology(vec![
+        let error = run_test_topology_redis(vec![
             Box::new(DebugPrinterConfig),
             Box::new(DebugPrinterConfig),
             Box::new(ParallelMapConfig {
@@ -379,7 +408,7 @@ foo source:
             Box::new(DebugPrinterConfig),
         ]);
 
-        let error = run_test_topology(vec![
+        let error = run_test_topology_redis(vec![
             Box::new(DebugPrinterConfig),
             Box::new(DebugPrinterConfig),
             Box::new(ParallelMapConfig {
@@ -412,7 +441,7 @@ foo source:
             Box::new(DebugPrinterConfig),
         ]);
 
-        let error = run_test_topology(vec![
+        let error = run_test_topology_redis(vec![
             Box::new(DebugPrinterConfig),
             Box::new(DebugPrinterConfig),
             Box::new(ParallelMapConfig {
@@ -434,8 +463,10 @@ foo source:
 Source name "foo" occurred more than once. Make sure all source names are unique. The names will be used in logging and metrics.
 "#;
 
-        let mut sources = create_source_from_chain(vec![Box::new(NullSinkConfig)]);
-        sources.extend(create_source_from_chain(vec![Box::new(NullSinkConfig)]));
+        let mut sources = create_source_from_chain_redis(vec![Box::new(NullSinkConfig)]);
+        sources.extend(create_source_from_chain_redis(vec![Box::new(
+            NullSinkConfig,
+        )]));
 
         let topology = Topology { sources };
         let (_sender, trigger_shutdown_rx) = watch::channel::<bool>(false);

--- a/shotover/src/transforms/cassandra/peers_rewrite.rs
+++ b/shotover/src/transforms/cassandra/peers_rewrite.rs
@@ -1,7 +1,9 @@
+use crate::frame::MessageType;
 use crate::message::{Message, MessageIdMap, Messages};
 use crate::transforms::cassandra::peers_rewrite::CassandraOperation::Event;
 use crate::transforms::{
-    Transform, TransformBuilder, TransformConfig, TransformContextBuilder, Wrapper,
+    DownChainProtocol, Transform, TransformBuilder, TransformConfig, TransformContextBuilder,
+    UpChainProtocol, Wrapper,
 };
 use crate::{
     frame::{
@@ -33,6 +35,14 @@ impl TransformConfig for CassandraPeersRewriteConfig {
         _transform_context: TransformContextConfig,
     ) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(CassandraPeersRewrite::new(self.port)))
+    }
+
+    fn up_chain_protocol(&self) -> UpChainProtocol {
+        UpChainProtocol::MustBeOneOf(vec![MessageType::Cassandra])
+    }
+
+    fn down_chain_protocol(&self) -> DownChainProtocol {
+        DownChainProtocol::SameAsUpChain
     }
 }
 

--- a/shotover/src/transforms/cassandra/sink_cluster/mod.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/mod.rs
@@ -2,12 +2,12 @@ use self::connection::CassandraConnection;
 use self::node_pool::{get_accessible_owned_connection, NodePoolBuilder, PreparedMetadata};
 use self::rewrite::{BatchMode, MessageRewriter};
 use crate::frame::cassandra::{CassandraMetadata, Tracing};
-use crate::frame::{CassandraFrame, CassandraOperation, CassandraResult, Frame};
+use crate::frame::{CassandraFrame, CassandraOperation, CassandraResult, Frame, MessageType};
 use crate::message::{Message, MessageIdMap, Messages, Metadata};
 use crate::tls::{TlsConnector, TlsConnectorConfig};
 use crate::transforms::{
-    Transform, TransformBuilder, TransformConfig, TransformContextBuilder, TransformContextConfig,
-    Wrapper,
+    DownChainProtocol, Transform, TransformBuilder, TransformConfig, TransformContextBuilder,
+    TransformContextConfig, UpChainProtocol, Wrapper,
 };
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
@@ -95,6 +95,14 @@ impl TransformConfig for CassandraSinkClusterConfig {
             self.connect_timeout_ms,
             self.read_timeout,
         )))
+    }
+
+    fn up_chain_protocol(&self) -> UpChainProtocol {
+        UpChainProtocol::MustBeOneOf(vec![MessageType::Cassandra])
+    }
+
+    fn down_chain_protocol(&self) -> DownChainProtocol {
+        DownChainProtocol::Terminating
     }
 }
 

--- a/shotover/src/transforms/cassandra/sink_single.rs
+++ b/shotover/src/transforms/cassandra/sink_single.rs
@@ -1,11 +1,12 @@
 use crate::codec::{cassandra::CassandraCodecBuilder, CodecBuilder, Direction};
 use crate::connection::SinkConnection;
 use crate::frame::cassandra::CassandraMetadata;
+use crate::frame::MessageType;
 use crate::message::{Messages, Metadata};
 use crate::tls::{TlsConnector, TlsConnectorConfig};
 use crate::transforms::{
-    Transform, TransformBuilder, TransformConfig, TransformContextBuilder, TransformContextConfig,
-    Wrapper,
+    DownChainProtocol, Transform, TransformBuilder, TransformConfig, TransformContextBuilder,
+    TransformContextConfig, UpChainProtocol, Wrapper,
 };
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -44,6 +45,14 @@ impl TransformConfig for CassandraSinkSingleConfig {
             self.connect_timeout_ms,
             self.read_timeout,
         )))
+    }
+
+    fn up_chain_protocol(&self) -> UpChainProtocol {
+        UpChainProtocol::MustBeOneOf(vec![MessageType::Cassandra])
+    }
+
+    fn down_chain_protocol(&self) -> DownChainProtocol {
+        DownChainProtocol::Terminating
     }
 }
 

--- a/shotover/src/transforms/coalesce.rs
+++ b/shotover/src/transforms/coalesce.rs
@@ -1,4 +1,4 @@
-use super::{TransformContextBuilder, TransformContextConfig};
+use super::{DownChainProtocol, TransformContextBuilder, TransformContextConfig, UpChainProtocol};
 use crate::message::Messages;
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
 use anyhow::Result;
@@ -35,6 +35,14 @@ impl TransformConfig for CoalesceConfig {
             flush_when_millis_since_last_flush: self.flush_when_millis_since_last_flush,
             last_write: Instant::now(),
         }))
+    }
+
+    fn up_chain_protocol(&self) -> UpChainProtocol {
+        UpChainProtocol::Any
+    }
+
+    fn down_chain_protocol(&self) -> DownChainProtocol {
+        DownChainProtocol::SameAsUpChain
     }
 }
 

--- a/shotover/src/transforms/debug/force_parse.rs
+++ b/shotover/src/transforms/debug/force_parse.rs
@@ -10,6 +10,8 @@ use crate::transforms::TransformConfig;
 use crate::transforms::TransformContextBuilder;
 #[cfg(feature = "alpha-transforms")]
 use crate::transforms::TransformContextConfig;
+#[cfg(feature = "alpha-transforms")]
+use crate::transforms::{DownChainProtocol, UpChainProtocol};
 use crate::transforms::{Transform, TransformBuilder, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -39,6 +41,14 @@ impl TransformConfig for DebugForceParseConfig {
             encode_responses: false,
         }))
     }
+
+    fn up_chain_protocol(&self) -> UpChainProtocol {
+        UpChainProtocol::Any
+    }
+
+    fn down_chain_protocol(&self) -> DownChainProtocol {
+        DownChainProtocol::SameAsUpChain
+    }
 }
 
 /// Messages that pass through this transform will be parsed and then reencoded.
@@ -65,6 +75,14 @@ impl TransformConfig for DebugForceEncodeConfig {
             encode_requests: self.encode_requests,
             encode_responses: self.encode_responses,
         }))
+    }
+
+    fn up_chain_protocol(&self) -> UpChainProtocol {
+        UpChainProtocol::Any
+    }
+
+    fn down_chain_protocol(&self) -> DownChainProtocol {
+        DownChainProtocol::SameAsUpChain
     }
 }
 

--- a/shotover/src/transforms/debug/log_to_file.rs
+++ b/shotover/src/transforms/debug/log_to_file.rs
@@ -1,4 +1,6 @@
 use crate::message::{Encodable, Message};
+#[cfg(feature = "alpha-transforms")]
+use crate::transforms::{DownChainProtocol, UpChainProtocol};
 use crate::transforms::{Transform, TransformBuilder, TransformContextBuilder, Wrapper};
 use anyhow::{Context, Result};
 use async_trait::async_trait;
@@ -27,6 +29,14 @@ impl crate::transforms::TransformConfig for DebugLogToFileConfig {
         Ok(Box::new(DebugLogToFileBuilder {
             connection_counter: Arc::new(AtomicU64::new(0)),
         }))
+    }
+
+    fn up_chain_protocol(&self) -> UpChainProtocol {
+        UpChainProtocol::Any
+    }
+
+    fn down_chain_protocol(&self) -> DownChainProtocol {
+        DownChainProtocol::SameAsUpChain
     }
 }
 

--- a/shotover/src/transforms/debug/printer.rs
+++ b/shotover/src/transforms/debug/printer.rs
@@ -1,7 +1,7 @@
 use crate::message::Messages;
 use crate::transforms::{
-    Transform, TransformBuilder, TransformConfig, TransformContextBuilder, TransformContextConfig,
-    Wrapper,
+    DownChainProtocol, Transform, TransformBuilder, TransformConfig, TransformContextBuilder,
+    TransformContextConfig, UpChainProtocol, Wrapper,
 };
 use anyhow::Result;
 use async_trait::async_trait;
@@ -21,6 +21,14 @@ impl TransformConfig for DebugPrinterConfig {
         _transform_context: TransformContextConfig,
     ) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(DebugPrinter::new()))
+    }
+
+    fn up_chain_protocol(&self) -> UpChainProtocol {
+        UpChainProtocol::Any
+    }
+
+    fn down_chain_protocol(&self) -> DownChainProtocol {
+        DownChainProtocol::SameAsUpChain
     }
 }
 

--- a/shotover/src/transforms/debug/returner.rs
+++ b/shotover/src/transforms/debug/returner.rs
@@ -1,7 +1,7 @@
 use crate::message::{Message, Messages};
 use crate::transforms::{
-    Transform, TransformBuilder, TransformConfig, TransformContextBuilder, TransformContextConfig,
-    Wrapper,
+    DownChainProtocol, Transform, TransformBuilder, TransformConfig, TransformContextBuilder,
+    TransformContextConfig, UpChainProtocol, Wrapper,
 };
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -23,6 +23,14 @@ impl TransformConfig for DebugReturnerConfig {
         _transform_context: TransformContextConfig,
     ) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(DebugReturner::new(self.response.clone())))
+    }
+
+    fn up_chain_protocol(&self) -> UpChainProtocol {
+        UpChainProtocol::Any
+    }
+
+    fn down_chain_protocol(&self) -> DownChainProtocol {
+        DownChainProtocol::SameAsUpChain
     }
 }
 

--- a/shotover/src/transforms/filter.rs
+++ b/shotover/src/transforms/filter.rs
@@ -1,4 +1,4 @@
-use super::{TransformContextBuilder, TransformContextConfig};
+use super::{DownChainProtocol, TransformContextBuilder, TransformContextConfig, UpChainProtocol};
 use crate::message::{Message, MessageIdMap, Messages, QueryType};
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
 use anyhow::Result;
@@ -37,6 +37,14 @@ impl TransformConfig for QueryTypeFilterConfig {
             filter: self.filter.clone(),
             filtered_requests: MessageIdMap::default(),
         }))
+    }
+
+    fn up_chain_protocol(&self) -> UpChainProtocol {
+        UpChainProtocol::Any
+    }
+
+    fn down_chain_protocol(&self) -> DownChainProtocol {
+        DownChainProtocol::SameAsUpChain
     }
 }
 

--- a/shotover/src/transforms/kafka/sink_cluster/mod.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/mod.rs
@@ -1,9 +1,12 @@
 use crate::connection::SinkConnection;
 use crate::frame::kafka::{KafkaFrame, RequestBody, ResponseBody};
-use crate::frame::Frame;
+use crate::frame::{Frame, MessageType};
 use crate::message::{Message, MessageIdMap, Messages};
 use crate::tls::{TlsConnector, TlsConnectorConfig};
-use crate::transforms::{Transform, TransformBuilder, TransformContextBuilder, Wrapper};
+use crate::transforms::{
+    DownChainProtocol, Transform, TransformBuilder, TransformContextBuilder, UpChainProtocol,
+    Wrapper,
+};
 use crate::transforms::{TransformConfig, TransformContextConfig};
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
@@ -103,6 +106,14 @@ impl TransformConfig for KafkaSinkClusterConfig {
             self.read_timeout,
             tls,
         )))
+    }
+
+    fn up_chain_protocol(&self) -> UpChainProtocol {
+        UpChainProtocol::MustBeOneOf(vec![MessageType::Kafka])
+    }
+
+    fn down_chain_protocol(&self) -> DownChainProtocol {
+        DownChainProtocol::Terminating
     }
 }
 

--- a/shotover/src/transforms/kafka/sink_single.rs
+++ b/shotover/src/transforms/kafka/sink_single.rs
@@ -1,10 +1,10 @@
 use crate::codec::{kafka::KafkaCodecBuilder, CodecBuilder, Direction};
 use crate::connection::SinkConnection;
 use crate::frame::kafka::{KafkaFrame, RequestBody, ResponseBody};
-use crate::frame::Frame;
+use crate::frame::{Frame, MessageType};
 use crate::message::Messages;
 use crate::tls::{TlsConnector, TlsConnectorConfig};
-use crate::transforms::TransformConfig;
+use crate::transforms::{DownChainProtocol, TransformConfig, UpChainProtocol};
 use crate::transforms::{
     Transform, TransformBuilder, TransformContextBuilder, TransformContextConfig, Wrapper,
 };
@@ -43,6 +43,14 @@ impl TransformConfig for KafkaSinkSingleConfig {
             self.read_timeout,
             tls,
         )))
+    }
+
+    fn up_chain_protocol(&self) -> UpChainProtocol {
+        UpChainProtocol::MustBeOneOf(vec![MessageType::Kafka])
+    }
+
+    fn down_chain_protocol(&self) -> DownChainProtocol {
+        DownChainProtocol::Terminating
     }
 }
 

--- a/shotover/src/transforms/load_balance.rs
+++ b/shotover/src/transforms/load_balance.rs
@@ -1,4 +1,4 @@
-use super::{TransformContextBuilder, TransformContextConfig};
+use super::{DownChainProtocol, TransformContextBuilder, TransformContextConfig, UpChainProtocol};
 use crate::config::chain::TransformChainConfig;
 use crate::message::Messages;
 use crate::transforms::chain::{BufferedChain, TransformChainBuilder};
@@ -32,6 +32,14 @@ impl TransformConfig for ConnectionBalanceAndPoolConfig {
             all_connections: Arc::new(Mutex::new(Vec::with_capacity(self.max_connections))),
             chain_to_clone: chain,
         }))
+    }
+
+    fn up_chain_protocol(&self) -> UpChainProtocol {
+        UpChainProtocol::Any
+    }
+
+    fn down_chain_protocol(&self) -> DownChainProtocol {
+        DownChainProtocol::SameAsUpChain
     }
 }
 

--- a/shotover/src/transforms/mod.rs
+++ b/shotover/src/transforms/mod.rs
@@ -36,6 +36,7 @@ pub mod query_counter;
 pub mod redis;
 pub mod sampler;
 pub mod tee;
+#[cfg(feature = "cassandra")]
 pub mod throttling;
 pub mod util;
 
@@ -85,15 +86,9 @@ pub trait TransformConfig: Debug {
         transform_context: TransformContextConfig,
     ) -> Result<Box<dyn TransformBuilder>>;
 
-    fn up_chain_protocol(&self) -> UpChainProtocol {
-        // TODO: Remove default implementation to force transforms to make a choice.
-        UpChainProtocol::Any
-    }
+    fn up_chain_protocol(&self) -> UpChainProtocol;
 
-    fn down_chain_protocol(&self) -> DownChainProtocol {
-        // TODO: Remove default implementation to force transforms to make a choice.
-        DownChainProtocol::SameAsIncoming
-    }
+    fn down_chain_protocol(&self) -> DownChainProtocol;
 }
 
 pub enum UpChainProtocol {
@@ -107,9 +102,9 @@ pub enum DownChainProtocol {
     /// The protocol sent down the chain will be this protocol.
     TransformedTo(MessageType),
     /// The protocol sent down the chain will be the same protocol received from up chain.
-    SameAsIncoming,
-    /// The transform is a sink transform and so it does not send any messages down chain.
-    Sink,
+    SameAsUpChain,
+    /// The transform is terminating and so it does not send any messages down chain.
+    Terminating,
 }
 
 /// Provides extra context that may be needed when creating a TransformBuilder

--- a/shotover/src/transforms/null.rs
+++ b/shotover/src/transforms/null.rs
@@ -1,4 +1,4 @@
-use super::{TransformContextBuilder, TransformContextConfig};
+use super::{DownChainProtocol, TransformContextBuilder, TransformContextConfig, UpChainProtocol};
 use crate::message::Messages;
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
 use anyhow::Result;
@@ -18,6 +18,14 @@ impl TransformConfig for NullSinkConfig {
         _transform_context: TransformContextConfig,
     ) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(NullSink {}))
+    }
+
+    fn up_chain_protocol(&self) -> UpChainProtocol {
+        UpChainProtocol::Any
+    }
+
+    fn down_chain_protocol(&self) -> DownChainProtocol {
+        DownChainProtocol::Terminating
     }
 }
 

--- a/shotover/src/transforms/opensearch/mod.rs
+++ b/shotover/src/transforms/opensearch/mod.rs
@@ -1,4 +1,5 @@
-use super::{TransformContextBuilder, TransformContextConfig};
+use super::{DownChainProtocol, TransformContextBuilder, TransformContextConfig, UpChainProtocol};
+use crate::frame::MessageType;
 use crate::tcp;
 use crate::transforms::{Messages, Transform, TransformBuilder, TransformConfig, Wrapper};
 use crate::{
@@ -35,6 +36,14 @@ impl TransformConfig for OpenSearchSinkSingleConfig {
             transform_context.chain_name,
             self.connect_timeout_ms,
         )))
+    }
+
+    fn up_chain_protocol(&self) -> UpChainProtocol {
+        UpChainProtocol::MustBeOneOf(vec![MessageType::OpenSearch])
+    }
+
+    fn down_chain_protocol(&self) -> DownChainProtocol {
+        DownChainProtocol::Terminating
     }
 }
 

--- a/shotover/src/transforms/parallel_map.rs
+++ b/shotover/src/transforms/parallel_map.rs
@@ -1,4 +1,4 @@
-use super::{TransformContextBuilder, TransformContextConfig};
+use super::{DownChainProtocol, TransformContextBuilder, TransformContextConfig, UpChainProtocol};
 use crate::config::chain::TransformChainConfig;
 use crate::message::Messages;
 use crate::transforms::chain::{TransformChain, TransformChainBuilder};
@@ -91,6 +91,14 @@ impl TransformConfig for ParallelMapConfig {
             chains,
             ordered: self.ordered_results,
         }))
+    }
+
+    fn up_chain_protocol(&self) -> UpChainProtocol {
+        UpChainProtocol::Any
+    }
+
+    fn down_chain_protocol(&self) -> DownChainProtocol {
+        DownChainProtocol::Terminating
     }
 }
 

--- a/shotover/src/transforms/protect/mod.rs
+++ b/shotover/src/transforms/protect/mod.rs
@@ -1,4 +1,8 @@
 use super::TransformContextBuilder;
+#[cfg(feature = "alpha-transforms")]
+use super::{DownChainProtocol, UpChainProtocol};
+#[cfg(feature = "alpha-transforms")]
+use crate::frame::MessageType;
 use crate::frame::{
     value::GenericValue, CassandraFrame, CassandraOperation, CassandraResult, Frame,
 };
@@ -59,6 +63,14 @@ impl crate::transforms::TransformConfig for ProtectConfig {
             key_id: "XXXXXXX".to_string(),
             requests: MessageIdMap::default(),
         }))
+    }
+
+    fn up_chain_protocol(&self) -> UpChainProtocol {
+        UpChainProtocol::MustBeOneOf(vec![MessageType::Cassandra])
+    }
+
+    fn down_chain_protocol(&self) -> DownChainProtocol {
+        DownChainProtocol::SameAsUpChain
     }
 }
 

--- a/shotover/src/transforms/query_counter.rs
+++ b/shotover/src/transforms/query_counter.rs
@@ -9,7 +9,9 @@ use metrics::counter;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::DownChainProtocol;
 use super::TransformContextConfig;
+use super::UpChainProtocol;
 
 #[derive(Clone)]
 pub struct QueryCounter {
@@ -93,5 +95,13 @@ impl TransformConfig for QueryCounterConfig {
         _transform_context: TransformContextConfig,
     ) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(QueryCounter::new(self.name.clone())))
+    }
+
+    fn up_chain_protocol(&self) -> UpChainProtocol {
+        UpChainProtocol::Any
+    }
+
+    fn down_chain_protocol(&self) -> DownChainProtocol {
+        DownChainProtocol::SameAsUpChain
     }
 }

--- a/shotover/src/transforms/redis/cache.rs
+++ b/shotover/src/transforms/redis/cache.rs
@@ -3,8 +3,8 @@ use crate::frame::{CassandraFrame, CassandraOperation, Frame, MessageType, Redis
 use crate::message::{Message, MessageIdMap, Messages, Metadata};
 use crate::transforms::chain::{TransformChain, TransformChainBuilder};
 use crate::transforms::{
-    Transform, TransformBuilder, TransformConfig, TransformContextBuilder, TransformContextConfig,
-    Wrapper,
+    DownChainProtocol, Transform, TransformBuilder, TransformConfig, TransformContextBuilder,
+    TransformContextConfig, UpChainProtocol, Wrapper,
 };
 use anyhow::{bail, Result};
 use async_trait::async_trait;
@@ -110,6 +110,14 @@ impl TransformConfig for RedisConfig {
             caching_schema,
             missed_requests,
         }))
+    }
+
+    fn up_chain_protocol(&self) -> UpChainProtocol {
+        UpChainProtocol::MustBeOneOf(vec![MessageType::Cassandra])
+    }
+
+    fn down_chain_protocol(&self) -> DownChainProtocol {
+        DownChainProtocol::SameAsUpChain
     }
 }
 

--- a/shotover/src/transforms/redis/cluster_ports_rewrite.rs
+++ b/shotover/src/transforms/redis/cluster_ports_rewrite.rs
@@ -1,8 +1,11 @@
 use crate::frame::Frame;
+use crate::frame::MessageType;
 use crate::frame::RedisFrame;
 use crate::message::{MessageIdMap, Messages};
+use crate::transforms::DownChainProtocol;
 use crate::transforms::TransformContextBuilder;
 use crate::transforms::TransformContextConfig;
+use crate::transforms::UpChainProtocol;
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
 use anyhow::{anyhow, bail, Context, Result};
 use async_trait::async_trait;
@@ -25,6 +28,14 @@ impl TransformConfig for RedisClusterPortsRewriteConfig {
         _transform_context: TransformContextConfig,
     ) -> Result<Box<dyn TransformBuilder>> {
         Ok(Box::new(RedisClusterPortsRewrite::new(self.new_port)))
+    }
+
+    fn up_chain_protocol(&self) -> UpChainProtocol {
+        UpChainProtocol::MustBeOneOf(vec![MessageType::Redis])
+    }
+
+    fn down_chain_protocol(&self) -> DownChainProtocol {
+        DownChainProtocol::SameAsUpChain
     }
 }
 

--- a/shotover/src/transforms/redis/sink_cluster.rs
+++ b/shotover/src/transforms/redis/sink_cluster.rs
@@ -1,6 +1,6 @@
 use crate::codec::redis::RedisCodecBuilder;
 use crate::codec::{CodecBuilder, Direction};
-use crate::frame::{Frame, RedisFrame};
+use crate::frame::{Frame, MessageType, RedisFrame};
 use crate::message::{Message, Messages};
 use crate::tls::TlsConnectorConfig;
 use crate::transforms::redis::RedisError;
@@ -8,8 +8,8 @@ use crate::transforms::redis::TransformError;
 use crate::transforms::util::cluster_connection_pool::{Authenticator, ConnectionPool};
 use crate::transforms::util::{Request, Response};
 use crate::transforms::{
-    ResponseFuture, Transform, TransformBuilder, TransformConfig, TransformContextBuilder,
-    TransformContextConfig, Wrapper,
+    DownChainProtocol, ResponseFuture, Transform, TransformBuilder, TransformConfig,
+    TransformContextBuilder, TransformContextConfig, UpChainProtocol, Wrapper,
 };
 use anyhow::{anyhow, bail, ensure, Context, Result};
 use async_trait::async_trait;
@@ -69,6 +69,14 @@ impl TransformConfig for RedisSinkClusterConfig {
             chain_name: transform_context.chain_name,
             shared_topology: Arc::new(RwLock::new(Topology::new())),
         }))
+    }
+
+    fn up_chain_protocol(&self) -> UpChainProtocol {
+        UpChainProtocol::MustBeOneOf(vec![MessageType::Redis])
+    }
+
+    fn down_chain_protocol(&self) -> DownChainProtocol {
+        DownChainProtocol::Terminating
     }
 }
 

--- a/shotover/src/transforms/redis/sink_single.rs
+++ b/shotover/src/transforms/redis/sink_single.rs
@@ -48,7 +48,7 @@ impl TransformConfig for RedisSinkSingleConfig {
     }
 
     fn down_chain_protocol(&self) -> DownChainProtocol {
-        DownChainProtocol::Sink
+        DownChainProtocol::Terminating
     }
 }
 

--- a/shotover/src/transforms/tee.rs
+++ b/shotover/src/transforms/tee.rs
@@ -1,4 +1,4 @@
-use super::{TransformContextBuilder, TransformContextConfig};
+use super::{DownChainProtocol, TransformContextBuilder, TransformContextConfig, UpChainProtocol};
 use crate::config::chain::TransformChainConfig;
 use crate::http::HttpServerError;
 use crate::message::{Message, MessageIdMap, Messages};
@@ -228,6 +228,14 @@ impl TransformConfig for TeeConfig {
             self.switch_port,
             transform_context.protocol.is_inorder(),
         )))
+    }
+
+    fn up_chain_protocol(&self) -> UpChainProtocol {
+        UpChainProtocol::Any
+    }
+
+    fn down_chain_protocol(&self) -> DownChainProtocol {
+        DownChainProtocol::SameAsUpChain
     }
 }
 

--- a/shotover/src/transforms/throttling.rs
+++ b/shotover/src/transforms/throttling.rs
@@ -1,4 +1,5 @@
-use super::{TransformContextBuilder, TransformContextConfig};
+use super::{DownChainProtocol, TransformContextBuilder, TransformContextConfig, UpChainProtocol};
+use crate::frame::MessageType;
 use crate::message::{Message, MessageIdMap, Messages};
 use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
 use anyhow::Result;
@@ -35,6 +36,14 @@ impl TransformConfig for RequestThrottlingConfig {
             max_requests_per_second: self.max_requests_per_second,
             throttled_requests: MessageIdMap::default(),
         }))
+    }
+
+    fn up_chain_protocol(&self) -> UpChainProtocol {
+        UpChainProtocol::MustBeOneOf(vec![MessageType::Cassandra])
+    }
+
+    fn down_chain_protocol(&self) -> DownChainProtocol {
+        DownChainProtocol::SameAsUpChain
     }
 }
 


### PR DESCRIPTION
This PR adds up_chain_protocol and down_chain_protocol implementations for every transform, and then removes the default implementation for these methods, making them mandatory.

I renamed some of the variants since looking at them with fresh eyes today I can see some issues:
* `Sink` -> `Terminating` - A terminating transform is one that does not send messages down chain, while a sink is a transform that sends messages to a DB. A sink is always terminating but a terminating transform is not always a sink. So this should have been called terminating.
* `SameAsIncoming` -> `SameAsUpChain` - UpChain used to be called Incoming and I missed this when renaming everything.
