### PR TITLE
deny unsafe_code in shotover

### DIFF
--- a/shotover/src/lib.rs
+++ b/shotover/src/lib.rs
@@ -24,11 +24,14 @@
 //!     shotover::runner::Shotover::new().run_block();
 //! }
 //! ```
-//!
 
+// If we absolutely need unsafe code, it should be isolated within a separate small crate that exposes a sound safe API.
+// "sound" means that it is impossible for any interaction with the public API of the crate to violate an unsafe invariant which causes UB.
+#![deny(unsafe_code)]
 // Accidentally printing would break json log output
 #![deny(clippy::print_stdout)]
 #![deny(clippy::print_stderr)]
+// allow some clippy lints that we disagree with
 #![allow(clippy::needless_doctest_main)]
 #![allow(clippy::box_default)]
 // Allow dead code if any of the protocol features are disabled


### PR DESCRIPTION
progress towards: https://github.com/shotover/shotover-proxy/issues/1615

We have long held the understanding that unsafe code should never go into the shotover crate itself.
With new contributors joining, lets make this rule explicit rather than implicit.