### PR TITLE
#1649 Reuse query counters

### DIFF
--- a/shotover/src/transforms/query_counter.rs
+++ b/shotover/src/transforms/query_counter.rs
@@ -29,6 +29,7 @@ impl QueryCounter {
         counter!("shotover_query_count", "name" => counter_name.clone());
 
         QueryCounter {
+            // Leaking here is fine since the builder is created only once during shotover startup.
             counter_name: counter_name.leak(),
         }
     }


### PR DESCRIPTION
This PR stores the query counters in a HashMap and reuses them when processing messages instead of registering query counters in every transform. According to the benchmark report, `query_counter_pre_used` gains 14% improvement thanks to the faster `transform`.
<img width="893" alt="image" src="https://github.com/shotover/shotover-proxy/assets/126037131/b6b07c61-1a84-487d-b5c0-ffd60c6c3146">

`query_counter_fresh` becomes a bit slower but it's expected because the first transform runs create the counters and insert them into the hashmap.
<img width="947" alt="image" src="https://github.com/shotover/shotover-proxy/assets/126037131/5bff4feb-f442-438a-bea7-76f6d5d69579">


Progress towards #1649 
