### PR TITLE
KafkaSinkCluster: scram_over_mtls - token recreation

### DIFF
--- a/docs/src/transforms.md
+++ b/docs/src/transforms.md
@@ -328,7 +328,9 @@ If SCRAM authentication against the first kafka broker fails, shotover will term
     #    certificate_path: "tls/mtls_localhost.crt"
     #    private_key_path: "tls/mtls_localhost.key"
     #    verify_hostname: true
-
+    #  # The lifetime that delegation tokens will be created with.
+    #  # Delegation tokens will automatically be recreated after they have passed half of their lifetime.
+    #  delegation_token_lifetime_seconds: 86400 # 1 day
 ```
 
 ### KafkaSinkSingle

--- a/shotover-proxy/tests/kafka_int_tests/test_cases.rs
+++ b/shotover-proxy/tests/kafka_int_tests/test_cases.rs
@@ -57,7 +57,7 @@ async fn admin_setup(connection_builder: &KafkaConnectionBuilder) {
     admin.delete_topics(&["to_delete"]).await
 }
 
-async fn produce_consume_partitions1(
+pub async fn produce_consume_partitions1(
     connection_builder: &KafkaConnectionBuilder,
     topic_name: &str,
 ) {
@@ -236,12 +236,12 @@ async fn produce_consume_acks0(connection_builder: &KafkaConnectionBuilder) {
     }
 }
 
-pub async fn standard_test_suite(connection_builder: KafkaConnectionBuilder) {
-    admin_setup(&connection_builder).await;
-    produce_consume_partitions1(&connection_builder, "partitions1").await;
-    produce_consume_partitions1(&connection_builder, "unknown_topic").await;
-    produce_consume_partitions3(&connection_builder).await;
-    produce_consume_acks0(&connection_builder).await;
+pub async fn standard_test_suite(connection_builder: &KafkaConnectionBuilder) {
+    admin_setup(connection_builder).await;
+    produce_consume_partitions1(connection_builder, "partitions1").await;
+    produce_consume_partitions1(connection_builder, "unknown_topic").await;
+    produce_consume_partitions3(connection_builder).await;
+    produce_consume_acks0(connection_builder).await;
     connection_builder.admin_cleanup().await;
 }
 

--- a/shotover-proxy/tests/test-configs/kafka/cluster-sasl-scram-over-mtls/topology-single.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-sasl-scram-over-mtls/topology-single.yaml
@@ -18,6 +18,7 @@ sources:
                 certificate_path: "tests/test-configs/kafka/tls/certs/localhost.crt"
                 private_key_path: "tests/test-configs/kafka/tls/certs/localhost.key"
                 verify_hostname: true
+              delegation_token_lifetime_seconds: 86400 # 1 day
             connect_timeout_ms: 3000
             tls:
               certificate_authority_path: "tests/test-configs/kafka/tls/certs/localhost_CA.crt"

--- a/shotover-proxy/tests/test-configs/kafka/cluster-sasl-scram-over-mtls/topology1.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-sasl-scram-over-mtls/topology1.yaml
@@ -25,6 +25,7 @@ sources:
                 certificate_path: "tests/test-configs/kafka/tls/certs/localhost.crt"
                 private_key_path: "tests/test-configs/kafka/tls/certs/localhost.key"
                 verify_hostname: true
+              delegation_token_lifetime_seconds: 15
             connect_timeout_ms: 3000
             tls:
               certificate_authority_path: "tests/test-configs/kafka/tls/certs/localhost_CA.crt"

--- a/shotover-proxy/tests/test-configs/kafka/cluster-sasl-scram-over-mtls/topology2.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-sasl-scram-over-mtls/topology2.yaml
@@ -25,6 +25,7 @@ sources:
                 certificate_path: "tests/test-configs/kafka/tls/certs/localhost.crt"
                 private_key_path: "tests/test-configs/kafka/tls/certs/localhost.key"
                 verify_hostname: true
+              delegation_token_lifetime_seconds: 15
             connect_timeout_ms: 3000
             tls:
               certificate_authority_path: "tests/test-configs/kafka/tls/certs/localhost_CA.crt"

--- a/shotover-proxy/tests/test-configs/kafka/cluster-sasl-scram-over-mtls/topology3.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-sasl-scram-over-mtls/topology3.yaml
@@ -25,6 +25,7 @@ sources:
                 certificate_path: "tests/test-configs/kafka/tls/certs/localhost.crt"
                 private_key_path: "tests/test-configs/kafka/tls/certs/localhost.key"
                 verify_hostname: true
+              delegation_token_lifetime_seconds: 15
             connect_timeout_ms: 3000
             tls:
               certificate_authority_path: "tests/test-configs/kafka/tls/certs/localhost_CA.crt"


### PR DESCRIPTION
This PR extends the token task to also recreate delegation tokens before they expire.

It exposes a new config option `delegation_token_lifetime_seconds` in the docs we give an example of
```yaml
delegation_token_lifetime_seconds: 86400 # 1 day
```
which is the recommended lifetime and the one we will be using internally.
Largely this config option was driven by my wanting a way to integration test this functionality without leaving a test running for 24 hours.
But I think its also going to be valuable for end users to tweak this value.

The queueing logic of new tokens to recreate is isolated into a RecreateTokenQueue type.

We then use a [tokio select](https://docs.rs/tokio/latest/tokio/macro.select.html) to await both the recreation queue and transform token requests.
We need to ensure that both of these are cancellation safe since we are using them in a select, and they are both cancellation safe, so no worries here.

A new metric is added:
`shotover_kafka_delegation_token_creation_seconds`
I believe its important to include the time taken as a metric because if this starts growing in production it can cause connection creation timeouts, so this metric will greatly help to diagnose such cases.
