### PR TITLE
Add a tip on docker-mac-net-connect

### DIFF
--- a/docs/src/dev-docs/contributing.md
+++ b/docs/src/dev-docs/contributing.md
@@ -7,7 +7,7 @@ This guide describes how to setup and use your environment for contributing to s
 Shotover requires [rustup](https://rustup.rs/) to be installed so that the project specific rust version will be used.
 
 The rest of the setup is specific to your operating system.
-Shotover supports development on linux and partiallly supports macOS.
+Shotover supports development on linux and partially supports macOS.
 
 ### Setting up on Linux
 
@@ -17,7 +17,7 @@ See the [Linux specific setup instructions](setting-up-linux.md)
 
 ### Setting up on macOS
 
-* All tests that use a single docker instance will pass. But anything with more than one docker instance will fail.
+* All tests that use a single docker instance will pass. But some tests with more than one docker instance will fail.
 * Tests that rely on external C++ dependencies cannot be built.
   * They are hidden behind the `cassandra-cpp-driver-tests` and `kafka-cpp-driver-tests` feature flags to allow the rest of the tests to build on macOS
 

--- a/docs/src/dev-docs/setting-up-macos.md
+++ b/docs/src/dev-docs/setting-up-macos.md
@@ -15,6 +15,8 @@ brew install chipmk/tap/docker-mac-net-connect
 sudo brew services start chipmk/tap/docker-mac-net-connect
 ```
 
+You may need to enable the option `Settings > Advanced > Allow the default Docker socket to be used (requires password)` in Docker Desktop, and restart Docker Desktop, for `docker-mac-net-connect` to work.
+
 Make sure that docker desktop is running when you run the tests.
 
 To continue running tests after a reboot, you will need to rerun:


### PR DESCRIPTION
This PR adds a tip on making [docker-mac-net-connect](https://github.com/chipmk/docker-mac-net-connect) work on macs with ARM CPUs.