### PR TITLE
Add connections_opened metric

### DIFF
--- a/docs/src/user-guide/observability.md
+++ b/docs/src/user-guide/observability.md
@@ -11,7 +11,8 @@ This optional interface will serve Prometheus metrics from `/metrics`. It will b
 | `shotover_chain_failures_count`            | `chain`     | [counter](#counter)     | Counts the amount of times `chain` fails                                  |
 | `shotover_chain_latency_seconds`           | `chain`     | [histogram](#histogram) | The latency for running `chain`                                           |
 | `shotover_chain_messages_per_batch_count`  | `chain`     | [histogram](#histogram) | The number of messages in each batch passing through `chain`.             |
-| `shotover_available_connections_count`     | `source`    | [gauge](#gauge)         | The number of connections currently connected to `source`                 |
+| `shotover_available_connections_count`     | `source`    | [gauge](#gauge)         | How many more connections can be opened to `source` before new connections will be rejected. |
+| `connections_opened`                       | `source`    | [counter](#counter)     | Counts the total number of connections that clients have opened against this source.         |
 | `shotover_source_to_sink_latency_seconds`  | `sink`      | [histogram](#histogram) | The milliseconds between reading a request from a source TCP connection and writing it to a sink TCP connection  |
 | `shotover_sink_to_source_latency_seconds`  | `source`    | [histogram](#histogram) | The milliseconds between reading a response from a sink TCP connection and writing it to a source TCP connection |
 

--- a/shotover-proxy/tests/runner/observability_int_tests.rs
+++ b/shotover-proxy/tests/runner/observability_int_tests.rs
@@ -11,6 +11,7 @@ async fn test_metrics() {
 
     // Expected string looks unnatural because it is sorted in alphabetical order to make it match the sorted error output
     let expected = r#"
+# TYPE connections_opened counter
 # TYPE shotover_available_connections_count gauge
 # TYPE shotover_chain_failures_count counter
 # TYPE shotover_chain_messages_per_batch_count summary
@@ -20,6 +21,7 @@ async fn test_metrics() {
 # TYPE shotover_transform_failures_count counter
 # TYPE shotover_transform_latency_seconds summary
 # TYPE shotover_transform_total_count counter
+connections_opened{source="redis"}
 shotover_available_connections_count{source="redis"}
 shotover_chain_failures_count{chain="redis"}
 shotover_chain_messages_per_batch_count_count{chain="redis"}


### PR DESCRIPTION
Opening new connections is quite expensive on kafka, not only do we have to reperform authentication, the new transform instance created for this new connection must fetch its own metadata from kafka.
To give visibility into this I have added this `connections_opened` metric which increments every time a new connection is opened.

The results of this metric on the windsock benchmark:
![image](https://github.com/user-attachments/assets/c68c851c-28e3-4213-897a-affb35922562)


We can see that
* we initially create 4 connections, presumably 2 for the producer and 2 for the consumer.
* after that no more connections are created

So we can conclude that the performance issues is not caused by the client creating more connections.
I believe this metric should still be added as its helpful for ruling out such possibilities in the future.
