### PR TITLE
KafkaSinkCluster: store first_contact_points as KafkaAddress

### DIFF
--- a/shotover/src/transforms/kafka/sink_cluster/mod.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/mod.rs
@@ -121,9 +121,15 @@ impl TransformConfig for KafkaSinkClusterConfig {
             })?;
         shotover_nodes.sort_by_key(|x| x.broker_id);
 
+        let first_contact_points: Result<Vec<_>> = self
+            .first_contact_points
+            .iter()
+            .map(|x| KafkaAddress::from_str(x))
+            .collect();
+
         Ok(Box::new(KafkaSinkClusterBuilder::new(
             transform_context.chain_name,
-            self.first_contact_points.clone(),
+            first_contact_points?,
             &self.authorize_scram_over_mtls,
             shotover_nodes,
             rack,
@@ -144,7 +150,7 @@ impl TransformConfig for KafkaSinkClusterConfig {
 
 struct KafkaSinkClusterBuilder {
     // contains address and port
-    first_contact_points: Vec<String>,
+    first_contact_points: Vec<KafkaAddress>,
     shotover_nodes: Vec<ShotoverNode>,
     rack: StrBytes,
     connect_timeout: Duration,
@@ -163,7 +169,7 @@ impl KafkaSinkClusterBuilder {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         chain_name: String,
-        first_contact_points: Vec<String>,
+        first_contact_points: Vec<KafkaAddress>,
         authorize_scram_over_mtls: &Option<AuthorizeScramOverMtlsConfig>,
         shotover_nodes: Vec<ShotoverNode>,
         rack: StrBytes,
@@ -266,7 +272,7 @@ impl AtomicBrokerId {
 }
 
 struct KafkaSinkCluster {
-    first_contact_points: Vec<String>,
+    first_contact_points: Vec<KafkaAddress>,
     shotover_nodes: Vec<ShotoverNode>,
     rack: StrBytes,
     nodes: Vec<KafkaNode>,
@@ -329,18 +335,11 @@ impl Transform for KafkaSinkCluster {
 
     async fn transform<'a>(&'a mut self, mut requests_wrapper: Wrapper<'a>) -> Result<Messages> {
         if self.nodes.is_empty() {
-            let nodes: Result<Vec<KafkaNode>> = self
+            self.nodes = self
                 .first_contact_points
                 .iter()
-                .map(|address| {
-                    Ok(KafkaNode::new(
-                        BrokerId(-1),
-                        KafkaAddress::from_str(address)?,
-                        None,
-                    ))
-                })
+                .map(|address| KafkaNode::new(BrokerId(-1), address.clone(), None))
                 .collect();
-            self.nodes = nodes?;
         }
 
         let mut responses = if requests_wrapper.requests.is_empty() {


### PR DESCRIPTION
This is reduces the need for reallocating and parsing address strings by moving the conversion from string into KafkaAddress into the TransformBuilder creation stage instead of the Transform creation stage.

It is also a prereq to https://github.com/shotover/shotover-proxy/pull/1703