### PR TITLE
Add comment on not being able to expire other users' delegation tokens 

### DIFF
--- a/shotover/src/transforms/kafka/sink_cluster/scram_over_mtls.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/scram_over_mtls.rs
@@ -126,6 +126,7 @@ async fn task(
 
                 // TODO: We would expire the old token here if it were possible, but it is not since kafka will not allow users (even super users) to expire a token belonging to another user.
                 // See details in https://github.com/shotover/shotover-proxy/pull/1685
+                // However, at this point, the token will automatically expire itself in delegation_token_lifetime / 2, so it is not a huge concern.
             }
             result = rx.recv() => {
                 if let Some(request) = result {

--- a/shotover/src/transforms/kafka/sink_cluster/scram_over_mtls.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/scram_over_mtls.rs
@@ -123,6 +123,9 @@ async fn task(
                 let passed = instant.elapsed();
                 tracing::info!("Delegation token for {username:?} recreated in {passed:?}");
                 token_creation_time_metric.record(passed);
+
+                // TODO: We would expire the old token here if it were possible, but it is not since kafka will not allow users (even super users) to expire a token belonging to another user.
+                // See details in https://github.com/shotover/shotover-proxy/pull/1685
             }
             result = rx.recv() => {
                 if let Some(request) = result {


### PR DESCRIPTION
closes https://github.com/shotover/shotover-proxy/issues/1667
This PR is to add a comment to the token task in scram_over_mtls about not bing able to expire other users' delegation tokens at the moment. See more details in https://github.com/shotover/shotover-proxy/pull/1685.