### PR TITLE
rename Wrapper -> ChainState

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,8 @@ This assists us in knowing when to make the next release a breaking release and 
 
 ### shotover rust API
 
-`Transform::transform` now takes `&mut Wrapper` instead of `Wrapper`.
+* `Transform::transform` now takes `&mut Wrapper` instead of `Wrapper`.
+* `Wrapper` is renamed to ChainState.
 
 ## 0.4.0
 

--- a/shotover/src/transforms/cassandra/sink_cluster/mod.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/mod.rs
@@ -6,8 +6,8 @@ use crate::frame::{CassandraFrame, CassandraOperation, CassandraResult, Frame, M
 use crate::message::{Message, MessageIdMap, Messages, Metadata};
 use crate::tls::{TlsConnector, TlsConnectorConfig};
 use crate::transforms::{
-    DownChainProtocol, Transform, TransformBuilder, TransformConfig, TransformContextBuilder,
-    TransformContextConfig, UpChainProtocol, Wrapper,
+    ChainState, DownChainProtocol, Transform, TransformBuilder, TransformConfig,
+    TransformContextBuilder, TransformContextConfig, UpChainProtocol,
 };
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
@@ -763,9 +763,9 @@ impl Transform for CassandraSinkCluster {
 
     async fn transform<'shorter, 'longer: 'shorter>(
         &mut self,
-        requests_wrapper: &'shorter mut Wrapper<'longer>,
+        chain_state: &'shorter mut ChainState<'longer>,
     ) -> Result<Messages> {
-        self.send_message(std::mem::take(&mut requests_wrapper.requests))
+        self.send_message(std::mem::take(&mut chain_state.requests))
             .await
     }
 }

--- a/shotover/src/transforms/cassandra/sink_single.rs
+++ b/shotover/src/transforms/cassandra/sink_single.rs
@@ -5,8 +5,8 @@ use crate::frame::MessageType;
 use crate::message::{Messages, Metadata};
 use crate::tls::{TlsConnector, TlsConnectorConfig};
 use crate::transforms::{
-    DownChainProtocol, Transform, TransformBuilder, TransformConfig, TransformContextBuilder,
-    TransformContextConfig, UpChainProtocol, Wrapper,
+    ChainState, DownChainProtocol, Transform, TransformBuilder, TransformConfig,
+    TransformContextBuilder, TransformContextConfig, UpChainProtocol,
 };
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -214,9 +214,9 @@ impl Transform for CassandraSinkSingle {
 
     async fn transform<'shorter, 'longer: 'shorter>(
         &mut self,
-        requests_wrapper: &'shorter mut Wrapper<'longer>,
+        chain_state: &'shorter mut ChainState<'longer>,
     ) -> Result<Messages> {
-        self.send_message(std::mem::take(&mut requests_wrapper.requests))
+        self.send_message(std::mem::take(&mut chain_state.requests))
             .await
     }
 }

--- a/shotover/src/transforms/debug/force_parse.rs
+++ b/shotover/src/transforms/debug/force_parse.rs
@@ -8,8 +8,8 @@ use crate::message::Messages;
 use crate::transforms::TransformConfig;
 use crate::transforms::TransformContextBuilder;
 use crate::transforms::TransformContextConfig;
+use crate::transforms::{ChainState, Transform, TransformBuilder};
 use crate::transforms::{DownChainProtocol, UpChainProtocol};
