### PR TITLE
Fix sarama and kafkajs drivers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /docs/mdbook_bin
 /shotover-proxy/build/packages
 /some_local_file
+/test-helpers/src/connection/kafka/node/node_modules

--- a/shotover/src/transforms/kafka/sink_cluster/mod.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/mod.rs
@@ -457,7 +457,7 @@ impl KafkaSinkCluster {
                     })) => {
                         if let Some(scram_over_mtls) = &mut self.authorize_scram_over_mtls {
                             if let Some(username) = get_username_from_scram_request(auth_bytes) {
-                                scram_over_mtls.username = username;
+                                scram_over_mtls.set_username(username).await?;
                             }
                         }
                         self.connection_factory.add_auth_request(request.clone());

--- a/test-helpers/src/connection/kafka/mod.rs
+++ b/test-helpers/src/connection/kafka/mod.rs
@@ -3,6 +3,7 @@ use pretty_assertions::assert_eq;
 #[cfg(feature = "kafka-cpp-driver-tests")]
 pub mod cpp;
 pub mod java;
+pub mod node;
 
 use anyhow::Result;
 #[cfg(feature = "kafka-cpp-driver-tests")]

--- a/test-helpers/src/connection/kafka/node.rs
+++ b/test-helpers/src/connection/kafka/node.rs
@@ -1,0 +1,46 @@
+use std::path::Path;
+
+pub async fn run_node_smoke_test(address: &str) {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/connection/kafka/node");
+    let config = format!(
+        r#"({{
+    clientId: 'nodejs-client',
+    brokers: ["{address}"],
+}})"#
+    );
+    run_command(&dir, "npm", &["install"]).await;
+    run_command(&dir, "npm", &["start", &config]).await;
+}
+
+pub async fn run_node_smoke_test_scram(address: &str, user: &str, password: &str) {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/connection/kafka/node");
+    let config = format!(
+        r#"({{
+    clientId: 'nodejs-client',
+    brokers: ["{address}"],
+    sasl: {{
+       mechanism: 'scram-sha-256',
+       username: '{user}',
+       password: '{password}'
+    }}
+}})"#
+    );
+    run_command(&dir, "npm", &["install"]).await;
+    run_command(&dir, "npm", &["start", &config]).await;
+}
+
+async fn run_command(current_dir: &Path, command: &str, args: &[&str]) -> String {
+    let output = tokio::process::Command::new(command)
+        .args(args)
+        .current_dir(current_dir)
+        .output()
+        .await
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    if !output.status.success() {
+        panic!("command {command} {args:?} failed:\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    }
+    stdout
+}

--- a/test-helpers/src/connection/kafka/node/index.js
+++ b/test-helpers/src/connection/kafka/node/index.js
@@ -1,0 +1,70 @@
+const { Kafka } = require('kafkajs')
+const fs = require('fs')
+const assert = require('assert')
+
+function delay(time) {
+    return new Promise(resolve => setTimeout(resolve, time));
+}
+
+const run = async () => {
+    const args = process.argv.slice(2);
+    const config = args[0];
+
+    const kafka = new Kafka(eval(config))
+
+    // Producing
+    const producer = kafka.producer()
+    await producer.connect()
+    await producer.send({
+        topic: 'test',
+        messages: [
+            { value: 'foo' },
+        ],
+    })
+    await producer.send({
+        topic: 'test',
+        messages: [
+            { value: 'a longer string' },
+        ],
+    })
+    await producer.disconnect()
+
+    // Consuming
+    const consumer = kafka.consumer({ groupId: 'test-group' })
+    await consumer.connect()
+    await consumer.subscribe({ topic: 'test', fromBeginning: true })
+
+    messages = []
+    await consumer.run({
+        eachMessage: async ({ topic, partition, message }) => {
+            messages.push({
+                topic,
+                partition,
+                offset: message.offset,
+                value: message.value.toString(),
+            })
+        },
+    })
+
+    // Use a very primitive sleep loop since nodejs doesnt seem to have any kind of mpsc or channel functionality :/
+    while (messages.length < 2) {
+        await delay(10);
+    }
+    assert.deepStrictEqual(messages, [
+        {
+            topic: 'test',
+            partition: 0,
+            offset: '0',
+            value: 'foo',
+        },
+        {
+            topic: 'test',
+            partition: 0,
+            offset: '1',
+            value: 'a longer string',
+        }
+    ])
+    await consumer.disconnect()
+}
+
+run()

--- a/test-helpers/src/connection/kafka/node/package-lock.json
+++ b/test-helpers/src/connection/kafka/node/package-lock.json
@@ -1,0 +1,25 @@
+{
+  "name": "kafkajs_wrapper",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "kafkajs_wrapper",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "kafkajs": "^2.2.4"
+      }
+    },
+    "node_modules/kafkajs": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/kafkajs/-/kafkajs-2.2.4.tgz",
+      "integrity": "sha512-j/YeapB1vfPT2iOIUn/vxdyKEuhuY2PxMBvf5JWux6iSaukAccrMtXEY/Lb7OvavDhOWME589bpLrEdnVHjfjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    }
+  }
+}

--- a/test-helpers/src/connection/kafka/node/package.json
+++ b/test-helpers/src/connection/kafka/node/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "kafkajs_wrapper",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "author": "",
+  "license": "Apache-2.0",
+  "description": "",
+  "dependencies": {
+    "kafkajs": "^2.2.4"
+  }
+}


### PR DESCRIPTION
The exact difference in behaviour is that all the existing drivers will always send an ApiVersions request as the first request when opening a new connection.
However the sarama and kafkajs driver will sometimes skip the ApiVersions request when opening a connection. This is valid use of the protocol and its a bug in shotover that we are not handling this case properly.

Skipping the ApiVersions request resulted in shotover attempting to open the first outgoing connection of an incoming connection using a delegation token, this failed since we havent yet gathered the username required for creating a delegation token.

The fix here is to only use token auth when OriginalScramState::AuthSuccess.
If we are in any other state we should perform no handshake.

Along with the fix, this PR also refactors AuthorizeScramOverMtls to make it impossible to retrieve the username until a successful auth has completed.
While this is impossible to reach due to the above fix, I believe the security in depth is valuable here.
Additionally this refactor enables us to prefetch tokens which should be a reasonable perf gain on production systems with many nodes.

The first commit introduces a failing test case `cluster_sasl_scram_over_mtls_nodejs` which is fixed by the 2nd commit.
The kafkajs tests are added as a simple smoke test for now.
However, in the future we should be able to extend this into:
* A generic nodejs+rust interop crate with interop performed by sending js strings over IPC sockets to be eval'd on the javascript side and the return value JSON'd and sent back over the socket.
  + The current use of eval to create the kafka config is a small demonstration of this.
  + stdout should not be used for communication because kafkajs logs things there
* A full implementation of the kafka connection abstraction for nodejs.