### PR TITLE
KafkaSinkCluster scram_over_mtls - full integration tests

### DIFF
--- a/shotover-proxy/tests/kafka_int_tests/mod.rs
+++ b/shotover-proxy/tests/kafka_int_tests/mod.rs
@@ -5,7 +5,7 @@ use pretty_assertions::assert_eq;
 use rstest::rstest;
 use std::time::Duration;
 use std::time::Instant;
-use test_cases::smoke_test;
+use test_cases::produce_consume_partitions1;
 use test_cases::{assert_topic_creation_is_denied_due_to_acl, setup_basic_user_acls};
 use test_helpers::connection::kafka::{KafkaConnectionBuilder, KafkaDriver};
 use test_helpers::docker_compose::docker_compose;
@@ -411,7 +411,8 @@ async fn cluster_sasl_scram_over_mtls_single_shotover(#[case] driver: KafkaDrive
         // admin requests sent by regular user remain unsuccessful
         let connection_super = KafkaConnectionBuilder::new(driver, "127.0.0.1:9192")
             .use_sasl_scram("super_user", "super_password");
-        smoke_test(&connection_super).await;
+        produce_consume_partitions1(&connection_super, "c3220ff0-9390-425d-a56d-9d880a339c8c")
+            .await;
         assert_topic_creation_is_denied_due_to_acl(&connection_basic).await;
         assert_connection_fails_with_incorrect_password(driver, "basic_user").await;
         assert_connection_fails_with_incorrect_password(driver, "super_user").await;

--- a/shotover-proxy/tests/kafka_int_tests/test_cases.rs
+++ b/shotover-proxy/tests/kafka_int_tests/test_cases.rs
@@ -290,20 +290,3 @@ pub async fn assert_topic_creation_is_denied_due_to_acl(connection: &KafkaConnec
         "org.apache.kafka.common.errors.UnknownTopicOrPartitionException: This server does not host this topic-partition.\n"
     )
 }
-
-// A quick test without running the whole test suite
-// Assumes that admin_setup or standard_test_suite has already been run.
-pub async fn smoke_test(connection_builder: &KafkaConnectionBuilder) {
-    let producer = connection_builder.connect_producer(1).await;
-
-    producer
-        .assert_produce(
-            Record {
-                payload: "initial",
-                topic_name: "partitions1",
-                key: Some("Key"),
-            },
-            None,
-        )
-        .await;
-}

--- a/shotover-proxy/tests/kafka_int_tests/test_cases.rs
+++ b/shotover-proxy/tests/kafka_int_tests/test_cases.rs
@@ -290,3 +290,20 @@ pub async fn assert_topic_creation_is_denied_due_to_acl(connection: &KafkaConnec
         "org.apache.kafka.common.errors.UnknownTopicOrPartitionException: This server does not host this topic-partition.\n"
     )
 }
+
+// A quick test without running the whole test suite
+// Assumes that admin_setup or standard_test_suite has already been run.
+pub async fn smoke_test(connection_builder: &KafkaConnectionBuilder) {
+    let producer = connection_builder.connect_producer(1).await;
+
+    producer
+        .assert_produce(
+            Record {
+                payload: "initial",
+                topic_name: "partitions1",
+                key: Some("Key"),
+            },
+            None,
+        )
+        .await;
+}

--- a/shotover/src/transforms/kafka/sink_cluster/node.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/node.rs
@@ -8,6 +8,7 @@ use crate::tls::TlsConnector;
 use crate::transforms::kafka::sink_cluster::SASL_SCRAM_MECHANISMS;
 use anyhow::{anyhow, Context, Result};
 use bytes::Bytes;
+use derivative::Derivative;
 use kafka_protocol::messages::{ApiKey, BrokerId, RequestHeader, SaslAuthenticateRequest};
 use kafka_protocol::protocol::{Builder, StrBytes};
 use kafka_protocol::ResponseError;
@@ -256,10 +257,13 @@ impl KafkaAddress {
     }
 }
 
+#[derive(Derivative)]
+#[derivative(Debug)]
 pub struct KafkaNode {
     pub broker_id: BrokerId,
     pub rack: Option<StrBytes>,
     pub kafka_address: KafkaAddress,
+    #[derivative(Debug = "ignore")]
     connection: Option<SinkConnection>,
 }
 


### PR DESCRIPTION
This PR extends the test cases added in https://github.com/shotover/shotover-proxy/pull/1652
It introduces a very similar case, run on a fresh shotover instance but running the stages of the test in a different order, in an effort to find possible token usage edge cases.

In doing so it uncovered a race condition in shotover.
When parsing metadata responses, we were previously updating the local nodes list only when the node was new globally.
However this is incorrect, we may still need to update the local nodes list even if the node is not new globally.
So this PR fixes this issue by pulling `self.update_local_nodes()` out of the `if new {` statement.

I've also left in a debug implementation for KafkaNode since I've found that we often want to be able to include it in temporary debug logs when investigating kafka bugs.