-use crate::transforms::{Transform, TransformBuilder, Wrapper};
 use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -107,9 +107,9 @@ impl Transform for DebugForceParse {
 
     async fn transform<'shorter, 'longer: 'shorter>(
         &mut self,
-        requests_wrapper: &'shorter mut Wrapper<'longer>,
+        chain_state: &'shorter mut ChainState<'longer>,
     ) -> Result<Messages> {
-        for message in &mut requests_wrapper.requests {
+        for message in &mut chain_state.requests {
             if self.parse_requests {
                 message.frame();
             }
@@ -118,7 +118,7 @@ impl Transform for DebugForceParse {
             }
         }
 
-        let mut response = requests_wrapper.call_next_transform().await;
+        let mut response = chain_state.call_next_transform().await;
 
         if let Ok(response) = response.as_mut() {
             for message in response {

--- a/shotover/src/transforms/debug/log_to_file.rs
+++ b/shotover/src/transforms/debug/log_to_file.rs
@@ -1,7 +1,7 @@
 use crate::message::{Encodable, Message};
+use crate::transforms::{ChainState, Transform, TransformBuilder, TransformContextBuilder};
 #[cfg(feature = "alpha-transforms")]
 use crate::transforms::{DownChainProtocol, UpChainProtocol};
-use crate::transforms::{Transform, TransformBuilder, TransformContextBuilder, Wrapper};
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -91,9 +91,9 @@ impl Transform for DebugLogToFile {
 
     async fn transform<'shorter, 'longer: 'shorter>(
         &mut self,
-        requests_wrapper: &'shorter mut Wrapper<'longer>,
+        chain_state: &'shorter mut ChainState<'longer>,
     ) -> Result<Vec<Message>> {
-        for message in &requests_wrapper.requests {
+        for message in &chain_state.requests {
             self.request_counter += 1;
             let path = self
                 .requests
@@ -101,7 +101,7 @@ impl Transform for DebugLogToFile {
             log_message(message, path.as_path()).await?;
         }
 
-        let response = requests_wrapper.call_next_transform().await?;
+        let response = chain_state.call_next_transform().await?;
 
         for message in &response {
             self.response_counter += 1;

--- a/shotover/src/transforms/debug/printer.rs
+++ b/shotover/src/transforms/debug/printer.rs
@@ -1,7 +1,7 @@
 use crate::message::Messages;
 use crate::transforms::{
-    DownChainProtocol, Transform, TransformBuilder, TransformConfig, TransformContextBuilder,
-    TransformContextConfig, UpChainProtocol, Wrapper,
+    ChainState, DownChainProtocol, Transform, TransformBuilder, TransformConfig,
+    TransformContextBuilder, TransformContextConfig, UpChainProtocol,
 };
 use anyhow::Result;
 use async_trait::async_trait;
@@ -67,14 +67,14 @@ impl Transform for DebugPrinter {
 
     async fn transform<'shorter, 'longer: 'shorter>(
         &mut self,
-        requests_wrapper: &'shorter mut Wrapper<'longer>,
+        chain_state: &'shorter mut ChainState<'longer>,
     ) -> Result<Messages> {
-        for request in &mut requests_wrapper.requests {
+        for request in &mut chain_state.requests {
             info!("Request: {}", request.to_high_level_string());
         }
 
         self.counter += 1;
-        let mut responses = requests_wrapper.call_next_transform().await?;
+        let mut responses = chain_state.call_next_transform().await?;
 
         for response in &mut responses {
             info!("Response: {}", response.to_high_level_string());

--- a/shotover/src/transforms/debug/returner.rs
+++ b/shotover/src/transforms/debug/returner.rs
@@ -1,7 +1,7 @@
 use crate::message::{Message, Messages};
 use crate::transforms::{
-    DownChainProtocol, Transform, TransformBuilder, TransformConfig, TransformContextBuilder,
-    TransformContextConfig, UpChainProtocol, Wrapper,
+    ChainState, DownChainProtocol, Transform, TransformBuilder, TransformConfig,
+    TransformContextBuilder, TransformContextConfig, UpChainProtocol,
 };
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -77,9 +77,9 @@ impl Transform for DebugReturner {
 
     async fn transform<'shorter, 'longer: 'shorter>(
         &mut self,
-        requests_wrapper: &'shorter mut Wrapper<'longer>,
+        chain_state: &'shorter mut ChainState<'longer>,
     ) -> Result<Messages> {
-        requests_wrapper
+        chain_state
             .requests
             .iter_mut()
             .map(|request| match &self.response {

--- a/shotover/src/transforms/load_balance.rs
+++ b/shotover/src/transforms/load_balance.rs
@@ -2,7 +2,7 @@ use super::{DownChainProtocol, TransformContextBuilder, TransformContextConfig, 
 use crate::config::chain::TransformChainConfig;
 use crate::message::Messages;
 use crate::transforms::chain::{BufferedChain, TransformChainBuilder};
-use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
+use crate::transforms::{ChainState, Transform, TransformBuilder, TransformConfig};
 use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -87,7 +87,7 @@ impl Transform for ConnectionBalanceAndPool {
 
     async fn transform<'shorter, 'longer: 'shorter>(
         &mut self,
-        requests_wrapper: &'shorter mut Wrapper<'longer>,
+        chain_state: &'shorter mut ChainState<'longer>,
     ) -> Result<Messages> {
         if self.active_connection.is_none() {
             let mut all_connections = self.all_connections.lock().await;
@@ -108,7 +108,7 @@ impl Transform for ConnectionBalanceAndPool {
         self.active_connection
             .as_mut()
             .unwrap()
-            .process_request(requests_wrapper.take(), None)
+            .process_request(chain_state.take(), None)
             .await
     }
 }

--- a/shotover/src/transforms/loopback.rs
+++ b/shotover/src/transforms/loopback.rs
@@ -1,6 +1,6 @@
 use super::TransformContextBuilder;
 use crate::message::Messages;
-use crate::transforms::{Transform, TransformBuilder, Wrapper};
+use crate::transforms::{ChainState, Transform, TransformBuilder};
 use anyhow::Result;
 use async_trait::async_trait;
 
@@ -31,13 +31,13 @@ impl Transform for Loopback {
 
     async fn transform<'shorter, 'longer: 'shorter>(
         &mut self,
-        requests_wrapper: &'shorter mut Wrapper<'longer>,
+        chain_state: &'shorter mut ChainState<'longer>,
     ) -> Result<Messages> {
         // This transform ultimately doesnt make a lot of sense semantically
         // but make a vague attempt to follow transform invariants anyway.
-        for request in &mut requests_wrapper.requests {
+        for request in &mut chain_state.requests {
             request.set_request_id(request.id());
         }
-        Ok(std::mem::take(&mut requests_wrapper.requests))
+        Ok(std::mem::take(&mut chain_state.requests))
     }
 }

--- a/shotover/src/transforms/mod.rs
+++ b/shotover/src/transforms/mod.rs
@@ -148,7 +148,7 @@ pub struct TransformContextConfig {
 /// The [`Wrapper`] struct is passed into each transform and contains a list of mutable references to the
 /// remaining transforms that will process the messages attached to this [`Wrapper`].
 /// Most [`Transform`] authors will only be interested in [`wrapper.requests`].
-pub struct Wrapper<'a> {
+pub struct ChainState<'a> {
     /// Requests received from the client
     pub requests: Messages,
     transforms: IterMut<'a, TransformAndMetrics>,
@@ -168,9 +168,9 @@ pub struct Wrapper<'a> {
 /// [`Wrapper`] will not (cannot) bring the current list of transforms that it needs to traverse with it
 /// This is purely to make it convenient to clone all the data within Wrapper rather than it's transform
 /// state.
-impl<'a> Clone for Wrapper<'a> {
+impl<'a> Clone for ChainState<'a> {
     fn clone(&self) -> Self {
-        Wrapper {
+        ChainState {
             requests: self.requests.clone(),
             transforms: [].iter_mut(),
             local_addr: self.local_addr,
@@ -180,9 +180,9 @@ impl<'a> Clone for Wrapper<'a> {
     }
 }
 
-impl<'shorter, 'longer: 'shorter> Wrapper<'longer> {
+impl<'shorter, 'longer: 'shorter> ChainState<'longer> {
     fn take(&mut self) -> Self {
-        Wrapper {
+        ChainState {
             requests: std::mem::take(&mut self.requests),
             transforms: std::mem::take(&mut self.transforms),
             local_addr: self.local_addr,
@@ -234,7 +234,7 @@ impl<'shorter, 'longer: 'shorter> Wrapper<'longer> {
 
     #[cfg(test)]
     pub fn new_test(requests: Messages) -> Self {
-        Wrapper {
+        ChainState {
             requests,
             transforms: [].iter_mut(),
             local_addr: "127.0.0.1:8000".parse().unwrap(),
@@ -244,7 +244,7 @@ impl<'shorter, 'longer: 'shorter> Wrapper<'longer> {
     }
 
     pub fn new_with_addr(requests: Messages, local_addr: SocketAddr) -> Self {
-        Wrapper {
+        ChainState {
             requests,
             transforms: [].iter_mut(),
             local_addr,
@@ -254,7 +254,7 @@ impl<'shorter, 'longer: 'shorter> Wrapper<'longer> {
     }
 
     pub fn flush() -> Self {
-        Wrapper {
+        ChainState {
             requests: vec![],
             transforms: [].iter_mut(),
             // The connection is closed so we need to just fake an address here
@@ -299,9 +299,9 @@ impl<'shorter, 'longer: 'shorter> Wrapper<'longer> {
 #[async_trait]
 pub trait Transform: Send {
     /// In order to implement your transform you can modify the messages:
-    /// * contained in requests_wrapper.requests
+    /// * contained in chain_state.requests
     ///     + these are the requests that will flow into the next transform in the chain.
-    /// * contained in the return value of `requests_wrapper.call_next_transform()`
+    /// * contained in the return value of `chain_state.call_next_transform()`
     ///     + These are the responses that will flow back to the previous transform in the chain.
     ///
     /// But while doing so, also make sure to follow the below invariants when modifying the messages.
@@ -310,12 +310,12 @@ pub trait Transform: Send {
     ///
     /// * Non-terminating specific invariants
     ///     + If your transform does not send the message to an external system or generate its own response to the query,
-    /// it will need to call and return the response from `requests_wrapper.call_next_transform()`.
+    /// it will need to call and return the response from `chain_state.call_next_transform()`.
     ///     + This ensures that your transform will call any subsequent downstream transforms without needing to know about what they
     /// do. This type of transform is called a non-terminating transform.
     ///
     /// * Terminating specific invariants
-    ///     + Your transform can also choose not to call `requests_wrapper.call_next_transform()` if it sends the
+    ///     + Your transform can also choose not to call `chain_state.call_next_transform()` if it sends the
     /// messages to an external system or generates its own response to the query e.g. `CassandraSinkSingle`.
     ///     + This type of transform is called a Terminating transform (as no subsequent transforms in the chain will be called).
     ///
@@ -327,7 +327,7 @@ pub trait Transform: Send {
     ///         - If a transform deletes a request it must return a simulated response message with its request_id set to the deleted request.
     ///             * For in order protocols: this simulated message must be in the correct location within the list of responses
     ///                 - The best way to achieve this is storing the [`crate::message::MessageId`] of the message before the deleted message.
-    ///         - If a transform introduces a new request into the requests_wrapper the response must be located and
+    ///         - If a transform introduces a new request into the chain_state the response must be located and
     ///           removed from the list of returned responses.
     ///     + For in order protocols, transforms must ensure that responses are kept in the same order in which they are received.
     ///         - When writing protocol generic transforms: always ensure this is upheld.
@@ -342,13 +342,13 @@ pub trait Transform: Send {
     /// # Naming
     /// Transform also have different naming conventions.
     /// * Transform that interact with an external system are called Sinks.
-    /// * Transform that don't call subsequent chains via `requests_wrapper.call_next_transform()` are called terminating transforms.
-    /// * Transform that do call subsquent chains via `requests_wrapper.call_next_transform()` are non-terminating transforms.
+    /// * Transform that don't call subsequent chains via `chain_state.call_next_transform()` are called terminating transforms.
+    /// * Transform that do call subsquent chains via `chain_state.call_next_transform()` are non-terminating transforms.
     ///
     /// You can have have a transform that is both non-terminating and a sink.
     async fn transform<'shorter, 'longer: 'shorter>(
         &mut self,
-        requests_wrapper: &'shorter mut Wrapper<'longer>,
+        chain_state: &'shorter mut ChainState<'longer>,
     ) -> Result<Messages>;
 
     /// Name of the transform used in logs and displayed to the user

--- a/shotover/src/transforms/null.rs
+++ b/shotover/src/transforms/null.rs
@@ -1,6 +1,6 @@
 use super::{DownChainProtocol, TransformContextBuilder, TransformContextConfig, UpChainProtocol};
 use crate::message::Messages;
-use crate::transforms::{Transform, TransformBuilder, TransformConfig, Wrapper};
+use crate::transforms::{ChainState, Transform, TransformBuilder, TransformConfig};
 use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -54,13 +54,13 @@ impl Transform for NullSink {
 
     async fn transform<'shorter, 'longer: 'shorter>(
         &mut self,
-        requests_wrapper: &'shorter mut Wrapper<'longer>,
+        chain_state: &'shorter mut ChainState<'longer>,
     ) -> Result<Messages> {
-        for request in &mut requests_wrapper.requests {
+        for request in &mut chain_state.requests {
             // reuse the requests to hold the responses to avoid an allocation
             *request = request
                 .from_request_to_error_response("Handled by shotover null transform".to_string())?;
         }
-        Ok(std::mem::take(&mut requests_wrapper.requests))
+        Ok(std::mem::take(&mut chain_state.requests))
     }
 }

--- a/shotover/src/transforms/query_counter.rs
+++ b/shotover/src/transforms/query_counter.rs
@@ -2,7 +2,7 @@ use crate::frame::Frame;
 use crate::message::Messages;
 use crate::transforms::TransformConfig;
 use crate::transforms::TransformContextBuilder;
-use crate::transforms::{Transform, TransformBuilder, Wrapper};
+use crate::transforms::{ChainState, Transform, TransformBuilder};
 use anyhow::Result;
 use async_trait::async_trait;
 use metrics::counter;
@@ -66,9 +66,9 @@ impl Transform for QueryCounter {
 
     async fn transform<'shorter, 'longer: 'shorter>(
         &mut self,
-        requests_wrapper: &'shorter mut Wrapper<'longer>,
+        chain_state: &'shorter mut ChainState<'longer>,
     ) -> Result<Messages> {
-        for m in &mut requests_wrapper.requests {
+        for m in &mut chain_state.requests {
             match m.frame() {
                 #[cfg(feature = "cassandra")]
                 Some(Frame::Cassandra(frame)) => {
@@ -101,7 +101,7 @@ impl Transform for QueryCounter {
             }
         }
 
-        requests_wrapper.call_next_transform().await
+        chain_state.call_next_transform().await
     }
 }
 


### PR DESCRIPTION
The name `Wrapper` can be traced back to the beginning of time.
Its not a very useful name and doesnt really mean anything at all.
Lets rename it to `ChainState` since it holds various state about the chain that the transform is in.