### PR TITLE
Cassandra 5 vector support

### DIFF
--- a/shotover-proxy/tests/cassandra_int_tests/collections/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/collections/mod.rs
@@ -7,6 +7,7 @@ use test_helpers::connection::cassandra::{
 mod list;
 mod map;
 mod set;
+mod vector;
 
 fn supported_native_col_types(connection: &CassandraConnection) -> &'static [ColType] {
     match connection {
@@ -337,4 +338,19 @@ pub async fn test(connection: &CassandraConnection, driver: CassandraDriver) {
     list::test(connection, driver).await;
     set::test(connection, driver).await;
     map::test(connection, driver).await;
+}
+
+pub async fn test_cassandra_5(connection: &CassandraConnection, driver: CassandraDriver) {
+    run_query(
+        connection,
+        "CREATE KEYSPACE collections WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };"
+    ).await;
+
+    list::test(connection, driver).await;
+    set::test(connection, driver).await;
+    map::test(connection, driver).await;
+
+    if let CassandraDriver::Java = driver {
+        vector::test(connection).await;
+    }
 }

--- a/shotover-proxy/tests/cassandra_int_tests/collections/vector.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/collections/vector.rs
@@ -1,0 +1,47 @@
+use super::*;
+
+// We dont use the collection abstractions used by list/map/set since vectors only support a small subset of data types.
+
+async fn create(connection: &CassandraConnection) {
+    run_query(
+        connection,
+        "CREATE TABLE collections.vector (id int PRIMARY KEY, col0 vector<int, 1>, col1 vector<bigint, 2>, col2 vector<float, 2>, col3 vector<double, 2>);",
+    )
+    .await;
+}
+
+async fn insert(connection: &CassandraConnection) {
+    run_query(
+        connection,
+        "INSERT INTO collections.vector (id, col0, col1, col2, col3) VALUES (1, [1], [2, 3], [4.1, 5.2], [6.1, 7.2]);",
+    )
+    .await;
+}
+
+async fn select(connection: &CassandraConnection) {
+    let results = vec![
+        ResultValue::Vector(vec![ResultValue::Int(1)]),
+        ResultValue::Vector(vec![ResultValue::BigInt(2), ResultValue::BigInt(3)]),
+        ResultValue::Vector(vec![
+            ResultValue::Float(4.1.into()),
+            ResultValue::Float(5.2.into()),
+        ]),
+        ResultValue::Vector(vec![
+            ResultValue::Double(6.1.into()),
+            ResultValue::Double(7.2.into()),
+        ]),
+    ];
+
+    assert_query_result(
+        connection,
+        "SELECT col0, col1, col2, col3 FROM collections.vector;",
+        &[&results],
+    )
+    .await;
+}
+
+pub async fn test(connection: &CassandraConnection) {
+    create(connection).await;
+    insert(connection).await;
+    select(connection).await;
+}

--- a/shotover/src/frame/value.rs
+++ b/shotover/src/frame/value.rs
@@ -39,6 +39,7 @@ pub enum GenericValue {
     Counter(i64),
     Tuple(Vec<GenericValue>),
     Udt(BTreeMap<String, GenericValue>),
+    Custom(Bytes),
 }
 
 #[derive(PartialEq, Debug, Clone, Serialize, Deserialize, Hash, Eq, PartialOrd, Ord)]

--- a/shotover/src/frame/value/redis.rs
+++ b/shotover/src/frame/value/redis.rs
@@ -62,6 +62,7 @@ impl From<GenericValue> for RedisFrame {
             GenericValue::Tuple(_) => todo!(),
             GenericValue::Udt(_) => todo!(),
             GenericValue::Duration(_) => todo!(),
+            GenericValue::Custom(_) => todo!(),
         }
     }
 }

--- a/test-helpers/src/connection/cassandra/result_value.rs
+++ b/test-helpers/src/connection/cassandra/result_value.rs
@@ -32,6 +32,7 @@ pub enum ResultValue {
     Set(Vec<ResultValue>),
     List(Vec<ResultValue>),
     Tuple(Vec<ResultValue>),
+    Vector(Vec<ResultValue>),
     Map(Vec<(ResultValue, ResultValue)>),
     Null,
     /// Never output by the DB
@@ -66,6 +67,7 @@ impl PartialEq for ResultValue {
             (Self::List(l0), Self::List(r0)) => l0 == r0,
             (Self::Tuple(l0), Self::Tuple(r0)) => l0 == r0,
             (Self::Map(l0), Self::Map(r0)) => l0 == r0,
+            (Self::Vector(l0), Self::Vector(r0)) => l0 == r0,
             (Self::Null, Self::Null) => true,
             (Self::Any, _) => true,
             (_, Self::Any) => true,

--- a/test-helpers/src/connection/java.rs
+++ b/test-helpers/src/connection/java.rs
@@ -333,7 +333,7 @@ impl Value {
         self.cast_fallible(name).unwrap()
     }
 
-    fn cast_fallible(&self, name: &str) -> Result<Self> {
+    pub(crate) fn cast_fallible(&self, name: &str) -> Result<Self> {
         let instance = self.jvm.cast(&self.instance, name)?;
         Ok(Self {
             instance,


### PR DESCRIPTION
This PR fixes a bug causing shotover to error out when processing cassandra custom types.
In doing so we enable support for cassandra 5's new vector types.

The problem is that the cassandra-protocol crate will return an Error when it tries to parse a Custom cassandra value, this makes sense from the perspective of the crate since it does not know how to handle this type. If the user wants to use the custom type they should use a driver that knows about this type.
However from the shotover perspective its reasonable for the client and cassandra to use a custom type that shotover knows nothing about, in this case we should just pass on the bytes as is.

To achieve this we add an enum `CustomOrStandardType` which allows us to store either a Custom type (not supported by cassandra-protocol) or any other standard type supported by cassandra-protocol.
Long term I consider this a hack, but unless we have a push to improve cassandra performance I think we'll be living with this hack forever.

As demonstrated [here](https://github.com/rukai/cassandra_vector_bug/blob/main/src/main/java/com/mycompany/app/App.java) the java driver only supports 4 data types for use with vectors. So even though cassandra returns results for the other data types that could in theory be interpreted by a driver, we dont test those since there's no way to do that through the java driver. Shotover doesn't parse these anyway so in reality the coverage isnt important.