### PR TITLE
Enable tls 1.2

### DIFF
--- a/shotover/Cargo.toml
+++ b/shotover/Cargo.toml
@@ -112,7 +112,7 @@ aws-sdk-kms = { version = "1.1.0", optional = true }
 chacha20poly1305 = { version = "0.10.0", features = ["std"], optional = true }
 generic-array = { version = "0.14", features = ["serde"], optional = true }
 kafka-protocol = { version = "0.10.0", optional = true }
-rustls = { version = "0.23.0", default-features = false }
+rustls = { version = "0.23.0", default-features = false, features = ["tls12"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
 rustls-pemfile = "2.0.0"
 rustls-pki-types = "1.0.1"


### PR DESCRIPTION
https://github.com/shotover/shotover-proxy/pull/1564 accidentally disabled tls 1.2 by setting `default-features = false` and not manually reenabling the `tls12` feature.

This PR fixes that by reenabling the `tls12` feature