### PR TITLE
Move cql ws to shotover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,20 +1211,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cql-ws"
-version = "0.1.0"
-source = "git+https://github.com/shotover/cql-ws#11ec9db0acc0c1e605eae214a81a327571f4cd97"
-dependencies = [
- "cassandra-protocol",
- "futures-util",
- "http 1.1.0",
- "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
- "tokio",
- "tokio-tungstenite 0.20.1",
-]
-
-[[package]]
 name = "cql3-parser"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4646,7 +4632,6 @@ dependencies = [
  "cdrs-tokio",
  "chacha20poly1305",
  "clap",
- "cql-ws",
  "csv",
  "fred",
  "futures",
@@ -4982,6 +4967,8 @@ dependencies = [
  "cassandra-protocol",
  "cdrs-tokio",
  "docker-compose-runner",
+ "futures-util",
+ "http 1.1.0",
  "itertools 0.12.1",
  "j4rs",
  "openssl",
@@ -4990,12 +4977,15 @@ dependencies = [
  "rdkafka",
  "redis",
  "reqwest 0.12.4",
+ "rustls 0.21.12",
+ "rustls-pemfile 1.0.4",
  "scylla",
  "subprocess",
  "tokio",
  "tokio-bin-process",
  "tokio-io-timeout",
  "tokio-openssl",
+ "tokio-tungstenite 0.20.1",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -49,7 +49,6 @@ rustls-pki-types = "1.1.0"
 aws-throwaway.workspace = true
 windsock = "0.1.0"
 regex = "1.7.0"
-cql-ws = { git = "https://github.com/shotover/cql-ws" }
 opensearch = "2.1.0"
 serde_json = "1.0.103"
 time = { version = "0.3.25" }

--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -17,7 +17,8 @@ use test_helpers::connection::cassandra::Compression;
 use test_helpers::connection::cassandra::ProtocolVersion;
 use test_helpers::connection::cassandra::{
     assert_query_result, run_query, CassandraConnection, CassandraConnectionBuilder,
-    CassandraDriver, CassandraDriver::CdrsTokio, CassandraDriver::Scylla, ResultValue,
+    CassandraDriver, CassandraDriver::CdrsTokio, CassandraDriver::Scylla, CqlWsSession,
+    ResultValue,
 };
 use test_helpers::connection::redis_connection;
 use test_helpers::docker_compose::docker_compose;
@@ -1011,7 +1012,7 @@ async fn passthrough_websockets() {
             .start()
             .await;
 
-    let mut session = cql_ws::Session::new("ws://0.0.0.0:9042").await;
+    let mut session = CqlWsSession::new("ws://0.0.0.0:9042").await;
     let rows = session.query("SELECT bootstrapped FROM system.local").await;
     assert_eq!(rows, vec![vec![CassandraType::Varchar("COMPLETED".into())]]);
 
@@ -1029,7 +1030,7 @@ async fn encode_websockets() {
             .start()
             .await;
 
-    let mut session = cql_ws::Session::new("ws://0.0.0.0:9042").await;
+    let mut session = CqlWsSession::new("ws://0.0.0.0:9042").await;
     let rows = session.query("SELECT bootstrapped FROM system.local").await;
     assert_eq!(rows, vec![vec![CassandraType::Varchar("COMPLETED".into())]]);
 
@@ -1050,7 +1051,7 @@ async fn passthrough_tls_websockets() {
 
     let ca_cert = "tests/test-configs/cassandra/tls/certs/localhost_CA.crt";
 
-    let mut session = cql_ws::Session::new_tls("wss://0.0.0.0:9042", ca_cert).await;
+    let mut session = CqlWsSession::new_tls("wss://0.0.0.0:9042", ca_cert).await;
     let rows = session.query("SELECT bootstrapped FROM system.local").await;
     assert_eq!(rows, vec![vec![CassandraType::Varchar("COMPLETED".into())]]);
 

--- a/test-helpers/Cargo.toml
+++ b/test-helpers/Cargo.toml
@@ -34,3 +34,8 @@ rcgen.workspace = true
 rdkafka = { version = "0.36", features = ["cmake-build"], optional = true }
 docker-compose-runner = "0.3.0"
 j4rs = "0.18.0"
+futures-util = "0.3.28"
+http = "1.1.0"
+rustls = { version = "0.21.2" ,features = ["dangerous_configuration"] }
+rustls-pemfile = "1.0.2"
+tokio-tungstenite = { git = "https://github.com/shotover/tokio-tungstenite", features = ["rustls-tls-native-roots"], rev = "2f1cc11e491c2d0401d01a83f623623182784b3a" }

--- a/test-helpers/src/connection/cassandra/cql_ws.rs
+++ b/test-helpers/src/connection/cassandra/cql_ws.rs
@@ -1,0 +1,283 @@
+use cassandra_protocol::compression::Compression;
+use cassandra_protocol::frame::message_query::BodyReqQuery;
+use cassandra_protocol::frame::message_response::ResponseBody;
+use cassandra_protocol::frame::message_result::{BodyResResultRows, ResResultBody};
+use cassandra_protocol::frame::Envelope;
+use cassandra_protocol::frame::Flags;
+use cassandra_protocol::frame::Opcode;
+use cassandra_protocol::frame::Version;
+use cassandra_protocol::query::query_params::QueryParams;
+use cassandra_protocol::types::cassandra_type::{wrapper_fn, CassandraType};
+use futures_util::{SinkExt, StreamExt};
+use rustls::client::{ServerCertVerified, ServerCertVerifier, WebPkiVerifier};
+use rustls::{Certificate, CertificateError, RootCertStore, ServerName};
+use std::fs::File;
+use std::io::BufReader;
+use std::sync::Arc;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+use tokio_tungstenite::tungstenite::error::Error;
+use tokio_tungstenite::tungstenite::error::ProtocolError;
+use tokio_tungstenite::tungstenite::handshake::client::generate_key;
+use tokio_tungstenite::tungstenite::handshake::server::Request;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::Connector;
+use tokio_tungstenite::WebSocketStream;
+
+pub struct CqlWsSession {
+    in_rx: UnboundedReceiver<Message>,
+    out_tx: UnboundedSender<Message>,
+}
+
+impl CqlWsSession {
+    fn construct_request(uri: &str) -> Request {
+        let uri = uri.parse::<http::Uri>().unwrap();
+
+        let authority = uri.authority().unwrap().as_str();
+        let host = authority
+            .find('@')
+            .map(|idx| authority.split_at(idx + 1).1)
+            .unwrap_or_else(|| authority);
+
+        if host.is_empty() {
+            panic!("Empty host name");
+        }
+
+        http::Request::builder()
+            .method("GET")
+            .header("Host", host)
+            .header("Connection", "Upgrade")
+            .header("Upgrade", "websocket")
+            .header("Sec-WebSocket-Version", "13")
+            .header("Sec-WebSocket-Key", generate_key())
+            .header(
+                "Sec-WebSocket-Protocol",
+                "cql".parse::<http::HeaderValue>().unwrap(),
+            )
+            .uri(uri)
+            .body(())
+            .unwrap()
+    }
+
+    pub async fn new(address: &str) -> Self {
+        let (ws_stream, _) = tokio_tungstenite::connect_async(Self::construct_request(address))
+            .await
+            .unwrap();
+
+        let (in_tx, in_rx) = unbounded_channel::<Message>();
+        let (out_tx, out_rx) = unbounded_channel::<Message>();
+
+        spawn_read_write_tasks(ws_stream, in_tx, out_rx);
+
+        let mut session = Self { in_rx, out_tx };
+        session.startup().await;
+        session
+    }
+
+    pub async fn new_tls(address: &str, ca_path: &str) -> Self {
+        let root_cert_store = load_ca(ca_path);
+
+        let tls_client_config = rustls::ClientConfig::builder()
+            .with_safe_defaults()
+            .with_custom_certificate_verifier(Arc::new(SkipVerifyHostName::new(root_cert_store)))
+            .with_no_client_auth();
+
+        let (ws_stream, _) = tokio_tungstenite::connect_async_tls_with_config(
+            Self::construct_request(address),
+            None,
+            false,
+            Some(Connector::Rustls(Arc::new(tls_client_config))),
+        )
+        .await
+        .unwrap();
+
+        let (in_tx, in_rx) = unbounded_channel::<Message>();
+        let (out_tx, out_rx) = unbounded_channel::<Message>();
+
+        spawn_read_write_tasks(ws_stream, in_tx, out_rx);
+
+        let mut session = Self { in_rx, out_tx };
+        session.startup().await;
+        session
+    }
+
+    async fn startup(&mut self) {
+        let envelope = Envelope::new_req_startup(None, Version::V4);
+        self.out_tx.send(Self::encode(envelope)).unwrap();
+
+        let envelope = Self::decode(self.in_rx.recv().await.unwrap());
+
+        match envelope.opcode {
+            Opcode::Ready => println!("cql-ws: received: {:?}", envelope),
+            Opcode::Authenticate => {
+                todo!();
+            }
+            _ => panic!("expected to receive a ready or authenticate message"),
+        }
+    }
+
+    pub async fn query(&mut self, query: &str) -> Vec<Vec<CassandraType>> {
+        let envelope = Envelope::new_query(
+            BodyReqQuery {
+                query: query.into(),
+                query_params: QueryParams::default(),
+            },
+            Flags::empty(),
+            Version::V4,
+        );
+
+        self.out_tx.send(Self::encode(envelope)).unwrap();
+
+        let envelope = Self::decode(self.in_rx.recv().await.unwrap());
+
+        if let ResponseBody::Result(ResResultBody::Rows(BodyResResultRows {
+            rows_content,
+            metadata,
+            ..
+        })) = envelope.response_body().unwrap()
+        {
+            let mut result_values = vec![];
+            for row in &rows_content {
+                let mut row_result_values = vec![];
+                for (i, col_spec) in metadata.col_specs.iter().enumerate() {
+                    let wrapper = wrapper_fn(&col_spec.col_type.id);
+                    let value = wrapper(&row[i], &col_spec.col_type, envelope.version).unwrap();
+
+                    row_result_values.push(value);
+                }
+                result_values.push(row_result_values);
+            }
+
+            result_values
+        } else {
+            panic!("unexpected to recieve a result envelope");
+        }
+    }
+
+    fn encode(envelope: Envelope) -> Message {
+        let data = envelope.encode_with(Compression::None).unwrap();
+        Message::Binary(data)
+    }
+
+    fn decode(ws_message: Message) -> Envelope {
+        match ws_message {
+            Message::Binary(data) => {
+                Envelope::from_buffer(data.as_slice(), Compression::None)
+                    .unwrap()
+                    .envelope
+            }
+            _ => panic!("expected to receive a binary message"),
+        }
+    }
+
+    pub async fn send_raw_ws_message(&mut self, ws_message: Message) {
+        self.out_tx.send(ws_message).unwrap();
+    }
+
+    pub async fn wait_for_raw_ws_message_resp(&mut self) -> Message {
+        self.in_rx.recv().await.unwrap()
+    }
+}
+
+fn spawn_read_write_tasks<S: AsyncRead + AsyncWrite + Unpin + Send + 'static>(
+    ws_stream: WebSocketStream<S>,
+    in_tx: UnboundedSender<Message>,
+    mut out_rx: UnboundedReceiver<Message>,
+) {
+    let (mut write, mut read) = ws_stream.split();
+
+    // read task
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                result = read.next() => {
+                    if let Some(message) = result {
+                        match message {
+                            Ok(ws_message @ Message::Binary(_)) => {
+                                in_tx.send(ws_message).unwrap();
+                            }
+                            Ok(Message::Close(_)) => {
+                                return;
+                            }
+                            Ok(_) => panic!("expected to recieve a binary message"),
+                            Err(err) => panic!("{err}")
+                        }
+                    }
+                }
+                _ = in_tx.closed() => {
+                    return;
+                }
+            }
+        }
+    });
+
+    // write task
+    tokio::spawn(async move {
+        loop {
+            if let Some(ws_message) = out_rx.recv().await {
+                write.send(ws_message).await.unwrap();
+            } else {
+                match write.send(Message::Close(None)).await {
+                    Ok(_) => {}
+                    Err(Error::Protocol(ProtocolError::SendAfterClosing)) => {}
+                    Err(err) => panic!("{err}"),
+                }
+                break;
+            }
+        }
+    });
+}
+
+fn load_ca(path: &str) -> RootCertStore {
+    let mut pem = BufReader::new(File::open(path).unwrap());
+    let certs = rustls_pemfile::certs(&mut pem).unwrap();
+
+    let mut root_cert_store = RootCertStore::empty();
+    for cert in certs {
+        root_cert_store.add(&Certificate(cert)).unwrap();
+    }
+    root_cert_store
+}
+
+pub struct SkipVerifyHostName {
+    verifier: WebPkiVerifier,
+}
+
+impl SkipVerifyHostName {
+    pub fn new(roots: RootCertStore) -> Self {
+        SkipVerifyHostName {
+            verifier: WebPkiVerifier::new(roots, None),
+        }
+    }
+}
+
+// This recreates the verify_hostname(false) functionality from openssl.
+// This adds an opening for MitM attacks but we provide this functionality because there are some
+// circumstances where providing a cert per instance in a cluster is difficult and this allows at least some security by sharing a single cert between all instances.
+// Note that the SAN dnsname wildcards (e.g. *foo.com) wouldnt help here because we need to refer to destinations by ip address and there is no such wildcard functionality for ip addresses.
+impl ServerCertVerifier for SkipVerifyHostName {
+    fn verify_server_cert(
+        &self,
+        end_entity: &Certificate,
+        intermediates: &[Certificate],
+        server_name: &ServerName,
+        scts: &mut dyn Iterator<Item = &[u8]>,
+        ocsp_response: &[u8],
+        now: std::time::SystemTime,
+    ) -> std::result::Result<rustls::client::ServerCertVerified, rustls::Error> {
+        match self.verifier.verify_server_cert(
+            end_entity,
+            intermediates,
+            server_name,
+            scts,
+            ocsp_response,
+            now,
+        ) {
+            Ok(result) => Ok(result),
+            Err(rustls::Error::InvalidCertificate(CertificateError::NotValidForName)) => {
+                Ok(ServerCertVerified::assertion())
+            }
+            Err(err) => Err(err),
+        }
+    }
+}

--- a/test-helpers/src/connection/cassandra/mod.rs
+++ b/test-helpers/src/connection/cassandra/mod.rs
@@ -1,10 +1,12 @@
 pub mod connection;
+pub mod cql_ws;
 pub mod result_value;
 
 pub use connection::{
     CassandraConnection, CassandraConnectionBuilder, CassandraDriver, Compression, Consistency,
     ProtocolVersion,
 };
+pub use cql_ws::CqlWsSession;
 pub use result_value::ResultValue;
 
 /// Execute a `query` against the `session` and assert that the result rows match `expected_rows`


### PR DESCRIPTION
We had some maintenance issues keeping this dependency in a repo. https://github.com/shotover/cql-ws
It's small enough that it can just be a module within our `test-helpers` crate. 

~~https://github.com/shotover/shotover-proxy/pull/1602 is a pre-req~~