### PR TITLE
KafkaSinkCluster: scram_over_mtls broker discovery

### DIFF
--- a/shotover-proxy/tests/test-configs/kafka/cluster-sasl-scram-over-mtls/topology1.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-sasl-scram-over-mtls/topology1.yaml
@@ -2,16 +2,23 @@
 sources:
   - Kafka:
       name: "kafka"
-      listen_addr: "127.0.0.1:9192"
+      listen_addr: "127.0.0.1:9191"
       chain:
         - KafkaSinkCluster:
             shotover_nodes:
-              - address: "127.0.0.1:9192"
+              - address: "127.0.0.1:9191"
                 rack: "rack0"
                 broker_id: 0
+              - address: "127.0.0.1:9192"
+                rack: "rack0"
+                broker_id: 1
+              - address: "127.0.0.1:9193"
+                rack: "rack0"
+                broker_id: 2
             local_shotover_broker_id: 0
             first_contact_points: ["172.16.1.2:9092"]
             authorize_scram_over_mtls:
+              # every shotover node purposefully tests a different number of contact points
               mtls_port_contact_points: ["172.16.1.2:9094"]
               tls:
                 certificate_authority_path: "tests/test-configs/kafka/tls/certs/localhost_CA.crt"

--- a/shotover-proxy/tests/test-configs/kafka/cluster-sasl-scram-over-mtls/topology2.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-sasl-scram-over-mtls/topology2.yaml
@@ -6,13 +6,20 @@ sources:
       chain:
         - KafkaSinkCluster:
             shotover_nodes:
-              - address: "127.0.0.1:9192"
+              - address: "127.0.0.1:9191"
                 rack: "rack0"
                 broker_id: 0
+              - address: "127.0.0.1:9192"
+                rack: "rack0"
+                broker_id: 1
+              - address: "127.0.0.1:9193"
+                rack: "rack0"
+                broker_id: 2
             local_shotover_broker_id: 0
             first_contact_points: ["172.16.1.2:9092"]
             authorize_scram_over_mtls:
-              mtls_port_contact_points: ["172.16.1.2:9094"]
+              # every shotover node purposefully tests a different number of contact points
+              mtls_port_contact_points: ["172.16.1.2:9094", "172.16.1.3:9094"]
               tls:
                 certificate_authority_path: "tests/test-configs/kafka/tls/certs/localhost_CA.crt"
                 certificate_path: "tests/test-configs/kafka/tls/certs/localhost.crt"

--- a/shotover-proxy/tests/test-configs/kafka/cluster-sasl-scram-over-mtls/topology3.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-sasl-scram-over-mtls/topology3.yaml
@@ -2,17 +2,24 @@
 sources:
   - Kafka:
       name: "kafka"
-      listen_addr: "127.0.0.1:9192"
+      listen_addr: "127.0.0.1:9193"
       chain:
         - KafkaSinkCluster:
             shotover_nodes:
-              - address: "127.0.0.1:9192"
+              - address: "127.0.0.1:9191"
                 rack: "rack0"
                 broker_id: 0
+              - address: "127.0.0.1:9192"
+                rack: "rack0"
+                broker_id: 1
+              - address: "127.0.0.1:9193"
+                rack: "rack0"
+                broker_id: 2
             local_shotover_broker_id: 0
             first_contact_points: ["172.16.1.2:9092"]
             authorize_scram_over_mtls:
-              mtls_port_contact_points: ["172.16.1.2:9094"]
+              # every shotover node purposefully tests a different number of contact points
+              mtls_port_contact_points: ["172.16.1.2:9094", "172.16.1.3:9094", "172.16.1.4:9094"]
               tls:
                 certificate_authority_path: "tests/test-configs/kafka/tls/certs/localhost_CA.crt"
                 certificate_path: "tests/test-configs/kafka/tls/certs/localhost.crt"


### PR DESCRIPTION
progress towards https://github.com/shotover/shotover-proxy/issues/1618

This PR:
* introduces a new integration test `cluster_sasl_scram_over_mtls_multi_shotover`, previously we just had `cluster_sasl_scram_over_mtls_single_shotover`
   + This tests with multiple shotover's running which could reveal some edge cases
   + It also uses various numbers of elements in `mtls_port_contact_points` for each shotover yaml, which will exercise different cases within the broker discovery logic
* Replaces the simple list of connections with a list of nodes.
   + This is needed so we can avoid creating duplicate connections and recreate connections if they go down.
* Adds a `find_new_brokers` method which performs broker discovery.