### PR TITLE
#1649 Leak query counter name to improve QueryCounter performance

### DIFF
--- a/shotover/src/transforms/query_counter.rs
+++ b/shotover/src/transforms/query_counter.rs
@@ -29,6 +29,7 @@ impl QueryCounter {
         counter!("shotover_query_count", "name" => counter_name.clone());
 
         QueryCounter {
+            // Leaking here is fine since the builder is created only once during shotover startup.
             counter_name: counter_name.leak(),
         }
     }


### PR DESCRIPTION
 Stores QueryCounter's `counter_name` as `&'static str` (i.e., leaks the `counter_name` string so that its memory allocation is not freed for the lifetime of the shotover process. This should improve shotover performance as it reduces cloning.

We can observe minor improvement in query_counter benchmark regarding allocating and freeing memory.
<img width="821" alt="image" src="https://github.com/shotover/shotover-proxy/assets/126037131/d9147150-3de1-443d-a4c9-04053154523c">


Progress towards #1649.