### PR TITLE
fix `shotover_chain_messages_per_batch_count` metric

### DIFF
--- a/docs/src/user-guide/observability.md
+++ b/docs/src/user-guide/observability.md
@@ -10,9 +10,11 @@ This optional interface will serve Prometheus metrics from `/metrics`. It will b
 | `shotover_chain_total_count`               | `chain`     | [counter](#counter)     | Counts the amount of times `chain` is used                                |
 | `shotover_chain_failures_count`            | `chain`     | [counter](#counter)     | Counts the amount of times `chain` fails                                  |
 | `shotover_chain_latency_seconds`           | `chain`     | [histogram](#histogram) | The latency for running `chain`                                           |
-| `shotover_chain_messages_per_batch_count`  | `chain`     | [histogram](#histogram) | The number of messages in each batch passing through `chain`.             |
 | `shotover_available_connections_count`     | `source`    | [gauge](#gauge)         | How many more connections can be opened to `source` before new connections will be rejected. |
 | `connections_opened`                       | `source`    | [counter](#counter)     | Counts the total number of connections that clients have opened against this source.         |
+| `shotover_chain_requests_batch_size`       | `chain`     | [histogram](#histogram) | The number of requests in each request batch passing through `chain`.     |
+| `shotover_chain_responses_batch_size`      | `chain`     | [histogram](#histogram) | The number of responses in each response batch passing through `chain`.   |
+| `shotover_available_connections_count`     | `source`    | [gauge](#gauge)         | The number of connections currently connected to `source`                 |
 | `shotover_source_to_sink_latency_seconds`  | `sink`      | [histogram](#histogram) | The milliseconds between reading a request from a source TCP connection and writing it to a sink TCP connection  |
 | `shotover_sink_to_source_latency_seconds`  | `source`    | [histogram](#histogram) | The milliseconds between reading a response from a sink TCP connection and writing it to a source TCP connection |
 

--- a/docs/src/user-guide/observability.md
+++ b/docs/src/user-guide/observability.md
@@ -10,11 +10,10 @@ This optional interface will serve Prometheus metrics from `/metrics`. It will b
 | `shotover_chain_total_count`               | `chain`     | [counter](#counter)     | Counts the amount of times `chain` is used                                |
 | `shotover_chain_failures_count`            | `chain`     | [counter](#counter)     | Counts the amount of times `chain` fails                                  |
 | `shotover_chain_latency_seconds`           | `chain`     | [histogram](#histogram) | The latency for running `chain`                                           |
-| `shotover_available_connections_count`     | `source`    | [gauge](#gauge)         | How many more connections can be opened to `source` before new connections will be rejected. |
-| `connections_opened`                       | `source`    | [counter](#counter)     | Counts the total number of connections that clients have opened against this source.         |
 | `shotover_chain_requests_batch_size`       | `chain`     | [histogram](#histogram) | The number of requests in each request batch passing through `chain`.     |
 | `shotover_chain_responses_batch_size`      | `chain`     | [histogram](#histogram) | The number of responses in each response batch passing through `chain`.   |
-| `shotover_available_connections_count`     | `source`    | [gauge](#gauge)         | The number of connections currently connected to `source`                 |
+| `shotover_available_connections_count`     | `source`    | [gauge](#gauge)         | How many more connections can be opened to `source` before new connections will be rejected. |
+| `connections_opened`                       | `source`    | [counter](#counter)     | Counts the total number of connections that clients have opened against this source.         |
 | `shotover_source_to_sink_latency_seconds`  | `sink`      | [histogram](#histogram) | The milliseconds between reading a request from a source TCP connection and writing it to a sink TCP connection  |
 | `shotover_sink_to_source_latency_seconds`  | `source`    | [histogram](#histogram) | The milliseconds between reading a response from a sink TCP connection and writing it to a source TCP connection |
 

--- a/shotover-proxy/tests/runner/observability_int_tests.rs
+++ b/shotover-proxy/tests/runner/observability_int_tests.rs
@@ -14,7 +14,8 @@ async fn test_metrics() {
 # TYPE connections_opened counter
 # TYPE shotover_available_connections_count gauge
 # TYPE shotover_chain_failures_count counter
-# TYPE shotover_chain_messages_per_batch_count summary
+# TYPE shotover_chain_requests_batch_size summary
+# TYPE shotover_chain_responses_batch_size summary
 # TYPE shotover_chain_total_count counter
 # TYPE shotover_query_count counter
 # TYPE shotover_sink_to_source_latency_seconds summary
@@ -24,16 +25,26 @@ async fn test_metrics() {
 connections_opened{source="redis"}
 shotover_available_connections_count{source="redis"}
 shotover_chain_failures_count{chain="redis"}
-shotover_chain_messages_per_batch_count_count{chain="redis"}
-shotover_chain_messages_per_batch_count_sum{chain="redis"}
-shotover_chain_messages_per_batch_count{chain="redis",quantile="0"}
-shotover_chain_messages_per_batch_count{chain="redis",quantile="0.1"}
-shotover_chain_messages_per_batch_count{chain="redis",quantile="0.5"}
-shotover_chain_messages_per_batch_count{chain="redis",quantile="0.9"}
-shotover_chain_messages_per_batch_count{chain="redis",quantile="0.95"}
-shotover_chain_messages_per_batch_count{chain="redis",quantile="0.99"}
-shotover_chain_messages_per_batch_count{chain="redis",quantile="0.999"}
-shotover_chain_messages_per_batch_count{chain="redis",quantile="1"}
+shotover_chain_requests_batch_size_count{chain="redis"}
+shotover_chain_requests_batch_size_sum{chain="redis"}
+shotover_chain_requests_batch_size{chain="redis",quantile="0"}
+shotover_chain_requests_batch_size{chain="redis",quantile="0.1"}
+shotover_chain_requests_batch_size{chain="redis",quantile="0.5"}
+shotover_chain_requests_batch_size{chain="redis",quantile="0.9"}
+shotover_chain_requests_batch_size{chain="redis",quantile="0.95"}
+shotover_chain_requests_batch_size{chain="redis",quantile="0.99"}
+shotover_chain_requests_batch_size{chain="redis",quantile="0.999"}
+shotover_chain_requests_batch_size{chain="redis",quantile="1"}
+shotover_chain_responses_batch_size_count{chain="redis"}
+shotover_chain_responses_batch_size_sum{chain="redis"}
+shotover_chain_responses_batch_size{chain="redis",quantile="0"}
+shotover_chain_responses_batch_size{chain="redis",quantile="0.1"}
+shotover_chain_responses_batch_size{chain="redis",quantile="0.5"}
+shotover_chain_responses_batch_size{chain="redis",quantile="0.9"}
+shotover_chain_responses_batch_size{chain="redis",quantile="0.95"}
+shotover_chain_responses_batch_size{chain="redis",quantile="0.99"}
+shotover_chain_responses_batch_size{chain="redis",quantile="0.999"}
+shotover_chain_responses_batch_size{chain="redis",quantile="1"}
 shotover_chain_total_count{chain="redis"}
 shotover_query_count{name="redis-chain"}
 shotover_sink_to_source_latency_seconds_count{source="redis"}

--- a/shotover-proxy/tests/runner/observability_int_tests.rs
+++ b/shotover-proxy/tests/runner/observability_int_tests.rs
@@ -14,6 +14,7 @@ async fn test_metrics() {
 # TYPE connections_opened counter
 # TYPE shotover_available_connections_count gauge
 # TYPE shotover_chain_failures_count counter
+# TYPE shotover_chain_messages_per_batch_count summary
 # TYPE shotover_chain_requests_batch_size summary
 # TYPE shotover_chain_responses_batch_size summary
 # TYPE shotover_chain_total_count counter
@@ -25,6 +26,16 @@ async fn test_metrics() {
 connections_opened{source="redis"}
 shotover_available_connections_count{source="redis"}
 shotover_chain_failures_count{chain="redis"}
+shotover_chain_messages_per_batch_count_count{chain="redis"}
+shotover_chain_messages_per_batch_count_sum{chain="redis"}
+shotover_chain_messages_per_batch_count{chain="redis",quantile="0"}
+shotover_chain_messages_per_batch_count{chain="redis",quantile="0.1"}
+shotover_chain_messages_per_batch_count{chain="redis",quantile="0.5"}
+shotover_chain_messages_per_batch_count{chain="redis",quantile="0.9"}
+shotover_chain_messages_per_batch_count{chain="redis",quantile="0.95"}
+shotover_chain_messages_per_batch_count{chain="redis",quantile="0.99"}
+shotover_chain_messages_per_batch_count{chain="redis",quantile="0.999"}
+shotover_chain_messages_per_batch_count{chain="redis",quantile="1"}
 shotover_chain_requests_batch_size_count{chain="redis"}
 shotover_chain_requests_batch_size_sum{chain="redis"}
 shotover_chain_requests_batch_size{chain="redis",quantile="0"}

--- a/shotover/src/transforms/chain.rs
+++ b/shotover/src/transforms/chain.rs
@@ -246,6 +246,9 @@ impl TransformChainBuilder {
             }
         ).collect();
 
+        // This is deprecated but give users some time to migrate to the requests/responses versions that have replaced this metric
+        histogram!("shotover_chain_messages_per_batch_count", "chain" => name).record(0);
+
         let chain_requests_batch_size =
             histogram!("shotover_chain_requests_batch_size", "chain" => name);
         let chain_responses_batch_size =


### PR DESCRIPTION
## Change 1
Every time shotover processes a transform chain, multiple requests and responses are batched and processed together.
This can be seen by the ChainState, which is passed through each transform in the chain, [containing multiple requests](https://github.com/shotover/shotover-proxy/blob/4693aab8b6f1a4bdcc5cfdf6789860d34baede73/shotover/src/transforms/mod.rs#L151).
This batching is purely opportunistic, we don't intentionally wait for requests or responses but if there are multiple requests or responses pending at the time we go to process them then they will be all processed in a single batch.
Lets call this batch a "chain batch".

Shotover has an existing metric `shotover_chain_messages_per_batch_count` which measures the number of requests included in a chain batch.
At the time this metric was written the number of responses returned by a transform chain call was guaranteed to be the number of requests in the request batch.
However, for performance reasons, this guarantee was removed and now any number of responses can be returned in a chain call.
This internal change has altered the meaning of this metric, leaving it kind of broken:
* The metric measures the size of request batches, but from the  `messages` in the name its ambiguous if its measuring the batch size of requests or responses.
* There is no way to measure the batch size of responses.

So the existing `shotover_chain_messages_per_batch_count` metric should be split into 2 separate metrics one for requests and one for responses.

TL;DR
`shotover_chain_messages_per_batch_count` is no longer meaningful after some internal changes to shotover that occurred a year ago, to fix it, it needs to be split into two separate metrics.

## Change 2

Additionally, this PR changes the metric logic of the two metrics to only write to the metric when the batch is not empty.
Previously empty batches never occured, but now that requests and responses are decoupled it is common for a response batch to have responses while the request batch is empty, and vice versa.
In order to ensure the histogram continues to show meaningful data (not full of zeroes) we skip those cases.

While there could be some value in seeing how often we hit empty batches, that is not the point of these metrics, instead we are trying to get a good picture of the spread of batch sizes.
If we find the need to measure empty batches in the future we could add simple shotover_empty_request_batch + shotover_empty_response_batch counter metrics.