### PR TITLE
Fix transform lifetimes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,12 @@
 Any breaking changes to the `topology.yaml` or `shotover` rust API should be documented here.
 This assists us in knowing when to make the next release a breaking release and assists users with making upgrades to new breaking releases.
 
+## 0.5.0
+
+### shotover rust API
+
+`Transform::transform` now takes `&mut Wrapper` instead of `Wrapper`.
+
 ## 0.4.0
 
 ### shotover rust API

--- a/custom-transforms-example/src/redis_get_rewrite.rs
+++ b/custom-transforms-example/src/redis_get_rewrite.rs
@@ -64,9 +64,9 @@ impl Transform for RedisGetRewrite {
         NAME
     }
 
-    async fn transform<'a>(
-        &'a mut self,
-        requests_wrapper: &'a mut Wrapper<'a>,
+    async fn transform<'shorter, 'longer: 'shorter>(
+        &mut self,
+        requests_wrapper: &'shorter mut Wrapper<'longer>,
     ) -> Result<Messages> {
         for message in requests_wrapper.requests.iter_mut() {
             if let Some(frame) = message.frame() {

--- a/shotover/src/transforms/cassandra/peers_rewrite.rs
+++ b/shotover/src/transforms/cassandra/peers_rewrite.rs
@@ -79,9 +79,9 @@ impl Transform for CassandraPeersRewrite {
         NAME
     }
 
-    async fn transform<'a>(
-        &'a mut self,
-        requests_wrapper: &'a mut Wrapper<'a>,
+    async fn transform<'shorter, 'longer: 'shorter>(
+        &mut self,
+        requests_wrapper: &'shorter mut Wrapper<'longer>,
     ) -> Result<Messages> {
         // Find the indices of queries to system.peers & system.peers_v2
         // we need to know which columns in which CQL queries in which messages have system peers

--- a/shotover/src/transforms/cassandra/sink_cluster/mod.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/mod.rs
@@ -761,9 +761,9 @@ impl Transform for CassandraSinkCluster {
         NAME
     }
 
-    async fn transform<'a>(
-        &'a mut self,
-        requests_wrapper: &'a mut Wrapper<'a>,
+    async fn transform<'shorter, 'longer: 'shorter>(
+        &mut self,
+        requests_wrapper: &'shorter mut Wrapper<'longer>,
     ) -> Result<Messages> {
         self.send_message(std::mem::take(&mut requests_wrapper.requests))
             .await

--- a/shotover/src/transforms/cassandra/sink_single.rs
+++ b/shotover/src/transforms/cassandra/sink_single.rs
@@ -212,9 +212,9 @@ impl Transform for CassandraSinkSingle {
         NAME
     }
 
-    async fn transform<'a>(
-        &'a mut self,
-        requests_wrapper: &'a mut Wrapper<'a>,
+    async fn transform<'shorter, 'longer: 'shorter>(
+        &mut self,
+        requests_wrapper: &'shorter mut Wrapper<'longer>,
     ) -> Result<Messages> {
         self.send_message(std::mem::take(&mut requests_wrapper.requests))
             .await

--- a/shotover/src/transforms/chain.rs
+++ b/shotover/src/transforms/chain.rs
@@ -157,9 +157,9 @@ impl BufferedChain {
 }
 
 impl TransformChain {
-    pub async fn process_request<'a>(
-        &'a mut self,
-        wrapper: &'a mut Wrapper<'a>,
+    pub async fn process_request<'shorter, 'longer: 'shorter>(
+        &'longer mut self,
+        wrapper: &'shorter mut Wrapper<'longer>,
     ) -> Result<Messages> {
         let start = Instant::now();
         wrapper.reset(&mut self.chain);

--- a/shotover/src/transforms/coalesce.rs
+++ b/shotover/src/transforms/coalesce.rs
@@ -81,9 +81,9 @@ impl Transform for Coalesce {
         NAME
     }
 
-    async fn transform<'a>(
-        &'a mut self,
-        requests_wrapper: &'a mut Wrapper<'a>,
+    async fn transform<'shorter, 'longer: 'shorter>(
+        &mut self,
+        requests_wrapper: &'shorter mut Wrapper<'longer>,
     ) -> Result<Messages> {
         self.buffer.append(&mut requests_wrapper.requests);
 

--- a/shotover/src/transforms/debug/force_parse.rs
+++ b/shotover/src/transforms/debug/force_parse.rs
@@ -105,9 +105,9 @@ impl Transform for DebugForceParse {
         NAME
     }
 
-    async fn transform<'a>(
-        &'a mut self,
-        requests_wrapper: &'a mut Wrapper<'a>,
+    async fn transform<'shorter, 'longer: 'shorter>(
+        &mut self,
+        requests_wrapper: &'shorter mut Wrapper<'longer>,
     ) -> Result<Messages> {
         for message in &mut requests_wrapper.requests {
             if self.parse_requests {

--- a/shotover/src/transforms/debug/log_to_file.rs
+++ b/shotover/src/transforms/debug/log_to_file.rs
@@ -89,9 +89,9 @@ impl Transform for DebugLogToFile {
         NAME
     }
 
-    async fn transform<'a>(
-        &'a mut self,
-        requests_wrapper: &'a mut Wrapper<'a>,
+    async fn transform<'shorter, 'longer: 'shorter>(
+        &mut self,
+        requests_wrapper: &'shorter mut Wrapper<'longer>,
     ) -> Result<Vec<Message>> {
         for message in &requests_wrapper.requests {
             self.request_counter += 1;

--- a/shotover/src/transforms/debug/printer.rs
+++ b/shotover/src/transforms/debug/printer.rs
@@ -65,9 +65,9 @@ impl Transform for DebugPrinter {
         NAME
     }
 
-    async fn transform<'a>(
-        &'a mut self,
-        requests_wrapper: &'a mut Wrapper<'a>,
+    async fn transform<'shorter, 'longer: 'shorter>(
+        &mut self,
+        requests_wrapper: &'shorter mut Wrapper<'longer>,
     ) -> Result<Messages> {
         for request in &mut requests_wrapper.requests {
             info!("Request: {}", request.to_high_level_string());

--- a/shotover/src/transforms/debug/returner.rs
+++ b/shotover/src/transforms/debug/returner.rs
@@ -75,9 +75,9 @@ impl Transform for DebugReturner {
         NAME
     }
 
-    async fn transform<'a>(
-        &'a mut self,
-        requests_wrapper: &'a mut Wrapper<'a>,
+    async fn transform<'shorter, 'longer: 'shorter>(
+        &mut self,
+        requests_wrapper: &'shorter mut Wrapper<'longer>,
     ) -> Result<Messages> {
         requests_wrapper
             .requests

--- a/shotover/src/transforms/filter.rs
+++ b/shotover/src/transforms/filter.rs
@@ -64,9 +64,9 @@ impl Transform for QueryTypeFilter {
         NAME
     }
 
-    async fn transform<'a>(
-        &'a mut self,
-        requests_wrapper: &'a mut Wrapper<'a>,
+    async fn transform<'shorter, 'longer: 'shorter>(
+        &mut self,
+        requests_wrapper: &'shorter mut Wrapper<'longer>,
     ) -> Result<Messages> {
         for request in requests_wrapper.requests.iter_mut() {
             let filter_out = match &self.filter {

--- a/shotover/src/transforms/kafka/sink_cluster/mod.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/mod.rs
@@ -339,9 +339,9 @@ impl Transform for KafkaSinkCluster {
         NAME
     }
 
-    async fn transform<'a>(
-        &'a mut self,
-        requests_wrapper: &'a mut Wrapper<'a>,
+    async fn transform<'shorter, 'longer: 'shorter>(
+        &mut self,
+        requests_wrapper: &'shorter mut Wrapper<'longer>,
     ) -> Result<Messages> {
         let mut responses = if requests_wrapper.requests.is_empty() {
             // there are no requests, so no point sending any, but we should check for any responses without awaiting

--- a/shotover/src/transforms/kafka/sink_single.rs
+++ b/shotover/src/transforms/kafka/sink_single.rs
@@ -117,9 +117,9 @@ impl Transform for KafkaSinkSingle {
         NAME
     }
 
-    async fn transform<'a>(
-        &'a mut self,
-        requests_wrapper: &'a mut Wrapper<'a>,
+    async fn transform<'shorter, 'longer: 'shorter>(
+        &mut self,
+        requests_wrapper: &'shorter mut Wrapper<'longer>,
     ) -> Result<Messages> {
         if self.connection.is_none() {
             let codec = KafkaCodecBuilder::new(Direction::Sink, "KafkaSinkSingle".to_owned());

--- a/shotover/src/transforms/load_balance.rs
+++ b/shotover/src/transforms/load_balance.rs
@@ -85,9 +85,9 @@ impl Transform for ConnectionBalanceAndPool {
         NAME
     }
 
-    async fn transform<'a>(
-        &'a mut self,
-        requests_wrapper: &'a mut Wrapper<'a>,
+    async fn transform<'shorter, 'longer: 'shorter>(
+        &mut self,
+        requests_wrapper: &'shorter mut Wrapper<'longer>,
     ) -> Result<Messages> {
         if self.active_connection.is_none() {
             let mut all_connections = self.all_connections.lock().await;

--- a/shotover/src/transforms/loopback.rs
+++ b/shotover/src/transforms/loopback.rs
@@ -29,9 +29,9 @@ impl Transform for Loopback {
         NAME
     }
 
-    async fn transform<'a>(
-        &'a mut self,
-        requests_wrapper: &'a mut Wrapper<'a>,
+    async fn transform<'shorter, 'longer: 'shorter>(
+        &mut self,
+        requests_wrapper: &'shorter mut Wrapper<'longer>,
     ) -> Result<Messages> {
         // This transform ultimately doesnt make a lot of sense semantically
         // but make a vague attempt to follow transform invariants anyway.

--- a/shotover/src/transforms/mod.rs
+++ b/shotover/src/transforms/mod.rs
@@ -174,7 +174,7 @@ impl<'a> Clone for Wrapper<'a> {
     }
 }
 
-impl<'a> Wrapper<'a> {
+impl<'shorter, 'longer: 'shorter> Wrapper<'longer> {
     fn take(&mut self) -> Self {
         Wrapper {
             requests: std::mem::take(&mut self.requests),
@@ -192,7 +192,7 @@ impl<'a> Wrapper<'a> {
     /// the execution time of the [Transform::transform] function as a metrics latency histogram.
     ///
     /// The result of calling the next transform is then provided as a response.
-    pub async fn call_next_transform(&'a mut self) -> Result<Messages> {
+    pub async fn call_next_transform(&'shorter mut self) -> Result<Messages> {
         let TransformAndMetrics {
             transform,
             transform_total,
@@ -266,7 +266,7 @@ impl<'a> Wrapper<'a> {
         format!("{:?}", messages)
     }
 
-    pub fn reset(&mut self, transforms: &'a mut [TransformAndMetrics]) {
+    pub fn reset(&mut self, transforms: &'longer mut [TransformAndMetrics]) {
         self.transforms = transforms.iter_mut();
     }
 }
@@ -336,8 +336,10 @@ pub trait Transform: Send {
     /// * Transform that do call subsquent chains via `requests_wrapper.call_next_transform()` are non-terminating transforms.
     ///
     /// You can have have a transform that is both non-terminating and a sink.
-    async fn transform<'a>(&'a mut self, requests_wrapper: &'a mut Wrapper<'a>)
-        -> Result<Messages>;
+    async fn transform<'shorter, 'longer: 'shorter>(
+        &mut self,
+        requests_wrapper: &'shorter mut Wrapper<'longer>,
+    ) -> Result<Messages>;
 
     /// Name of the transform used in logs and displayed to the user
     fn get_name(&self) -> &'static str;

--- a/shotover/src/transforms/null.rs
+++ b/shotover/src/transforms/null.rs
@@ -52,9 +52,9 @@ impl Transform for NullSink {
         NAME
     }
 
-    async fn transform<'a>(
-        &'a mut self,
-        requests_wrapper: &'a mut Wrapper<'a>,
+    async fn transform<'shorter, 'longer: 'shorter>(
+        &mut self,
+        requests_wrapper: &'shorter mut Wrapper<'longer>,
     ) -> Result<Messages> {
         for request in &mut requests_wrapper.requests {
             // reuse the requests to hold the responses to avoid an allocation

--- a/shotover/src/transforms/opensearch/mod.rs
+++ b/shotover/src/transforms/opensearch/mod.rs
@@ -95,9 +95,9 @@ impl Transform for OpenSearchSinkSingle {
         NAME
     }
 
-    async fn transform<'a>(
-        &'a mut self,
-        requests_wrapper: &'a mut Wrapper<'a>,
+    async fn transform<'shorter, 'longer: 'shorter>(
+        &mut self,
+        requests_wrapper: &'shorter mut Wrapper<'longer>,
     ) -> Result<Messages> {
         // Return immediately if we have no messages.
         // If we tried to send no messages we would block forever waiting for a reply that will never come.

--- a/shotover/src/transforms/parallel_map.rs
+++ b/shotover/src/transforms/parallel_map.rs
@@ -108,9 +108,9 @@ impl Transform for ParallelMap {
         NAME
     }
 
-    async fn transform<'a>(
-        &'a mut self,
-        requests_wrapper: &'a mut Wrapper<'a>,
+    async fn transform<'shorter, 'longer: 'shorter>(
+        &mut self,
+        requests_wrapper: &'shorter mut Wrapper<'longer>,
     ) -> Result<Messages> {
         let mut results = Vec::with_capacity(requests_wrapper.requests.len());
         let mut message_iter = requests_wrapper.requests.drain(..);

--- a/shotover/src/transforms/protect/mod.rs
+++ b/shotover/src/transforms/protect/mod.rs
@@ -184,9 +184,9 @@ impl Transform for Protect {
         NAME
     }
 
-    async fn transform<'a>(
-        &'a mut self,
-        requests_wrapper: &'a mut Wrapper<'a>,
+    async fn transform<'shorter, 'longer: 'shorter>(
+        &mut self,
+        requests_wrapper: &'shorter mut Wrapper<'longer>,
     ) -> Result<Messages> {
         // encrypt the values included in any INSERT or UPDATE queries
         for message in requests_wrapper.requests.iter_mut() {

--- a/shotover/src/transforms/query_counter.rs
+++ b/shotover/src/transforms/query_counter.rs
@@ -64,9 +64,9 @@ impl Transform for QueryCounter {
         NAME
     }
 
-    async fn transform<'a>(
-        &'a mut self,
-        requests_wrapper: &'a mut Wrapper<'a>,
+    async fn transform<'shorter, 'longer: 'shorter>(
+        &mut self,
+        requests_wrapper: &'shorter mut Wrapper<'longer>,
     ) -> Result<Messages> {
         for m in &mut requests_wrapper.requests {
             match m.frame() {

--- a/shotover/src/transforms/redis/cache.rs
+++ b/shotover/src/transforms/redis/cache.rs
@@ -374,9 +374,9 @@ impl SimpleRedisCache {
     }
 
     /// calls the next transform and process the result for caching.
-    async fn execute_upstream_and_write_to_cache<'a>(
+    async fn execute_upstream_and_write_to_cache(
         &mut self,
-        requests_wrapper: &'a mut Wrapper<'a>,
+        requests_wrapper: &mut Wrapper<'_>,
     ) -> Result<Messages> {
         let local_addr = requests_wrapper.local_addr;
         let mut request_messages: Vec<_> = requests_wrapper
@@ -618,9 +618,9 @@ impl Transform for SimpleRedisCache {
         NAME
     }
 
-    async fn transform<'a>(
-        &'a mut self,
-        requests_wrapper: &'a mut Wrapper<'a>,
+    async fn transform<'shorter, 'longer: 'shorter>(
+        &mut self,
+        requests_wrapper: &'shorter mut Wrapper<'longer>,
     ) -> Result<Messages> {
         self.read_from_cache(&mut requests_wrapper.requests, requests_wrapper.local_addr)
             .await

--- a/shotover/src/transforms/redis/cluster_ports_rewrite.rs
+++ b/shotover/src/transforms/redis/cluster_ports_rewrite.rs
@@ -76,9 +76,9 @@ impl Transform for RedisClusterPortsRewrite {
         NAME
     }
 
-    async fn transform<'a>(
-        &'a mut self,
-        requests_wrapper: &'a mut Wrapper<'a>,
+    async fn transform<'shorter, 'longer: 'shorter>(
+        &mut self,
+        requests_wrapper: &'shorter mut Wrapper<'longer>,
     ) -> Result<Messages> {
         for message in requests_wrapper.requests.iter_mut() {
             let message_id = message.id();

--- a/shotover/src/transforms/redis/sink_cluster.rs
+++ b/shotover/src/transforms/redis/sink_cluster.rs
@@ -1017,9 +1017,9 @@ impl Transform for RedisSinkCluster {
         NAME
     }
 
-    async fn transform<'a>(
-        &'a mut self,
-        requests_wrapper: &'a mut Wrapper<'a>,
+    async fn transform<'shorter, 'longer: 'shorter>(
+        &mut self,
+        requests_wrapper: &'shorter mut Wrapper<'longer>,
     ) -> Result<Messages> {
         if !self.has_run_init {
             self.topology = (*self.shared_topology.read().await).clone();

--- a/shotover/src/transforms/redis/sink_single.rs
+++ b/shotover/src/transforms/redis/sink_single.rs
@@ -114,9 +114,9 @@ impl Transform for RedisSinkSingle {
         NAME
     }
 
-    async fn transform<'a>(
-        &'a mut self,
-        requests_wrapper: &'a mut Wrapper<'a>,
+    async fn transform<'shorter, 'longer: 'shorter>(
+        &mut self,
+        requests_wrapper: &'shorter mut Wrapper<'longer>,
     ) -> Result<Messages> {
         if self.connection.is_none() {
             let codec = RedisCodecBuilder::new(Direction::Sink, "RedisSinkSingle".to_owned());

--- a/shotover/src/transforms/tee.rs
+++ b/shotover/src/transforms/tee.rs
@@ -243,9 +243,9 @@ impl Transform for Tee {
         NAME
     }
 
-    async fn transform<'a>(
-        &'a mut self,
-        requests_wrapper: &'a mut Wrapper<'a>,
+    async fn transform<'shorter, 'longer: 'shorter>(
+        &mut self,
+        requests_wrapper: &'shorter mut Wrapper<'longer>,
     ) -> Result<Messages> {
         match &mut self.behavior {
             ConsistencyBehavior::Ignore => self.ignore_behaviour(requests_wrapper).await,
@@ -483,9 +483,9 @@ impl IncomingResponses {
 }
 
 impl Tee {
-    async fn ignore_behaviour<'a>(
-        &'a mut self,
-        requests_wrapper: &'a mut Wrapper<'a>,
+    async fn ignore_behaviour<'shorter, 'longer: 'shorter>(
+        &mut self,
+        requests_wrapper: &'shorter mut Wrapper<'longer>,
     ) -> Result<Messages> {
         let result_source: ResultSource = self.result_source.load(Ordering::Relaxed);
         match result_source {

--- a/shotover/src/transforms/throttling.rs
+++ b/shotover/src/transforms/throttling.rs
@@ -81,9 +81,9 @@ impl Transform for RequestThrottling {
         NAME
     }
 
-    async fn transform<'a>(
-        &'a mut self,
-        requests_wrapper: &'a mut Wrapper<'a>,
+    async fn transform<'shorter, 'longer: 'shorter>(
+        &mut self,
+        requests_wrapper: &'shorter mut Wrapper<'longer>,
     ) -> Result<Messages> {
         for request in &mut requests_wrapper.requests {
             if let Ok(cell_count) = request.cell_count() {


### PR DESCRIPTION
Fixes some issues with https://github.com/shotover/shotover-proxy/pull/1724/files

I found that trying to use Wrapper after it was borrowed by `Transform::transform` was impossible.
That is:
```rust
let mut wrapper = Wrapper::new();
// this line is fine by itself
transform.transform(&mut wrapper);
// but this line fails to compile due to the above line holding onto the reference forever.
println!("{:?}", wrapper.requests);
```

This is very strange since after `transform.transform(&mut wrapper)` the reference to the wrapper should be dropped and we should be able to use wrapper again.
However it turns out this is expected behavior.
I found this article helpful in explaining why exactly this was occurring.
https://tfpk.github.io/lifetimekata/chapter_4.html

The article suggests using different lifetimes but we also have situations where we need the lifetimes to be the same.
But I found a solution which I have implemented in this PR:

* We need to define that the lifetime of the contents of the wrapper outlives the lifetime wrapper itself.
   + To achieve this we introduce a 'shorter and 'longer lifetime in `Transform::transform` and some of the functions that call it.
       - The `'longer: 'shorter` syntax declares that `'longer` will live longer than `'shorter` (inclusive) 
* There is no need for self in `Transform::transform` to be assigned a lifetime
   + not strictly needed but makes sense.

Adding the `'longer` and `'shorter` lifetimes makes the function signature more confusing to read, but it actually relaxes the lifetime requirements instead of adding more.
Previously the two lifetimes had to be exactly the same.
Now they can be exactly the same or `'longer` can outlive `'shorter`.

I also updated the changelog since that was missed in #1724

## TL;DR
This PR should have no impact on functionality or performance but enables the way that we call `Transform::transform` to be more flexible, unblocking https://github.com/shotover/shotover-proxy/pull/1717