### PR TITLE
Kafka: fix producing with acks=0

### DIFF
--- a/shotover-proxy/tests/kafka_int_tests/test_cases.rs
+++ b/shotover-proxy/tests/kafka_int_tests/test_cases.rs
@@ -250,9 +250,7 @@ pub async fn minimal_test_suite(connection_builder: KafkaConnectionBuilder) {
     produce_consume_partitions1(&connection_builder, "partitions1").await;
     // fails due to missing metadata on the unknown_topic (out of bounds error)
     //produce_consume_partitions1(&connection_builder, "unknown_topic").await;
-    // Failed to decode kafka_protocol::messages::produce_response::ProduceResponse v9
-    //produce_consume_partitions3(&connection_builder).await;
-    // Failed to decode kafka_protocol::messages::produce_response::ProduceResponse v9
-    //produce_consume_acks0(&connection_builder).await;
+    produce_consume_partitions3(&connection_builder).await;
+    produce_consume_acks0(&connection_builder).await;
     connection_builder.admin_cleanup().await;
 }

--- a/shotover/benches/benches/codec/kafka.rs
+++ b/shotover/benches/benches/codec/kafka.rs
@@ -16,6 +16,7 @@ const KAFKA_REQUESTS: &[(&[u8], &str)] = &[
     ),
     (include_bytes!("kafka_requests/fetch.bin"), "request_fetch"),
     (
+        // is acks=0
         include_bytes!("kafka_requests/produce.bin"),
         "request_produce",
     ),


### PR DESCRIPTION
## Discovery

This managed to avoid being hit because the test cases were running acks=0 last and never sending any more messages down those connections.
But while investigating https://github.com/shotover/shotover-proxy/pull/1588 this started showing up in the acks0 test case presumably because the java driver was reusing the connections it sent the acks=0 produce requests down.

## Background info

Codecs are an optional helper mechanism provided by the `tokio_util` crate.
They make it easy to attach an implementation of a protocol to a TCP socket.
In shotover every database that we support has a unique codec implemented for its protocol.
There is no single `Codec` type, instead there are separate read and write codecs, called the [Encoder](https://docs.rs/tokio-util/latest/tokio_util/codec/trait.Encoder.html) and the [Decoder](https://docs.rs/tokio-util/latest/tokio_util/codec/trait.Decoder.html).

The kafka protocol does not specify the message type of the responses sent by the kafka broker.
Instead it is up to the client to remember the message type of each request it sends out and then match up each response that comes in with its corresponding request so that the response can be correctly decoded.

In order to decode kafka responses, shotover needs the kafka outgoing encoder to instruct the outgoing decoder on how to decode each response.
This is done via an mpsc channel, specifically we use the [mpsc channel from the standard library](https://doc.rust-lang.org/stable/std/sync/mpsc/fn.channel.html).

https://github.com/shotover/shotover-proxy/blob/c1331f8944a1d2b1b005bfd6f728aecfd9b5154c/shotover/src/codec/kafka.rs#L42-L48

## The problem

However there is one exception to this that we were not handling!
The kafka produce request can set a field named `acks` to determine how many acks the leader broker must receive before responding to the request.
As a special case if `acks = 0` then the leader broker will never respond to that request.
This is used if latency is the highest concern and lost messages are acceptable.

Shotover will never receive a response for a produce with acks=0.
So if the encoder tells the decoder to expect a produce response it will expect the next message to be a produce even though that is not the case. This results in attempting to decode responses as the wrong type and therefore failure to decode.

## The fix

The correct fix here is to have the encoder skip sending message type information if `acks = 0`.
Specifically that is done by checking the result of the `Message::response_is_dummy()` method which checks if the request will not receive a response, including a check for `acks = 0` on kafka messages.

Now that the issue is fixed we can enable the failing tests in `kafka_int_tests/test_cases.rs`.