### PR TITLE
KafkaSinkCluster: handle broker closing connection due to idle timeout

### DIFF
--- a/shotover-proxy/tests/test-configs/kafka/cluster-1-rack/docker-compose-short-idle-timeout.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-1-rack/docker-compose-short-idle-timeout.yaml
@@ -1,0 +1,56 @@
+networks:
+  cluster_subnet:
+    name: cluster_subnet
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.16.1.0/24
+          gateway: 172.16.1.1
+services:
+  kafka0:
+    image: &image 'bitnami/kafka:3.6.1-debian-11-r24'
+    networks:
+      cluster_subnet:
+        ipv4_address: 172.16.1.2
+    environment: &environment
+      KAFKA_CFG_LISTENERS: "BROKER://:9092,CONTROLLER://:9093"
+      KAFKA_CFG_ADVERTISED_LISTENERS: "BROKER://172.16.1.2:9092"
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: "CONTROLLER:PLAINTEXT,BROKER:PLAINTEXT"
+      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: "BROKER"
+      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: "CONTROLLER"
+      KAFKA_CFG_PROCESS_ROLES: "controller,broker"
+      KAFKA_KRAFT_CLUSTER_ID: "abcdefghijklmnopqrstuv"
+      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: "0@kafka0:9093,1@kafka1:9093,2@kafka2:9093,3@kafka3:9093"
+      KAFKA_CFG_NODE_ID: 0
+      ALLOW_PLAINTEXT_LISTENER: "yes"
+      # Required for high availability
+      KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
+      KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 3
+      KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR: 2
+
+      # connections.max.idle.ms is set to 20s for testing shotovers handling of idle connection timeouts
+      KAFKA_CFG_CONNECTIONS_MAX_IDLE_MS: 20000
+    volumes: &volumes
+      - type: tmpfs
+        target: /bitnami/kafka
+  kafka1:
+    image: *image
+    networks:
+      cluster_subnet:
+        ipv4_address: 172.16.1.3
+    environment:
+      <<: *environment
+      KAFKA_CFG_ADVERTISED_LISTENERS: "BROKER://172.16.1.3:9092"
+      KAFKA_CFG_NODE_ID: 1
+    volumes: *volumes
+  kafka2:
+    image: *image
+    networks:
+      cluster_subnet:
+        ipv4_address: 172.16.1.4
+    environment:
+      <<: *environment
+      KAFKA_CFG_ADVERTISED_LISTENERS: "BROKER://172.16.1.4:9092"
+      KAFKA_CFG_NODE_ID: 2
+    volumes: *volumes

--- a/shotover/src/connection.rs
+++ b/shotover/src/connection.rs
@@ -96,15 +96,27 @@ impl SinkConnection {
         self.error.clone().unwrap()
     }
 
+    pub fn get_error(&mut self) -> Option<ConnectionError> {
+        if self.error.is_none() {
+            self.error = self.connection_closed_rx.try_recv().ok();
+        }
+        self.error.clone()
+    }
+
     /// Send messages.
     /// If there is a problem with the connection an error is returned.
-    pub fn send(&mut self, mut messages: Vec<Message>) -> Result<(), ConnectionError> {
+    pub fn send(&mut self, mut messages: Vec<Message>) -> Result<(), SendError> {
         self.dummy_response_inserter.process_requests(&mut messages);
 
         if let Some(error) = &self.error {
-            Err(error.clone())
+            Err(SendError::RequestsUnsent(error.clone(), messages))
+        } else if let Ok(error) = self.connection_closed_rx.try_recv() {
+            self.error = Some(error.clone());
+            Err(SendError::RequestsUnsent(error, messages))
         } else {
-            self.out_tx.send(messages).map_err(|_| self.set_get_error())
+            self.out_tx
+                .send(messages)
+                .map_err(|_| SendError::RequestPossiblySent(self.set_get_error()))
         }
     }
 
@@ -198,6 +210,20 @@ impl SinkConnection {
             Ok(())
         }
     }
