### PR TITLE
Test kafka with replication_factor 3

### DIFF
--- a/shotover-proxy/tests/kafka_int_tests/mod.rs
+++ b/shotover-proxy/tests/kafka_int_tests/mod.rs
@@ -115,7 +115,7 @@ async fn cluster_tls(#[case] driver: KafkaDriver) {
 
     let connection_builder = KafkaConnectionBuilder::new(driver, "127.0.0.1:9192")
         .use_tls("tests/test-configs/kafka/tls/certs");
-    test_cases::standard_test_suite(&connection_builder).await;
+    test_cases::cluster_test_suite(&connection_builder).await;
 
     tokio::time::timeout(
         Duration::from_secs(10),
@@ -139,7 +139,7 @@ async fn cluster_mtls(#[case] driver: KafkaDriver) {
 
     let connection_builder = KafkaConnectionBuilder::new(driver, "127.0.0.1:9192")
         .use_tls("tests/test-configs/kafka/tls/certs");
-    test_cases::standard_test_suite(&connection_builder).await;
+    test_cases::cluster_test_suite(&connection_builder).await;
 
     tokio::time::timeout(
         Duration::from_secs(10),
@@ -254,7 +254,7 @@ async fn cluster_1_rack_single_shotover(#[case] driver: KafkaDriver) {
         .await;
 
     let connection_builder = KafkaConnectionBuilder::new(driver, "127.0.0.1:9192");
-    test_cases::standard_test_suite(&connection_builder).await;
+    test_cases::cluster_test_suite(&connection_builder).await;
 
     tokio::time::timeout(
         Duration::from_secs(10),
@@ -287,7 +287,7 @@ async fn cluster_1_rack_multi_shotover(#[case] driver: KafkaDriver) {
     }
 
     let connection_builder = KafkaConnectionBuilder::new(driver, "127.0.0.1:9192");
-    test_cases::standard_test_suite(&connection_builder).await;
+    test_cases::cluster_test_suite(&connection_builder).await;
 
     for shotover in shotovers {
         tokio::time::timeout(
@@ -324,7 +324,7 @@ async fn cluster_2_racks_multi_shotover(#[case] driver: KafkaDriver) {
     }
 
     let connection_builder = KafkaConnectionBuilder::new(driver, "127.0.0.1:9192");
-    test_cases::standard_test_suite(&connection_builder).await;
+    test_cases::cluster_test_suite(&connection_builder).await;
 
     for shotover in shotovers {
         tokio::time::timeout(
@@ -394,7 +394,7 @@ async fn cluster_sasl_scram_over_mtls_single_shotover(#[case] driver: KafkaDrive
         let connection_super = KafkaConnectionBuilder::new(driver, "127.0.0.1:9192")
             .use_sasl_scram("super_user", "super_password");
         setup_basic_user_acls(&connection_super, "basic_user").await;
-        test_cases::standard_test_suite(&connection_super).await;
+        test_cases::cluster_test_suite(&connection_super).await;
         assert_connection_fails_with_incorrect_password(driver, "super_user").await;
 
         // admin requests sent by basic user are unsuccessful
@@ -505,7 +505,7 @@ async fn cluster_sasl_scram_over_mtls_multi_shotover(#[case] driver: KafkaDriver
     let instant = Instant::now();
     let connection_builder = KafkaConnectionBuilder::new(driver, "127.0.0.1:9192")
         .use_sasl_scram("super_user", "super_password");
-    test_cases::standard_test_suite(&connection_builder).await;
+    test_cases::cluster_test_suite(&connection_builder).await;
 
     // Wait 20s since we started the initial run to ensure that we hit the 15s token lifetime limit
     tokio::time::sleep_until((instant + Duration::from_secs(20)).into()).await;
@@ -549,7 +549,7 @@ async fn cluster_sasl_plain_multi_shotover(#[case] driver: KafkaDriver) {
 
     let connection_builder =
         KafkaConnectionBuilder::new(driver, "127.0.0.1:9192").use_sasl_plain("user", "password");
-    test_cases::standard_test_suite(&connection_builder).await;
+    test_cases::cluster_test_suite(&connection_builder).await;
 
     // Test invalid credentials
     // We perform the regular test suite first in an attempt to catch a scenario

--- a/test-helpers/src/connection/kafka/cpp.rs
+++ b/test-helpers/src/connection/kafka/cpp.rs
@@ -50,13 +50,13 @@ impl KafkaConnectionBuilderCpp {
         self
     }
 
-    pub async fn connect_producer(&self, acks: i32) -> KafkaProducerCpp {
+    pub async fn connect_producer(&self, acks: &str) -> KafkaProducerCpp {
         KafkaProducerCpp {
             producer: self
                 .client
                 .clone()
                 .set("message.timeout.ms", "5000")
-                .set("acks", acks.to_string())
+                .set("acks", acks)
                 .create()
                 .unwrap(),
         }

--- a/test-helpers/src/connection/kafka/java.rs
+++ b/test-helpers/src/connection/kafka/java.rs
@@ -79,7 +79,7 @@ impl KafkaConnectionBuilderJava {
         self
     }
 
-    pub async fn connect_producer(&self, acks: i32) -> KafkaProducerJava {
+    pub async fn connect_producer(&self, acks: &str) -> KafkaProducerJava {
         let mut config = self.base_config.clone();
         config.insert("acks".to_owned(), acks.to_string());
         config.insert(

--- a/test-helpers/src/connection/kafka/mod.rs
+++ b/test-helpers/src/connection/kafka/mod.rs
@@ -57,7 +57,7 @@ impl KafkaConnectionBuilder {
         }
     }
 
-    pub async fn connect_producer(&self, acks: i32) -> KafkaProducer {
+    pub async fn connect_producer(&self, acks: &str) -> KafkaProducer {
         match self {
             #[cfg(feature = "kafka-cpp-driver-tests")]
             Self::Cpp(cpp) => KafkaProducer::Cpp(cpp.connect_producer(acks).await),


### PR DESCRIPTION
This was a missing test case that upon implementation revealed a bug in shotover.
Since we cannot create a topic with replication_factor 3 on a kafka cluster with only 1 node, `cluster_test_suite` is introduced for the cluster tests to use without regressing the single/passthrough tests.

To get the tests to pass we required:
* one change to the test logic - we need to set produce [acks](https://docs.confluent.io/platform/current/installation/configuration/producer-configs.html#acks) to "all"
  + It kind of makes sense in that, adding replicas means that there is now a difference in behavior between `acks=1` and `acks=all`, acks=1 will not wait for the replicas to acknowledge the produced record.
  + On the other hand I'm not entirely sure why we need it since an ack from the leader should be sufficient as the consumer and producer only routes to the leader.
* one change to shotover routing logic - we need to route fetch requests to the leader instead of the replicas.
  + The comment I added to the code justifies the change pretty well. But basically implementing shotover to route fetch requests to the replicas was a mistake that sounded correct at the time. kafka does not allow routing to replicas in the same way that cassandra and redis do. In kafka, replicas are purely for "high availability" with some extra request handling tacked on.
