### PR TITLE
CassandraSinkCluster: pull routing logic into separate function

### DIFF
--- a/shotover/src/transforms/cassandra/sink_cluster/mod.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/mod.rs
@@ -445,6 +445,154 @@ impl CassandraSinkCluster {
         Ok(responses)
     }
 
+    async fn route_requests(
+        &mut self,
+        requests: Vec<Message>,
+        responses: &mut Vec<Message>,
+    ) -> Result<()> {
+        for mut message in requests.into_iter() {
+            if self.pool.nodes().is_empty()
+                || !self.init_handshake_complete
+                // system.local and system.peers must be routed to the same node otherwise the system.local node will be amongst the system.peers nodes and a node will be missing
+                // DDL statements and system.local must be routed through the same connection, so that schema_version changes appear immediately in system.local
+                || is_ddl_statement(&mut message)
+                || self.is_system_query(&mut message)
+            {
+                self.control_connection
+                    .as_mut()
+                    .unwrap()
+                    .send(vec![message])?;
+            } else if is_use_statement(&mut message) {
+                // Adding the USE statement to the handshake ensures that any new connection
+                // created will have the correct keyspace setup.
+                self.connection_factory.set_use_message(message.clone());
+
+                // route to the control connection
+                self.control_connection
+                    .as_mut()
+                    .unwrap()
+                    .send(vec![message])?;
+
+                // Close all other connections as they are now invalidated.
+                // They will be recreated as needed with the correct use statement used automatically after the handshake
+                for node in self.pool.nodes_mut() {
+                    node.outbound = None;
+                }
+
+                // Sending the use statement to these connections to keep them alive instead is possible but tricky.
+                // 1. The destinations need to be calculated here, at sending time, to ensure no new connections have been created in the meantime.
+                // 2. We need a way to filter out these extra responses from reaching the client.
+                // 3. But we cant use the TableRewrite abstraction since that occurs too early. See 1.
+                //
+                // It might be worth doing in the future.
+            } else if is_prepare_message(&mut message) {
+                let next_host_id = self.message_rewriter.get_destination_for_prepare(&message);
+                match self
+                    .pool
+                    .nodes_mut()
+                    .iter_mut()
+                    .find(|node| node.host_id == next_host_id)
+                    .ok_or_else(|| anyhow!("node {next_host_id} has dissapeared"))?
+                    .get_connection(&self.connection_factory)
+                    .await
+                {
+                    Ok(connection) => connection.send(vec![message])?,
+                    Err(err) => responses.push(send_error_in_response_to_message(
+                        &message,
+                        &format!("{err}"),
+                    )?),
+                }
+            } else if let Some((execute, metadata)) = get_execute_message(&mut message) {
+                // If the message is an execute we should perform token aware routing
+                let rack = &self.message_rewriter.local_shotover_node.rack;
+                let connection = self
+                    .pool
+                    .get_replica_connection_in_dc(
+                        execute,
+                        rack,
+                        &mut self.rng,
+                        &self.connection_factory,
+                    )
+                    .await;
+
+                match connection {
+                    Ok(connection) => connection.send(vec![message])?,
+                    Err(
+                        err @ GetReplicaErr::NoKeyspaceMetadata | err @ GetReplicaErr::NoRoutingKey,
+                    ) => {
+                        if matches!(err, GetReplicaErr::NoRoutingKey)
+                            && self.version.unwrap() != Version::V3
+                        {
+                            tracing::error!(
+                                "No routing key found for message on version: {}",
+                                self.version.unwrap()
+                            );
+                        };
+
+                        match self
+                            .pool
+                            .get_random_connection_in_dc_rack(
+                                rack,
+                                &mut self.rng,
+                                &self.connection_factory,
+                            )
+                            .await
+                        {
+                            Ok(connection) => connection.send(vec![message])?,
+                            Err(err) => responses.push(send_error_in_response_to_metadata(
+                                &metadata,
+                                &format!("{err}"),
+                            )),
+                        }
+                    }
+                    Err(GetReplicaErr::NoPreparedMetadata) => {
+                        let id = execute.id.clone();
+                        tracing::info!("forcing re-prepare on {:?}", id);
+                        // this shotover node doesn't have the metadata.
+                        // send an unprepared error in response to force
+                        // the client to reprepare the query
+                        responses.push(Message::from_frame(Frame::Cassandra(
+                            CassandraFrame {
+                                operation: CassandraOperation::Error(ErrorBody {
+                                    message: "Shotover does not have this query's metadata. Please re-prepare on this Shotover host before sending again.".into(),
+                                    ty: ErrorType::Unprepared(UnpreparedError { id }),
+                                }),
+                                stream_id: metadata.stream_id,
+                                tracing: Tracing::Response(None), // We didn't actually hit a node so we don't have a tracing id
+                                version: self.version.unwrap(),
+                                warnings: vec![],
+                            },
+                        )));
+                    }
+                    Err(GetReplicaErr::NoNodeAvailable(err)) => responses.push(
+                        send_error_in_response_to_metadata(&metadata, &format!("{err}")),
+                    ),
+                    Err(GetReplicaErr::Other(err)) => {
+                        return Err(err);
+                    }
+                }
+            } else {
+                // otherwise just send to a random node
+                match self
+                    .pool
+                    .get_random_connection_in_dc_rack(
+                        &self.message_rewriter.local_shotover_node.rack,
+                        &mut self.rng,
+                        &self.connection_factory,
+                    )
+                    .await
+                {
+                    Ok(connection) => connection.send(vec![message])?,
+                    Err(err) => responses.push(send_error_in_response_to_message(
+                        &message,
+                        &format!("{err}"),
+                    )?),
+                }
+            };
+        }
+        Ok(())
+    }
+
     async fn complete_handshake(&mut self) -> Result<()> {
         // Only send a handshake if the task really needs it
         // i.e. when the channel of size 1 is empty


### PR DESCRIPTION
CassandraSinkCluster has a really large `send_message` method, it should be broken down into multiple smaller functions.
To start with lets pull out the request routing logic into a `route_requests` method, this matches a function of the same name and purpose in `KafkaSinkCluster`.

The `send_message` function is also really poorly named but that should be addressed by moving the contents into `Transform::transform` which should occur in another PR to keep scope down.

The "Files changed" diff is very confusing and doesnt properly show the moving of the routing logic.
If you look at the individual commits you can see that the routing logic is removed and then readded as a separate function.
I recommend pasting the large chunk of logic that is removed and readded into a diff tool to verify the logic remains identical.