### PR TITLE
KafkaSinkCluster: route LeaveGroup requests

### DIFF
--- a/docs/src/transforms.md
+++ b/docs/src/transforms.md
@@ -246,7 +246,7 @@ This transform will route kafka messages to a broker within a Kafka cluster:
 
 * produce messages are routed to the partition leader
 * fetch messages are routed to a random partition replica
-* heartbeat, syncgroup, offsetfetch and joingroup are all routed to the group coordinator
+* heartbeat, syncgroup, offsetfetch, joingroup and leavegroup are all routed to the group coordinator
 * all other messages go to a random node.
 
 The fact that Shotover is routing to multiple destination nodes will be hidden from the client.


### PR DESCRIPTION
When running `cargo nextest run --no-default-features --features kafka kafka_int_tests::cluster_1_rack_single_shotover --nocapture` logs from the java driver can be observed complaining that leavegroup requests were not routed to the coordinator of the group.

This is because shotover is simply not performing that routing!
So this PR implements routing for LeaveGroup requests.

The fix can be confirmed by rerunning  `cargo nextest run --no-default-features --features kafka kafka_int_tests::cluster_1_rack_single_shotover --nocapture` and observing that the error level logs are gone now.