### PR TITLE
Add cassandra java driver to test suite

### DIFF
--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -18,7 +18,8 @@ use test_helpers::connection::cassandra::Compression;
 use test_helpers::connection::cassandra::ProtocolVersion;
 use test_helpers::connection::cassandra::{
     assert_query_result, run_query, CassandraConnection, CassandraConnectionBuilder,
-    CassandraDriver, CassandraDriver::Cdrs, CassandraDriver::Scylla, CqlWsSession, ResultValue,
+    CassandraDriver, CassandraDriver::Cdrs, CassandraDriver::Java, CassandraDriver::Scylla,
+    CqlWsSession, ResultValue,
 };
 use test_helpers::connection::redis_connection;
 use test_helpers::docker_compose::docker_compose;
@@ -84,9 +85,10 @@ where
 
 #[template]
 #[rstest]
-#[case::cdrs(Cdrs)]
 #[cfg_attr(feature = "cassandra-cpp-driver-tests", case::cpp(Cpp))]
 #[case::scylla(Scylla)]
+#[case::cdrs(Cdrs)]
+#[case::java(Java)]
 fn all_cassandra_drivers(#[case] driver: CassandraDriver) {}
 
 #[apply(all_cassandra_drivers)]

--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -242,7 +242,11 @@ async fn cluster_single_rack_v3(#[case] driver: CassandraDriver) {
     cluster::single_rack_v3::test_topology_task(None).await;
 }
 
-#[apply(all_cassandra_drivers)]
+#[rstest]
+#[cfg_attr(feature = "cassandra-cpp-driver-tests", case::cpp(Cpp))]
+#[case::scylla(Scylla)]
+#[case::cdrs(Cdrs)]
+//#[case::java(Java)] // Need to create JVM in builder to avoid recreating for each connection instance.
 #[tokio::test(flavor = "multi_thread")]
 async fn cluster_single_rack_v4(#[case] driver: CassandraDriver) {
     let mut compose = docker_compose("tests/test-configs/cassandra/cluster-v4/docker-compose.yaml");
@@ -1076,7 +1080,10 @@ async fn cassandra_5(#[case] driver: CassandraDriver) {
     shotover.shutdown_and_then_consume_events(&[]).await;
 }
 
-#[apply(all_cassandra_drivers)]
+#[rstest]
+#[cfg_attr(feature = "cassandra-cpp-driver-tests", case::cpp(Cpp))]
+#[case::scylla(Scylla)]
+#[case::cdrs(Cdrs)]
 #[tokio::test(flavor = "multi_thread")]
 async fn cassandra_5_cluster(#[case] driver: CassandraDriver) {
     let _compose = docker_compose("tests/test-configs/cassandra/cluster-v5/docker-compose.yaml");

--- a/shotover-proxy/tests/cassandra_int_tests/prepared_statements_all.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/prepared_statements_all.rs
@@ -1,6 +1,6 @@
 use pretty_assertions::assert_eq;
 use test_helpers::connection::cassandra::{
-    assert_query_result, run_query, CassandraConnection, Consistency, ResultValue,
+    assert_query_result, run_query, CassandraConnection, CassandraDriver, Consistency, ResultValue,
 };
 
 fn values() -> Vec<ResultValue> {
@@ -25,11 +25,11 @@ fn values() -> Vec<ResultValue> {
 
 async fn insert(connection: &CassandraConnection, replication_factor: u32) {
     #[cfg(feature = "cassandra-cpp-driver-tests")]
-    let datastax = matches!(connection, CassandraConnection::Cpp { .. });
+    let no_decimal_support = [CassandraDriver::Cpp, CassandraDriver::Java];
     #[cfg(not(feature = "cassandra-cpp-driver-tests"))]
-    let datastax = false;
+    let no_decimal_support = [CassandraDriver::Java];
 
-    if datastax {
+    if connection.is(&no_decimal_support) {
         // workaround cassandra-cpp not yet supporting binding decimal values
         let prepared = connection
                 .prepare(&format!("INSERT INTO test_prepare_statements_all{replication_factor}.test (id, v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13) VALUES (?, ?, ?, ?, ?, 1.0, ?, ?, ?, ?, ?, ?, ?, ?, ?);"))

--- a/test-helpers/src/connection/cassandra/connection.rs
+++ b/test-helpers/src/connection/cassandra/connection.rs
@@ -4,7 +4,7 @@ use cdrs::CdrsTokioPreparedQuery;
 use cdrs::{CdrsConnection, CdrsTokioSessionInstance};
 #[cfg(feature = "cassandra-cpp-driver-tests")]
 use cpp::{CppConnection, PreparedStatementCpp, SslCpp};
-use java::JavaConnection;
+use java::{JavaConnection, PreparedStatementJava};
 use openssl::ssl::{SslContext, SslMethod};
 use pretty_assertions::assert_eq;
 use scylla::{PreparedStatementScylla, ScyllaConnection, SessionBuilderScylla};
@@ -103,6 +103,7 @@ pub enum PreparedQuery {
     Cpp(PreparedStatementCpp),
     CdrsTokio(CdrsTokioPreparedQuery),
     Scylla(PreparedStatementScylla),
+    Java(PreparedStatementJava),
 }
 
 impl PreparedQuery {
@@ -125,6 +126,13 @@ impl PreparedQuery {
         match self {
             PreparedQuery::Scylla(s) => s,
             _ => panic!("Not PreparedQuery::Scylla"),
+        }
+    }
+
+    pub fn as_java(&self) -> &PreparedStatementJava {
+        match self {
+            PreparedQuery::Java(j) => j,
+            _ => panic!("Not PreparedQuery::Java"),
         }
     }
 }

--- a/test-helpers/src/connection/cassandra/connection/java.rs
+++ b/test-helpers/src/connection/cassandra/connection/java.rs
@@ -1,0 +1,227 @@
+use super::scylla::SessionScylla;
+use super::{Compression, Consistency, PreparedQuery, ProtocolVersion, Tls};
+use crate::connection::cassandra::ResultValue;
+use crate::connection::java::{Jvm, Value};
+use cdrs_tokio::frame::message_error::ErrorBody;
+use cdrs_tokio::frame::message_result::ColType;
+use std::net::IpAddr;
+
+pub struct JavaConnection {
+    jvm: Jvm,
+    session: Value,
+    pub schema_awaiter: Option<SessionScylla>,
+}
+
+impl JavaConnection {
+    pub async fn new(
+        contact_points: &str,
+        port: u16,
+        _compression: Option<Compression>,
+        _tls: Option<Tls>,
+        _protocol: Option<ProtocolVersion>,
+    ) -> Self {
+        // specify maven dep for java-driver-core-shaded and all of its dependencies since j4rs does not support dependency resolution
+        // The list of dependencies can be found here: https://mvnrepository.com/artifact/org.apache.cassandra/java-driver-core-shaded/4.18.1
+        // These are deployed to and loaded from a path like target/debug/jassets
+        let jvm = Jvm::new(&[
+            "org.apache.cassandra:java-driver-core-shaded:4.18.1",
+            "com.datastax.oss:java-driver-shaded-guava:24.1-jre",
+            "com.datastax.oss:native-protocol:1.5.1",
+            "org.slf4j:slf4j-api:1.7.36",
+            "org.slf4j:slf4j-simple:1.7.36",
+            "com.typesafe:config:1.4.1",
+            "com.github.jnr:jnr-posix:3.1.15",
+            "org.reactivestreams:reactive-streams:1.0.3",
+        ]);
+
+        let session_builder =
+            jvm.construct("com.datastax.oss.driver.api.core.CqlSessionBuilder", vec![]);
+
+        for address in contact_points.split(',') {
+            let point = jvm.construct(
+                "java.net.InetSocketAddress",
+                vec![jvm.new_string(address), jvm.new_int(port as i32)],
+            );
+            session_builder.call("addContactPoint", vec![point]);
+        }
+        let session = session_builder
+            .call("withLocalDatacenter", vec![jvm.new_string("datacenter1")])
+            .call("buildAsync", vec![])
+            .call_async("toCompletableFuture", vec![])
+            .await;
+
+        JavaConnection {
+            jvm,
+            session,
+            schema_awaiter: None,
+        }
+    }
+    pub async fn execute_prepared_coordinator_node(
+        &self,
+        _prepared_query: &PreparedQuery,
+        _values: &[ResultValue],
+    ) -> IpAddr {
+        todo!()
+    }
+
+    pub async fn execute_fallible(&self, query: &str) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
+        match self
+            .session
+            .call("executeAsync", vec![self.jvm.new_string(query)])
+            .call_async_fallible("toCompletableFuture", vec![])
+            .await
+        {
+            Ok(result) => {
+                let types: Vec<ColType> = result
+                    .cast("com.datastax.oss.driver.api.core.cql.AsyncResultSet")
+                    .call("getColumnDefinitions", vec![])
+                    .call("iterator", vec![])
+                    .into_iter()
+                    .map(|col_def| {
+                        let code: i32 = col_def
+                            .cast("com.datastax.oss.driver.api.core.cql.ColumnDefinition")
+                            .call("getType", vec![])
+                            .call("getProtocolCode", vec![])
+                            .into_rust();
+                        ColType::try_from(code as i16).unwrap()
+                    })
+                    .collect();
+
+                let mut rows = vec![];
+                for record in result.call("currentPage", vec![]).call("iterator", vec![]) {
+                    let record = record.cast("com.datastax.oss.driver.api.core.cql.Row");
+                    let row = types
+                        .iter()
+                        .enumerate()
+                        .map(|(i, ty)| Self::java_value_to_rust(&self.jvm, i, &record, *ty))
+                        .collect();
+
+                    rows.push(row);
+                }
+                Ok(rows)
+            }
+            Err(err) => todo!("return ErrorBody {err:?}"),
+        }
+    }
+
+    fn java_value_to_rust(jvm: &Jvm, i: usize, record: &Value, ty: ColType) -> ResultValue {
+        let args = vec![jvm.new_int(i as i32)];
+        let container_args = vec![jvm.new_int(i as i32)];
+        match ty {
+            ColType::Varchar => ResultValue::Varchar(record.call("getString", args).into_rust()),
+            ColType::Ascii => ResultValue::Ascii(record.call("getString", args).into_rust()),
+            ColType::Boolean => ResultValue::Boolean(record.call("getBool", args).into_rust()),
+            ColType::Bigint => ResultValue::BigInt(record.call("getLong", args).into_rust()),
+            ColType::Int => ResultValue::Int(record.call("getInt", args).into_rust()),
+            ColType::Smallint => ResultValue::SmallInt(record.call("getShort", args).into_rust()),
+            ColType::Tinyint => ResultValue::TinyInt(record.call("getByte", args).into_rust()),
+            ColType::Blob => ResultValue::Blob({
+                let bytes: Vec<i8> = record
+                    .call("getByteBuffer", args)
+                    .call("array", vec![])
+                    .into_rust();
+
+                bytes.into_iter().map(|x| x as u8).collect()
+            }),
+            ColType::Date => ResultValue::Date(
+                record
+                    .call("getLocalDate", args)
+                    .call("toEpochDay", vec![])
+                    .into_rust::<u32>()
+                    // as per cassandra spec, dates are represented with epoch starting at 2**31
+                    + 2u32.pow(31u32),
+            ),
+            ColType::Decimal => ResultValue::Decimal({
+                let bytes: Vec<i8> = record
+                    .call("getBytesUnsafe", args)
+                    .call("array", vec![])
+                    .into_rust();
+                bytes.into_iter().map(|x| x as u8).collect()
+            }),
+            ColType::Double => ResultValue::Double(record.call("getDouble", args).into_rust()),
+            ColType::Float => ResultValue::Float(record.call("getFloat", args).into_rust()),
+            ColType::Timestamp => ResultValue::Timestamp(
+                record
+                    .call("getInstant", args)
+                    .call("toEpochMilli", vec![])
+                    .into_rust(),
+            ),
+            ColType::Inet => ResultValue::Inet({
+                let string: String = record
+                    .call("getInetAddress", args)
+                    .call("toString", vec![])
+                    .into_rust();
+                string[1..]
+                    .parse()
+                    .map_err(|_| format!("Failed to parse IP {string}"))
+                    .unwrap()
+            }),
+            ColType::Time => ResultValue::Time(
+                record
+                    .call("getLocalTime", args)
+                    .call("toNanoOfDay", vec![])
+                    .into_rust(),
+            ),
+            ColType::Timeuuid => ResultValue::TimeUuid({
+                let string: String = record
+                    .call("getUuid", args)
+                    .call("toString", vec![])
+                    .into_rust();
+                string.parse().unwrap()
+            }),
+            ColType::Uuid => ResultValue::Uuid({
+                let string: String = record
+                    .call("getUuid", args)
+                    .call("toString", vec![])
+                    .into_rust();
+                string.parse().unwrap()
+            }),
+            ColType::Varint => ResultValue::VarInt({
+                let bytes: Vec<i8> = record
+                    .call("getBytesUnsafe", args)
+                    .call("array", vec![])
+                    .into_rust();
+                bytes.into_iter().map(|x| x as u8).collect()
+            }),
+            ColType::List => ResultValue::List(
+                record
+                    .call("getList", container_args)
+                    .call("iterator", vec![])
+                    .into_iter()
+                    .map(|_| ResultValue::Any)
+                    .collect(),
+            ),
+            ColType::Set => ResultValue::Set(Default::default()),
+            ColType::Map => ResultValue::Map(Default::default()),
+            ty => todo!("{ty}"),
+        }
+    }
+
+    pub async fn execute_with_timestamp(
+        &self,
+        _query: &str,
+        _timestamp: i64,
+    ) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
+        todo!()
+    }
+
+    pub async fn prepare(&self, _query: &str) -> PreparedQuery {
+        todo!()
+    }
+
+    pub async fn execute_prepared(
+        &self,
+        _prepared_query: &PreparedQuery,
+        _values: &[ResultValue],
+        _consistency: Consistency,
+    ) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
+        todo!()
+    }
+
+    pub async fn execute_batch_fallible(
+        &self,
+        _queries: Vec<String>,
+    ) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
+        todo!()
+    }
+}

--- a/test-helpers/src/connection/cassandra/connection/java.rs
+++ b/test-helpers/src/connection/cassandra/connection/java.rs
@@ -16,10 +16,20 @@ impl JavaConnection {
     pub async fn new(
         contact_points: &str,
         port: u16,
-        _compression: Option<Compression>,
-        _tls: Option<Tls>,
-        _protocol: Option<ProtocolVersion>,
+        compression: Option<Compression>,
+        tls: Option<Tls>,
+        protocol: Option<ProtocolVersion>,
     ) -> Self {
+        if tls.is_some() {
+            todo!("Java driver TLS not yet implemented");
+        }
+        if compression.is_some() {
+            todo!("Java driver compression not yet implemented");
+        }
+        if protocol.is_some() {
+            todo!("Java driver protocol not yet implemented");
+        }
+
         // specify maven dep for java-driver-core-shaded and all of its dependencies since j4rs does not support dependency resolution
         // The list of dependencies can be found here: https://mvnrepository.com/artifact/org.apache.cassandra/java-driver-core-shaded/4.18.1
         // These are deployed to and loaded from a path like target/debug/jassets
@@ -58,32 +68,40 @@ impl JavaConnection {
     }
     pub async fn execute_prepared_coordinator_node(
         &self,
-        _prepared_query: &PreparedQuery,
-        _values: &[ResultValue],
+        prepared_query: &PreparedQuery,
+        values: &[ResultValue],
     ) -> IpAddr {
+        let _result = self
+            .execute_prepared(prepared_query, values, Consistency::All)
+            .await
+            .unwrap();
         todo!()
     }
 
     pub async fn execute_fallible(&self, query: &str) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
+        self.execute(self.jvm.new_string(query)).await
+    }
+
+    /// Due to java function overloading this method can execute both a prepared statement a simple string query.
+    async fn execute(&self, statement: Value) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
         match self
             .session
-            .call("executeAsync", vec![self.jvm.new_string(query)])
+            .call("executeAsync", vec![statement])
             .call_async_fallible("toCompletableFuture", vec![])
             .await
         {
             Ok(result) => {
-                let types: Vec<ColType> = result
+                let types: Vec<DataType> = result
                     .cast("com.datastax.oss.driver.api.core.cql.AsyncResultSet")
                     .call("getColumnDefinitions", vec![])
                     .call("iterator", vec![])
                     .into_iter()
                     .map(|col_def| {
-                        let code: i32 = col_def
-                            .cast("com.datastax.oss.driver.api.core.cql.ColumnDefinition")
-                            .call("getType", vec![])
-                            .call("getProtocolCode", vec![])
-                            .into_rust();
-                        ColType::try_from(code as i16).unwrap()
+                        DataType(
+                            col_def
+                                .cast("com.datastax.oss.driver.api.core.cql.ColumnDefinition")
+                                .call("getType", vec![]),
+                        )
                     })
                     .collect();
 
@@ -93,7 +111,12 @@ impl JavaConnection {
                     let row = types
                         .iter()
                         .enumerate()
-                        .map(|(i, ty)| Self::java_value_to_rust(&self.jvm, i, &record, *ty))
+                        .map(|(i, ty)| {
+                            let value = record.call("getObject", vec![self.jvm.new_int(i as i32)]);
+                            let raw_bytes =
+                                record.call("getBytesUnsafe", vec![self.jvm.new_int(i as i32)]);
+                            Self::java_value_to_rust(value, &raw_bytes, ty)
+                        })
                         .collect();
 
                     rows.push(row);
@@ -104,51 +127,69 @@ impl JavaConnection {
         }
     }
 
-    fn java_value_to_rust(jvm: &Jvm, i: usize, record: &Value, ty: ColType) -> ResultValue {
-        let args = vec![jvm.new_int(i as i32)];
-        let container_args = vec![jvm.new_int(i as i32)];
-        match ty {
-            ColType::Varchar => ResultValue::Varchar(record.call("getString", args).into_rust()),
-            ColType::Ascii => ResultValue::Ascii(record.call("getString", args).into_rust()),
-            ColType::Boolean => ResultValue::Boolean(record.call("getBool", args).into_rust()),
-            ColType::Bigint => ResultValue::BigInt(record.call("getLong", args).into_rust()),
-            ColType::Int => ResultValue::Int(record.call("getInt", args).into_rust()),
-            ColType::Smallint => ResultValue::SmallInt(record.call("getShort", args).into_rust()),
-            ColType::Tinyint => ResultValue::TinyInt(record.call("getByte", args).into_rust()),
-            ColType::Blob => ResultValue::Blob({
-                let bytes: Vec<i8> = record
-                    .call("getByteBuffer", args)
-                    .call("array", vec![])
-                    .into_rust();
-
+    fn java_value_to_rust(value: Value, raw_bytes: &Value, ty: &DataType) -> ResultValue {
+        match ty.col_type() {
+            ColType::Ascii => ResultValue::Ascii(value.cast("java.lang.String").into_rust()),
+            ColType::Varchar => ResultValue::Varchar(value.cast("java.lang.String").into_rust()),
+            ColType::Boolean => ResultValue::Boolean(value.cast("java.lang.Boolean").into_rust()),
+            ColType::Bigint => ResultValue::BigInt(value.cast("java.lang.Long").into_rust()),
+            ColType::Int => ResultValue::Int(value.cast("java.lang.Integer").into_rust()),
+            ColType::Smallint => ResultValue::SmallInt(value.cast("java.lang.Short").into_rust()),
+            ColType::Tinyint => ResultValue::TinyInt(value.cast("java.lang.Byte").into_rust()),
+            ColType::Double => ResultValue::Double(value.cast("java.lang.Double").into_rust()),
+            ColType::Float => ResultValue::Float(value.cast("java.lang.Float").into_rust()),
+            ColType::Decimal => ResultValue::Decimal({
+                let bytes: Vec<i8> = raw_bytes.call("array", vec![]).cast("[B").into_rust();
                 bytes.into_iter().map(|x| x as u8).collect()
+            }),
+            ColType::Blob => ResultValue::Blob({
+                let value = value.cast("java.nio.ByteBuffer");
+                let bytes: Vec<i8> = value.call("array", vec![]).cast("[B").into_rust();
+                let start: i32 = value.call("arrayOffset", vec![]).into_rust();
+                let limit: i32 = value.call("limit", vec![]).into_rust();
+
+                bytes[start as usize..start as usize + limit as usize]
+                    .iter()
+                    .map(|x| *x as u8)
+                    .collect()
             }),
             ColType::Date => ResultValue::Date(
-                record
-                    .call("getLocalDate", args)
-                    .call("toEpochDay", vec![])
-                    .into_rust::<u32>()
-                    // as per cassandra spec, dates are represented with epoch starting at 2**31
-                    + 2u32.pow(31u32),
+                (value
+                .cast("java.time.LocalDate")
+                .call("toEpochDay", vec![])
+                .into_rust::<i64>()
+                // as per cassandra spec, dates are represented with epoch starting at 2**31
+                + 2i64.pow(31)) as u32,
             ),
-            ColType::Decimal => ResultValue::Decimal({
-                let bytes: Vec<i8> = record
-                    .call("getBytesUnsafe", args)
-                    .call("array", vec![])
-                    .into_rust();
-                bytes.into_iter().map(|x| x as u8).collect()
-            }),
-            ColType::Double => ResultValue::Double(record.call("getDouble", args).into_rust()),
-            ColType::Float => ResultValue::Float(record.call("getFloat", args).into_rust()),
             ColType::Timestamp => ResultValue::Timestamp(
-                record
-                    .call("getInstant", args)
+                value
+                    .cast("java.time.Instant")
                     .call("toEpochMilli", vec![])
                     .into_rust(),
             ),
+            ColType::Time => ResultValue::Time(
+                value
+                    .cast("java.time.LocalTime")
+                    .call("toNanoOfDay", vec![])
+                    .into_rust(),
+            ),
+            ColType::Timeuuid => ResultValue::TimeUuid({
+                let string: String = value
+                    .cast("java.util.UUID")
+                    .call("toString", vec![])
+                    .into_rust();
+                string.parse().unwrap()
+            }),
+            ColType::Uuid => ResultValue::Uuid({
+                let string: String = value
+                    .cast("java.util.UUID")
+                    .call("toString", vec![])
+                    .into_rust();
+                string.parse().unwrap()
+            }),
             ColType::Inet => ResultValue::Inet({
-                let string: String = record
-                    .call("getInetAddress", args)
+                let string: String = value
+                    .cast("java.net.InetAddress")
                     .call("toString", vec![])
                     .into_rust();
                 string[1..]
@@ -156,72 +197,235 @@ impl JavaConnection {
                     .map_err(|_| format!("Failed to parse IP {string}"))
                     .unwrap()
             }),
-            ColType::Time => ResultValue::Time(
-                record
-                    .call("getLocalTime", args)
-                    .call("toNanoOfDay", vec![])
-                    .into_rust(),
-            ),
-            ColType::Timeuuid => ResultValue::TimeUuid({
-                let string: String = record
-                    .call("getUuid", args)
-                    .call("toString", vec![])
-                    .into_rust();
-                string.parse().unwrap()
-            }),
-            ColType::Uuid => ResultValue::Uuid({
-                let string: String = record
-                    .call("getUuid", args)
-                    .call("toString", vec![])
-                    .into_rust();
-                string.parse().unwrap()
-            }),
             ColType::Varint => ResultValue::VarInt({
-                let bytes: Vec<i8> = record
-                    .call("getBytesUnsafe", args)
-                    .call("array", vec![])
-                    .into_rust();
+                let bytes: Vec<i8> = raw_bytes.call("array", vec![]).cast("[B").into_rust();
                 bytes.into_iter().map(|x| x as u8).collect()
             }),
             ColType::List => ResultValue::List(
-                record
-                    .call("getList", container_args)
+                value
+                    .cast("java.util.List")
                     .call("iterator", vec![])
                     .into_iter()
-                    .map(|_| ResultValue::Any)
+                    // TODO: no way to provide a correct raw_bytes value here,
+                    // need to change tests to not use raw_bytes instead.
+                    .map(|value| Self::java_value_to_rust(value, raw_bytes, &ty.element_col_type()))
                     .collect(),
             ),
-            ColType::Set => ResultValue::Set(Default::default()),
-            ColType::Map => ResultValue::Map(Default::default()),
+            ColType::Set => ResultValue::Set(
+                value
+                    .cast("java.util.Set")
+                    .call("iterator", vec![])
+                    .into_iter()
+                    // TODO: no way to provide a correct raw_bytes value here,
+                    // need to change tests to not use raw_bytes instead.
+                    .map(|value| Self::java_value_to_rust(value, raw_bytes, &ty.element_col_type()))
+                    .collect(),
+            ),
+            ColType::Map => ResultValue::Map({
+                let (ty_key, ty_value) = ty.key_value_type();
+                value
+                    .cast("java.util.Map")
+                    .call("entrySet", vec![])
+                    .call("iterator", vec![])
+                    .into_iter()
+                    .map(|value| {
+                        let value = value.cast("java.util.Map$Entry");
+                        (
+                            Self::java_value_to_rust(
+                                value.call("getKey", vec![]),
+                                // TODO: no way to provide a correct raw_bytes value here,
+                                // need to change tests to not use raw_bytes instead.
+                                raw_bytes,
+                                &ty_key,
+                            ),
+                            Self::java_value_to_rust(
+                                value.call("getValue", vec![]),
+                                // TODO: no way to provide a correct raw_bytes value here,
+                                // need to change tests to not use raw_bytes instead.
+                                raw_bytes,
+                                &ty_value,
+                            ),
+                        )
+                    })
+                    .collect()
+            }),
             ty => todo!("{ty}"),
         }
     }
 
     pub async fn execute_with_timestamp(
         &self,
-        _query: &str,
-        _timestamp: i64,
+        query: &str,
+        timestamp: i64,
     ) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
-        todo!()
+        self.execute(
+            self.jvm
+                .construct(
+                    "com.datastax.oss.driver.api.core.cql.SimpleStatementBuilder",
+                    vec![self.jvm.new_string(query)],
+                )
+                .call("setQueryTimestamp", vec![self.jvm.new_long(timestamp)])
+                .call("build", vec![]),
+        )
+        .await
     }
 
-    pub async fn prepare(&self, _query: &str) -> PreparedQuery {
-        todo!()
+    pub async fn prepare(&self, query: &str) -> PreparedQuery {
+        PreparedQuery::Java(PreparedStatementJava(
+            self.session
+                .call("prepareAsync", vec![self.jvm.new_string(query)])
+                .call_async("toCompletableFuture", vec![])
+                .await,
+        ))
+    }
+
+    fn values_to_java(&self, values: &[ResultValue]) -> Vec<Value> {
+        values
+            .iter()
+            .map(|x| {
+                match x {
+                    ResultValue::TinyInt(x) => self.jvm.new_byte_object(*x),
+                    ResultValue::SmallInt(x) => self.jvm.new_short_object(*x),
+                    ResultValue::Int(x) => self.jvm.new_int_object(*x),
+                    ResultValue::BigInt(x) => self.jvm.new_long_object(*x),
+                    ResultValue::Boolean(x) => self.jvm.new_bool_object(*x),
+                    ResultValue::Float(x) => self.jvm.new_float_object(x.0),
+                    ResultValue::Double(x) => self.jvm.new_double_object(x.0),
+                    ResultValue::Timestamp(x) => self.jvm.call_static(
+                        "java.time.Instant",
+                        "ofEpochMilli",
+                        vec![self.jvm.new_long(*x)],
+                    ),
+                    ResultValue::Date(x) => self.jvm.call_static(
+                        "java.time.LocalDate",
+                        "ofEpochDay",
+                        vec![self.jvm.new_long(*x as i64 - 2i64.pow(31))],
+                    ),
+                    ResultValue::Time(x) => self.jvm.call_static(
+                        "java.time.LocalTime",
+                        "ofNanoOfDay",
+                        vec![self.jvm.new_long(*x)],
+                    ),
+                    ResultValue::Decimal(_) => panic!(r#"Java driver does support decimal.
+However in order to use it we need to store ResultValue::Decimal as unscaledval + scale rather than a bunch of bytes.
+Then we can call BigDecimal(BigInteger unscaledVal, int scale) constructor"#),
+                    ResultValue::Uuid(x) | ResultValue::TimeUuid(x) => self.jvm.call_static(
+                        "java.util.UUID",
+                        "fromString",
+                        vec![self.jvm.new_string(&x.to_string())],
+                    ),
+                    ResultValue::Inet(x) => self.jvm.call_static(
+                        "java.net.InetAddress",
+                        "getByName",
+                        vec![self.jvm.new_string(&x.to_string())],
+                    ),
+                    ResultValue::Blob(x) => self.jvm.call_static(
+                        "java.nio.ByteBuffer",
+                        "wrap",
+                        vec![self
+                            .jvm
+                            // WARN: If we ever try to pass in a large amount of binary data this will be terribly slow.
+                            //       For now its fine and j4rs doesnt currently provide a better way.
+                            .new_array(
+                                "byte",
+                                x.iter().map(|x| self.jvm.new_byte(*x as i8)).collect(),
+                            )],
+                    ),
+                    ResultValue::Ascii(x) | ResultValue::Varchar(x) => self.jvm.new_string(x),
+                    value => todo!("Implement handling of {value:?} for java"),
+                }
+                .cast("java.lang.Object")
+            })
+            .collect()
     }
 
     pub async fn execute_prepared(
         &self,
-        _prepared_query: &PreparedQuery,
-        _values: &[ResultValue],
-        _consistency: Consistency,
+        prepared_query: &PreparedQuery,
+        values: &[ResultValue],
+        consistency: Consistency,
     ) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
-        todo!()
+        let consistency_level_java = self
+            .jvm
+            .class("com.datastax.oss.driver.api.core.ConsistencyLevel");
+
+        let values = self.values_to_java(values);
+
+        let statement = prepared_query
+            .as_java()
+            .0
+            .call(
+                "boundStatementBuilder",
+                vec![self.jvm.new_array("java.lang.Object", values)],
+            )
+            .call(
+                "setConsistencyLevel",
+                vec![match consistency {
+                    Consistency::One => consistency_level_java.field("ONE"),
+                    Consistency::All => consistency_level_java.field("ALL"),
+                }],
+            )
+            .call("build", vec![]);
+        self.execute(statement).await
     }
 
     pub async fn execute_batch_fallible(
         &self,
-        _queries: Vec<String>,
+        queries: Vec<String>,
     ) -> Result<Vec<Vec<ResultValue>>, ErrorBody> {
-        todo!()
+        let batch_type = self
+            .jvm
+            .class("com.datastax.oss.driver.api.core.cql.BatchType");
+
+        let queries: Vec<Value> = queries
+            .iter()
+            .map(|query| {
+                self.jvm
+                    .construct(
+                        "com.datastax.oss.driver.api.core.cql.SimpleStatementBuilder",
+                        vec![self.jvm.new_string(query)],
+                    )
+                    .call("build", vec![])
+                    .cast("com.datastax.oss.driver.api.core.cql.BatchableStatement")
+            })
+            .collect();
+        let batch_builder = self.jvm.construct(
+            "com.datastax.oss.driver.api.core.cql.BatchStatementBuilder",
+            vec![batch_type.field("LOGGED")],
+        );
+        for query in queries {
+            batch_builder.call("addStatement", vec![query]);
+        }
+        let batch = batch_builder.call("build", vec![]);
+        self.execute(batch).await
+    }
+}
+
+#[derive(Debug)]
+pub struct PreparedStatementJava(Value);
+
+/// Wrapper around https://docs.datastax.com/en/drivers/java/4.17/com/datastax/oss/driver/api/core/type/DataType.html
+struct DataType(Value);
+
+impl DataType {
+    fn col_type(&self) -> ColType {
+        let code: i32 = self.0.call("getProtocolCode", vec![]).into_rust();
+        ColType::try_from(code as i16).unwrap()
+    }
+
+    fn element_col_type(&self) -> DataType {
+        DataType(
+            self.0
+                .cast("com.datastax.oss.driver.api.core.type.ContainerType")
+                .call("getElementType", vec![]),
+        )
+    }
+
+    fn key_value_type(&self) -> (DataType, DataType) {
+        let map_type = self.0.cast("com.datastax.oss.driver.api.core.type.MapType");
+        (
+            DataType(map_type.call("getKeyType", vec![])),
+            DataType(map_type.call("getValueType", vec![])),
+        )
     }
 }

--- a/test-helpers/src/connection/java.rs
+++ b/test-helpers/src/connection/java.rs
@@ -74,6 +74,134 @@ impl Jvm {
         )
     }
 
+    /// Create a java `short`.
+    pub(crate) fn new_byte(&self, value: i8) -> Value {
+        self.new_primitive(
+            "java.lang.Byte",
+            "byteValue",
+            InvocationArg::try_from(value).unwrap(),
+        )
+    }
+
+    /// Create a java.lang.Long
+    pub(crate) fn new_long_object(&self, value: i64) -> Value {
+        Value {
+            instance: self
+                .0
+                .create_instance(
+                    "java.lang.Long",
+                    &[InvocationArg::try_from(value)
+                        .unwrap()
+                        .into_primitive()
+                        .unwrap()],
+                )
+                .unwrap(),
+            jvm: self.0.clone(),
+        }
+    }
+
+    /// Create a java.lang.Integer
+    pub(crate) fn new_int_object(&self, value: i32) -> Value {
+        Value {
+            instance: self
+                .0
+                .create_instance(
+                    "java.lang.Integer",
+                    &[InvocationArg::try_from(value)
+                        .unwrap()
+                        .into_primitive()
+                        .unwrap()],
+                )
+                .unwrap(),
+            jvm: self.0.clone(),
+        }
+    }
+
+    /// Create a java.lang.Integer
+    pub(crate) fn new_short_object(&self, value: i16) -> Value {
+        Value {
+            instance: self
+                .0
+                .create_instance(
+                    "java.lang.Short",
+                    &[InvocationArg::try_from(value)
+                        .unwrap()
+                        .into_primitive()
+                        .unwrap()],
+                )
+                .unwrap(),
+            jvm: self.0.clone(),
+        }
+    }
+
+    /// Create a java.lang.Byte
+    pub(crate) fn new_byte_object(&self, value: i8) -> Value {
+        Value {
+            instance: self
+                .0
+                .create_instance(
+                    "java.lang.Byte",
+                    &[InvocationArg::try_from(value)
+                        .unwrap()
+                        .into_primitive()
+                        .unwrap()],
+                )
+                .unwrap(),
+            jvm: self.0.clone(),
+        }
+    }
+
+    /// Create a java.lang.Boolean
+    pub(crate) fn new_bool_object(&self, value: bool) -> Value {
+        Value {
+            instance: self
+                .0
+                .create_instance(
+                    "java.lang.Boolean",
+                    &[InvocationArg::try_from(value)
+                        .unwrap()
+                        .into_primitive()
+                        .unwrap()],
+                )
+                .unwrap(),
+            jvm: self.0.clone(),
+        }
+    }
+
+    /// Create a java.lang.Float
+    pub(crate) fn new_float_object(&self, value: f32) -> Value {
+        Value {
+            instance: self
+                .0
+                .create_instance(
+                    "java.lang.Float",
+                    &[InvocationArg::try_from(value)
+                        .unwrap()
+                        .into_primitive()
+                        .unwrap()],
+                )
+                .unwrap(),
+            jvm: self.0.clone(),
+        }
+    }
+
+    /// Create a java.lang.Double
+    pub(crate) fn new_double_object(&self, value: f64) -> Value {
+        Value {
+            instance: self
+                .0
+                .create_instance(
+                    "java.lang.Double",
+                    &[InvocationArg::try_from(value)
+                        .unwrap()
+                        .into_primitive()
+                        .unwrap()],
+                )
+                .unwrap(),
+            jvm: self.0.clone(),
+        }
+    }
+
     fn new_primitive(&self, class_name: &str, convert_method: &str, value: InvocationArg) -> Value {
         Value {
             instance: self
@@ -92,6 +220,15 @@ impl Jvm {
                     InvocationArg::empty(),
                 )
                 .unwrap(),
+            jvm: self.0.clone(),
+        }
+    }
+
+    /// Construct a java array containing the provided elements
+    pub(crate) fn new_array(&self, element_type: &str, elements: Vec<Value>) -> Value {
+        let args: Vec<InvocationArg> = elements.into_iter().map(|x| x.instance.into()).collect();
+        Value {
+            instance: self.0.create_java_array(element_type, &args).unwrap(),
             jvm: self.0.clone(),
         }
     }

--- a/test-helpers/src/connection/java.rs
+++ b/test-helpers/src/connection/java.rs
@@ -233,6 +233,13 @@ impl Value {
     }
 }
 
+impl std::fmt::Debug for Value {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let string: String = self.call("toString", vec![]).into_rust();
+        write!(f, "{string}")
+    }
+}
+
 impl IntoIterator for Value {
     type Item = Value;
 


### PR DESCRIPTION
This PR implements support for the cassandra java driver for a subset of our cassandra integration tests:
* passthrough_standard
* passthrough_encode
* cassandra_redis_cache
* cassandra_5

Other tests do not run with the cassandra driver due to missing features in the cassandra driver abstraction.
We can come back to these at a later time.

`NATIVE_COL_TYPES` becomes `fn supported_native_col_types` so that we can disable the Decimal and Varint types for the cassandra driver.
We will need to do some complex refactoring to enable those types in the cassandra driver, so its left out of scope of this PR.

Again, since we cant support decimal from the java driver right now we avoid testing decimals in prepared_statement_all.rs like we already do for the cpp driver.

Various functionality of the java driver is not exposed (e.g. TLS, protocol selection) since they arent needed for the initial tests that we are supporting.
The java driver wrapper intentionally panics when these functionalities are enabled to ensure that it does not silently misbehave.