### PR TITLE
Store delegation token hmac as base64

### DIFF
--- a/shotover/src/transforms/kafka/sink_cluster/node.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/node.rs
@@ -7,8 +7,6 @@ use crate::message::Message;
 use crate::tls::TlsConnector;
 use crate::transforms::kafka::sink_cluster::SASL_SCRAM_MECHANISMS;
 use anyhow::{anyhow, Context, Result};
-use base64::engine::general_purpose;
-use base64::Engine;
 use bytes::Bytes;
 use kafka_protocol::messages::{ApiKey, BrokerId, RequestHeader, SaslAuthenticateRequest};
 use kafka_protocol::protocol::{Builder, StrBytes};
@@ -143,10 +141,9 @@ impl ConnectionFactory {
         }
 
         // SCRAM client-first
-        let hmac = general_purpose::STANDARD.encode(&scram_over_mtls.delegation_token.hmac);
         let mut scram = Scram::<Sha256>::new(
             scram_over_mtls.delegation_token.token_id.clone(),
-            hmac,
+            scram_over_mtls.delegation_token.hmac.to_string(),
             ChannelBinding::None,
             "tokenauth=true".to_owned(),
             String::new(),


### PR DESCRIPTION
This PR completes a TODO left in the code from https://github.com/shotover/shotover-proxy/pull/1626

[Delegation tokens](https://docs.confluent.io/platform/current/kafka/authentication_sasl/authentication_sasl_delegation.html) are created by a super user and allows a connection to kafka to authenticate as a specific user.
Shotover creates them to allow proxying scram connections which would otherwise be unable to be proxied.

The token task in scram_over_mtls.rs creates  delegation tokens when the transforms request them.
It will cache the token and fetch new tokens if they are not in the cache yet.

The tokens are stored in a type called `DelegationToken`.
This contains the `token_id` which acts as the tokens username and the `hmac` which acts as the tokens password.
https://github.com/shotover/shotover-proxy/blob/c1331f8944a1d2b1b005bfd6f728aecfd9b5154c/shotover/src/transforms/kafka/sink_cluster/scram_over_mtls.rs#L328-L333

Currently the `hmac` field stores the raw bytes of the hmac, in a `Vec<u8>`.
This PR changes the `hmac` field to instead store the base64 encoding of the hmac, in a `StrBytes`.

This is more efficient as we dont need to convert to base64 every time we use the hmac to login with token.