### PR TITLE
Install new deps in cargo-ec2

### DIFF
--- a/ec2-cargo/src/main.rs
+++ b/ec2-cargo/src/main.rs
@@ -66,7 +66,7 @@ until sudo apt-get update -qq
 do
   sleep 1
 done
-sudo apt-get install -y cmake pkg-config g++ libssl-dev librdkafka-dev unzip
+sudo apt-get install -y cmake pkg-config g++ libssl-dev librdkafka-dev unzip default-jre-headless npm
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 curl -sSL https://get.docker.com/ | sudo sh

--- a/shotover-proxy/build/install_ubuntu_deps.sh
+++ b/shotover-proxy/build/install_ubuntu_deps.sh
@@ -23,6 +23,9 @@ usermod -aG docker $USER`
 # Install dependencies for kafka java driver tests
 sudo apt-get install -y default-jre-headless`
 
+# Install dependencies for npm tests
+sudo apt-get install -y npm`
+
 # The remaining dependencies are for tests behind optional features.
 # So feel free to skip them.
 


### PR DESCRIPTION
We have recently added external dependencies for our integration tests and were not careful about updating scripts that need to install them.

So this PR:
* Adds jre + npm to ec2-cargo installed deps
* Adds npm to install_ubuntu_deps.sh script