### PR TITLE
KafkaSinkCluster - set KafkaNode::state

### DIFF
--- a/shotover/src/transforms/kafka/sink_cluster/node.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/node.rs
@@ -282,7 +282,6 @@ pub struct KafkaNode {
     pub broker_id: BrokerId,
     pub rack: Option<StrBytes>,
     pub kafka_address: KafkaAddress,
-    #[allow(unused)]
     pub state: Arc<AtomicNodeState>,
 }
 


### PR DESCRIPTION
This PR:
* sets the `KafkaNode::state` field to `NodeState::Down` whenever a connection error is encountered.
   + This sets us up to make use of that fields value as part of our routing logic in a follow up PR.
* recreates lost connections where it is safe to do so.
   + send - never recreate lost connections on send, since we cant tell if the sent message was received or not. Possibly in the future we could recreate lost connections in certain conditions. But its not really important.
   + receive - never recreate lost connections on receive, we only check for received messages if they are pending, and if there were pending responses we would not be able to recreate the connection.
   + control_send_receive - we can recreate connections as needed. Since control connections are used for metadata requests generated by shotover instead of arbitrary requests coming from the client, we can just recreate connections without fear of idempotency issues.

To enable this a `Connections::handle_connection_error` method is added.
This method is called anytime a connection error occurs.

It creates a new connection to check if the node is broken.
If the connection fails the node is marked as down and `Err(..)` is returned, otherwise the old connection is replaced with the new connection and `Ok(())` is returned.

It is then up to the caller (send/receive/control_send_receive) to decide how to handle this success or failure.
* send ignores the success and fails anyway.
* receive will hit the `Succesfully reopened outgoing connection but previous outgoing connection had pending requests.` error since it always has a pending request (thats why its receiving!)
* control_send_receive has its own extensive logic that calls `handle_connection_error` first to check if the original node is bad or just the connection, then it proceeds to try new nodes without going through handle_connection_error. It can recover from issues at any point since control_send_receive is used for internal shotover requests.

<!--
1. client creates connection to shotover
2. client sends bad auth to shotover
3. shotover sends bad auth to broker
4. broker responds with auth fail response
5. broker closes the connection to shotover
6. client receives auth fail response
7. client closes the connection since its unusable
8. shotover handles the closed connection by flushing the chain.
9. chain flush attempts to receive from outgoing connection but outgoing connection is closed
10. connection closed error is bubbled all the way up and reported as a shotover error log.

We need to avoid this error reaching a shotover error log.
Possible solutions:
* within SinkConnection, during flush only receive from connections that have pending requests
  + This would prevent received push messages from reaching the client during a flush. Probably fine but I'd rather avoid it.
* within KafkaSinkCluster, only flush if auth_complete
  + easy to implement
  + one weird edge case: we wouldnt flush ApiVersions responses that occur before auth_complete
* within KafkaSinkCluster, detect outgoing connection was closed due to auth error and remove it from list of connections
  + we would be allowing the client to retry auth after a failed auth. This goes against the behaviour of an actual kafka broker.
* add functionality to shotover to allow transforms to close the incoming connection
  + This is needed to exactly recreate the functionality of the downstream DB.
  + If kafka closes the connection on us in a specific scenario then we should attempt to recreate that behaviour exactly.
  + In this we would have shotover close the connection on auth failure just like kafka does.
-->
