### PR TITLE
Cassandra 5.0 beta1 -> rc1

### DIFF
--- a/shotover-proxy/tests/test-configs/cassandra/cassandra-5/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra/cassandra-5/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   cassandra-one:
-    image: shotover/cassandra-test:5.0-beta1-r2
+    image: shotover/cassandra-test:5.0-rc1-r3
     ports:
       - "9043:9042"
     environment:

--- a/shotover-proxy/tests/test-configs/cassandra/cluster-v5/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra/cluster-v5/docker-compose.yaml
@@ -10,7 +10,7 @@ networks:
 
 services:
   cassandra-one:
-    image: &image shotover/cassandra-test:5.0-beta1-r2
+    image: &image shotover/cassandra-test:5.0-rc1-r3
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.2

--- a/test-helpers/src/docker_compose.rs
+++ b/test-helpers/src/docker_compose.rs
@@ -64,6 +64,11 @@ pub static IMAGE_WAITERS: [Image; 11] = [
         timeout: Duration::from_secs(120),
     },
     Image {
+        name: "shotover/cassandra-test:5.0-rc1-r3",
+        log_regex_to_wait_for: r"Starting listening for CQL clients",
+        timeout: Duration::from_secs(120),
+    },
+    Image {
         name: "bitnami/kafka:3.6.1-debian-11-r24",
         log_regex_to_wait_for: r"Kafka Server started",
         timeout: Duration::from_secs(120),
@@ -71,11 +76,6 @@ pub static IMAGE_WAITERS: [Image; 11] = [
     Image {
         name: "opensearchproject/opensearch:2.9.0",
         log_regex_to_wait_for: r"Node started",
-        timeout: Duration::from_secs(120),
-    },
-    Image {
-        name: "shotover/cassandra-test:5.0-beta1-r2",
-        log_regex_to_wait_for: r"Starting listening for CQL clients",
         timeout: Duration::from_secs(120),
     },
 ];


### PR DESCRIPTION
Actually use the new image added by https://github.com/shotover/cassandra-test-images/pull/7