### PR TITLE
windsock: measure consume latency

### DIFF
--- a/.github/workflows/windsock_benches.yaml
+++ b/.github/workflows/windsock_benches.yaml
@@ -39,7 +39,7 @@ jobs:
         # run some extra cases that arent handled by nextest
         cargo windsock local-run --bench-length-seconds 5 --operations-per-second 100 --profilers flamegraph db=cassandra,compression=none,connection_count=1,driver=scylla,operation=read_i64,protocol=v4,shotover=standard,topology=single
         cargo windsock local-run --bench-length-seconds 5 --operations-per-second 100 --profilers samply db=cassandra,compression=none,connection_count=1,driver=scylla,operation=read_i64,protocol=v4,shotover=standard,topology=single
-        cargo windsock local-run --bench-length-seconds 5 --operations-per-second 100 --profilers sys_monitor db=kafka,shotover=standard,size=1B,topology=single
+        cargo windsock local-run --bench-length-seconds 5 --operations-per-second 100 --profilers sys_monitor db=kafka,shotover=standard,size=12B,topology=single
         cargo windsock local-run --bench-length-seconds 5 --operations-per-second 100 --profilers shotover_metrics db=redis,encryption=none,operation=get,shotover=standard,topology=single
     - name: Ensure that tests did not create or modify any files that arent .gitignore'd
       run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5934,9 +5934,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windsock"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4fe4435a550d5c9d0361a420bd02d3fd77c7cb15d22743e7857597a5fdb8388"
+checksum = "8f186f03f8f547e6eb32a314c55e52754e3315eb299c9d27e4d1758eb1e254f8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -46,7 +46,7 @@ tokio-bin-process.workspace = true
 rustls-pemfile = "2.0.0"
 rustls-pki-types = "1.1.0"
 aws-throwaway.workspace = true
-windsock = "0.1.0"
+windsock = "0.2.0"
 regex = "1.7.0"
 opensearch = { version = "2.1.0", default-features = false, features = ["rustls-tls"] }
 serde_json = "1.0.103"

--- a/shotover-proxy/benches/windsock/kafka/mod.rs
+++ b/shotover-proxy/benches/windsock/kafka/mod.rs
@@ -16,7 +16,7 @@ pub fn benches() -> Vec<ShotoverBench> {
             KafkaTopology::Cluster1,
             KafkaTopology::Cluster3
         ],
-        [Size::B1, Size::KB1, Size::KB100]
+        [Size::B12, Size::KB1, Size::KB100]
     )
     .map(|(shotover, topology, size)| {
         Box::new(KafkaBench::new(shotover, topology, size)) as ShotoverBench


### PR DESCRIPTION
Updates to latest windsock, making use of the new consumer latency functionality.
To calculate the consumer latency we:
* serialize the current `SystemTime` in the first 12 bytes of the produced record payload
* take those bytes from the consumed record payload and turn them back into a `SystemTime` then call `.elapsed()` to determine the amount of time passed.

This matches the behaviour of rdkafka_performance: https://github.com/confluentinc/librdkafka/blob/master/examples/rdkafka_performance.c

I did not use a serialization library for this as I need to ensure they fit exactly into 12 bytes so we know what our minimum size of payload needs to be.

As a result of the new minimum of 12 bytes, the existing 1B bench case was turned into a 12B bench case.