### PR TITLE
Splitup cassandra connection abstraction

### DIFF
--- a/shotover-proxy/tests/cassandra_int_tests/cluster/single_rack_v4.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cluster/single_rack_v4.rs
@@ -68,7 +68,7 @@ async fn test_rewrite_system_peers_dummy_peers(
         ResultValue::Any,
         // Unfortunately token generation appears to be non-deterministic but we can at least assert that
         // there are 128 tokens per node
-        if let CassandraDriver::CdrsTokio = driver {
+        if let CassandraDriver::Cdrs = driver {
             ResultValue::List(std::iter::repeat(ResultValue::Any).take(3 * 128).collect())
         } else {
             ResultValue::Set(std::iter::repeat(ResultValue::Any).take(3 * 128).collect())
@@ -87,7 +87,7 @@ async fn test_rewrite_system_peers_dummy_peers(
         ResultValue::Any,
         // Unfortunately token generation appears to be non-deterministic but we can at least assert that
         // there are 128 tokens per node
-        if let CassandraDriver::CdrsTokio = driver {
+        if let CassandraDriver::Cdrs = driver {
             ResultValue::List(std::iter::repeat(ResultValue::Any).take(3 * 128).collect())
         } else {
             ResultValue::Set(std::iter::repeat(ResultValue::Any).take(3 * 128).collect())
@@ -137,7 +137,7 @@ async fn test_rewrite_system_peers_v2_dummy_peers(
         ResultValue::Any,
         // Unfortunately token generation appears to be non-deterministic but we can at least assert that
         // there are 128 tokens per node
-        if let CassandraDriver::CdrsTokio = driver {
+        if let CassandraDriver::Cdrs = driver {
             ResultValue::List(std::iter::repeat(ResultValue::Any).take(3 * 128).collect())
         } else {
             ResultValue::Set(std::iter::repeat(ResultValue::Any).take(3 * 128).collect())
@@ -158,7 +158,7 @@ async fn test_rewrite_system_peers_v2_dummy_peers(
         ResultValue::Any,
         // Unfortunately token generation appears to be non-deterministic but we can at least assert that
         // there are 128 tokens per node
-        if let CassandraDriver::CdrsTokio = driver {
+        if let CassandraDriver::Cdrs = driver {
             ResultValue::List(std::iter::repeat(ResultValue::Any).take(3 * 128).collect())
         } else {
             ResultValue::Set(std::iter::repeat(ResultValue::Any).take(3 * 128).collect())
@@ -214,7 +214,7 @@ async fn test_rewrite_system_local(connection: &CassandraConnection, driver: Cas
         ResultValue::Any,
         // Unfortunately token generation appears to be non-deterministic but we can at least assert that
         // there are 128 tokens per node
-        if let CassandraDriver::CdrsTokio = driver {
+        if let CassandraDriver::Cdrs = driver {
             ResultValue::List(std::iter::repeat(ResultValue::Any).take(3 * 128).collect())
         } else {
             ResultValue::Set(std::iter::repeat(ResultValue::Any).take(3 * 128).collect())
@@ -356,7 +356,7 @@ pub async fn test_node_going_down(compose: &mut DockerCompose, driver: Cassandra
             .build()
             .await;
         test_connection_handles_node_down_with_one_retry(&new_connection).await;
-        if connection_shotover.is(&[CassandraDriver::CdrsTokio, CassandraDriver::Scylla]) {
+        if connection_shotover.is(&[CassandraDriver::Cdrs, CassandraDriver::Scylla]) {
             test_connection_handles_node_down_with_one_retry(&connection_shotover).await;
         }
     }
@@ -372,7 +372,7 @@ pub async fn test_node_going_down(compose: &mut DockerCompose, driver: Cassandra
             .build()
             .await;
         test_connection_handles_node_down_with_one_retry(&new_connection).await;
-        if connection_shotover.is(&[CassandraDriver::CdrsTokio, CassandraDriver::Scylla]) {
+        if connection_shotover.is(&[CassandraDriver::Cdrs, CassandraDriver::Scylla]) {
             test_connection_handles_node_down_with_one_retry(&connection_shotover).await;
         }
     }
@@ -387,16 +387,14 @@ struct EventConnections {
 
 impl EventConnections {
     async fn new() -> Self {
-        let direct =
-            CassandraConnectionBuilder::new("172.16.1.2", 9044, CassandraDriver::CdrsTokio)
-                .build()
-                .await;
+        let direct = CassandraConnectionBuilder::new("172.16.1.2", 9044, CassandraDriver::Cdrs)
+            .build()
+            .await;
         let recv_direct = direct.as_cdrs().create_event_receiver();
 
-        let shotover =
-            CassandraConnectionBuilder::new("127.0.0.1", 9042, CassandraDriver::CdrsTokio)
-                .build()
-                .await;
+        let shotover = CassandraConnectionBuilder::new("127.0.0.1", 9042, CassandraDriver::Cdrs)
+            .build()
+            .await;
         let recv_shotover = shotover.as_cdrs().create_event_receiver();
 
         EventConnections {

--- a/shotover-proxy/tests/cassandra_int_tests/collections/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/collections/mod.rs
@@ -287,7 +287,7 @@ async fn select_table(
     // TODO: fix upstream to remove hack
     //       because cdrs-tokio doesnt support set properly, we need to map any sets into lists
     #[allow(irrefutable_let_patterns)]
-    if let CassandraDriver::CdrsTokio = driver {
+    if let CassandraDriver::Cdrs = driver {
         for value in &mut results {
             set_to_list(value);
         }

--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -18,8 +18,7 @@ use test_helpers::connection::cassandra::Compression;
 use test_helpers::connection::cassandra::ProtocolVersion;
 use test_helpers::connection::cassandra::{
     assert_query_result, run_query, CassandraConnection, CassandraConnectionBuilder,
-    CassandraDriver, CassandraDriver::CdrsTokio, CassandraDriver::Scylla, CqlWsSession,
-    ResultValue,
+    CassandraDriver, CassandraDriver::Cdrs, CassandraDriver::Scylla, CqlWsSession, ResultValue,
 };
 use test_helpers::connection::redis_connection;
 use test_helpers::docker_compose::docker_compose;
@@ -85,7 +84,7 @@ where
 
 #[template]
 #[rstest]
-#[case::cdrs(CdrsTokio)]
+#[case::cdrs(Cdrs)]
 #[cfg_attr(feature = "cassandra-cpp-driver-tests", case::cpp(Cpp))]
 #[case::scylla(Scylla)]
 fn all_cassandra_drivers(#[case] driver: CassandraDriver) {}
@@ -170,7 +169,7 @@ async fn passthrough_encode(#[case] driver: CassandraDriver) {
 
 #[rstest]
 #[case::scylla(Scylla)]
-//#[case::cdrs(CdrsTokio)] // TODO
+//#[case::cdrs(Cdrs)] // TODO
 #[tokio::test(flavor = "multi_thread")]
 async fn source_tls_and_single_tls(#[case] driver: CassandraDriver) {
     test_helpers::cert::generate_cassandra_test_certs();
@@ -208,7 +207,7 @@ async fn source_tls_and_single_tls(#[case] driver: CassandraDriver) {
 }
 
 #[rstest]
-//#[case::cdrs(CdrsTokio)] // TODO
+//#[case::cdrs(Cdrs)] // TODO
 #[cfg_attr(feature = "cassandra-cpp-driver-tests", case::cpp(Cpp))]
 #[case::scylla(Scylla)]
 #[tokio::test(flavor = "multi_thread")]
@@ -298,7 +297,7 @@ async fn cluster_single_rack_v4(#[case] driver: CassandraDriver) {
 }
 
 #[rstest]
-//#[case::cdrs(CdrsTokio)] // TODO
+//#[case::cdrs(Cdrs)] // TODO
 #[cfg_attr(feature = "cassandra-cpp-driver-tests", case::cpp(Cpp))]
 #[case::scylla(Scylla)]
 #[tokio::test(flavor = "multi_thread")]
@@ -412,7 +411,7 @@ async fn cluster_multi_rack_2_per_rack(#[case] driver: CassandraDriver) {
 
 #[rstest]
 #[case::scylla(Scylla)]
-//#[case::cdrs(CdrsTokio)] // TODO
+//#[case::cdrs(Cdrs)] // TODO
 #[tokio::test(flavor = "multi_thread")]
 async fn source_tls_and_cluster_tls(#[case] driver: CassandraDriver) {
     test_helpers::cert::generate_cassandra_test_certs();
@@ -485,7 +484,7 @@ async fn cassandra_redis_cache(#[case] driver: CassandraDriver) {
 
 #[cfg(feature = "alpha-transforms")]
 #[rstest]
-// #[case::cdrs(CdrsTokio)] // TODO
+// #[case::cdrs(Cdrs)] // TODO
 #[cfg_attr(feature = "cassandra-cpp-driver-tests", case::cpp(Cpp))]
 #[case::scylla(Scylla)]
 #[tokio::test(flavor = "multi_thread")]
@@ -509,7 +508,7 @@ async fn protect_transform_local(#[case] driver: CassandraDriver) {
 
 #[cfg(feature = "alpha-transforms")]
 #[rstest]
-//#[case::cdrs(CdrsTokio)] // TODO
+//#[case::cdrs(Cdrs)] // TODO
 #[cfg_attr(feature = "cassandra-cpp-driver-tests", case::cpp(Cpp))]
 #[case::scylla(Scylla)]
 #[tokio::test(flavor = "multi_thread")]
@@ -533,7 +532,7 @@ async fn protect_transform_aws(#[case] driver: CassandraDriver) {
 }
 
 #[rstest]
-//#[case::cdrs(CdrsTokio)] // TODO
+//#[case::cdrs(Cdrs)] // TODO
 #[cfg_attr(feature = "cassandra-cpp-driver-tests", case::cpp(Cpp))]
 #[case::scylla(Scylla)]
 #[tokio::test(flavor = "multi_thread")]
@@ -632,7 +631,7 @@ async fn peers_rewrite_v4(#[case] driver: CassandraDriver) {
 }
 
 #[rstest]
-//#[case::cdrs(CdrsTokio)] // Disabled due to intermittent failure that only occurs on v3
+//#[case::cdrs(Cdrs)] // Disabled due to intermittent failure that only occurs on v3
 #[case::scylla(Scylla)]
 #[cfg_attr(feature = "cassandra-cpp-driver-tests", case::cpp(Cpp))]
 #[tokio::test(flavor = "multi_thread")]
@@ -667,7 +666,7 @@ async fn peers_rewrite_v3(#[case] driver: CassandraDriver) {
 }
 
 #[rstest]
-//#[case::cdrs(CdrsTokio)] // TODO: cdrs-tokio seems to be sending extra messages triggering the rate limiter
+//#[case::cdrs(Cdrs)] // TODO: cdrs-tokio seems to be sending extra messages triggering the rate limiter
 #[case::scylla(Scylla)]
 #[cfg_attr(feature = "cassandra-cpp-driver-tests", case::cpp(Cpp))]
 #[tokio::test(flavor = "multi_thread")]
@@ -841,7 +840,7 @@ async fn compression_cluster(#[case] driver: CassandraDriver) {
 }
 
 #[rstest]
-#[case::cdrs(CdrsTokio)]
+#[case::cdrs(Cdrs)]
 #[tokio::test(flavor = "multi_thread")]
 async fn events_keyspace(#[case] driver: CassandraDriver) {
     let _docker_compose =
@@ -880,7 +879,7 @@ async fn events_keyspace(#[case] driver: CassandraDriver) {
 // TODO find and fix the cause of this failing test https://github.com/shotover/shotover-proxy/issues/1096
 #[cfg(feature = "alpha-transforms")]
 #[rstest]
-#[case::cdrs(CdrsTokio)]
+#[case::cdrs(Cdrs)]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_protocol_v3(#[case] driver: CassandraDriver) {
     let _docker_compose =
@@ -904,7 +903,7 @@ async fn test_protocol_v3(#[case] driver: CassandraDriver) {
 
 #[cfg(feature = "alpha-transforms")]
 #[rstest]
-#[case::cdrs(CdrsTokio)]
+#[case::cdrs(Cdrs)]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_protocol_v4(#[case] driver: CassandraDriver) {
     let _docker_compose =
@@ -928,7 +927,7 @@ async fn test_protocol_v4(#[case] driver: CassandraDriver) {
 
 #[cfg(feature = "alpha-transforms")]
 #[rstest]
-#[case::cdrs(CdrsTokio)]
+#[case::cdrs(Cdrs)]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_protocol_v5_single(#[case] driver: CassandraDriver) {
     let _docker_compose =
@@ -952,7 +951,7 @@ async fn test_protocol_v5_single(#[case] driver: CassandraDriver) {
 
 #[cfg(feature = "alpha-transforms")]
 #[rstest]
-#[case::cdrs(CdrsTokio)]
+#[case::cdrs(Cdrs)]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_protocol_v5_compression_passthrough(#[case] driver: CassandraDriver) {
     {
@@ -978,7 +977,7 @@ async fn test_protocol_v5_compression_passthrough(#[case] driver: CassandraDrive
 
 #[cfg(feature = "alpha-transforms")]
 #[rstest]
-#[case::cdrs(CdrsTokio)]
+#[case::cdrs(Cdrs)]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_protocol_v5_compression_encode(#[case] driver: CassandraDriver) {
     {

--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -12,7 +12,7 @@ use rstest_reuse::{self, *};
 use scylla::SessionBuilder;
 use std::net::SocketAddr;
 #[cfg(feature = "cassandra-cpp-driver-tests")]
-use test_helpers::connection::cassandra::CassandraDriver::Datastax;
+use test_helpers::connection::cassandra::CassandraDriver::Cpp;
 use test_helpers::connection::cassandra::Compression;
 #[cfg(feature = "alpha-transforms")]
 use test_helpers::connection::cassandra::ProtocolVersion;
@@ -86,7 +86,7 @@ where
 #[template]
 #[rstest]
 #[case::cdrs(CdrsTokio)]
-#[cfg_attr(feature = "cassandra-cpp-driver-tests", case::datastax(Datastax))]
+#[cfg_attr(feature = "cassandra-cpp-driver-tests", case::cpp(Cpp))]
 #[case::scylla(Scylla)]
 fn all_cassandra_drivers(#[case] driver: CassandraDriver) {}
 
@@ -209,7 +209,7 @@ async fn source_tls_and_single_tls(#[case] driver: CassandraDriver) {
 
 #[rstest]
 //#[case::cdrs(CdrsTokio)] // TODO
-#[cfg_attr(feature = "cassandra-cpp-driver-tests", case::datastax(Datastax))]
+#[cfg_attr(feature = "cassandra-cpp-driver-tests", case::cpp(Cpp))]
 #[case::scylla(Scylla)]
 #[tokio::test(flavor = "multi_thread")]
 async fn cluster_single_rack_v3(#[case] driver: CassandraDriver) {
@@ -299,7 +299,7 @@ async fn cluster_single_rack_v4(#[case] driver: CassandraDriver) {
 
 #[rstest]
 //#[case::cdrs(CdrsTokio)] // TODO
-#[cfg_attr(feature = "cassandra-cpp-driver-tests", case::datastax(Datastax))]
+#[cfg_attr(feature = "cassandra-cpp-driver-tests", case::cpp(Cpp))]
 #[case::scylla(Scylla)]
 #[tokio::test(flavor = "multi_thread")]
 async fn cluster_multi_rack_1_per_rack(#[case] driver: CassandraDriver) {
@@ -486,7 +486,7 @@ async fn cassandra_redis_cache(#[case] driver: CassandraDriver) {
 #[cfg(feature = "alpha-transforms")]
 #[rstest]
 // #[case::cdrs(CdrsTokio)] // TODO
-#[cfg_attr(feature = "cassandra-cpp-driver-tests", case::datastax(Datastax))]
+#[cfg_attr(feature = "cassandra-cpp-driver-tests", case::cpp(Cpp))]
 #[case::scylla(Scylla)]
 #[tokio::test(flavor = "multi_thread")]
 async fn protect_transform_local(#[case] driver: CassandraDriver) {
@@ -510,7 +510,7 @@ async fn protect_transform_local(#[case] driver: CassandraDriver) {
 #[cfg(feature = "alpha-transforms")]
 #[rstest]
 //#[case::cdrs(CdrsTokio)] // TODO
-#[cfg_attr(feature = "cassandra-cpp-driver-tests", case::datastax(Datastax))]
+#[cfg_attr(feature = "cassandra-cpp-driver-tests", case::cpp(Cpp))]
 #[case::scylla(Scylla)]
 #[tokio::test(flavor = "multi_thread")]
 async fn protect_transform_aws(#[case] driver: CassandraDriver) {
@@ -534,7 +534,7 @@ async fn protect_transform_aws(#[case] driver: CassandraDriver) {
 
 #[rstest]
 //#[case::cdrs(CdrsTokio)] // TODO
-#[cfg_attr(feature = "cassandra-cpp-driver-tests", case::datastax(Datastax))]
+#[cfg_attr(feature = "cassandra-cpp-driver-tests", case::cpp(Cpp))]
 #[case::scylla(Scylla)]
 #[tokio::test(flavor = "multi_thread")]
 async fn peers_rewrite_v4(#[case] driver: CassandraDriver) {
@@ -634,7 +634,7 @@ async fn peers_rewrite_v4(#[case] driver: CassandraDriver) {
 #[rstest]
 //#[case::cdrs(CdrsTokio)] // Disabled due to intermittent failure that only occurs on v3
 #[case::scylla(Scylla)]
-#[cfg_attr(feature = "cassandra-cpp-driver-tests", case::datastax(Datastax))]
+#[cfg_attr(feature = "cassandra-cpp-driver-tests", case::cpp(Cpp))]
 #[tokio::test(flavor = "multi_thread")]
 async fn peers_rewrite_v3(#[case] driver: CassandraDriver) {
     let _docker_compose = docker_compose(
@@ -669,7 +669,7 @@ async fn peers_rewrite_v3(#[case] driver: CassandraDriver) {
 #[rstest]
 //#[case::cdrs(CdrsTokio)] // TODO: cdrs-tokio seems to be sending extra messages triggering the rate limiter
 #[case::scylla(Scylla)]
-#[cfg_attr(feature = "cassandra-cpp-driver-tests", case::datastax(Datastax))]
+#[cfg_attr(feature = "cassandra-cpp-driver-tests", case::cpp(Cpp))]
 #[tokio::test(flavor = "multi_thread")]
 async fn request_throttling(#[case] driver: CassandraDriver) {
     let _docker_compose =

--- a/shotover-proxy/tests/cassandra_int_tests/prepared_statements_all.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/prepared_statements_all.rs
@@ -25,7 +25,7 @@ fn values() -> Vec<ResultValue> {
 
 async fn insert(connection: &CassandraConnection, replication_factor: u32) {
     #[cfg(feature = "cassandra-cpp-driver-tests")]
-    let datastax = matches!(connection, CassandraConnection::Datastax { .. });
+    let datastax = matches!(connection, CassandraConnection::Cpp { .. });
     #[cfg(not(feature = "cassandra-cpp-driver-tests"))]
     let datastax = false;
 
@@ -75,7 +75,7 @@ async fn insert(connection: &CassandraConnection, replication_factor: u32) {
 }
 
 async fn select(connection: &CassandraConnection, replication_factor: u32) {
-    if let CassandraConnection::CdrsTokio { .. } = connection {
+    if let CassandraConnection::Cdrs { .. } = connection {
         // workaround cdrs-tokio having broken encoding for bytes
         assert_query_result(
             connection,

--- a/shotover-proxy/tests/cassandra_int_tests/routing.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/routing.rs
@@ -390,7 +390,7 @@ pub async fn test(
 ) {
     // execute_prepared_coordinator_node doesnt support cassandra-cpp yet.
     #[cfg(feature = "cassandra-cpp-driver-tests")]
-    let run = !matches!(driver, CassandraDriver::Datastax);
+    let run = !matches!(driver, CassandraDriver::Cpp);
     #[cfg(not(feature = "cassandra-cpp-driver-tests"))]
     let run = true;
 

--- a/test-helpers/src/connection/cassandra/connection.rs
+++ b/test-helpers/src/connection/cassandra/connection.rs
@@ -1,46 +1,23 @@
+use super::result_value::ResultValue;
+use ::scylla::SessionBuilder as SessionBuilderScylla;
 #[cfg(feature = "cassandra-cpp-driver-tests")]
-use cassandra_cpp::{
-    BatchType, CassErrorCode, CassResult, Cluster, Consistency as DatastaxConsistency, Error,
-    ErrorKind, LendingIterator, PreparedStatement as PreparedStatementCpp,
-    Session as DatastaxSession, Ssl, Statement as StatementCpp,
-};
-use cassandra_protocol::frame::message_error::ErrorType;
-use cassandra_protocol::query::QueryValues;
-use cassandra_protocol::types::IntoRustByIndex;
-use cassandra_protocol::{frame::message_error::ErrorBody, types::cassandra_type::wrapper_fn};
-use cdrs_tokio::query::{QueryParams, QueryParamsBuilder};
-use cdrs_tokio::statement::{StatementParams, StatementParamsBuilder};
-use cdrs_tokio::{
-    authenticators::StaticPasswordAuthenticatorProvider,
-    cluster::session::{Session as CdrsTokioSession, SessionBuilder, TcpSessionBuilder},
-    cluster::{NodeAddress, NodeTcpConfigBuilder, TcpConnectionManager},
-    consistency::Consistency as CdrsConsistency,
-    frame::{message_response::ResponseBody, message_result::ResResultBody, Envelope, Version},
-    load_balancing::TopologyAwareLoadBalancingStrategy,
-    query::{BatchQueryBuilder, PreparedQuery as CdrsTokioPreparedQuery},
-    query_values,
-    transport::TransportTcp,
-};
+use cassandra_cpp::{PreparedStatement as PreparedStatementCpp, Ssl};
+use cassandra_protocol::frame::message_error::ErrorBody;
+use cdrs::CdrsTokioPreparedQuery;
+use cdrs::{CdrsConnection, CdrsTokioSessionInstance};
+use cpp::CppConnection;
 use openssl::ssl::{SslContext, SslMethod};
 use pretty_assertions::assert_eq;
-use scylla::batch::Batch as ScyllaBatch;
-use scylla::frame::types::Consistency as ScyllaConsistency;
-use scylla::frame::value::{CqlDate, CqlDecimal, CqlTime, CqlTimestamp};
-use scylla::prepared_statement::PreparedStatement as PreparedStatementScylla;
-use scylla::serialize::value::SerializeCql;
-use scylla::statement::query::Query as ScyllaQuery;
-use scylla::transport::errors::{DbError, QueryError};
-use scylla::{
-    ExecutionProfile, QueryResult, Session as SessionScylla, SessionBuilder as SessionBuilderScylla,
-};
+use scylla::{PreparedStatementScylla, ScyllaConnection};
 #[cfg(feature = "cassandra-cpp-driver-tests")]
 use std::fs::read_to_string;
 use std::net::IpAddr;
-use std::sync::Arc;
 use std::time::Duration;
-use tokio::time::timeout;
 
-use super::result_value::ResultValue;
+mod cdrs;
+#[cfg(feature = "cassandra-cpp-driver-tests")]
+mod cpp;
+mod scylla;
 
 const TIMEOUT: u64 = 10;
 
@@ -84,12 +61,12 @@ impl CassandraConnectionBuilder {
         let tls = if let Some(ca_cert_path) = self.ca_cert_path {
             match self.driver {
                 #[cfg(feature = "cassandra-cpp-driver-tests")]
-                CassandraDriver::Datastax => {
+                CassandraDriver::Cpp => {
                     let ca_cert = read_to_string(ca_cert_path).unwrap();
                     let mut ssl = Ssl::default();
                     Ssl::add_trusted_cert(&mut ssl, &ca_cert).unwrap();
 
-                    Some(Tls::Datastax(ssl))
+                    Some(Tls::Cpp(ssl))
                 }
                 // TODO actually implement TLS for cdrs-tokio
                 CassandraDriver::CdrsTokio => todo!(),
@@ -120,7 +97,7 @@ impl CassandraConnectionBuilder {
 #[derive(Debug)]
 pub enum PreparedQuery {
     #[cfg(feature = "cassandra-cpp-driver-tests")]
-    Datastax(PreparedStatementCpp),
+    Cpp(PreparedStatementCpp),
     CdrsTokio(CdrsTokioPreparedQuery),
     Scylla(PreparedStatementScylla),
 }
@@ -129,8 +106,8 @@ impl PreparedQuery {
     #[cfg(feature = "cassandra-cpp-driver-tests")]
     pub fn as_datastax(&self) -> &PreparedStatementCpp {
         match self {
-            PreparedQuery::Datastax(p) => p,
-            _ => panic!("Not PreparedQuery::Datastax"),
+            PreparedQuery::Cpp(p) => p,
+            _ => panic!("Not PreparedQuery::Cpp"),
         }
     }
 
@@ -169,38 +146,23 @@ pub enum Consistency {
 
 pub enum Tls {
     #[cfg(feature = "cassandra-cpp-driver-tests")]
-    Datastax(Ssl),
+    Cpp(Ssl),
     Scylla(SslContext),
 }
 
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub enum CassandraDriver {
     #[cfg(feature = "cassandra-cpp-driver-tests")]
-    Datastax,
+    Cpp,
     CdrsTokio,
     Scylla,
 }
 
-type CdrsTokioSessionInstance = CdrsTokioSession<
-    TransportTcp,
-    TcpConnectionManager,
-    TopologyAwareLoadBalancingStrategy<TransportTcp, TcpConnectionManager>,
->;
-
 pub enum CassandraConnection {
     #[cfg(feature = "cassandra-cpp-driver-tests")]
-    Datastax {
-        session: DatastaxSession,
-        schema_awaiter: Option<SessionScylla>,
-    },
-    CdrsTokio {
-        session: CdrsTokioSessionInstance,
-        schema_awaiter: Option<SessionScylla>,
-    },
-    Scylla {
-        session: SessionScylla,
-        schema_awaiter: Option<SessionScylla>,
-    },
+    Cpp(CppConnection),
+    Cdrs(CdrsConnection),
+    Scylla(ScyllaConnection),
 }
 
 impl CassandraConnection {
@@ -214,155 +176,31 @@ impl CassandraConnection {
     ) -> Self {
         match driver {
             #[cfg(feature = "cassandra-cpp-driver-tests")]
-            CassandraDriver::Datastax => {
-                cassandra_cpp::set_log_logger();
-                let mut cluster = Cluster::default();
-                cluster.set_contact_points(contact_points).unwrap();
-                cluster.set_credentials("cassandra", "cassandra").unwrap();
-                cluster.set_port(port).unwrap();
-                cluster.set_load_balance_round_robin();
-
-                if let Some(protocol) = protocol {
-                    cluster
-                        .set_protocol_version(match protocol {
-                            ProtocolVersion::V3 => 3,
-                            ProtocolVersion::V4 => 4,
-                            ProtocolVersion::V5 => 5,
-                        })
-                        .unwrap();
-                }
-
-                if compression.is_some() {
-                    panic!("Cannot set compression with Datastax driver");
-                }
-
-                if let Some(Tls::Datastax(ssl)) = tls {
-                    cluster.set_ssl(ssl);
-                }
-
-                CassandraConnection::Datastax {
-                    session: cluster
-                        .connect()
-                        .await
-                        // By default unwrap uses the Debug formatter `{:?}` which is extremely noisy for the error type returned by `connect()`.
-                        // So we instead force the Display formatter `{}` on the error.
-                        .map_err(|err| format!("{err}"))
-                        .unwrap(),
-                    schema_awaiter: None,
-                }
-            }
-            CassandraDriver::CdrsTokio => {
-                let user = "cassandra";
-                let password = "cassandra";
-                let auth = StaticPasswordAuthenticatorProvider::new(&user, &password);
-
-                let node_addresses = contact_points
-                    .split(',')
-                    .map(|contact_point| NodeAddress::from(format!("{contact_point}:{port}")))
-                    .collect::<Vec<NodeAddress>>();
-
-                let mut node_config_builder = NodeTcpConfigBuilder::new()
-                    .with_contact_points(node_addresses)
-                    .with_authenticator_provider(Arc::new(auth));
-
-                if let Some(protocol) = protocol {
-                    node_config_builder = node_config_builder.with_version(match protocol {
-                        ProtocolVersion::V3 => Version::V3,
-                        ProtocolVersion::V4 => Version::V4,
-                        ProtocolVersion::V5 => Version::V5,
-                    });
-                }
-
-                let config = timeout(Duration::from_secs(TIMEOUT), node_config_builder.build())
-                    .await
-                    .unwrap()
-                    .unwrap();
-
-                let mut session_builder = TcpSessionBuilder::new(
-                    TopologyAwareLoadBalancingStrategy::new(None, true),
-                    config,
-                );
-
-                if let Some(compression) = compression {
-                    let compression = match compression {
-                        Compression::Snappy => cassandra_protocol::compression::Compression::Snappy,
-                        Compression::Lz4 => cassandra_protocol::compression::Compression::Lz4,
-                    };
-
-                    session_builder = session_builder.with_compression(compression);
-                }
-
-                let session = timeout(Duration::from_secs(TIMEOUT), session_builder.build())
-                    .await
-                    .unwrap()
-                    .unwrap();
-                CassandraConnection::CdrsTokio {
-                    session,
-                    schema_awaiter: None,
-                }
-            }
-            CassandraDriver::Scylla => {
-                let mut builder = SessionBuilderScylla::new()
-                    .known_nodes(
-                        contact_points
-                            .split(',')
-                            .map(|contact_point| format!("{contact_point}:{port}"))
-                            .collect::<Vec<String>>(),
-                    )
-                    .user("cassandra", "cassandra")
-                    // We do not need to refresh metadata as there is nothing else fiddling with the topology or schema.
-                    // By default the metadata refreshes every 60s and that can cause performance issues so we disable it by using an absurdly high refresh interval
-                    .cluster_metadata_refresh_interval(Duration::from_secs(10000000000))
-                    .compression(compression.map(|x| match x {
-                        Compression::Snappy => scylla::transport::Compression::Snappy,
-                        Compression::Lz4 => scylla::transport::Compression::Lz4,
-                    }))
-                    .default_execution_profile_handle(
-                        ExecutionProfile::builder()
-                            .consistency(ScyllaConsistency::One)
-                            .build()
-                            .into_handle(),
-                    );
-
-                if protocol.is_some() {
-                    panic!("Cannot set protocol with Scylla");
-                }
-
-                if let Some(Tls::Scylla(ssl_context)) = tls {
-                    builder = builder.ssl_context(Some(ssl_context));
-                }
-
-                let session = builder.build().await.unwrap();
-
-                CassandraConnection::Scylla {
-                    session,
-                    schema_awaiter: None,
-                }
-            }
+            CassandraDriver::Cpp => CassandraConnection::Cpp(
+                CppConnection::new(contact_points, port, compression, tls, protocol).await,
+            ),
+            CassandraDriver::CdrsTokio => CassandraConnection::Cdrs(
+                CdrsConnection::new(contact_points, port, compression, tls, protocol).await,
+            ),
+            CassandraDriver::Scylla => CassandraConnection::Scylla(
+                ScyllaConnection::new(contact_points, port, compression, tls, protocol).await,
+            ),
         }
     }
 
     pub fn as_cdrs(&self) -> &CdrsTokioSessionInstance {
         match self {
-            Self::CdrsTokio { session, .. } => session,
+            Self::Cdrs(connection) => &connection.session,
             _ => panic!("Not CdrsTokio"),
         }
     }
 
     pub fn is(&self, drivers: &[CassandraDriver]) -> bool {
         match self {
-            Self::CdrsTokio { .. } => drivers.contains(&CassandraDriver::CdrsTokio),
+            Self::Cdrs { .. } => drivers.contains(&CassandraDriver::CdrsTokio),
             #[cfg(feature = "cassandra-cpp-driver-tests")]
-            Self::Datastax { .. } => drivers.contains(&CassandraDriver::Datastax),
+            Self::Cpp { .. } => drivers.contains(&CassandraDriver::Cpp),
             Self::Scylla { .. } => drivers.contains(&CassandraDriver::Scylla),
-        }
-    }
-
-    #[cfg(feature = "cassandra-cpp-driver-tests")]
-    pub fn as_datastax(&self) -> &DatastaxSession {
-        match self {
-            Self::Datastax { session, .. } => session,
-            _ => panic!("Not Datastax"),
         }
     }
 
@@ -375,9 +213,9 @@ impl CassandraConnection {
 
         let schema_awaiter = match self {
             #[cfg(feature = "cassandra-cpp-driver-tests")]
-            Self::Datastax { schema_awaiter, .. } => schema_awaiter,
-            Self::CdrsTokio { schema_awaiter, .. } => schema_awaiter,
-            Self::Scylla { schema_awaiter, .. } => schema_awaiter,
+            Self::Cpp(connection) => &mut connection.schema_awaiter,
+            Self::Cdrs(connection) => &mut connection.schema_awaiter,
+            Self::Scylla(connection) => &mut connection.schema_awaiter,
         };
 
         *schema_awaiter = Some(
@@ -394,9 +232,9 @@ impl CassandraConnection {
     pub async fn await_schema_agreement(&self) {
         let schema_awaiter = match self {
             #[cfg(feature = "cassandra-cpp-driver-tests")]
-            Self::Datastax { schema_awaiter, .. } => schema_awaiter,
-            Self::CdrsTokio { schema_awaiter, .. } => schema_awaiter,
-            Self::Scylla { schema_awaiter, .. } => schema_awaiter,
+            Self::Cpp(connection) => &connection.schema_awaiter,
+            Self::Cdrs(connection) => &connection.schema_awaiter,
+            Self::Scylla(connection) => &connection.schema_awaiter,
         };
         if let Some(schema_awaiter) = schema_awaiter {
             schema_awaiter.await_schema_agreement().await.unwrap();
@@ -425,15 +263,9 @@ impl CassandraConnection {
     ) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
         let result = match self {
             #[cfg(feature = "cassandra-cpp-driver-tests")]
-            Self::Datastax { session, .. } => {
-                Self::process_datastax_response(session.execute(query).await)
-            }
-            Self::CdrsTokio { session, .. } => {
-                Self::process_cdrs_response(session.query(query).await)
-            }
-            Self::Scylla { session, .. } => {
-                Self::process_scylla_response(session.query(query, ()).await)
-            }
+            Self::Cpp(connection) => connection.execute_fallible(query).await,
+            Self::Cdrs(connection) => connection.execute_fallible(query).await,
+            Self::Scylla(connection) => connection.execute_fallible(query).await,
         };
 
         let query = query.to_uppercase();
@@ -457,6 +289,7 @@ impl CassandraConnection {
         .await
         .unwrap_or_else(|_| panic!("The CQL query: {query}\nTimed out after 10s"))
     }
+
     pub async fn execute_with_timestamp_inner(
         &self,
         query: &str,
@@ -464,24 +297,9 @@ impl CassandraConnection {
     ) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
         let result = match self {
             #[cfg(feature = "cassandra-cpp-driver-tests")]
-            Self::Datastax { session, .. } => {
-                let mut statement = session.statement(query);
-                statement.set_timestamp(timestamp).unwrap();
-                Self::process_datastax_response(statement.execute().await)
-            }
-            Self::CdrsTokio { session, .. } => {
-                let statement_params = StatementParamsBuilder::new()
-                    .with_timestamp(timestamp)
-                    .build();
-
-                let response = session.query_with_params(query, statement_params).await;
-                Self::process_cdrs_response(response)
-            }
-            Self::Scylla { session, .. } => {
-                let mut query = ScyllaQuery::new(query);
-                query.set_timestamp(Some(timestamp));
-                Self::process_scylla_response(session.query(query, ()).await)
-            }
+            Self::Cpp(connection) => connection.execute_with_timestamp(query, timestamp).await,
+            Self::Cdrs(connection) => connection.execute_with_timestamp(query, timestamp).await,
+            Self::Scylla(connection) => connection.execute_with_timestamp(query, timestamp).await,
         };
 
         let query = query.to_uppercase();
@@ -502,18 +320,9 @@ impl CassandraConnection {
     pub async fn prepare_inner(&self, query: &str) -> PreparedQuery {
         match self {
             #[cfg(feature = "cassandra-cpp-driver-tests")]
-            Self::Datastax { session, .. } => {
-                PreparedQuery::Datastax(session.prepare(query).await.unwrap())
-            }
-            Self::CdrsTokio { session, .. } => {
-                let query = session.prepare(query).await.unwrap();
-                PreparedQuery::CdrsTokio(query)
-            }
-            Self::Scylla { session, .. } => {
-                let mut prepared = session.prepare(query).await.unwrap();
-                prepared.set_tracing(true);
-                PreparedQuery::Scylla(prepared)
-            }
+            Self::Cpp(connection) => connection.prepare(query).await,
+            Self::Cdrs(connection) => connection.prepare(query).await,
+            Self::Scylla(connection) => connection.prepare(query).await,
         }
     }
 
@@ -537,59 +346,16 @@ impl CassandraConnection {
     ) -> IpAddr {
         match self {
             #[cfg(feature = "cassandra-cpp-driver-tests")]
-            Self::Datastax { .. } => {
-                todo!();
-            }
-            Self::CdrsTokio { session, .. } => {
-                let statement = prepared_query.as_cdrs();
-
-                let query_params = Self::bind_values_cdrs(values);
-
-                let params = StatementParams {
-                    query_params,
-                    is_idempotent: false,
-                    keyspace: None,
-                    token: None,
-                    routing_key: None,
-                    tracing: true,
-                    warnings: false,
-                    speculative_execution_policy: None,
-                    retry_policy: None,
-                    beta_protocol: false,
-                };
-
-                let response = session.exec_with_params(statement, &params).await.unwrap();
-
-                let tracing_id = response.tracing_id.unwrap();
-                tokio::time::sleep(tokio::time::Duration::from_millis(100)).await; // let cassandra finish writing to the tracing table
-                let row = session
-                    .query(format!(
-                        "SELECT coordinator FROM system_traces.sessions WHERE session_id = {}",
-                        tracing_id
-                    ))
+            Self::Cpp(_connection) => todo!(),
+            Self::Cdrs(connection) => {
+                connection
+                    .execute_prepared_coordinator_node(prepared_query, values)
                     .await
-                    .unwrap()
-                    .response_body()
-                    .unwrap()
-                    .into_rows()
-                    .unwrap();
-
-                row[0].get_by_index(0).unwrap().unwrap()
             }
-            Self::Scylla { session, .. } => {
-                let statement = prepared_query.as_scylla();
-                let values = Self::build_values_scylla(values);
-
-                let response = session.execute(statement, values).await.unwrap();
-                let tracing_id = response.tracing_id.unwrap();
-
-                tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-                session
-                    .get_tracing_info(&tracing_id)
+            Self::Scylla(connection) => {
+                connection
+                    .execute_prepared_coordinator_node(prepared_query, values)
                     .await
-                    .unwrap()
-                    .coordinator
-                    .unwrap()
             }
         }
     }
@@ -616,142 +382,22 @@ impl CassandraConnection {
     ) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
         match self {
             #[cfg(feature = "cassandra-cpp-driver-tests")]
-            Self::Datastax { .. } => {
-                let mut statement = prepared_query.as_datastax().bind();
-                for (i, value) in values.iter().enumerate() {
-                    Self::bind_statement_values_cpp(&mut statement, i, value);
-                }
-
-                statement.set_tracing(true).unwrap();
-                statement
-                    .set_consistency(match consistency {
-                        Consistency::All => DatastaxConsistency::ALL,
-                        Consistency::One => DatastaxConsistency::ONE,
-                    })
-                    .unwrap();
-                Self::process_datastax_response(statement.execute().await)
+            Self::Cpp(connection) => {
+                connection
+                    .execute_prepared(prepared_query, values, consistency)
+                    .await
             }
-            Self::CdrsTokio { session, .. } => {
-                let statement = prepared_query.as_cdrs();
-                let mut query_params = Self::bind_values_cdrs(values);
-                query_params.consistency = match consistency {
-                    Consistency::All => CdrsConsistency::All,
-                    Consistency::One => CdrsConsistency::One,
-                };
-
-                let params = StatementParams {
-                    query_params,
-                    is_idempotent: false,
-                    keyspace: None,
-                    token: None,
-                    routing_key: None,
-                    tracing: true,
-                    warnings: false,
-                    speculative_execution_policy: None,
-                    retry_policy: None,
-                    beta_protocol: false,
-                };
-
-                Self::process_cdrs_response(session.exec_with_params(statement, &params).await)
+            Self::Cdrs(connection) => {
+                connection
+                    .execute_prepared(prepared_query, values, consistency)
+                    .await
             }
-            Self::Scylla { session, .. } => {
-                // clone to avoid changing default consistency
-                let mut statement = prepared_query.as_scylla().clone();
-                statement.set_consistency(match consistency {
-                    Consistency::All => ScyllaConsistency::All,
-                    Consistency::One => ScyllaConsistency::One,
-                });
-                let values = Self::build_values_scylla(values);
-
-                Self::process_scylla_response(session.execute(&statement, values).await)
+            Self::Scylla(connection) => {
+                connection
+                    .execute_prepared(prepared_query, values, consistency)
+                    .await
             }
         }
-    }
-
-    fn bind_values_cdrs(values: &[ResultValue]) -> QueryParams {
-        QueryParamsBuilder::new()
-            .with_values(QueryValues::SimpleValues(
-                values
-                    .iter()
-                    .map(|v| match v {
-                        ResultValue::Int(v) => (*v).into(),
-                        ResultValue::Ascii(v) => v.as_str().into(),
-                        ResultValue::BigInt(v) => (*v).into(),
-                        ResultValue::Blob(v) => v.clone().into(),
-                        ResultValue::Boolean(v) => (*v).into(),
-                        ResultValue::Decimal(v) => v.clone().into(),
-                        ResultValue::Double(v) => (*v.as_ref()).into(),
-                        ResultValue::Float(v) => (*v.as_ref()).into(),
-                        ResultValue::Timestamp(v) => (*v).into(),
-                        ResultValue::Uuid(v) => (*v).into(),
-                        ResultValue::Inet(v) => (*v).into(),
-                        ResultValue::Date(v) => (*v).into(),
-                        ResultValue::Time(v) => (*v).into(),
-                        ResultValue::SmallInt(v) => (*v).into(),
-                        ResultValue::TinyInt(v) => (*v).into(),
-                        ResultValue::Varchar(v) => v.as_str().into(),
-                        value => todo!("Implement handling of {value:?} for cdrs-tokio"),
-                    })
-                    .collect(),
-            ))
-            .build()
-    }
-
-    // TODO: lets return Vec<CqlValue> instead, as it provides better guarantees for correctness
-    fn build_values_scylla(values: &[ResultValue]) -> Vec<Box<dyn SerializeCql + '_>> {
-        values
-            .iter()
-            .map(|v| match v {
-                ResultValue::Int(v) => Box::new(v) as Box<dyn SerializeCql>,
-                ResultValue::Ascii(v) => Box::new(v),
-                ResultValue::BigInt(v) => Box::new(v),
-                ResultValue::Blob(v) => Box::new(v),
-                ResultValue::Boolean(v) => Box::new(v),
-                ResultValue::Decimal(buf) => {
-                    let scale = i32::from_be_bytes(buf[0..4].try_into().unwrap());
-                    let bytes = &buf[4..];
-                    Box::new(CqlDecimal::from_signed_be_bytes_slice_and_exponent(
-                        bytes, scale,
-                    ))
-                }
-                ResultValue::Double(v) => Box::new(*v.as_ref()),
-                ResultValue::Float(v) => Box::new(*v.as_ref()),
-                ResultValue::Timestamp(v) => Box::new(CqlTimestamp(*v)),
-                ResultValue::Uuid(v) => Box::new(v),
-                ResultValue::Inet(v) => Box::new(v),
-                ResultValue::Date(v) => Box::new(CqlDate(*v)),
-                ResultValue::Time(v) => Box::new(CqlTime(*v)),
-                ResultValue::SmallInt(v) => Box::new(v),
-                ResultValue::TinyInt(v) => Box::new(v),
-                ResultValue::Varchar(v) => Box::new(v),
-                value => todo!("Implement handling of {value:?} for scylla"),
-            })
-            .collect()
-    }
-
-    #[cfg(feature = "cassandra-cpp-driver-tests")]
-    fn bind_statement_values_cpp(statement: &mut StatementCpp, i: usize, value: &ResultValue) {
-        match value {
-            ResultValue::Int(v) => statement.bind_int32(i, *v).unwrap(),
-            ResultValue::Ascii(v) => statement.bind_string(i, v).unwrap(),
-            ResultValue::BigInt(v) => statement.bind_int64(i, *v).unwrap(),
-            ResultValue::Blob(v) => statement.bind_bytes(i, v.clone()).unwrap(),
-            ResultValue::Boolean(v) => statement.bind_bool(i, *v).unwrap(),
-            ResultValue::Decimal(_) => {
-                todo!("cassandra-cpp wrapper does not expose bind_decimal yet")
-            }
-            ResultValue::Double(v) => statement.bind_double(i, **v).unwrap(),
-            ResultValue::Float(v) => statement.bind_float(i, **v).unwrap(),
-            ResultValue::Timestamp(v) => statement.bind_int64(i, *v).unwrap(),
-            ResultValue::Uuid(v) => statement.bind_uuid(i, (*v).into()).unwrap(),
-            ResultValue::Inet(v) => statement.bind_inet(i, v.into()).unwrap(),
-            ResultValue::Date(v) => statement.bind_uint32(i, *v).unwrap(),
-            ResultValue::Time(v) => statement.bind_int64(i, *v).unwrap(),
-            ResultValue::SmallInt(v) => statement.bind_int16(i, *v).unwrap(),
-            ResultValue::TinyInt(v) => statement.bind_int8(i, *v).unwrap(),
-            ResultValue::Varchar(v) => statement.bind_string(i, v).unwrap(),
-            value => todo!("Implement handling of {value:?} for datastax"),
-        };
     }
 
     pub async fn execute_batch_fallible(
@@ -772,146 +418,14 @@ impl CassandraConnection {
     ) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
         match self {
             #[cfg(feature = "cassandra-cpp-driver-tests")]
-            Self::Datastax { session, .. } => {
-                let mut batch = session.batch(BatchType::LOGGED);
-                for query in queries {
-                    batch
-                        .add_statement(session.statement(query.as_str()))
-                        .unwrap();
-                }
-
-                Self::process_datastax_response(batch.execute().await)
-            }
-            Self::CdrsTokio { session, .. } => {
-                let mut builder = BatchQueryBuilder::new();
-                for query in queries {
-                    builder = builder.add_query(query, query_values!());
-                }
-                let batch = builder.build().unwrap();
-
-                Self::process_cdrs_response(session.batch(batch).await)
-            }
-            Self::Scylla { session, .. } => {
-                let mut values = vec![];
-                let mut batch: ScyllaBatch = Default::default();
-                for query in queries {
-                    batch.append_statement(query.as_str());
-                    values.push(());
-                }
-
-                Self::process_scylla_response(session.batch(&batch, values).await)
-            }
+            Self::Cpp(connection) => connection.execute_batch_fallible(queries).await,
+            Self::Cdrs(connection) => connection.execute_batch_fallible(queries).await,
+            Self::Scylla(connection) => connection.execute_batch_fallible(queries).await,
         }
     }
 
     pub async fn execute_batch(&self, queries: Vec<String>) {
         let result = self.execute_batch_fallible(queries).await.unwrap();
         assert_eq!(result.len(), 0, "Batches should never return results");
-    }
-
-    #[cfg(feature = "cassandra-cpp-driver-tests")]
-    fn process_datastax_response(
-        response: Result<CassResult, cassandra_cpp::Error>,
-    ) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
-        match response {
-            Ok(response) => {
-                let mut response_result = vec![];
-                let mut iter = response.iter();
-                while let Some(row) = iter.next() {
-                    let mut row_result = vec![];
-                    let mut iter = row.iter();
-                    while let Some(value) = iter.next() {
-                        row_result.push(ResultValue::new_from_cpp(value));
-                    }
-                    response_result.push(row_result)
-                }
-                Ok(response_result)
-            }
-            Err(Error(ErrorKind::CassErrorResult(code, message, ..), _)) => Err(ErrorBody {
-                ty: match code {
-                    CassErrorCode::SERVER_OVERLOADED => ErrorType::Overloaded,
-                    CassErrorCode::SERVER_SERVER_ERROR => ErrorType::Server,
-                    CassErrorCode::SERVER_INVALID_QUERY => ErrorType::Invalid,
-                    code => todo!("Implement handling for cassandra_cpp err: {code:?}"),
-                },
-                message,
-            }),
-            Err(err) => panic!("Unexpected cassandra_cpp error: {err}"),
-        }
-    }
-
-    fn process_scylla_response(
-        response: Result<QueryResult, QueryError>,
-    ) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
-        match response {
-            Ok(value) => Ok(match value.rows {
-                Some(rows) => rows
-                    .into_iter()
-                    .map(|x| {
-                        x.columns
-                            .into_iter()
-                            .map(ResultValue::new_from_scylla)
-                            .collect()
-                    })
-                    .collect(),
-                None => vec![],
-            }),
-            Err(QueryError::DbError(code, message)) => Err(ErrorBody {
-                ty: match code {
-                    DbError::Overloaded => ErrorType::Overloaded,
-                    DbError::ServerError => ErrorType::Server,
-                    DbError::Invalid => ErrorType::Invalid,
-                    code => todo!("Implement handling for scylla err: {code:?}"),
-                },
-                message,
-            }),
-            Err(err) => panic!("Unexpected scylla error: {err:?}"),
-        }
-    }
-
-    fn process_cdrs_response(
-        response: Result<Envelope, cassandra_protocol::Error>,
-    ) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
-        match response {
-            Ok(response) => {
-                let version = response.version;
-                let response_body = response.response_body().unwrap();
-
-                Ok(match response_body {
-                    ResponseBody::Error(err) => {
-                        panic!("CQL query Failed with: {err:?}")
-                    }
-                    ResponseBody::Result(res_result_body) => match res_result_body {
-                        ResResultBody::Rows(rows) => {
-                            let mut result_values = vec![];
-
-                            for row in &rows.rows_content {
-                                let mut row_result_values = vec![];
-                                for (i, col_spec) in rows.metadata.col_specs.iter().enumerate() {
-                                    let wrapper = wrapper_fn(&col_spec.col_type.id);
-                                    let value = ResultValue::new_from_cdrs(
-                                        wrapper(&row[i], &col_spec.col_type, version).unwrap(),
-                                        version,
-                                    );
-
-                                    row_result_values.push(value);
-                                }
-                                result_values.push(row_result_values);
-                            }
-
-                            result_values
-                        }
-                        ResResultBody::Prepared(_) => todo!(),
-                        ResResultBody::SchemaChange(_) => vec![],
-                        ResResultBody::SetKeyspace(_) => vec![],
-                        ResResultBody::Void => vec![],
-                        _ => unreachable!(),
-                    },
-                    _ => todo!(),
-                })
-            }
-            Err(cassandra_protocol::Error::Server { body, .. }) => Err(body),
-            Err(err) => panic!("Unexpected cdrs-tokio error: {err:?}"),
-        }
     }
 }

--- a/test-helpers/src/connection/cassandra/connection/cdrs.rs
+++ b/test-helpers/src/connection/cassandra/connection/cdrs.rs
@@ -1,0 +1,280 @@
+use super::{Compression, Consistency, PreparedQuery, ProtocolVersion, Tls, TIMEOUT};
+use crate::connection::cassandra::ResultValue;
+use cassandra_protocol::query::QueryValues;
+use cassandra_protocol::types::IntoRustByIndex;
+use cassandra_protocol::{frame::message_error::ErrorBody, types::cassandra_type::wrapper_fn};
+use cdrs_tokio::query::{QueryParams, QueryParamsBuilder};
+use cdrs_tokio::statement::{StatementParams, StatementParamsBuilder};
+use cdrs_tokio::{
+    authenticators::StaticPasswordAuthenticatorProvider,
+    cluster::session::{Session as CdrsTokioSession, SessionBuilder, TcpSessionBuilder},
+    cluster::{NodeAddress, NodeTcpConfigBuilder, TcpConnectionManager},
+    consistency::Consistency as CdrsConsistency,
+    frame::{message_response::ResponseBody, message_result::ResResultBody, Envelope, Version},
+    load_balancing::TopologyAwareLoadBalancingStrategy,
+    query::BatchQueryBuilder,
+    query_values,
+    transport::TransportTcp,
+};
+use scylla::Session as SessionScylla;
+use std::net::IpAddr;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::timeout;
+
+pub use cdrs_tokio::query::PreparedQuery as CdrsTokioPreparedQuery;
+
+pub type CdrsTokioSessionInstance = CdrsTokioSession<
+    TransportTcp,
+    TcpConnectionManager,
+    TopologyAwareLoadBalancingStrategy<TransportTcp, TcpConnectionManager>,
+>;
+
+pub struct CdrsConnection {
+    pub session: CdrsTokioSessionInstance,
+    pub schema_awaiter: Option<SessionScylla>,
+}
+
+impl CdrsConnection {
+    pub async fn new(
+        contact_points: &str,
+        port: u16,
+        compression: Option<Compression>,
+        _tls: Option<Tls>,
+        protocol: Option<ProtocolVersion>,
+    ) -> Self {
+        let user = "cassandra";
+        let password = "cassandra";
+        let auth = StaticPasswordAuthenticatorProvider::new(&user, &password);
+
+        let node_addresses = contact_points
+            .split(',')
+            .map(|contact_point| NodeAddress::from(format!("{contact_point}:{port}")))
+            .collect::<Vec<NodeAddress>>();
+
+        let mut node_config_builder = NodeTcpConfigBuilder::new()
+            .with_contact_points(node_addresses)
+            .with_authenticator_provider(Arc::new(auth));
+
+        if let Some(protocol) = protocol {
+            node_config_builder = node_config_builder.with_version(match protocol {
+                ProtocolVersion::V3 => Version::V3,
+                ProtocolVersion::V4 => Version::V4,
+                ProtocolVersion::V5 => Version::V5,
+            });
+        }
+
+        let config = timeout(Duration::from_secs(TIMEOUT), node_config_builder.build())
+            .await
+            .unwrap()
+            .unwrap();
+
+        let mut session_builder =
+            TcpSessionBuilder::new(TopologyAwareLoadBalancingStrategy::new(None, true), config);
+
+        if let Some(compression) = compression {
+            let compression = match compression {
+                Compression::Snappy => cassandra_protocol::compression::Compression::Snappy,
+                Compression::Lz4 => cassandra_protocol::compression::Compression::Lz4,
+            };
+
+            session_builder = session_builder.with_compression(compression);
+        }
+
+        let session = timeout(Duration::from_secs(TIMEOUT), session_builder.build())
+            .await
+            .unwrap()
+            .unwrap();
+        CdrsConnection {
+            session,
+            schema_awaiter: None,
+        }
+    }
+
+    pub async fn execute_batch_fallible(
+        &self,
+        queries: Vec<String>,
+    ) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
+        let mut builder = BatchQueryBuilder::new();
+        for query in queries {
+            builder = builder.add_query(query, query_values!());
+        }
+        let batch = builder.build().unwrap();
+
+        Self::process_cdrs_response(self.session.batch(batch).await)
+    }
+
+    pub async fn execute_with_timestamp(
+        &self,
+        query: &str,
+        timestamp: i64,
+    ) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
+        let statement_params = StatementParamsBuilder::new()
+            .with_timestamp(timestamp)
+            .build();
+
+        let response = self
+            .session
+            .query_with_params(query, statement_params)
+            .await;
+        Self::process_cdrs_response(response)
+    }
+
+    pub async fn prepare(&self, query: &str) -> PreparedQuery {
+        let query = self.session.prepare(query).await.unwrap();
+        PreparedQuery::CdrsTokio(query)
+    }
+
+    pub async fn execute_prepared_coordinator_node(
+        &self,
+        prepared_query: &PreparedQuery,
+        values: &[ResultValue],
+    ) -> IpAddr {
+        let statement = prepared_query.as_cdrs();
+
+        let query_params = Self::bind_values_cdrs(values);
+
+        let params = StatementParams {
+            query_params,
+            is_idempotent: false,
+            keyspace: None,
+            token: None,
+            routing_key: None,
+            tracing: true,
+            warnings: false,
+            speculative_execution_policy: None,
+            retry_policy: None,
+            beta_protocol: false,
+        };
+
+        let response = self
+            .session
+            .exec_with_params(statement, &params)
+            .await
+            .unwrap();
+
+        let tracing_id = response.tracing_id.unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await; // let cassandra finish writing to the tracing table
+        let row = self
+            .session
+            .query(format!(
+                "SELECT coordinator FROM system_traces.sessions WHERE session_id = {}",
+                tracing_id
+            ))
+            .await
+            .unwrap()
+            .response_body()
+            .unwrap()
+            .into_rows()
+            .unwrap();
+
+        row[0].get_by_index(0).unwrap().unwrap()
+    }
+
+    pub async fn execute_prepared(
+        &self,
+        prepared_query: &PreparedQuery,
+        values: &[ResultValue],
+        consistency: Consistency,
+    ) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
+        let statement = prepared_query.as_cdrs();
+        let mut query_params = Self::bind_values_cdrs(values);
+        query_params.consistency = match consistency {
+            Consistency::All => CdrsConsistency::All,
+            Consistency::One => CdrsConsistency::One,
+        };
+
+        let params = StatementParams {
+            query_params,
+            is_idempotent: false,
+            keyspace: None,
+            token: None,
+            routing_key: None,
+            tracing: true,
+            warnings: false,
+            speculative_execution_policy: None,
+            retry_policy: None,
+            beta_protocol: false,
+        };
+
+        Self::process_cdrs_response(self.session.exec_with_params(statement, &params).await)
+    }
+    pub async fn execute_fallible(&self, query: &str) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
+        Self::process_cdrs_response(self.session.query(query).await)
+    }
+
+    fn process_cdrs_response(
+        response: Result<Envelope, cassandra_protocol::Error>,
+    ) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
+        match response {
+            Ok(response) => {
+                let version = response.version;
+                let response_body = response.response_body().unwrap();
+
+                Ok(match response_body {
+                    ResponseBody::Error(err) => {
+                        panic!("CQL query Failed with: {err:?}")
+                    }
+                    ResponseBody::Result(res_result_body) => match res_result_body {
+                        ResResultBody::Rows(rows) => {
+                            let mut result_values = vec![];
+
+                            for row in &rows.rows_content {
+                                let mut row_result_values = vec![];
+                                for (i, col_spec) in rows.metadata.col_specs.iter().enumerate() {
+                                    let wrapper = wrapper_fn(&col_spec.col_type.id);
+                                    let value = ResultValue::new_from_cdrs(
+                                        wrapper(&row[i], &col_spec.col_type, version).unwrap(),
+                                        version,
+                                    );
+
+                                    row_result_values.push(value);
+                                }
+                                result_values.push(row_result_values);
+                            }
+
+                            result_values
+                        }
+                        ResResultBody::Prepared(_) => todo!(),
+                        ResResultBody::SchemaChange(_) => vec![],
+                        ResResultBody::SetKeyspace(_) => vec![],
+                        ResResultBody::Void => vec![],
+                        _ => unreachable!(),
+                    },
+                    _ => todo!(),
+                })
+            }
+            Err(cassandra_protocol::Error::Server { body, .. }) => Err(body),
+            Err(err) => panic!("Unexpected cdrs-tokio error: {err:?}"),
+        }
+    }
+
+    fn bind_values_cdrs(values: &[ResultValue]) -> QueryParams {
+        QueryParamsBuilder::new()
+            .with_values(QueryValues::SimpleValues(
+                values
+                    .iter()
+                    .map(|v| match v {
+                        ResultValue::Int(v) => (*v).into(),
+                        ResultValue::Ascii(v) => v.as_str().into(),
+                        ResultValue::BigInt(v) => (*v).into(),
+                        ResultValue::Blob(v) => v.clone().into(),
+                        ResultValue::Boolean(v) => (*v).into(),
+                        ResultValue::Decimal(v) => v.clone().into(),
+                        ResultValue::Double(v) => (*v.as_ref()).into(),
+                        ResultValue::Float(v) => (*v.as_ref()).into(),
+                        ResultValue::Timestamp(v) => (*v).into(),
+                        ResultValue::Uuid(v) => (*v).into(),
+                        ResultValue::Inet(v) => (*v).into(),
+                        ResultValue::Date(v) => (*v).into(),
+                        ResultValue::Time(v) => (*v).into(),
+                        ResultValue::SmallInt(v) => (*v).into(),
+                        ResultValue::TinyInt(v) => (*v).into(),
+                        ResultValue::Varchar(v) => v.as_str().into(),
+                        value => todo!("Implement handling of {value:?} for cdrs-tokio"),
+                    })
+                    .collect(),
+            ))
+            .build()
+    }
+}

--- a/test-helpers/src/connection/cassandra/connection/cpp.rs
+++ b/test-helpers/src/connection/cassandra/connection/cpp.rs
@@ -1,0 +1,165 @@
+use super::{Compression, Consistency, PreparedQuery, ProtocolVersion, Tls};
+use crate::connection::cassandra::ResultValue;
+use cassandra_cpp::{
+    BatchType, CassErrorCode, CassResult, Cluster, Consistency as DatastaxConsistency, Error,
+    ErrorKind, LendingIterator, Session as DatastaxSession, Statement as StatementCpp,
+};
+use cdrs_tokio::frame::message_error::{ErrorBody, ErrorType};
+use scylla::Session as SessionScylla;
+
+pub struct CppConnection {
+    pub session: DatastaxSession,
+    pub schema_awaiter: Option<SessionScylla>,
+}
+
+impl CppConnection {
+    pub async fn new(
+        contact_points: &str,
+        port: u16,
+        compression: Option<Compression>,
+        tls: Option<Tls>,
+        protocol: Option<ProtocolVersion>,
+    ) -> Self {
+        cassandra_cpp::set_log_logger();
+        let mut cluster = Cluster::default();
+        cluster.set_contact_points(contact_points).unwrap();
+        cluster.set_credentials("cassandra", "cassandra").unwrap();
+        cluster.set_port(port).unwrap();
+        cluster.set_load_balance_round_robin();
+
+        if let Some(protocol) = protocol {
+            cluster
+                .set_protocol_version(match protocol {
+                    ProtocolVersion::V3 => 3,
+                    ProtocolVersion::V4 => 4,
+                    ProtocolVersion::V5 => 5,
+                })
+                .unwrap();
+        }
+
+        if compression.is_some() {
+            panic!("Cannot set compression with Datastax driver");
+        }
+
+        if let Some(Tls::Cpp(ssl)) = tls {
+            cluster.set_ssl(ssl);
+        }
+
+        CppConnection {
+            session: cluster
+                .connect()
+                .await
+                // By default unwrap uses the Debug formatter `{:?}` which is extremely noisy for the error type returned by `connect()`.
+                // So we instead force the Display formatter `{}` on the error.
+                .map_err(|err| format!("{err}"))
+                .unwrap(),
+            schema_awaiter: None,
+        }
+    }
+
+    pub async fn execute_fallible(&self, query: &str) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
+        Self::process_datastax_response(self.session.execute(query).await)
+    }
+
+    pub async fn execute_with_timestamp(
+        &self,
+        query: &str,
+        timestamp: i64,
+    ) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
+        let mut statement = self.session.statement(query);
+        statement.set_timestamp(timestamp).unwrap();
+        Self::process_datastax_response(statement.execute().await)
+    }
+
+    pub async fn prepare(&self, query: &str) -> PreparedQuery {
+        PreparedQuery::Cpp(self.session.prepare(query).await.unwrap())
+    }
+
+    pub async fn execute_prepared(
+        &self,
+        prepared_query: &PreparedQuery,
+        values: &[ResultValue],
+        consistency: Consistency,
+    ) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
+        let mut statement = prepared_query.as_datastax().bind();
+        for (i, value) in values.iter().enumerate() {
+            Self::bind_statement_values_cpp(&mut statement, i, value);
+        }
+
+        statement.set_tracing(true).unwrap();
+        statement
+            .set_consistency(match consistency {
+                Consistency::All => DatastaxConsistency::ALL,
+                Consistency::One => DatastaxConsistency::ONE,
+            })
+            .unwrap();
+        Self::process_datastax_response(statement.execute().await)
+    }
+    pub async fn execute_batch_fallible(
+        &self,
+        queries: Vec<String>,
+    ) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
+        let mut batch = self.session.batch(BatchType::LOGGED);
+        for query in queries {
+            batch
+                .add_statement(self.session.statement(query.as_str()))
+                .unwrap();
+        }
+
+        Self::process_datastax_response(batch.execute().await)
+    }
+
+    fn bind_statement_values_cpp(statement: &mut StatementCpp, i: usize, value: &ResultValue) {
+        match value {
+            ResultValue::Int(v) => statement.bind_int32(i, *v).unwrap(),
+            ResultValue::Ascii(v) => statement.bind_string(i, v).unwrap(),
+            ResultValue::BigInt(v) => statement.bind_int64(i, *v).unwrap(),
+            ResultValue::Blob(v) => statement.bind_bytes(i, v.clone()).unwrap(),
+            ResultValue::Boolean(v) => statement.bind_bool(i, *v).unwrap(),
+            ResultValue::Decimal(_) => {
+                todo!("cassandra-cpp wrapper does not expose bind_decimal yet")
+            }
+            ResultValue::Double(v) => statement.bind_double(i, **v).unwrap(),
+            ResultValue::Float(v) => statement.bind_float(i, **v).unwrap(),
+            ResultValue::Timestamp(v) => statement.bind_int64(i, *v).unwrap(),
+            ResultValue::Uuid(v) => statement.bind_uuid(i, (*v).into()).unwrap(),
+            ResultValue::Inet(v) => statement.bind_inet(i, v.into()).unwrap(),
+            ResultValue::Date(v) => statement.bind_uint32(i, *v).unwrap(),
+            ResultValue::Time(v) => statement.bind_int64(i, *v).unwrap(),
+            ResultValue::SmallInt(v) => statement.bind_int16(i, *v).unwrap(),
+            ResultValue::TinyInt(v) => statement.bind_int8(i, *v).unwrap(),
+            ResultValue::Varchar(v) => statement.bind_string(i, v).unwrap(),
+            value => todo!("Implement handling of {value:?} for Cpp"),
+        };
+    }
+
+    fn process_datastax_response(
+        response: Result<CassResult, cassandra_cpp::Error>,
+    ) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
+        match response {
+            Ok(response) => {
+                let mut response_result = vec![];
+                let mut iter = response.iter();
+                while let Some(row) = iter.next() {
+                    let mut row_result = vec![];
+                    let mut iter = row.iter();
+                    while let Some(value) = iter.next() {
+                        row_result.push(ResultValue::new_from_cpp(value));
+                    }
+                    response_result.push(row_result)
+                }
+                Ok(response_result)
+            }
+            Err(Error(ErrorKind::CassErrorResult(code, message, ..), _)) => Err(ErrorBody {
+                ty: match code {
+                    CassErrorCode::SERVER_OVERLOADED => ErrorType::Overloaded,
+                    CassErrorCode::SERVER_SERVER_ERROR => ErrorType::Server,
+                    CassErrorCode::SERVER_INVALID_QUERY => ErrorType::Invalid,
+                    code => todo!("Implement handling for cassandra_cpp err: {code:?}"),
+                },
+                message,
+            }),
+            Err(err) => panic!("Unexpected cassandra_cpp error: {err}"),
+        }
+    }
+}

--- a/test-helpers/src/connection/cassandra/connection/cpp.rs
+++ b/test-helpers/src/connection/cassandra/connection/cpp.rs
@@ -1,14 +1,16 @@
+use super::scylla::SessionScylla;
 use super::{Compression, Consistency, PreparedQuery, ProtocolVersion, Tls};
 use crate::connection::cassandra::ResultValue;
 use cassandra_cpp::{
-    BatchType, CassErrorCode, CassResult, Cluster, Consistency as DatastaxConsistency, Error,
-    ErrorKind, LendingIterator, Session as DatastaxSession, Statement as StatementCpp,
+    BatchType, CassErrorCode, CassResult, Cluster, Consistency as ConsistencyCpp, Error, ErrorKind,
+    LendingIterator, Session, Statement as StatementCpp,
 };
 use cdrs_tokio::frame::message_error::{ErrorBody, ErrorType};
-use scylla::Session as SessionScylla;
+
+pub use cassandra_cpp::{PreparedStatement as PreparedStatementCpp, Ssl as SslCpp};
 
 pub struct CppConnection {
-    pub session: DatastaxSession,
+    pub session: Session,
     pub schema_awaiter: Option<SessionScylla>,
 }
 
@@ -89,8 +91,8 @@ impl CppConnection {
         statement.set_tracing(true).unwrap();
         statement
             .set_consistency(match consistency {
-                Consistency::All => DatastaxConsistency::ALL,
-                Consistency::One => DatastaxConsistency::ONE,
+                Consistency::All => ConsistencyCpp::ALL,
+                Consistency::One => ConsistencyCpp::ONE,
             })
             .unwrap();
         Self::process_datastax_response(statement.execute().await)

--- a/test-helpers/src/connection/cassandra/connection/scylla.rs
+++ b/test-helpers/src/connection/cassandra/connection/scylla.rs
@@ -1,0 +1,200 @@
+use super::{Compression, Consistency, PreparedQuery, ProtocolVersion, Tls};
+use crate::connection::cassandra::ResultValue;
+use cdrs_tokio::frame::message_error::{ErrorBody, ErrorType};
+use scylla::batch::Batch as ScyllaBatch;
+use scylla::frame::types::Consistency as ScyllaConsistency;
+use scylla::frame::value::{CqlDate, CqlDecimal, CqlTime, CqlTimestamp};
+use scylla::serialize::value::SerializeCql;
+use scylla::statement::query::Query as ScyllaQuery;
+use scylla::transport::errors::{DbError, QueryError};
+use scylla::{
+    ExecutionProfile, QueryResult, Session as SessionScylla, SessionBuilder as SessionBuilderScylla,
+};
+use std::net::IpAddr;
+use std::time::Duration;
+
+pub use scylla::prepared_statement::PreparedStatement as PreparedStatementScylla;
+
+pub struct ScyllaConnection {
+    session: SessionScylla,
+    pub schema_awaiter: Option<SessionScylla>,
+}
+
+impl ScyllaConnection {
+    pub async fn new(
+        contact_points: &str,
+        port: u16,
+        compression: Option<Compression>,
+        tls: Option<Tls>,
+        protocol: Option<ProtocolVersion>,
+    ) -> Self {
+        let mut builder = SessionBuilderScylla::new()
+            .known_nodes(
+                contact_points
+                    .split(',')
+                    .map(|contact_point| format!("{contact_point}:{port}"))
+                    .collect::<Vec<String>>(),
+            )
+            .user("cassandra", "cassandra")
+            // We do not need to refresh metadata as there is nothing else fiddling with the topology or schema.
+            // By default the metadata refreshes every 60s and that can cause performance issues so we disable it by using an absurdly high refresh interval
+            .cluster_metadata_refresh_interval(Duration::from_secs(10000000000))
+            .compression(compression.map(|x| match x {
+                Compression::Snappy => scylla::transport::Compression::Snappy,
+                Compression::Lz4 => scylla::transport::Compression::Lz4,
+            }))
+            .default_execution_profile_handle(
+                ExecutionProfile::builder()
+                    .consistency(ScyllaConsistency::One)
+                    .build()
+                    .into_handle(),
+            );
+
+        if protocol.is_some() {
+            panic!("Cannot set protocol with Scylla");
+        }
+
+        if let Some(Tls::Scylla(ssl_context)) = tls {
+            builder = builder.ssl_context(Some(ssl_context));
+        }
+
+        let session = builder.build().await.unwrap();
+
+        ScyllaConnection {
+            session,
+            schema_awaiter: None,
+        }
+    }
+
+    pub async fn execute_prepared_coordinator_node(
+        &self,
+        prepared_query: &PreparedQuery,
+        values: &[ResultValue],
+    ) -> IpAddr {
+        let statement = prepared_query.as_scylla();
+        let values = Self::build_values_scylla(values);
+
+        let response = self.session.execute(statement, values).await.unwrap();
+        let tracing_id = response.tracing_id.unwrap();
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        self.session
+            .get_tracing_info(&tracing_id)
+            .await
+            .unwrap()
+            .coordinator
+            .unwrap()
+    }
+
+    pub async fn execute_batch_fallible(
+        &self,
+        queries: Vec<String>,
+    ) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
+        let mut values = vec![];
+        let mut batch: ScyllaBatch = Default::default();
+        for query in queries {
+            batch.append_statement(query.as_str());
+            values.push(());
+        }
+
+        Self::process_scylla_response(self.session.batch(&batch, values).await)
+    }
+
+    pub async fn execute_fallible(&self, query: &str) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
+        Self::process_scylla_response(self.session.query(query, ()).await)
+    }
+
+    pub async fn execute_with_timestamp(
+        &self,
+        query: &str,
+        timestamp: i64,
+    ) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
+        let mut query = ScyllaQuery::new(query);
+        query.set_timestamp(Some(timestamp));
+        Self::process_scylla_response(self.session.query(query, ()).await)
+    }
+
+    pub async fn prepare(&self, query: &str) -> PreparedQuery {
+        let mut prepared = self.session.prepare(query).await.unwrap();
+        prepared.set_tracing(true);
+        PreparedQuery::Scylla(prepared)
+    }
+
+    pub async fn execute_prepared(
+        &self,
+        prepared_query: &PreparedQuery,
+        values: &[ResultValue],
+        consistency: Consistency,
+    ) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
+        // clone to avoid changing default consistency
+        let mut statement = prepared_query.as_scylla().clone();
+        statement.set_consistency(match consistency {
+            Consistency::All => ScyllaConsistency::All,
+            Consistency::One => ScyllaConsistency::One,
+        });
+        let values = Self::build_values_scylla(values);
+
+        Self::process_scylla_response(self.session.execute(&statement, values).await)
+    }
+
+    fn process_scylla_response(
+        response: Result<QueryResult, QueryError>,
+    ) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
+        match response {
+            Ok(value) => Ok(match value.rows {
+                Some(rows) => rows
+                    .into_iter()
+                    .map(|x| {
+                        x.columns
+                            .into_iter()
+                            .map(ResultValue::new_from_scylla)
+                            .collect()
+                    })
+                    .collect(),
+                None => vec![],
+            }),
+            Err(QueryError::DbError(code, message)) => Err(ErrorBody {
+                ty: match code {
+                    DbError::Overloaded => ErrorType::Overloaded,
+                    DbError::ServerError => ErrorType::Server,
+                    DbError::Invalid => ErrorType::Invalid,
+                    code => todo!("Implement handling for scylla err: {code:?}"),
+                },
+                message,
+            }),
+            Err(err) => panic!("Unexpected scylla error: {err:?}"),
+        }
+    }
+
+    // TODO: lets return Vec<CqlValue> instead, as it provides better guarantees for correctness
+    fn build_values_scylla(values: &[ResultValue]) -> Vec<Box<dyn SerializeCql + '_>> {
+        values
+            .iter()
+            .map(|v| match v {
+                ResultValue::Int(v) => Box::new(v) as Box<dyn SerializeCql>,
+                ResultValue::Ascii(v) => Box::new(v),
+                ResultValue::BigInt(v) => Box::new(v),
+                ResultValue::Blob(v) => Box::new(v),
+                ResultValue::Boolean(v) => Box::new(v),
+                ResultValue::Decimal(buf) => {
+                    let scale = i32::from_be_bytes(buf[0..4].try_into().unwrap());
+                    let bytes = &buf[4..];
+                    Box::new(CqlDecimal::from_signed_be_bytes_slice_and_exponent(
+                        bytes, scale,
+                    ))
+                }
+                ResultValue::Double(v) => Box::new(*v.as_ref()),
+                ResultValue::Float(v) => Box::new(*v.as_ref()),
+                ResultValue::Timestamp(v) => Box::new(CqlTimestamp(*v)),
+                ResultValue::Uuid(v) => Box::new(v),
+                ResultValue::Inet(v) => Box::new(v),
+                ResultValue::Date(v) => Box::new(CqlDate(*v)),
+                ResultValue::Time(v) => Box::new(CqlTime(*v)),
+                ResultValue::SmallInt(v) => Box::new(v),
+                ResultValue::TinyInt(v) => Box::new(v),
+                ResultValue::Varchar(v) => Box::new(v),
+                value => todo!("Implement handling of {value:?} for scylla"),
+            })
+            .collect()
+    }
+}

--- a/test-helpers/src/connection/cassandra/connection/scylla.rs
+++ b/test-helpers/src/connection/cassandra/connection/scylla.rs
@@ -1,19 +1,19 @@
 use super::{Compression, Consistency, PreparedQuery, ProtocolVersion, Tls};
 use crate::connection::cassandra::ResultValue;
 use cdrs_tokio::frame::message_error::{ErrorBody, ErrorType};
-use scylla::batch::Batch as ScyllaBatch;
+use scylla::batch::Batch;
 use scylla::frame::types::Consistency as ScyllaConsistency;
 use scylla::frame::value::{CqlDate, CqlDecimal, CqlTime, CqlTimestamp};
 use scylla::serialize::value::SerializeCql;
-use scylla::statement::query::Query as ScyllaQuery;
+use scylla::statement::query::Query;
 use scylla::transport::errors::{DbError, QueryError};
-use scylla::{
-    ExecutionProfile, QueryResult, Session as SessionScylla, SessionBuilder as SessionBuilderScylla,
-};
+use scylla::{ExecutionProfile, QueryResult};
 use std::net::IpAddr;
 use std::time::Duration;
 
 pub use scylla::prepared_statement::PreparedStatement as PreparedStatementScylla;
+pub use scylla::Session as SessionScylla;
+pub use scylla::SessionBuilder as SessionBuilderScylla;
 
 pub struct ScyllaConnection {
     session: SessionScylla,
@@ -91,7 +91,7 @@ impl ScyllaConnection {
         queries: Vec<String>,
     ) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
         let mut values = vec![];
-        let mut batch: ScyllaBatch = Default::default();
+        let mut batch: Batch = Default::default();
         for query in queries {
             batch.append_statement(query.as_str());
             values.push(());
@@ -109,7 +109,7 @@ impl ScyllaConnection {
         query: &str,
         timestamp: i64,
     ) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
-        let mut query = ScyllaQuery::new(query);
+        let mut query = Query::new(query);
         query.set_timestamp(Some(timestamp));
         Self::process_scylla_response(self.session.query(query, ()).await)
     }


### PR DESCRIPTION
This PR only changes test code.
This PR contains no functional changes to the tests.

`cassandra/connection.rs` is split up into connection.rs, scylla.rs, cdrs.rs and cpp.rs.
This is done by introducing `ScyllaConnection`, `CdrsConnection` and `CppConnection` types that hold all wrapping logic for each driver.

I attempted to keep this as straightforward as possible, however there were some important renames that needed to be done, so I included those in this PR.
The renames include:
* CdrsTokio -> Cdrs - Shortened form since we write this so much
* datastax -> cpp - while the driver is written by datastax, so is other drivers, so its a bit ambiguous. Cpp matches the naming style used by the kafka drivers abstraction.
* Types like `ScyllaBatch` are renamed to just `Batch` since its no longer ambiguous because they live in their own scylla specific module now.

Additionally the TIMEOUT constant is changed to include the whole `Duration` type.
Previously it was not clear what unit of time the timeout was in.