### PR TITLE
Fix cargo-deny

### DIFF
--- a/.github/workflows/license_check.yaml
+++ b/.github/workflows/license_check.yaml
@@ -21,5 +21,8 @@ jobs:
     name: License Check
     steps:
       - uses: actions/checkout@v4
-      - run: cargo install --locked cargo-deny
+      - name: Install cargo deny
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny@0.15.1
       - run: cargo deny check licenses


### PR DESCRIPTION
We use cargo-deny to ensure that we only depend on licenses that are compatible with shotovers apache license.
The [latest release](https://github.com/EmbarkStudios/cargo-deny/releases/tag/0.16.0) of cargo-deny includes breaking changes to the configuration and we werent pinning the version of cargo-deny that we use.
This results in CI being broken since the last release of cargo-deny.
Oops.

This PR fixes CI by pinning the version of cargo-deny to the last release our config is compatible with.