### PR TITLE
Rename TransformContextConfig::protocol -> up_chain_protocol

### DIFF
--- a/shotover/benches/benches/chain.rs
+++ b/shotover/benches/benches/chain.rs
@@ -133,7 +133,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     }
                     .get_builder(TransformContextConfig {
                         chain_name: "".into(),
-                        protocol: MessageType::Redis,
+                        up_chain_protocol: MessageType::Redis,
                     }),
                 )
                 .unwrap(),
@@ -239,7 +239,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     }
                     .get_builder(TransformContextConfig {
                         chain_name: "".into(),
-                        protocol: MessageType::Redis,
+                        up_chain_protocol: MessageType::Redis,
                     }),
                 )
                 .unwrap(),

--- a/shotover/src/config/chain.rs
+++ b/shotover/src/config/chain.rs
@@ -21,7 +21,7 @@ impl TransformChainConfig {
         mut transform_context: TransformContextConfig,
     ) -> Result<TransformChainBuilder> {
         let mut transforms: Vec<Box<dyn TransformBuilder>> = Vec::new();
-        let mut upchain_protocol = transform_context.protocol;
+        let mut upchain_protocol = transform_context.up_chain_protocol;
         for (i, tc) in self.0.iter().enumerate() {
             let name = tc.typetag_name();
             match tc.up_chain_protocol() {
@@ -34,7 +34,7 @@ impl TransformChainConfig {
                     // anything is fine
                 }
             }
-            transform_context.protocol = upchain_protocol;
+            transform_context.up_chain_protocol = upchain_protocol;
             transforms.push(tc.get_builder(transform_context.clone()).await?);
 
             upchain_protocol = match tc.down_chain_protocol() {

--- a/shotover/src/server.rs
+++ b/shotover/src/server.rs
@@ -95,7 +95,7 @@ impl<C: CodecBuilder + 'static> TcpCodecListener<C> {
 
         let chain_usage_config = TransformContextConfig {
             chain_name: source_name.clone(),
-            protocol: codec.protocol(),
+            up_chain_protocol: codec.protocol(),
         };
         let chain_builder = chain_config
             .get_builder(chain_usage_config)

--- a/shotover/src/transforms/mod.rs
+++ b/shotover/src/transforms/mod.rs
@@ -140,9 +140,8 @@ pub enum DownChainProtocol {
 pub struct TransformContextConfig {
     /// The name of the chain that this transform is configured in.
     pub chain_name: String,
-    // TODO: rename to up_chain_protocol
     /// The protocol that the transform will receive requests in.
-    pub protocol: MessageType,
+    pub up_chain_protocol: MessageType,
 }
 
 /// The [`Wrapper`] struct is passed into each transform and contains a list of mutable references to the

--- a/shotover/src/transforms/parallel_map.rs
+++ b/shotover/src/transforms/parallel_map.rs
@@ -82,7 +82,7 @@ impl TransformConfig for ParallelMapConfig {
         for _ in 0..self.parallelism {
             let transform_context_config = TransformContextConfig {
                 chain_name: "parallel_map_chain".into(),
-                protocol: transform_context.protocol,
+                up_chain_protocol: transform_context.up_chain_protocol,
             };
             chains.push(self.chain.get_builder(transform_context_config).await?);
         }

--- a/shotover/src/transforms/redis/cache.rs
+++ b/shotover/src/transforms/redis/cache.rs
@@ -103,7 +103,7 @@ impl TransformConfig for RedisConfig {
 
         let transform_context_config = TransformContextConfig {
             chain_name: "cache_chain".into(),
-            protocol: MessageType::Redis,
+            up_chain_protocol: MessageType::Redis,
         };
 
         Ok(Box::new(SimpleRedisCacheBuilder {

--- a/shotover/src/transforms/tee.rs
+++ b/shotover/src/transforms/tee.rs
@@ -203,7 +203,7 @@ impl TransformConfig for TeeConfig {
                     mismatch_chain
                         .get_builder(TransformContextConfig {
                             chain_name: "mismatch_chain".to_string(),
-                            protocol: transform_context.protocol,
+                            up_chain_protocol: transform_context.up_chain_protocol,
                         })
                         .await?,
                 )
@@ -214,7 +214,7 @@ impl TransformConfig for TeeConfig {
             .chain
             .get_builder(TransformContextConfig {
                 chain_name: "tee_chain".to_string(),
-                protocol: transform_context.protocol,
+                up_chain_protocol: transform_context.up_chain_protocol,
             })
             .await?;
 
@@ -224,7 +224,7 @@ impl TransformConfig for TeeConfig {
             behavior,
             self.timeout_micros,
             self.switch_port,
-            transform_context.protocol.is_inorder(),
+            transform_context.up_chain_protocol.is_inorder(),
         )))
     }
 
@@ -606,7 +606,7 @@ mod tests {
 
         let transform_context_config = TransformContextConfig {
             chain_name: "".into(),
-            protocol: MessageType::Redis,
+            up_chain_protocol: MessageType::Redis,
         };
         let transform = config.get_builder(transform_context_config).await.unwrap();
         let result = transform.validate();
@@ -625,7 +625,7 @@ mod tests {
 
         let transform_context_config = TransformContextConfig {
             chain_name: "".into(),
-            protocol: MessageType::Redis,
+            up_chain_protocol: MessageType::Redis,
         };
         let transform = config.get_builder(transform_context_config).await.unwrap();
         let result = transform.validate().join("\n");
@@ -646,7 +646,7 @@ mod tests {
         };
         let transform_context_config = TransformContextConfig {
             chain_name: "".into(),
-            protocol: MessageType::Redis,
+            up_chain_protocol: MessageType::Redis,
         };
         let transform = config.get_builder(transform_context_config).await.unwrap();
         let result = transform.validate();
@@ -664,7 +664,7 @@ mod tests {
         };
         let transform_context_config = TransformContextConfig {
             chain_name: "".into(),
-            protocol: MessageType::Redis,
+            up_chain_protocol: MessageType::Redis,
         };
         let transform = config.get_builder(transform_context_config).await.unwrap();
         let result = transform.validate();
@@ -685,7 +685,7 @@ mod tests {
 
         let transform_context_config = TransformContextConfig {
             chain_name: "".into(),
-            protocol: MessageType::Redis,
+            up_chain_protocol: MessageType::Redis,
         };
         let transform = config.get_builder(transform_context_config).await.unwrap();
         let result = transform.validate().join("\n");
@@ -709,7 +709,7 @@ mod tests {
 
         let transform_context_config = TransformContextConfig {
             chain_name: "".into(),
-            protocol: MessageType::Redis,
+            up_chain_protocol: MessageType::Redis,
         };
         let transform = config.get_builder(transform_context_config).await.unwrap();
         let result = transform.validate();


### PR DESCRIPTION
This was left as a TODO to avoid breaking changes, since then we found the need for breaking changes anyway, so lets make the change now.