+}
+
+/// This represents an error to the connection encountered while sending requests.
+/// The connection is no longer usable after this error is received.
+#[derive(thiserror::Error, Debug, Clone)]
+pub enum SendError {
+    /// The error was detected before the requests were sent
+    /// The request was not received and it can be resent on a new connection if allowed by the protocol.
+    #[error("An error was detected before the requests were sent: {0}")]
+    RequestsUnsent(ConnectionError, Vec<Message>),
+    /// The error was detected after the requests were sent.
+    /// It is unknown if the request was received or not.
+    #[error("An error was detected after the requests were sent: {0}")]
+    RequestPossiblySent(ConnectionError),
 }
 
 /// This represents an unrecoverable error to the connection.

--- a/shotover/src/transforms/kafka/sink_cluster/scram_over_mtls/connection.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/scram_over_mtls/connection.rs
@@ -1,5 +1,5 @@
 use crate::{
-    connection::{ConnectionError, SendError, SinkConnection},
+    connection::{ConnectionError, SinkConnection},
     message::Message,
     transforms::kafka::sink_cluster::connections::ConnectionState,
 };
@@ -64,7 +64,7 @@ impl ScramOverMtlsConnection {
 
     /// Send messages.
     /// If there is a problem with the connection an error is returned.
-    pub fn send(&mut self, messages: Vec<Message>) -> Result<(), SendError> {
+    pub fn send(&mut self, messages: Vec<Message>) -> Result<(), ConnectionError> {
         self.connection.send(messages)
     }
 

--- a/shotover/src/transforms/kafka/sink_cluster/scram_over_mtls/connection.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/scram_over_mtls/connection.rs
@@ -1,5 +1,5 @@
 use crate::{
-    connection::{ConnectionError, SinkConnection},
+    connection::{ConnectionError, SendError, SinkConnection},
     message::Message,
     transforms::kafka::sink_cluster::connections::ConnectionState,
 };
@@ -64,7 +64,7 @@ impl ScramOverMtlsConnection {
 
     /// Send messages.
     /// If there is a problem with the connection an error is returned.
-    pub fn send(&mut self, messages: Vec<Message>) -> Result<(), ConnectionError> {
+    pub fn send(&mut self, messages: Vec<Message>) -> Result<(), SendError> {
         self.connection.send(messages)
     }
 
@@ -84,6 +84,10 @@ impl ScramOverMtlsConnection {
         } else {
             self.connection.recv().await
         }
+    }
+
+    pub fn get_error(&mut self) -> Option<ConnectionError> {
+        self.connection.get_error()
     }
 
     pub fn pending_requests_count(&self) -> usize {

--- a/test-helpers/src/connection/kafka/mod.rs
+++ b/test-helpers/src/connection/kafka/mod.rs
@@ -162,10 +162,13 @@ impl KafkaConsumer {
             expected_response.key, response.key,
             "Unexpected key for topic {topic}"
         );
-        assert_eq!(
-            expected_response.offset, response.offset,
-            "Unexpected offset for topic {topic}"
-        );
+
+        if expected_response.offset.is_some() {
+            assert_eq!(
+                expected_response.offset, response.offset,
+                "Unexpected offset for topic {topic}"
+            );
+        }
     }
 
     pub async fn assert_consume_in_any_order(&mut self, expected_responses: Vec<ExpectedResponse>) {


### PR DESCRIPTION
Kafka brokers have a config field `connections.max.idle.ms`, when a connection has been idle for longer than this timeout.
Normally a client can expect idle connections to timeout after some time of being unused.
However when KafkaSinkCluster is sitting in between the client and the broker there can be some unexpected behaviour.

For example:
1. We have a kafka cluster configured with `connections.max.idle.ms=5s`.
2. A client sends a request every 1s.
3. Shotover routes the first request to node A
4. Shotover routes the next 10 requests to node B
5. Shotover routes another request to node A
    + this request will fail due to the connection hitting idle time out even though the client was sending one request per second, well within the timeout!

With more reasonable timeout values this issue is harder to hit, but we are still still hitting this in our preprod environment with the default idle timeout of 10 minutes.

## Integration test

This PR introduces an integration test that runs kafka with a very low connections.max.idle.ms (30s), this reproduces the issue described above.
The new integration test fails when running the shotover main branch.

## Fix implementation

This PR then fixes the failing test by adding a check into our connection getting logic to recreate the connection if it has hit an error.
This does not attempt to fix all possible failures due to closed connection, as that would be impossible due to race conditions.
Instead we make a best effort handling which will catch the regular failures we are seeing.