### PR TITLE
Introduce j4rs wrapper to simplify testing java drivers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5001,6 +5001,7 @@ dependencies = [
  "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
  "scylla",
+ "serde",
  "subprocess",
  "tokio",
  "tokio-bin-process",

--- a/test-helpers/Cargo.toml
+++ b/test-helpers/Cargo.toml
@@ -40,3 +40,4 @@ rustls = { version = "0.21.2" ,features = ["dangerous_configuration"] }
 rustls-pemfile = "1.0.2"
 tokio-tungstenite = { git = "https://github.com/shotover/tokio-tungstenite", features = ["rustls-tls-native-roots"], rev = "2f1cc11e491c2d0401d01a83f623623182784b3a" }
 pretty_assertions.workspace = true
+serde.workspace = true

--- a/test-helpers/src/connection/java.rs
+++ b/test-helpers/src/connection/java.rs
@@ -1,0 +1,183 @@
+use anyhow::Result;
+use j4rs::{Instance, InvocationArg, Jvm};
+use serde::de::DeserializeOwned;
+use std::{any::Any, rc::Rc};
+
+pub(crate) struct JavaIterator(Value);
+
+impl JavaIterator {
+    fn new(iterator_instance: Value) -> Self {
+        JavaIterator(iterator_instance)
+    }
+}
+
+impl Iterator for JavaIterator {
+    type Item = Value;
+
+    fn next(&mut self) -> Option<Value> {
+        let has_next: bool = self.0.call("hasNext", &[]).into_rust();
+        if has_next {
+            Some(self.0.call("next", &[]))
+        } else {
+            None
+        }
+    }
+}
+
+struct Java(Rc<Jvm>);
+
+impl Java {}
+
+// enum ValueTy {
+//     Arg(InvocationArg),
+//     Instance(Instance),
+// }
+
+pub(crate) struct Value {
+    pub instance: Instance,
+    jvm: Rc<Jvm>,
+}
+
+impl Value {
+    pub(crate) fn new_int(jvm: &Rc<Jvm>, int: i32) -> Self {
+        Self {
+            instance: InvocationArg::try_from(int).unwrap().instance().unwrap(),
+            jvm: jvm.clone(),
+        }
+    }
+
+    pub(crate) fn new_long(jvm: &Rc<Jvm>, int: i64) -> Self {
+        Self {
+            instance: Self::new(
+                jvm,
+                "java.lang.Long",
+                &[&InvocationArg::try_from(int)
+                    .unwrap()
+                    .into_primitive()
+                    .unwrap()],
+            )
+            .call("longValue", &[])
+            .instance,
+            jvm: jvm.clone(),
+        }
+    }
+
+    pub(crate) fn new(jvm: &Rc<Jvm>, name: &str, args: &[&InvocationArg]) -> Self {
+        Self::new_fallible(jvm, name, args).unwrap()
+    }
+
+    pub(crate) fn new_fallible(jvm: &Rc<Jvm>, name: &str, args: &[&InvocationArg]) -> Result<Self> {
+        Ok(Self {
+            instance: jvm.create_instance(name, args)?,
+            jvm: jvm.clone(),
+        })
+    }
+
+    pub(crate) fn new_list(jvm: &Rc<Jvm>, inner_class_name: &str, args: &[InvocationArg]) -> Self {
+        // TODO: Discuss with upstream why this was deprecated, `Jvm::java_list` is very difficult to use due to Result in input.
+        Self {
+            #[allow(deprecated)]
+            instance: jvm.create_java_list(inner_class_name, args).unwrap(),
+            jvm: jvm.clone(),
+        }
+    }
+
+    pub(crate) fn new_map(jvm: &Rc<Jvm>, key_values: Vec<(Value, Value)>) -> Value {
+        let map = Value::new(jvm, "java.util.HashMap", &[]);
+        for (k, v) in key_values {
+            map.call("put", &[&k.into(), &v.into()]);
+        }
+        map
+    }
+
+    pub(crate) fn invoke_static(
+        jvm: &Rc<Jvm>,
+        class_name: &str,
+        method_name: &str,
+        args: &[&InvocationArg],
+    ) -> Self {
+        Self::invoke_static_fallible(jvm, class_name, method_name, args).unwrap()
+    }
+
+    pub(crate) fn invoke_static_fallible(
+        jvm: &Rc<Jvm>,
+        class_name: &str,
+        method_name: &str,
+        args: &[&InvocationArg],
+    ) -> Result<Self> {
+        Ok(Self {
+            instance: jvm.invoke_static(class_name, method_name, args)?,
+            jvm: jvm.clone(),
+        })
+    }
+
+    pub(crate) fn call(&self, name: &str, args: &[&InvocationArg]) -> Self {
+        self.call_fallible(name, args).unwrap()
+    }
+
+    fn call_fallible(&self, name: &str, args: &[&InvocationArg]) -> Result<Self> {
+        let instance = self.jvm.invoke(&self.instance, name, args)?;
+        Ok(Self {
+            instance,
+            jvm: self.jvm.clone(),
+        })
+    }
+
+    pub(crate) async fn call_async(&self, name: &str, args: &[InvocationArg]) -> Self {
+        self.call_async_fallible(name, args).await.unwrap()
+    }
+
+    pub(crate) async fn call_async_fallible(
+        &self,
+        name: &str,
+        args: &[InvocationArg],
+    ) -> Result<Self> {
+        let instance = self.jvm.invoke_async(&self.instance, name, args).await?;
+        Ok(Self {
+            instance,
+            jvm: self.jvm.clone(),
+        })
+    }
+
+    pub(crate) fn cast(&self, name: &str) -> Self {
+        self.cast_fallible(name).unwrap()
+    }
+
+    fn cast_fallible(&self, name: &str) -> Result<Self> {
+        let instance = self.jvm.cast(&self.instance, name)?;
+        Ok(Self {
+            instance,
+            jvm: self.jvm.clone(),
+        })
+    }
+
+    pub(crate) fn into_rust<T>(self) -> T
+    where
+        T: DeserializeOwned + Any,
+    {
+        self.into_rust_fallible().unwrap()
+    }
+
+    fn into_rust_fallible<T>(self) -> Result<T>
+    where
+        T: DeserializeOwned + Any,
+    {
+        Ok(self.jvm.to_rust(self.instance)?)
+    }
+}
+
+impl IntoIterator for Value {
+    type Item = Value;
+
+    type IntoIter = JavaIterator;
+
+    fn into_iter(self) -> Self::IntoIter {
+        JavaIterator::new(self)
+    }
+}
+
+impl From<Value> for InvocationArg {
+    fn from(value: Value) -> InvocationArg {
+        value.instance.into()
+    }
+}

--- a/test-helpers/src/connection/java.rs
+++ b/test-helpers/src/connection/java.rs
@@ -1,33 +1,15 @@
 use anyhow::Result;
-use j4rs::{Instance, InvocationArg, Jvm, JvmBuilder, MavenArtifact};
+use j4rs::{Instance, InvocationArg, Jvm as J4rsJvm, JvmBuilder, MavenArtifact};
 use serde::de::DeserializeOwned;
 use std::{any::Any, rc::Rc};
 
-pub(crate) struct JavaIterator(Value);
-
-impl JavaIterator {
-    fn new(iterator_instance: Value) -> Self {
-        JavaIterator(iterator_instance)
-    }
-}
-
-impl Iterator for JavaIterator {
-    type Item = Value;
-
-    fn next(&mut self) -> Option<Value> {
-        let has_next: bool = self.0.call("hasNext", &[]).into_rust();
-        if has_next {
-            Some(self.0.call("next", &[]))
-        } else {
-            None
-        }
-    }
-}
-
+/// Runs a JVM in the background and provides methods for constructing java [`Values`].
 #[derive(Clone)]
-pub(crate) struct Java(Rc<Jvm>);
+pub(crate) struct Jvm(Rc<J4rsJvm>);
 
-impl Java {
+impl Jvm {
+    /// Construct a JVM, downloads the list of deps from the maven repository.
+    /// Example dep string: "org.slf4j:slf4j-api:1.7.36"
     pub(crate) fn new(deps: &[&str]) -> Self {
         let jvm = Rc::new(JvmBuilder::new().build().unwrap());
 
@@ -51,6 +33,7 @@ impl Java {
         })
     }
 
+    /// Create a java `java.lang.String`.
     pub(crate) fn new_string(&self, string: &str) -> Value {
         Value {
             instance: self
@@ -62,6 +45,33 @@ impl Java {
                 .unwrap(),
             jvm: self.0.clone(),
         }
+    }
+
+    /// Create a java `long`.
+    pub(crate) fn new_long(&self, value: i64) -> Value {
+        self.new_primitive(
+            "java.lang.Long",
+            "longValue",
+            InvocationArg::try_from(value).unwrap(),
+        )
+    }
+
+    /// Create a java `int`.
+    pub(crate) fn new_int(&self, value: i32) -> Value {
+        self.new_primitive(
+            "java.lang.Integer",
+            "intValue",
+            InvocationArg::try_from(value).unwrap(),
+        )
+    }
+
+    /// Create a java `short`.
+    pub(crate) fn new_short(&self, value: i16) -> Value {
+        self.new_primitive(
+            "java.lang.Short",
+            "shortValue",
+            InvocationArg::try_from(value).unwrap(),
+        )
     }
 
     fn new_primitive(&self, class_name: &str, convert_method: &str, value: InvocationArg) -> Value {
@@ -86,74 +96,58 @@ impl Java {
         }
     }
 
-    pub(crate) fn new_long(&self, value: i64) -> Value {
-        self.new_primitive(
-            "java.lang.Long",
-            "longValue",
-            InvocationArg::try_from(value).unwrap(),
-        )
-    }
-
-    pub(crate) fn new_int(&self, value: i32) -> Value {
-        self.new_primitive(
-            "java.lang.Integer",
-            "intValue",
-            InvocationArg::try_from(value).unwrap(),
-        )
-    }
-
-    pub(crate) fn new_short(&self, value: i16) -> Value {
-        self.new_primitive(
-            "java.lang.Short",
-            "shortValue",
-            InvocationArg::try_from(value).unwrap(),
-        )
-    }
-
-    pub(crate) fn new_list(&self, inner_class_name: &str, args: &[InvocationArg]) -> Value {
-        // TODO: Discuss with upstream why this was deprecated, `Jvm::java_list` is very difficult to use due to Result in input.
+    /// Construct a java list containing the provided elements
+    pub(crate) fn new_list(&self, element_type: &str, elements: Vec<Value>) -> Value {
+        let args: Vec<InvocationArg> = elements.into_iter().map(|x| x.instance.into()).collect();
         Value {
+            // TODO: Discuss with upstream why this was deprecated,
+            // `Jvm::java_list` is very difficult to use due to Result in input.
             #[allow(deprecated)]
-            instance: self.0.create_java_list(inner_class_name, args).unwrap(),
+            instance: self.0.create_java_list(element_type, &args).unwrap(),
             jvm: self.0.clone(),
         }
     }
 
+    /// Construct a java map containing the provided key value pairs
     pub(crate) fn new_map(&self, key_values: Vec<(Value, Value)>) -> Value {
         let map = self.construct("java.util.HashMap", vec![]);
         for (k, v) in key_values {
-            map.call("put", &[&k.into(), &v.into()]);
+            map.call("put", vec![k, v]);
         }
         map
     }
 
-    pub(crate) fn invoke_static(
+    /// Call the specified static method on the specified class with the specified arguments.
+    pub(crate) fn call_static(
         &self,
         class_name: &str,
         method_name: &str,
-        args: &[&InvocationArg],
+        args: Vec<Value>,
     ) -> Value {
-        self.invoke_static_fallible(class_name, method_name, args)
+        self.call_static_fallible(class_name, method_name, args)
             .unwrap()
     }
 
-    pub(crate) fn invoke_static_fallible(
+    /// Call the specified static method on the specified class with the specified arguments.
+    pub(crate) fn call_static_fallible(
         &self,
         class_name: &str,
         method_name: &str,
-        args: &[&InvocationArg],
+        args: Vec<Value>,
     ) -> Result<Value> {
+        let args: Vec<InvocationArg> = args.into_iter().map(|x| x.instance.into()).collect();
         Ok(Value {
-            instance: self.0.invoke_static(class_name, method_name, args)?,
+            instance: self.0.invoke_static(class_name, method_name, &args)?,
             jvm: self.0.clone(),
         })
     }
 
-    pub(crate) fn static_class(&self, class_name: &str) -> Value {
-        self.static_class_fallible(class_name).unwrap()
+    /// Returns the specified class
+    pub(crate) fn class(&self, class_name: &str) -> Value {
+        self.class_fallible(class_name).unwrap()
     }
 
-    fn static_class_fallible(&self, class_name: &str) -> Result<Value> {
+    fn class_fallible(&self, class_name: &str) -> Result<Value> {
         Ok(Value {
             instance: self.0.static_class(class_name)?,
             jvm: self.0.clone(),
@@ -161,40 +155,43 @@ impl Java {
     }
 }
 
+/// An instance of a class or primitive in the jvm
 pub(crate) struct Value {
-    pub instance: Instance,
-    jvm: Rc<Jvm>,
+    instance: Instance,
+    jvm: Rc<J4rsJvm>,
 }
 
 impl Value {
-    pub(crate) fn call(&self, name: &str, args: &[&InvocationArg]) -> Self {
-        self.call_fallible(name, args).unwrap()
+    /// Call the specified method on this value
+    pub(crate) fn call(&self, method_name: &str, args: Vec<Value>) -> Self {
+        self.call_fallible(method_name, args).unwrap()
     }
 
-    fn call_fallible(&self, name: &str, args: &[&InvocationArg]) -> Result<Self> {
-        let instance = self.jvm.invoke(&self.instance, name, args)?;
+    fn call_fallible(&self, name: &str, args: Vec<Value>) -> Result<Self> {
+        let args: Vec<InvocationArg> = args.into_iter().map(|x| x.instance.into()).collect();
+        let instance = self.jvm.invoke(&self.instance, name, &args)?;
         Ok(Self {
             instance,
             jvm: self.jvm.clone(),
         })
     }
 
-    pub(crate) async fn call_async(&self, name: &str, args: &[InvocationArg]) -> Self {
+    /// Call the specified method on this value
+    pub(crate) async fn call_async(&self, name: &str, args: Vec<Value>) -> Self {
         self.call_async_fallible(name, args).await.unwrap()
     }
 
-    pub(crate) async fn call_async_fallible(
-        &self,
-        name: &str,
-        args: &[InvocationArg],
-    ) -> Result<Self> {
-        let instance = self.jvm.invoke_async(&self.instance, name, args).await?;
+    /// Call the specified method on this value
+    pub(crate) async fn call_async_fallible(&self, name: &str, args: Vec<Value>) -> Result<Self> {
+        let args: Vec<InvocationArg> = args.into_iter().map(|x| x.instance.into()).collect();
+        let instance = self.jvm.invoke_async(&self.instance, name, &args).await?;
         Ok(Self {
             instance,
             jvm: self.jvm.clone(),
         })
     }
 
+    /// Cast this value to another type
     pub(crate) fn cast(&self, name: &str) -> Self {
         self.cast_fallible(name).unwrap()
     }
@@ -207,6 +204,7 @@ impl Value {
         })
     }
 
+    /// Return the specified field of this value
     pub(crate) fn field(&self, field_name: &str) -> Self {
         self.field_fallible(field_name).unwrap()
     }
@@ -219,6 +217,7 @@ impl Value {
         })
     }
 
+    /// Convert this java value into a native rust type
     pub(crate) fn into_rust<T>(self) -> T
     where
         T: DeserializeOwned + Any,
@@ -244,8 +243,25 @@ impl IntoIterator for Value {
     }
 }
 
-impl From<Value> for InvocationArg {
-    fn from(value: Value) -> InvocationArg {
-        value.instance.into()
+/// Implements iteration logic for a java.util.Iterator
+/// https://docs.oracle.com/javase/8/docs/api/java/util/Iterator.html
+pub(crate) struct JavaIterator(Value);
+
+impl JavaIterator {
+    fn new(iterator_instance: Value) -> Self {
+        JavaIterator(iterator_instance)
+    }
+}
+
+impl Iterator for JavaIterator {
+    type Item = Value;
+
+    fn next(&mut self) -> Option<Value> {
+        let has_next: bool = self.0.call("hasNext", vec![]).into_rust();
+        if has_next {
+            Some(self.0.call("next", vec![]))
+        } else {
+            None
+        }
     }
 }

--- a/test-helpers/src/connection/mod.rs
+++ b/test-helpers/src/connection/mod.rs
@@ -1,5 +1,6 @@
 pub mod cassandra;
 
+pub(crate) mod java;
 pub mod kafka;
 // redis_connection is named differently to the cassandra module because it contains raw functions instead of a struct with methods
 pub mod redis_connection;


### PR DESCRIPTION
The j4rs java interop crate is quite flexible but it allows for a few things which bring us no value:
* working with multiple JVM's
   + We only use a single JVM
* returns a Result<T, E> on every operation that touches the JVM in case the jvm explodes
   + In this case the only reasonable thing for us to do is panic.
* Differentiates between values returned from java `Instance` and values that will be sent into java `InvocationArg`
   + I believe this is done for performance reasons, but we dont need to be concerned about that level of performance since this is an integration test

All of these features were causing great complexity for our java driver integration tests, so I introduced a wrapper that does not expose the above features.
It reduces the lines of code used to implement the kafka java driver from 687 to 484. ( 30% reduction in lines)
We should expect a similar reduction in complexity for the cassandra java driver.
The wrapper completely wraps j4rs and we should not interact directly with j4rs in our driver logic anymore.

The new wrapper consists of 2 types:
* `Jvm` - wraps `j4rs::Jvm`
  + constructor sets up JVM and installs any needed java dependencies from maven repository.
  + provides methods for creating new Values
* `Value` - wraps `j4rs::Instance` and additionally takes on the role of `j4rs::InvocationArg`
  + provides methods for interacting with the java value e.g. call methods or access fields

While this wrapper is closely matched to our own needs and probably not upstreamable exactly as is.
We might be able to see parts of it upstreamed either as an optional wrapper or integrated with the main API.
Doing so would reduce the complexity of the wrappers implementation.
But no hurry, we can land the wrapper as is for now.