### PR TITLE
Add Wrapper::close_client_connection

### DIFF
--- a/shotover/src/transforms/mod.rs
+++ b/shotover/src/transforms/mod.rs
@@ -157,7 +157,12 @@ pub struct Wrapper<'a> {
     /// When true transforms must flush any buffered messages into the messages field.
     /// This can occur at any time but will always occur before the transform is destroyed due to either
     /// shotover or the transform's chain shutting down.
+    /// The one exception is if [`Wrapper::close_client_connection`] was set to true, in which case no flush occurs.
     pub flush: bool,
+    /// Set to false by default.
+    /// Transforms can set this to true to force the connection to the client to be closed after the stack of `Transform::transform` calls returns.
+    /// When closed in this way, the chain will not be flushed and no further calls to the chain will be made before it is dropped.
+    pub close_client_connection: bool,
 }
 
 /// [`Wrapper`] will not (cannot) bring the current list of transforms that it needs to traverse with it
@@ -170,6 +175,7 @@ impl<'a> Clone for Wrapper<'a> {
             transforms: [].iter_mut(),
             local_addr: self.local_addr,
             flush: self.flush,
+            close_client_connection: self.close_client_connection,
         }
     }
 }
@@ -181,6 +187,7 @@ impl<'shorter, 'longer: 'shorter> Wrapper<'longer> {
             transforms: std::mem::take(&mut self.transforms),
             local_addr: self.local_addr,
             flush: self.flush,
+            close_client_connection: self.close_client_connection,
         }
     }
 
@@ -232,6 +239,7 @@ impl<'shorter, 'longer: 'shorter> Wrapper<'longer> {
             transforms: [].iter_mut(),
             local_addr: "127.0.0.1:8000".parse().unwrap(),
             flush: false,
+            close_client_connection: false,
         }
     }
 
@@ -241,6 +249,7 @@ impl<'shorter, 'longer: 'shorter> Wrapper<'longer> {
             transforms: [].iter_mut(),
             local_addr,
             flush: false,
+            close_client_connection: false,
         }
     }
 
@@ -251,6 +260,7 @@ impl<'shorter, 'longer: 'shorter> Wrapper<'longer> {
             // The connection is closed so we need to just fake an address here
             local_addr: "127.0.0.1:10000".parse().unwrap(),
             flush: true,
+            close_client_connection: false,
         }
     }
 


### PR DESCRIPTION
In order for shotover to properly recreate the behavior of certain databases it needs to be able to close incoming connections from the client.
Databases will close the connection on the client if it misbehaves, this can include things like failed auth and sending requests that cannot be parsed according to the databases wire protocol.
We need to be able to recreate this behavior to avoid subtle differences in behavior between shotover and the database.

Shotover currently lacks a way for a transform to close the incoming connection to the client.
This is a problem since cluster sink transforms need to be able to close the connection since they need to emulate a chunk of the servers behavior.

This PR fills this missing hole in the API shotover exposes to transforms and makes use of this new API in KafkaSinkCluster in order to close the client connection when authentication fails.

This is achieved by adding a `close_client_connection` field to `Wrapper`.
By default the field is false, but any transform can set it to true, allowing any transform to close the connection to the client.

Additionally we use the CloseReason enum to avoid flushing the chain when a transform requests the connection to be closed.
Chain flushing is needed to ensure we flush all pending responses back to the client, since shotover will not be sending anymore responses to the client it does not make sense to flush the chain.

This enables use cases such as:
* cluster sink transforms to close the connection for the purpose of better emulating a single server instance.
* single sink transforms to close the connection if they detect the server has closed its connection.
* custom auth implementations, implemented as a separate transform, to close the connection on auth failure.

In this PR, we only use `close_client_connection` for `KafkaSinkCluster` auth, as this is all we need for the "handling of down kafka nodes" project.