### PR TITLE
codec encode benches: reuse BytesMut

### DIFF
--- a/shotover/benches/benches/codec/cassandra.rs
+++ b/shotover/benches/benches/codec/cassandra.rs
@@ -36,13 +36,13 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         encoder.set_startup_state_ext("NONE".to_string(), Version::V4);
 
+        let mut bytes = BytesMut::new();
         group.bench_function("encode_system.local_query_v4_no_compression", |b| {
             b.iter_batched(
                 || messages.clone(),
                 |messages| {
-                    let mut bytes = BytesMut::new();
+                    bytes.clear();
                     encoder.encode(messages, &mut bytes).unwrap();
-                    bytes
                 },
                 BatchSize::SmallInput,
             )
@@ -83,13 +83,13 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         encoder.set_startup_state_ext("NONE".to_string(), Version::V4);
 
+        let mut bytes = BytesMut::new();
         group.bench_function("encode_system.local_query_v4_lz4_compression", |b| {
             b.iter_batched(
                 || messages.clone(),
                 |messages| {
-                    let mut bytes = BytesMut::new();
+                    bytes.clear();
                     encoder.encode(messages, &mut bytes).unwrap();
-                    bytes
                 },
                 BatchSize::SmallInput,
             )
@@ -127,13 +127,13 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         encoder.set_startup_state_ext("NONE".to_string(), Version::V5);
 
+        let mut bytes = BytesMut::new();
         group.bench_function("encode_system.local_result_v4_no_compression", |b| {
             b.iter_batched(
                 || messages.clone(),
                 |messages| {
-                    let mut bytes = BytesMut::new();
+                    bytes.clear();
                     encoder.encode(messages, &mut bytes).unwrap();
-                    bytes
                 },
                 BatchSize::SmallInput,
             )
@@ -171,13 +171,13 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         encoder.set_startup_state_ext("LZ4".to_string(), Version::V5);
 
+        let mut bytes = BytesMut::new();
         group.bench_function("encode_system.local_result_v4_lz4_compression", |b| {
             b.iter_batched(
                 || messages.clone(),
                 |messages| {
-                    let mut bytes = BytesMut::new();
+                    bytes.clear();
                     encoder.encode(messages, &mut bytes).unwrap();
-                    bytes
                 },
                 BatchSize::SmallInput,
             )
@@ -218,13 +218,13 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         encoder.set_startup_state_ext("NONE".to_string(), Version::V5);
 
+        let mut bytes = BytesMut::new();
         group.bench_function("encode_system.local_query_v5_no_compression", |b| {
             b.iter_batched(
                 || messages.clone(),
                 |messages| {
-                    let mut bytes = BytesMut::new();
+                    bytes.clear();
                     encoder.encode(messages, &mut bytes).unwrap();
-                    bytes
                 },
                 BatchSize::SmallInput,
             )
@@ -265,13 +265,13 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         encoder.set_startup_state_ext("LZ4".to_string(), Version::V5);
 
+        let mut bytes = BytesMut::new();
         group.bench_function("encode_system.local_query_v5_lz4_compression", |b| {
             b.iter_batched(
                 || messages.clone(),
                 |messages| {
-                    let mut bytes = BytesMut::new();
+                    bytes.clear();
                     encoder.encode(messages, &mut bytes).unwrap();
-                    bytes
                 },
                 BatchSize::SmallInput,
             )
@@ -309,13 +309,13 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         encoder.set_startup_state_ext("NONE".to_string(), Version::V5);
 
+        let mut bytes = BytesMut::new();
         group.bench_function("encode_system.local_result_v5_no_compression", |b| {
             b.iter_batched(
                 || messages.clone(),
                 |messages| {
-                    let mut bytes = BytesMut::new();
+                    bytes.clear();
                     encoder.encode(messages, &mut bytes).unwrap();
-                    bytes
                 },
                 BatchSize::SmallInput,
             )
@@ -353,13 +353,13 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         encoder.set_startup_state_ext("LZ4".to_string(), Version::V5);
 
+        let mut bytes = BytesMut::new();
         group.bench_function("encode_system.local_result_v5_lz4_compression", |b| {
             b.iter_batched(
                 || messages.clone(),
                 |messages| {
-                    let mut bytes = BytesMut::new();
+                    bytes.clear();
                     encoder.encode(messages, &mut bytes).unwrap();
-                    bytes
                 },
                 BatchSize::SmallInput,
             )

--- a/shotover/benches/benches/codec/kafka.rs
+++ b/shotover/benches/benches/codec/kafka.rs
@@ -1,5 +1,5 @@
 use bytes::{Bytes, BytesMut};
-use criterion::{black_box, criterion_group, BatchSize, Criterion};
+use criterion::{criterion_group, BatchSize, Criterion};
 use shotover::codec::kafka::KafkaCodecBuilder;
 use shotover::codec::{CodecBuilder, CodecState, Direction};
 use shotover::message::Message;
@@ -87,6 +87,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
             let messages = vec![message];
 
+            let mut bytes = BytesMut::new();
             group.bench_function(format!("encode_{file_name}"), |b| {
                 b.iter_batched(
                     || {
@@ -97,9 +98,8 @@ fn criterion_benchmark(c: &mut Criterion) {
                         )
                     },
                     |((decoder, mut encoder), messages)| {
-                        let mut bytes = BytesMut::new();
+                        bytes.clear();
                         encoder.encode(messages, &mut bytes).unwrap();
-                        std::mem::drop(black_box(bytes));
                         (encoder, decoder)
                     },
                     BatchSize::SmallInput,
@@ -124,6 +124,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             messages.push(message);
         }
 
+        let mut bytes = BytesMut::new();
         group.bench_function("encode_all", |b| {
             b.iter_batched(
                 || {
@@ -134,9 +135,8 @@ fn criterion_benchmark(c: &mut Criterion) {
                     )
                 },
                 |((decoder, mut encoder), messages)| {
-                    let mut bytes = BytesMut::new();
+                    bytes.clear();
                     encoder.encode(messages, &mut bytes).unwrap();
-                    std::mem::drop(black_box(bytes));
                     (encoder, decoder)
                 },
                 BatchSize::SmallInput,


### PR DESCRIPTION
This PR makes the encoding microbenchmarks more realistic.
Once some messages have passed through shotover, the BytesMut passed into the codecs will enough have capacity for the average message. So its not realistic to test against a BytesMut with no allocation.

Additionally I'm hoping this will resolve the noisy benches that codspeed keeps reporting, since the variability in the bench is due to the BytesMut allocation.
![image](https://github.com/shotover/shotover-proxy/assets/5120858/22a51912-d827-4ee5-a427-9bb92276be14)
