### PR TITLE
Update to rust 1.79 🦀🦀🦀

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.78"
+channel = "1.79"
 components = [ "rustfmt", "clippy" ]
 targets = [ "aarch64-unknown-linux-gnu" ]


### PR DESCRIPTION
We update to new rust versions as they come out.
They have strong backwards compatibility guarantees so are very low risk.
But also provide faster compile times and new features.