### PR TITLE
KafkaSinkCluster scram_over_mtls - initial integration tests

### DIFF
--- a/shotover-proxy/tests/kafka_int_tests/test_cases.rs
+++ b/shotover-proxy/tests/kafka_int_tests/test_cases.rs
@@ -1,6 +1,7 @@
 use test_helpers::connection::kafka::{
-    AlterConfig, ConfigEntry, ExpectedResponse, KafkaConnectionBuilder, NewPartition, NewTopic,
-    Record, ResourceSpecifier,
+    Acl, AclOperation, AclPermissionType, AlterConfig, ConfigEntry, ExpectedResponse,
+    KafkaConnectionBuilder, NewPartition, NewTopic, Record, ResourcePatternType, ResourceSpecifier,
+    ResourceType,
 };
 
 async fn admin_setup(connection_builder: &KafkaConnectionBuilder) {
@@ -242,4 +243,51 @@ pub async fn standard_test_suite(connection_builder: KafkaConnectionBuilder) {
     produce_consume_partitions3(&connection_builder).await;
     produce_consume_acks0(&connection_builder).await;
     connection_builder.admin_cleanup().await;
+}
+
+pub async fn setup_basic_user_acls(connection: &KafkaConnectionBuilder, username: &str) {
+    let admin = connection.connect_admin().await;
+    admin
+        .create_acls(vec![Acl {
+            resource_type: ResourceType::Topic,
+            resource_name: "*".to_owned(),
+            resource_pattern_type: ResourcePatternType::Literal,
+            principal: format!("User:{username}"),
+            host: "*".to_owned(),
+            operation: AclOperation::Describe,
+            permission_type: AclPermissionType::Allow,
+        }])
+        .await;
+}
+
+/// Invariants:
+/// * The passed connection is a user setup with the ACL's of `setup_basic_user_acls`
+/// Assertions:
+/// * Asserts that the user cannot perform the admin operation of creating new topics (not allowed by ACL)
+///     + Asserts that the topic was not created as a result of the failed topic creation.
+/// * Asserts that the user can perform the describe operation on topics (explicitly allowed by ACL)
+pub async fn assert_topic_creation_is_denied_due_to_acl(connection: &KafkaConnectionBuilder) {
+    let admin = connection.connect_admin().await;
+    // attempt to create topic and get auth failure due to missing ACL
+    assert_eq!(
+        connection.assert_admin_error().await.to_string(),
+        admin
+            .create_topics_fallible(&[NewTopic {
+                name: "acl_check_topic",
+                num_partitions: 1,
+                replication_factor: 1,
+            }])
+            .await
+            .unwrap_err()
+            .to_string(),
+        "org.apache.kafka.common.errors.TopicAuthorizationException: Authorization failed.\n"
+    );
+
+    // attempt to describe topic:
+    // * The request succeeds because user has AclOperation::Describe.
+    // * But no topic is found since the topic creation was denied.
+    assert_eq!(
+        admin.describe_topic("acl_check_topic").await.unwrap_err().to_string(),
+        "org.apache.kafka.common.errors.UnknownTopicOrPartitionException: This server does not host this topic-partition.\n"
+    )
 }

--- a/shotover-proxy/tests/kafka_int_tests/test_cases.rs
+++ b/shotover-proxy/tests/kafka_int_tests/test_cases.rs
@@ -270,7 +270,6 @@ pub async fn assert_topic_creation_is_denied_due_to_acl(connection: &KafkaConnec
     let admin = connection.connect_admin().await;
     // attempt to create topic and get auth failure due to missing ACL
     assert_eq!(
-        connection.assert_admin_error().await.to_string(),
         admin
             .create_topics_fallible(&[NewTopic {
                 name: "acl_check_topic",

--- a/shotover-proxy/tests/test-configs/kafka/cluster-sasl-scram-over-mtls/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-sasl-scram-over-mtls/docker-compose.yaml
@@ -22,8 +22,8 @@ services:
       KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: "CONTROLLER:SSL,BROKER:SASL_SSL,SHOTOVER_MTLS:SSL"
       KAFKA_CFG_ADVERTISED_LISTENERS: "BROKER://172.16.1.2:9092,SHOTOVER_MTLS://172.16.1.2:9094"
       KAFKA_CFG_DELEGATION_TOKEN_MASTER_KEY: THE_MASTER_KEY
-      KAFKA_CLIENT_USERS: "user"
-      KAFKA_CLIENT_PASSWORDS: "password"
+      KAFKA_CLIENT_USERS: "super_user,basic_user"
+      KAFKA_CLIENT_PASSWORDS: "super_password,basic_password"
       KAFKA_CFG_CONTROLLER_LISTENER_NAMES: "CONTROLLER"
       KAFKA_CFG_SASL_MECHANISM_CONTROLLER_PROTOCOL: "PLAIN"
       KAFKA_CFG_INTER_BROKER_LISTENER_NAME: "BROKER"
@@ -37,7 +37,7 @@ services:
       # Give the following super user access:
       # * the user named `user`
       # * any clients connected via a TLS certificate of `O=ShotoverTestCertificate,CN=Generic-Cert`
-      KAFKA_CFG_SUPER_USERS: "User:user;User:O=ShotoverTestCertificate,CN=Generic-Cert"
+      KAFKA_CFG_SUPER_USERS: "User:super_user;User:O=ShotoverTestCertificate,CN=Generic-Cert"
     volumes: &volumes
       - type: tmpfs
         target: /bitnami/kafka

--- a/test-helpers/src/connection/kafka/java.rs
+++ b/test-helpers/src/connection/kafka/java.rs
@@ -1,4 +1,7 @@
-use super::{AlterConfig, ExpectedResponse, NewPartition, NewTopic, Record, ResourceSpecifier};
+use super::{
+    Acl, AclOperation, AclPermissionType, AlterConfig, ExpectedResponse, NewPartition, NewTopic,
+    Record, ResourcePatternType, ResourceSpecifier, ResourceType, TopicDescription,
+};
 use anyhow::Result;
 use j4rs::{errors::J4RsError, Instance, InvocationArg, Jvm, JvmBuilder, MavenArtifact};
 use pretty_assertions::assert_eq;
@@ -346,6 +349,20 @@ impl KafkaAdminJava {
         self.create_topics_fallible(topics).await.unwrap();
     }
 
+    pub async fn describe_topic(&self, topic_name: &str) -> Result<TopicDescription> {
+        let topics = self
+            .jvm
+            .java_list("java.lang.String", vec![topic_name])
+            .unwrap();
+
+        let result = self
+            .jvm
+            .invoke(&self.admin, "describeTopics", &[&topics.into()])
+            .unwrap();
+        self.jvm.invoke_async(&result, "allTopicNames", &[]).await?;
+        Ok(TopicDescription {})
+    }
+
     pub async fn create_topics_fallible(&self, topics: &[NewTopic<'_>]) -> Result<()> {
         let topics: Vec<_> = topics
             .iter()
@@ -511,6 +528,124 @@ impl KafkaAdminJava {
         let result = self
             .jvm
             .invoke(&self.admin, "alterConfigs", &[&alter_configs.into()])
+            .unwrap();
+        self.jvm
+            .invoke_async(&result, "all", InvocationArg::empty())
+            .await
+            .unwrap();
+    }
+
+    pub async fn create_acls(&self, acls: Vec<Acl>) {
+        let resource_type = self
+            .jvm
+            .static_class("org.apache.kafka.common.resource.ResourceType")
+            .unwrap();
+        let resource_pattern_type = self
+            .jvm
+            .static_class("org.apache.kafka.common.resource.PatternType")
+            .unwrap();
+        let acl_operation = self
+            .jvm
+            .static_class("org.apache.kafka.common.acl.AclOperation")
+            .unwrap();
+        let acl_permission_type = self
+            .jvm
+            .static_class("org.apache.kafka.common.acl.AclPermissionType")
+            .unwrap();
+
+        let acls: Vec<_> = acls
+            .iter()
+            .map(|acl| {
+                let resource_type_field = match acl.resource_type {
+                    ResourceType::Any => "ANY",
+                    ResourceType::Cluster => "CLUSTER",
+                    ResourceType::DelegationToken => "DELEGATION_TOKEN",
+                    ResourceType::Group => "GROUP",
+                    ResourceType::Topic => "TOPIC",
+                    ResourceType::TransactionalId => "TRANSACTIONAL_ID",
+                    ResourceType::User => "USER",
+                };
+                let resource_pattern_type_field = match acl.resource_pattern_type {
+                    ResourcePatternType::Literal => "LITERAL",
+                    ResourcePatternType::Prefixed => "PREFIXED",
+                };
+                let resource = self
+                    .jvm
+                    .create_instance(
+                        "org.apache.kafka.common.resource.ResourcePattern",
+                        &[
+                            &self
+                                .jvm
+                                .field(&resource_type, resource_type_field)
+                                .unwrap()
+                                .into(),
+                            &InvocationArg::try_from(acl.resource_name.as_str()).unwrap(),
+                            &self
+                                .jvm
+                                .field(&resource_pattern_type, resource_pattern_type_field)
+                                .unwrap()
+                                .into(),
+                        ],
+                    )
+                    .unwrap();
+
+                let acl_operation_field = match acl.operation {
+                    AclOperation::All => "ALL",
+                    AclOperation::Alter => "ALTER",
+                    AclOperation::AlterConfigs => "ALTER_CONFIGS",
+                    AclOperation::ClusterAction => "CLUSTER_ACTION",
+                    AclOperation::Create => "CREATE",
+                    AclOperation::CreateTokens => "CREATE_TOKENS",
+                    AclOperation::Delete => "DELETE",
+                    AclOperation::Describe => "DESCRIBE",
+                    AclOperation::DescribeConfigs => "DESCRIBE_CONFIGS",
+                    AclOperation::DescribeTokens => "DESCRIBE_TOKENS",
+                    AclOperation::Read => "READ",
+                    AclOperation::Write => "WRITE",
+                };
+                let acl_permission_type_field = match acl.permission_type {
+                    AclPermissionType::Allow => "ALLOW",
+                    AclPermissionType::Deny => "DENY",
+                };
+                let entry = self
+                    .jvm
+                    .create_instance(
+                        "org.apache.kafka.common.acl.AccessControlEntry",
+                        &[
+                            &InvocationArg::try_from(acl.principal.as_str()).unwrap(),
+                            &InvocationArg::try_from(acl.host.as_str()).unwrap(),
+                            &self
+                                .jvm
+                                .field(&acl_operation, acl_operation_field)
+                                .unwrap()
+                                .into(),
+                            &self
+                                .jvm
+                                .field(&acl_permission_type, acl_permission_type_field)
+                                .unwrap()
+                                .into(),
+                        ],
+                    )
+                    .unwrap();
+
+                Ok(self
+                    .jvm
+                    .create_instance(
+                        "org.apache.kafka.common.acl.AclBinding",
+                        &[&resource.into(), &entry.into()],
+                    )
+                    .unwrap())
+            })
+            .collect();
+
+        let acls = self
+            .jvm
+            .java_list("org.apache.kafka.common.acl.AclBinding", acls)
+            .unwrap();
+
+        let result = self
+            .jvm
+            .invoke(&self.admin, "createAcls", &[&acls.into()])
             .unwrap();
         self.jvm
             .invoke_async(&result, "all", InvocationArg::empty())

--- a/test-helpers/src/connection/kafka/java.rs
+++ b/test-helpers/src/connection/kafka/java.rs
@@ -557,7 +557,6 @@ impl KafkaAdminJava {
             .iter()
             .map(|acl| {
                 let resource_type_field = match acl.resource_type {
-                    ResourceType::Any => "ANY",
                     ResourceType::Cluster => "CLUSTER",
                     ResourceType::DelegationToken => "DELEGATION_TOKEN",
                     ResourceType::Group => "GROUP",

--- a/test-helpers/src/connection/kafka/mod.rs
+++ b/test-helpers/src/connection/kafka/mod.rs
@@ -212,6 +212,14 @@ impl KafkaAdmin {
         }
     }
 
+    pub async fn describe_topic(&self, topic_name: &str) -> Result<TopicDescription> {
+        match self {
+            #[cfg(feature = "kafka-cpp-driver-tests")]
+            KafkaAdmin::Cpp(_) => unimplemented!(),
+            KafkaAdmin::Java(java) => java.describe_topic(topic_name).await,
+        }
+    }
+
     pub async fn delete_topics(&self, to_delete: &[&str]) {
         match self {
             #[cfg(feature = "kafka-cpp-driver-tests")]
@@ -243,6 +251,14 @@ impl KafkaAdmin {
             KafkaAdmin::Java(java) => java.alter_configs(alter_configs).await,
         }
     }
+
+    pub async fn create_acls(&self, acls: Vec<Acl>) {
+        match self {
+            #[cfg(feature = "kafka-cpp-driver-tests")]
+            KafkaAdmin::Cpp(_) => unimplemented!("CPP driver does not support creating ACL's"),
+            KafkaAdmin::Java(java) => java.create_acls(acls).await,
+        }
+    }
 }
 
 pub struct NewTopic<'a> {
@@ -268,4 +284,60 @@ pub struct AlterConfig<'a> {
 pub struct ConfigEntry {
     pub key: String,
     pub value: String,
+}
+
+pub struct Acl {
+    pub resource_type: ResourceType,
+    pub resource_name: String,
+    pub resource_pattern_type: ResourcePatternType,
+    pub principal: String,
+    pub host: String,
+    pub operation: AclOperation,
+    pub permission_type: AclPermissionType,
+}
+
+/// https://docs.confluent.io/platform/current/clients/javadocs/javadoc/org/apache/kafka/common/resource/ResourceType.html
+pub enum ResourceType {
+    Any,
+    Cluster,
+    DelegationToken,
+    Group,
+    Topic,
+    TransactionalId,
+    User,
+}
+
+/// https://docs.confluent.io/platform/current/clients/javadocs/javadoc/org/apache/kafka/common/resource/PatternType.html
+pub enum ResourcePatternType {
+    Literal,
+    Prefixed,
+}
+
+/// https://docs.confluent.io/platform/current/clients/javadocs/javadoc/org/apache/kafka/common/acl/AclOperation.html
+pub enum AclOperation {
+    All,
+    Alter,
+    AlterConfigs,
+    ClusterAction,
+    Create,
+    CreateTokens,
+    Delete,
+    Describe,
+    DescribeConfigs,
+    DescribeTokens,
+    Read,
+    Write,
+}
+
+/// https://docs.confluent.io/platform/current/clients/javadocs/javadoc/org/apache/kafka/common/acl/AclPermissionType.html
+pub enum AclPermissionType {
+    Allow,
+    Deny,
+}
+
+#[derive(Debug)]
+pub struct TopicDescription {
+    // None of our tests actually make use of the contents of TopicDescription,
+    // instead they just check if the describe succeeded or failed,
+    // so this is intentionally left empty for now
 }

--- a/test-helpers/src/connection/kafka/mod.rs
+++ b/test-helpers/src/connection/kafka/mod.rs
@@ -298,7 +298,6 @@ pub struct Acl {
 
 /// https://docs.confluent.io/platform/current/clients/javadocs/javadoc/org/apache/kafka/common/resource/ResourceType.html
 pub enum ResourceType {
-    Any,
     Cluster,
     DelegationToken,
     Group,


### PR DESCRIPTION
This PR pulls the majority of the changes out of https://github.com/shotover/shotover-proxy/pull/1651 since they require no code changes to land.

To support the new test cases, this PR first extends the kafka connection abstraction.
This abstraction abstracts over both the CPP driver and java driver.
For this PR we can get away with just supporting the java driver since the cpp driver doesnt support SCRAM and so we cant use it for this test anyway.
This PR adds:
* a `KafkaAdmin::describe_topic` method
   + we only care about checking if the describe request succeeded or failed, so we dont actually need to return any info on the topic. But we follow the structure of a proper describe_topic method so that it can be extended to a full implementation in the future if needed.
* a `KafkaAdmin::create_acls` method
  + ACL's have a lot of different enums they need, these are all defined here as well. 
    - Some of the enums have variants that arent actually used for acl creation, so I have not included those variants in the enums.
    - Usually for these kinds of enum's the `match`s in `create_acls` would go on methods on the enum. e.g. we would call something like `acl.resource_type.to_field_name()`. But I've not done this here, since that is a java specific implementation detail that I wouldnt want living on the generic `ResourceType` enum.
  + The actual implementation is largely java interop soup, dont stress about it too much.

Then this PR implements new test cases on top of the new connection abstraction methods:
* `setup_basic_user_acls` utilizes `KafkaAdmin::create_acls` to configure `basic_user` with the ability to describe topics.
* `assert_topic_creation_is_denied_due_to_acl` is then defined as an important correctness assertion, to prove that we are not mixing up tokens. It tests not just that the request returns an error but that the action of the request was not performed. i.e. no topic is created.

And then finally we run the test cases in various configurations in `cluster_sasl_scram_over_mtls_single_shotover`:
* Usually our integration tests just use a single user configured as a super user. However here we need to test multiple users with different access levels, so we setup a `super_user` and a `basic_user` in the `docker-compose.yaml`
  + this meant we also changed the user name in `cluster_sasl_scram_over_mtls_multi_shotover` to `super_user`
* `assert_topic_creation_is_denied_due_to_acl` is called with and without a concurrent super user connection
* Further test cases will be added in https://github.com/shotover/shotover-proxy/pull/1651