### PR TITLE
Release shotover 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4638,7 +4638,7 @@ dependencies = [
 
 [[package]]
 name = "shotover"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "a8da96aa9ee5ce956b7069f92a4ca762efc75133",
  "anyhow",
@@ -4710,7 +4710,7 @@ dependencies = [
 
 [[package]]
 name = "shotover-proxy"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shotover-proxy"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Ben <ben@instaclustr.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/shotover/Cargo.toml
+++ b/shotover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shotover"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Ben <ben@instaclustr.com>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
Needed for https://github.com/shotover/shotover-proxy/pull/1696

May as well wait for https://github.com/shotover/shotover-proxy/pull/1693 as well.