### PR TITLE
use const address for wrapper flush

### DIFF
--- a/shotover/src/transforms/mod.rs
+++ b/shotover/src/transforms/mod.rs
@@ -7,7 +7,7 @@ use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use futures::Future;
 use std::fmt::Debug;
-use std::net::SocketAddr;
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::pin::Pin;
 use std::slice::IterMut;
 use std::sync::Arc;
@@ -230,7 +230,7 @@ impl<'a> Wrapper<'a> {
         Wrapper {
             requests,
             transforms: [].iter_mut(),
-            local_addr: "127.0.0.1:8000".parse().unwrap(),
+            local_addr: DUMMY_ADDRESS,
             flush: false,
         }
     }
@@ -249,7 +249,7 @@ impl<'a> Wrapper<'a> {
             requests: vec![],
             transforms: [].iter_mut(),
             // The connection is closed so we need to just fake an address here
-            local_addr: "127.0.0.1:10000".parse().unwrap(),
+            local_addr: DUMMY_ADDRESS,
             flush: true,
         }
     }
@@ -270,6 +270,8 @@ impl<'a> Wrapper<'a> {
         self.transforms = transforms.iter_mut();
     }
 }
+
+const DUMMY_ADDRESS: SocketAddr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0));
 
 /// This trait is the primary extension point for Shotover-proxy.
 /// A [`Transform`] is a struct that implements the Transform trait and enables you to modify and observe database


### PR DESCRIPTION
avoids the possibility of runtime panic due to unwrap, which allows the optimizer to go harder.
Super minor performance improvement I doubt it will show up in any benchmarks, but it did reduce the size of the compiled binary by 2KB.

It also changes the address to 0.0.0.0:0 which is more clearly a dummy address.