### PR TITLE
Fix KafkaNode state field type

### DIFF
--- a/shotover/src/transforms/kafka/sink_cluster/node.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/node.rs
@@ -283,7 +283,7 @@ pub struct KafkaNode {
     pub rack: Option<StrBytes>,
     pub kafka_address: KafkaAddress,
     #[allow(unused)]
-    pub state: Box<NodeState>,
+    pub state: Arc<AtomicNodeState>,
 }
 
 impl KafkaNode {
@@ -292,7 +292,7 @@ impl KafkaNode {
             broker_id,
             kafka_address,
             rack,
-            state: Box::new(NodeState::Up),
+            state: Arc::new(AtomicNodeState::new(NodeState::Up)),
         }
     }
 }


### PR DESCRIPTION
I used the wrong type for this field in https://github.com/shotover/shotover-proxy/pull/1703 and didnt realize until I went to use it.
Calling clone on a box will clone the contents of the box as well which is not what we want.
What we want is an Arc, which will not clone its contents and instead share the contents between all its clones via reference counting.

