### PR TITLE
Fix redis_int_tests::passthrough_redis_down on macos

### DIFF
--- a/shotover-proxy/tests/lib.rs
+++ b/shotover-proxy/tests/lib.rs
@@ -22,3 +22,11 @@ pub fn shotover_process(topology_path: &str) -> ShotoverProcessBuilder {
         .with_bin(bin_path!("shotover-proxy"))
         .with_config("tests/test-configs/shotover-config/config1.yaml")
 }
+
+#[cfg(target_os = "macos")]
+#[cfg(feature = "redis")]
+const CONNECTION_REFUSED_OS_ERROR: i32 = 61;
+
+#[cfg(not(target_os = "macos"))]
+#[cfg(feature = "redis")]
+const CONNECTION_REFUSED_OS_ERROR: i32 = 111;

--- a/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
+++ b/shotover-proxy/tests/redis_int_tests/basic_driver_tests.rs
@@ -1,4 +1,5 @@
 use crate::redis_int_tests::assert::*;
+use crate::CONNECTION_REFUSED_OS_ERROR;
 use bytes::BytesMut;
 use fred::clients::RedisClient;
 use fred::interfaces::ClientLike;
@@ -1273,7 +1274,7 @@ pub async fn test_trigger_transform_failure_driver(client: &RedisClient) {
     assert_eq!(
         // fred sends a `CLIENT` command on startup to which shotover will reply with an error
         client.wait_for_connect().await.unwrap_err().details(),
-        "ERR Internal shotover (or custom transform) bug: Chain failed to send and/or receive messages, the connection will now be closed.  Caused by:     0: RedisSinkSingle transform failed     1: Failed to connect to destination 127.0.0.1:1111     2: Connection refused (os error 111)".to_string()
+        format!("ERR Internal shotover (or custom transform) bug: Chain failed to send and/or receive messages, the connection will now be closed.  Caused by:     0: RedisSinkSingle transform failed     1: Failed to connect to destination 127.0.0.1:1111     2: Connection refused (os error {CONNECTION_REFUSED_OS_ERROR})")
     );
 }
 
@@ -1292,7 +1293,7 @@ pub async fn test_trigger_transform_failure_raw() {
 
     assert_eq!(
         read_redis_message(&mut connection).await,
-        RedisFrame::Error("ERR Internal shotover (or custom transform) bug: Chain failed to send and/or receive messages, the connection will now be closed.  Caused by:     0: RedisSinkSingle transform failed     1: Failed to connect to destination 127.0.0.1:1111     2: Connection refused (os error 111)".into())
+        RedisFrame::Error(format!("ERR Internal shotover (or custom transform) bug: Chain failed to send and/or receive messages, the connection will now be closed.  Caused by:     0: RedisSinkSingle transform failed     1: Failed to connect to destination 127.0.0.1:1111     2: Connection refused (os error {CONNECTION_REFUSED_OS_ERROR})").into())
     );
 
     // If the connection was closed by shotover then we will succesfully read 0 bytes.

--- a/shotover-proxy/tests/redis_int_tests/mod.rs
+++ b/shotover-proxy/tests/redis_int_tests/mod.rs
@@ -1,4 +1,4 @@
-use crate::shotover_process;
+use crate::{shotover_process, CONNECTION_REFUSED_OS_ERROR};
 use basic_driver_tests::*;
 use fred::clients::RedisClient;
 use fred::interfaces::ClientLike;
@@ -66,15 +66,15 @@ async fn passthrough_redis_down() {
             EventMatcher::new()
                 .with_level(Level::Error)
                 .with_target("shotover::server")
-                .with_message(
+                .with_message(&format!(
                     r#"connection was unexpectedly terminated
 
 Caused by:
     0: Chain failed to send and/or receive messages, the connection will now be closed.
     1: RedisSinkSingle transform failed
     2: Failed to connect to destination 127.0.0.1:1111
-    3: Connection refused (os error 111)"#,
-                )
+    3: Connection refused (os error {CONNECTION_REFUSED_OS_ERROR})"#
+                ))
                 .with_count(Count::Times(2)),
             // This error occurs due to `test_invalid_frame`, it opens a connection, sends an invalid frame which
             // fails at the codec stage and never reaches the transform.
@@ -83,14 +83,14 @@ Caused by:
             EventMatcher::new()
                 .with_level(Level::Error)
                 .with_target("shotover::server")
-                .with_message(
+                .with_message(&format!(
                     r#"encountered an error when flushing the chain redis for shutdown
 
 Caused by:
     0: RedisSinkSingle transform failed
     1: Failed to connect to destination 127.0.0.1:1111
-    2: Connection refused (os error 111)"#,
-                )
+    2: Connection refused (os error {CONNECTION_REFUSED_OS_ERROR})"#
+                ))
                 .with_count(Count::Times(1)),
             invalid_frame_event(),
         ])


### PR DESCRIPTION
progress towards https://github.com/shotover/shotover-proxy/issues/1615

the test `passthrough_redis_down` asserts that a specific error is returned by shotover when the redis instance is down.
Since mac os and linux have different error codes for connection refused the test passes on linux but fails on macos.

This PR fixes the test to also run on macos.
This is done by having a constant included into the assertion that is equal to `61` on macos and equal to `111` on all other OSs.
There are probably other OSs that this doesnt fix but thats fine, at this time we only care about linux and macos.