### PR TITLE
scram_over_mtls - phase2 - caching task

### DIFF
--- a/shotover/src/transforms/kafka/sink_cluster/node.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/node.rs
@@ -117,10 +117,6 @@ impl ConnectionFactory {
         scram_over_mtls: &AuthorizeScramOverMtls,
         connection: &mut SinkConnection,
     ) -> Result<()> {
-        // TODO: This sleep is currently load bearing...
-        //       Need to delay progression until token has propagated.
-        tokio::time::sleep(std::time::Duration::from_secs(4)).await;
-
         let mut auth_requests = self.auth_requests.clone();
 
         // send/receive SaslHandshake

--- a/shotover/src/transforms/kafka/sink_cluster/scram_over_mtls.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/scram_over_mtls.rs
@@ -1,5 +1,6 @@
 use super::node::{ConnectionFactory, KafkaAddress};
 use crate::{
+    connection::SinkConnection,
     frame::{
         kafka::{KafkaFrame, RequestBody, ResponseBody},
         Frame,
@@ -12,11 +13,92 @@ use kafka_protocol::{
     messages::{ApiKey, CreateDelegationTokenRequest, RequestHeader},
     protocol::{Builder, StrBytes},
 };
-use rand::prelude::SliceRandom;
 use rand::rngs::SmallRng;
+use rand::{prelude::SliceRandom, SeedableRng};
 use serde::{Deserialize, Serialize};
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 use tokio::sync::Notify;
+use tokio::sync::{mpsc, oneshot};
+
+pub struct TokenRequest {
+    username: String,
+    response_tx: oneshot::Sender<DelegationToken>,
+}
+
+#[derive(Clone)]
+pub struct TokenTask {
+    tx: mpsc::Sender<TokenRequest>,
+}
+
+impl TokenTask {
+    #[allow(clippy::new_without_default)]
+    pub fn new(
+        mtls_connection_factory: ConnectionFactory,
+        mtls_port_contact_points: Vec<String>,
+    ) -> TokenTask {
+        let (tx, mut rx) = mpsc::channel::<TokenRequest>(1000);
+        tokio::spawn(async move {
+            loop {
+                match task(&mut rx, &mtls_connection_factory, &mtls_port_contact_points).await {
+                    Ok(()) => {
+                        // shotover is shutting down, terminate the task
+                        break;
+                    }
+                    Err(err) => {
+                        tracing::error!("Token task restarting due to failure, error was {err:?}");
+                    }
+                }
+            }
+        });
+        TokenTask { tx }
+    }
+
+    pub async fn get_token_for_user(&self, username: String) -> Result<DelegationToken> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.tx
+            .send(TokenRequest {
+                username,
+                response_tx,
+            })
+            .await?;
+        Ok(response_rx.await?)
+    }
+}
+
+async fn task(
+    rx: &mut mpsc::Receiver<TokenRequest>,
+    mtls_connection_factory: &ConnectionFactory,
+    mtls_port_contact_points: &[String],
+) -> Result<()> {
+    let mut rng = SmallRng::from_rng(rand::thread_rng())?;
+    let mut username_to_token = HashMap::new();
+    while let Some(request) = rx.recv().await {
+        let token = if let Some(token) = username_to_token.get(&request.username).cloned() {
+            token
+        } else {
+            let address =
+                KafkaAddress::from_str(mtls_port_contact_points.choose(&mut rng).unwrap())?;
+            let mut connection = mtls_connection_factory
+                // Must be unauthed since mTLS is its own auth.
+                .create_connection_unauthed(&address)
+                .await?;
+
+            let token =
+                create_delegation_token_for_user(&mut connection, request.username.clone()).await?;
+
+            // TODO: This sleep is currently load bearing...
+            //       Need to delay progression until token has propagated.
+            tokio::time::sleep(std::time::Duration::from_secs(4)).await;
+
+            username_to_token.insert(request.username, token.clone());
+            token
+        };
+        request.response_tx.send(token).ok();
+    }
+
+    // rx returned None which indicates shotover is shutting down
+    Ok(())
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
@@ -26,50 +108,48 @@ pub struct AuthorizeScramOverMtlsConfig {
 }
 
 impl AuthorizeScramOverMtlsConfig {
-    pub fn get_builder(&self) -> Result<AuthorizeScramOverMtlsBuilder> {
+    pub fn get_builder(
+        &self,
+        connect_timeout: Duration,
+        read_timeout: Option<Duration>,
+    ) -> Result<AuthorizeScramOverMtlsBuilder> {
+        let mtls_connection_factory = ConnectionFactory::new(
+            Some(TlsConnector::new(self.tls.clone())?),
+            connect_timeout,
+            read_timeout,
+            Arc::new(Notify::new()),
+        );
         Ok(AuthorizeScramOverMtlsBuilder {
-            mtls_port_contact_points: self.mtls_port_contact_points.clone(),
-            tls: TlsConnector::new(self.tls.clone())?,
+            token_task: TokenTask::new(
+                mtls_connection_factory,
+                self.mtls_port_contact_points.clone(),
+            ),
         })
     }
 }
 
 pub struct AuthorizeScramOverMtlsBuilder {
-    pub mtls_port_contact_points: Vec<String>,
-    pub tls: TlsConnector,
+    pub token_task: TokenTask,
 }
 
 impl AuthorizeScramOverMtlsBuilder {
-    pub fn build(
-        &self,
-        connect_timeout: Duration,
-        read_timeout: Option<Duration>,
-    ) -> AuthorizeScramOverMtls {
-        let mtls_connection_factory = ConnectionFactory::new(
-            Some(self.tls.clone()),
-            connect_timeout,
-            read_timeout,
-            Arc::new(Notify::new()),
-        );
+    pub fn build(&self) -> AuthorizeScramOverMtls {
         AuthorizeScramOverMtls {
-            mtls_port_contact_points: self.mtls_port_contact_points.clone(),
-            mtls_connection_factory,
+            original_scram_state: OriginalScramState::WaitingOnServerFirst,
+            token_task: self.token_task.clone(),
             delegation_token: DelegationToken {
                 token_id: String::new(),
                 hmac: vec![],
             },
-            original_scram_state: OriginalScramState::WaitingOnServerFirst,
         }
     }
 }
 
 pub struct AuthorizeScramOverMtls {
-    /// The destination to create mTLS connections from
-    pub mtls_port_contact_points: Vec<String>,
-    /// connection factory to create mTLS connections from
-    pub mtls_connection_factory: ConnectionFactory,
     /// Tracks the state of the original scram connections responses created from the clients actual requests
     pub original_scram_state: OriginalScramState,
+    /// Shared task that fetches and caches delegation tokens
+    pub token_task: TokenTask,
     /// The delegation token generated from the username used in the original scram auth
     pub delegation_token: DelegationToken,
 }
@@ -82,22 +162,9 @@ pub enum OriginalScramState {
 }
 
 pub async fn create_delegation_token_for_user(
-    scram_over_mtls: &AuthorizeScramOverMtls,
+    connection: &mut SinkConnection,
     username: String,
-    rng: &mut SmallRng,
 ) -> Result<DelegationToken> {
-    let address = KafkaAddress::from_str(
-        scram_over_mtls
-            .mtls_port_contact_points
-            .choose(rng)
-            .unwrap(),
-    )?;
-    let mut connection = scram_over_mtls
-        .mtls_connection_factory
-        // Must be unauthed since mTLS is its own auth.
-        .create_connection_unauthed(&address)
-        .await?;
-
     connection.send(vec![Message::from_frame(Frame::Kafka(
         KafkaFrame::Request {
             header: RequestHeader::builder()
@@ -131,7 +198,9 @@ pub async fn create_delegation_token_for_user(
     }
 }
 
+#[derive(Clone)]
 pub struct DelegationToken {
     pub token_id: String,
+    // TODO: store as base64 string
     pub hmac: Vec<u8>,
 }


### PR DESCRIPTION
progress towards: https://github.com/shotover/shotover-proxy/issues/1618

This PR is the first step towards a more robust scram_over_mtls implementation:
* It introduces a task that runs in the background and manages delegation tokens for all KafkaSinkCluster instances.
* The task currently just implements caching of tokens across all connections.

In the future the task will also be used for:
* detecting when tokens are ready to be used without a hardcoded sleep.
* recreating tokens before they expire
* prefetching all known tokens at startup

Since this task going down would leave the shotover instance in a very broken state:
* unwrap/panic is never used, instead an error is returned for all error cases.
* The task is wrapped in a loop that will restart the task from scratch if it encounters an error.
