### PR TITLE
Document running clustered tests on macos

### DIFF
--- a/docs/src/dev-docs/setting-up-macos.md
+++ b/docs/src/dev-docs/setting-up-macos.md
@@ -11,6 +11,14 @@ To run the tests capable of running on macOS, install the following dependencies
 ```shell
 brew install --cask docker
 brew install openssl@3
+brew install chipmk/tap/docker-mac-net-connect
+sudo brew services start chipmk/tap/docker-mac-net-connect
 ```
 
 Make sure that docker desktop is running when you run the tests.
+
+To continue running tests after a reboot, you will need to rerun:
+
+```shell
+sudo brew services start chipmk/tap/docker-mac-net-connect
+```


### PR DESCRIPTION
https://github.com/chipmk/docker-mac-net-connect allows us to access docker containers by IP, which is a requirement of our clustered tests.
This PR documents installing docker-mac-net-connect as a requirement for running shotover's integration tests on mac os.
After following these instructions, my macbook is now passing all tests except for 2 cassandra tests. And excluding the tests for optional drivers enabled by `--features`