### PR TITLE
#1643 Fix cassandra_int_tests::passthrough_cassandra_down on macOS

### DIFF
--- a/shotover-proxy/tests/lib.rs
+++ b/shotover-proxy/tests/lib.rs
@@ -24,9 +24,9 @@ pub fn shotover_process(topology_path: &str) -> ShotoverProcessBuilder {
 }
 
 #[cfg(target_os = "macos")]
-#[cfg(feature = "redis")]
+#[cfg(any(feature = "cassandra", feature = "redis"))]
 const CONNECTION_REFUSED_OS_ERROR: i32 = 61;
 
 #[cfg(not(target_os = "macos"))]
-#[cfg(feature = "redis")]
+#[cfg(any(feature = "cassandra", feature = "redis"))]
 const CONNECTION_REFUSED_OS_ERROR: i32 = 111;


### PR DESCRIPTION
Similar to https://github.com/shotover/shotover-proxy/pull/1617, this PR fixes the OS error code in `cassandra_int_tests::passthrough_cassandra_down` for macOS.

All the error messages of `Connection refused (os error ...)` should be using the OS-dependent `CONNECTION_REFUSED_OS_ERROR` now.

All the passthrough tests now pass on macOS.

<img width="908" alt="image" src="https://github.com/shotover/shotover-proxy/assets/126037131/06039f8c-798a-47ba-8c5d-5f1d1a91eccc">


Closes #1643 