### PR TITLE
#1649 Upgrade metrics + metrics-exporter-prometheus dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2824,9 +2824,9 @@ checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "metrics"
-version = "0.22.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2be3cbd384d4e955b231c895ce10685e3d8260c5ccffae898c96c723b0772835"
+checksum = "884adb57038347dfbaf2d5065887b6cf4312330dc8e94bc30a1a839bd79d3261"
 dependencies = [
  "ahash",
  "portable-atomic",
@@ -2834,9 +2834,9 @@ dependencies = [
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d58e362dc7206e9456ddbcdbd53c71ba441020e62104703075a69151e38d85f"
+checksum = "26eb45aff37b45cff885538e1dcbd6c2b462c04fe84ce0155ea469f325672c98"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.2.6",
@@ -2848,9 +2848,9 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.16.3"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b07a5eb561b8cbc16be2d216faf7757f9baf3bfb94dbb0fae3df8387a5bb47f"
+checksum = "4259040465c955f9f2f1a4a8a16dc46726169bca0f88e8fb2dbeced487c3e828"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",

--- a/shotover/Cargo.toml
+++ b/shotover/Cargo.toml
@@ -93,8 +93,8 @@ httparse = { version = "1.8.0", optional = true }
 http = { version = "1.0.0", optional = true }
 
 #Observability
-metrics = "0.22.0"
-metrics-exporter-prometheus = { version = "0.14.0", default-features = false }
+metrics = "0.23.0"
+metrics-exporter-prometheus = { version = "0.15.0", default-features = false }
 tracing.workspace = true
 tracing-subscriber.workspace = true
 tracing-appender.workspace = true

--- a/shotover/src/transforms/query_counter.rs
+++ b/shotover/src/transforms/query_counter.rs
@@ -28,6 +28,7 @@ pub struct QueryCounterConfig {
 }
 
 impl QueryCounter {
+    #![allow(unused_must_use)] // Allow shotover_query_count counter to be not used
     pub fn new(counter_name: String) -> Self {
         // Leaking here is fine since the builder is created only once during shotover startup.
         let counter_name_ref: &'static str = counter_name.leak();

--- a/shotover/src/transforms/query_counter.rs
+++ b/shotover/src/transforms/query_counter.rs
@@ -28,13 +28,12 @@ pub struct QueryCounterConfig {
 }
 
 impl QueryCounter {
-    #![allow(unused_must_use)] // Allow shotover_query_count counter to be not used
     pub fn new(counter_name: String) -> Self {
         // Leaking here is fine since the builder is created only once during shotover startup.
         let counter_name_ref: &'static str = counter_name.leak();
 
         // Although not incremented, this counter needs to be created to ensure shotover_query_count is 0 on shotover startup.
-        counter!("shotover_query_count", "name" => counter_name_ref);
+        let _ = counter!("shotover_query_count", "name" => counter_name_ref);
 
         QueryCounter {
             counter_name: counter_name_ref,


### PR DESCRIPTION
This PR upgrades the metrics + metrics-exporter-prometheus dependencies, and is the last task of https://github.com/shotover/shotover-proxy/issues/1649.