### PR TITLE
Fix CI by installing samply with --locked

### DIFF
--- a/shotover-proxy/benches/windsock/profilers/samply.rs
+++ b/shotover-proxy/benches/windsock/profilers/samply.rs
@@ -18,7 +18,8 @@ impl Samply {
                 "--git",
                 "https://github.com/mstange/samply",
                 "--rev",
-                "59a03a716cadab7835e3a961d0107ec797e458ec",
+                "75a8971b4291db8091a346431a1727ffcec4f038",
+                "--locked",
             ],
         )
         .await;


### PR DESCRIPTION
This PR fixes the currently broken CI.
e.g. https://github.com/shotover/shotover-proxy/pull/1723 -> https://github.com/shotover/shotover-proxy/actions/runs/10444413933/job/28918919779?pr=1723

Samply is an external tool used for profiling, our benchmarks automatically install the tool if its not already installed.
We started hitting compilation issues when building/installing samply due to a semver violation by one of it dependencies.
The addition of `--locked` fixes the compilation error by forcing it to use the versions specified in its Cargo.lock file.
I confirmed this  fixes the issue in this instance and should prevent future issues of this kind.
I also updated the installed commit to the latest commit of samply to `75a8971b4291db8091a346431a1727ffcec4f038`, in order to pull in any samply fixes since the previously pinned commit. May as well do this while touching this code.