### PR TITLE
#1667 Remove cached delegation token from AuthorizeScramOverMtls

### DIFF
--- a/shotover/src/transforms/kafka/sink_cluster/mod.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/mod.rs
@@ -457,10 +457,7 @@ impl KafkaSinkCluster {
                     })) => {
                         if let Some(scram_over_mtls) = &mut self.authorize_scram_over_mtls {
                             if let Some(username) = get_username_from_scram_request(auth_bytes) {
-                                scram_over_mtls.delegation_token = scram_over_mtls
-                                    .token_task
-                                    .get_token_for_user(username)
-                                    .await?;
+                                scram_over_mtls.username = username;
                             }
                         }
                         self.connection_factory.add_auth_request(request.clone());
@@ -477,11 +474,11 @@ impl KafkaSinkCluster {
 
                         if let Some(scram_over_mtls) = &self.authorize_scram_over_mtls {
                             // When performing SCRAM over mTLS, we need this security check to ensure that the
-                            // client cannot access delegation tokens that it has not succesfully authenticated for.
+                            // client cannot access delegation tokens that it has not successfully authenticated for.
                             //
                             // If the client were to send a request directly after the SCRAM requests,
                             // without waiting for responses to those scram requests first,
-                            // this error would be triggered even if the SCRAM requests were succesful.
+                            // this error would be triggered even if the SCRAM requests were successful.
                             // However that would be a violation of the SCRAM protocol as the client is supposed to check
                             // the server's signature contained in the server's final message in order to authenticate the server.
                             // So I dont think this problem is worth solving.
@@ -489,7 +486,7 @@ impl KafkaSinkCluster {
                                 scram_over_mtls.original_scram_state,
                                 OriginalScramState::AuthSuccess
                             ) {
-                                return Err(anyhow!("Client attempted to send requests before a succesful auth was completed or after an unsuccesful auth"));
+                                return Err(anyhow!("Client attempted to send requests before a successful auth was completed or after an unsuccessful auth"));
                             }
                         }
 

--- a/shotover/src/transforms/kafka/sink_cluster/node.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/node.rs
@@ -148,7 +148,7 @@ impl ConnectionFactory {
 
         // SCRAM client-first
         let mut scram = Scram::<Sha256>::new(
-            delegation_token.token_id.clone(),
+            delegation_token.token_id,
             delegation_token.hmac.to_string(),
             ChannelBinding::None,
             "tokenauth=true".to_owned(),

--- a/shotover/src/transforms/kafka/sink_cluster/node.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/node.rs
@@ -141,10 +141,15 @@ impl ConnectionFactory {
             ));
         }
 
+        let delegation_token = scram_over_mtls
+            .token_task
+            .get_token_for_user(scram_over_mtls.username.clone())
+            .await?;
+
         // SCRAM client-first
         let mut scram = Scram::<Sha256>::new(
-            scram_over_mtls.delegation_token.token_id.clone(),
-            scram_over_mtls.delegation_token.hmac.to_string(),
+            delegation_token.token_id.clone(),
+            delegation_token.hmac.to_string(),
             ChannelBinding::None,
             "tokenauth=true".to_owned(),
             String::new(),
@@ -170,7 +175,7 @@ impl ConnectionFactory {
             .context("Server gave invalid final response to delegation token SCRAM")
     }
 
-    /// For SASL plain it is sufficient to replay the requests made in a succesful exchange.
+    /// For SASL plain it is sufficient to replay the requests made in a successful exchange.
     /// This method performs such a replay on the passed connection.
     async fn replay_sasl(&self, connection: &mut SinkConnection) -> Result<()> {
         connection.send(self.auth_requests.clone())?;

--- a/shotover/src/transforms/kafka/sink_cluster/scram_over_mtls.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/scram_over_mtls.rs
@@ -231,10 +231,7 @@ impl AuthorizeScramOverMtlsBuilder {
         AuthorizeScramOverMtls {
             original_scram_state: OriginalScramState::WaitingOnServerFirst,
             token_task: self.token_task.clone(),
-            delegation_token: DelegationToken {
-                token_id: String::new(),
-                hmac: StrBytes::default(),
-            },
+            username: String::new(),
         }
     }
 }
@@ -242,10 +239,10 @@ impl AuthorizeScramOverMtlsBuilder {
 pub struct AuthorizeScramOverMtls {
     /// Tracks the state of the original scram connections responses created from the clients actual requests
     pub original_scram_state: OriginalScramState,
-    /// Shared task that fetches and caches delegation tokens
+    /// Shared task that fetches delegation tokens
     pub token_task: TokenTask,
-    /// The delegation token generated from the username used in the original scram auth
-    pub delegation_token: DelegationToken,
+    /// The username used in the original scram auth to generate the delegation token
+    pub username: String,
 }
 
 pub enum OriginalScramState {

--- a/shotover/src/transforms/kafka/sink_cluster/scram_over_mtls/create_token.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/scram_over_mtls/create_token.rs
@@ -221,7 +221,7 @@ async fn wait_until_delegation_token_ready_on_all_brokers(
             while !is_delegation_token_ready(connection, create_response, username.clone())
                 .await
                 .with_context(|| {
-                    format!("Failed to check delegation token was ready on broker {address:?}. Succesful connections {i}/{nodes_len}")
+                    format!("Failed to check delegation token was ready on broker {address:?}. Successful connections {i}/{nodes_len}")
                 })?
             {
                 tokio::time::sleep(Duration::from_millis(10)).await;


### PR DESCRIPTION
This PR removes the field `delegation_token` from the struct `AuthorizeScramOverMtls` to avoid caching the token in `AuthorizeScramOverMtls` instances. Instead, we store the username used to generate delegation tokens in this struct and fetch the delegation token from the `TokenTask` every time it's needed.

Progress towards #1667 