### PR TITLE
#1611 Allow disabling Shotover metrics

### DIFF
--- a/docs/src/user-guide/configuration.md
+++ b/docs/src/user-guide/configuration.md
@@ -8,7 +8,7 @@ and a topology file specified by `--topology-file`
 The configuration file is used to change general behavior of Shotover. Currently it supports two values:
 
 * `main_log_level`
-* `observability_interface`
+* `observability_interface` (optional)
 
 ### main_log_level
 
@@ -16,7 +16,7 @@ This is a single string that you can use to configure logging with Shotover. It 
 
 ### observability_interface
 
-Shotover has an observability interface for you to collect Prometheus data from. This value will define the address and port for Shotover's observability interface. It is configured as a string in the format of `127.0.0.1:8080` for IPV4 addresses or `[2001:db8::1]:8080` for IPV6 addresses. More information is on the [observability page](./observability.md).
+Shotover has an optional observability interface for you to collect Prometheus data from. This value will define the address and port for Shotover's observability interface. It is configured as a string in the format of `127.0.0.1:8080` for IPV4 addresses or `[2001:db8::1]:8080` for IPV6 addresses. To disable metrics reporting for Shotover, do not specify this field. More information is on the [observability page](./observability.md).
 
 ## topology.yaml
 

--- a/docs/src/user-guide/observability.md
+++ b/docs/src/user-guide/observability.md
@@ -1,6 +1,6 @@
 # Metrics
 
-This interface will serve Prometheus metrics from `/metrics`. The following metrics are included by default, others are transform specific.
+This optional interface will serve Prometheus metrics from `/metrics`. It will be disabled if the field `observability_interface` is not provided in `configuration.yaml`. The following metrics are included by default, others are transform specific.
 
 | Name                                       | Labels      | Data type               | Description                                                               |
 |--------------------------------------------|-------------|-------------------------|---------------------------------------------------------------------------|

--- a/shotover-proxy/tests/test-configs/shotover-config/config_metrics_disabled.yaml
+++ b/shotover-proxy/tests/test-configs/shotover-config/config_metrics_disabled.yaml
@@ -1,0 +1,1 @@
+main_log_level: "info, shotover::connection_span=debug"

--- a/shotover/src/config/mod.rs
+++ b/shotover/src/config/mod.rs
@@ -10,7 +10,7 @@ pub mod topology;
 #[serde(deny_unknown_fields)]
 pub struct Config {
     pub main_log_level: String,
-    pub observability_interface: String,
+    pub observability_interface: Option<String>,
 }
 
 impl Config {


### PR DESCRIPTION
This PR makes the field `observability_interface` optional in `configuration.yaml`. The Shotover metrics reporting will be disabled when this field is not specified.

A test function has been added to verify Shotover can still process Redis requests with metrics disabled. As discussed with @rukai, we don't need to check that querying the prometheus endpoint returns the error of connection refused because the endpoint address is not specified at all.

Closes #1611