### PR TITLE
Add NodeState to ShotoverNode + some renaming

### DIFF
--- a/shotover-proxy/benches/windsock/kafka/bench.rs
+++ b/shotover-proxy/benches/windsock/kafka/bench.rs
@@ -14,7 +14,8 @@ use pretty_assertions::assert_eq;
 use shotover::config::chain::TransformChainConfig;
 use shotover::sources::SourceConfig;
 use shotover::transforms::debug::force_parse::DebugForceEncodeConfig;
-use shotover::transforms::kafka::sink_cluster::{KafkaSinkClusterConfig, ShotoverNodeConfig};
+use shotover::transforms::kafka::sink_cluster::shotover_node::ShotoverNodeConfig;
+use shotover::transforms::kafka::sink_cluster::KafkaSinkClusterConfig;
 use shotover::transforms::kafka::sink_single::KafkaSinkSingleConfig;
 use shotover::transforms::TransformConfig;
 use std::sync::Arc;
@@ -96,6 +97,7 @@ impl KafkaBench {
             KafkaTopology::Cluster1 | KafkaTopology::Cluster3 => Box::new(KafkaSinkClusterConfig {
                 connect_timeout_ms: 3000,
                 read_timeout: None,
+                check_shotover_peers_delay_ms: None,
                 first_contact_points: vec![kafka_address],
                 shotover_nodes: vec![ShotoverNodeConfig {
                     address: host_address.parse().unwrap(),

--- a/shotover/src/transforms/kafka/sink_cluster/connections.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/connections.rs
@@ -10,7 +10,7 @@ use rand::{rngs::SmallRng, seq::IteratorRandom};
 use std::{collections::HashMap, time::Instant};
 
 use super::{
-    node::{ConnectionFactory, KafkaAddress, KafkaNode, NodeState},
+    kafka_node::{ConnectionFactory, KafkaAddress, KafkaNode, KafkaNodeState},
     scram_over_mtls::{connection::ScramOverMtlsConnection, AuthorizeScramOverMtls},
     SASL_SCRAM_MECHANISMS,
 };
@@ -234,9 +234,9 @@ impl Connections {
 
         // Update the node state according to whether we can currently open a connection.
         let node_state = if connection.is_err() {
-            NodeState::Down
+            KafkaNodeState::Down
         } else {
-            NodeState::Up
+            KafkaNodeState::Up
         };
         nodes
             .iter()

--- a/shotover/src/transforms/kafka/sink_cluster/kafka_node.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/kafka_node.rs
@@ -283,7 +283,7 @@ pub struct KafkaNode {
     pub broker_id: BrokerId,
     pub rack: Option<StrBytes>,
     pub kafka_address: KafkaAddress,
-    state: Arc<AtomicNodeState>,
+    state: Arc<AtomicKafkaNodeState>,
 }
 
 impl KafkaNode {
@@ -292,22 +292,22 @@ impl KafkaNode {
             broker_id,
             kafka_address,
             rack,
-            state: Arc::new(AtomicNodeState::new(NodeState::Up)),
+            state: Arc::new(AtomicKafkaNodeState::new(KafkaNodeState::Up)),
         }
     }
 
     pub fn is_up(&self) -> bool {
-        self.state.load(Ordering::Relaxed) == NodeState::Up
+        self.state.load(Ordering::Relaxed) == KafkaNodeState::Up
     }
 
-    pub fn set_state(&self, state: NodeState) {
+    pub fn set_state(&self, state: KafkaNodeState) {
         self.state.store(state, Ordering::Relaxed)
     }
 }
 
 #[atomic_enum]
 #[derive(PartialEq)]
-pub enum NodeState {
+pub enum KafkaNodeState {
     Up,
     Down,
 }

--- a/shotover/src/transforms/kafka/sink_cluster/scram_over_mtls.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/scram_over_mtls.rs
@@ -1,4 +1,4 @@
-use super::node::{ConnectionFactory, KafkaAddress};
+use super::kafka_node::{ConnectionFactory, KafkaAddress};
 use crate::{
     connection::SinkConnection,
     tls::{TlsConnector, TlsConnectorConfig},

--- a/shotover/src/transforms/kafka/sink_cluster/scram_over_mtls/create_token.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/scram_over_mtls/create_token.rs
@@ -13,7 +13,7 @@ use kafka_protocol::{
 };
 use rand::{rngs::SmallRng, seq::IteratorRandom};
 
-use crate::transforms::kafka::sink_cluster::node::{ConnectionFactory, KafkaAddress};
+use crate::transforms::kafka::sink_cluster::kafka_node::{ConnectionFactory, KafkaAddress};
 use crate::transforms::kafka::sink_cluster::scram_over_mtls::{DelegationToken, Node};
 use crate::{
     connection::SinkConnection,

--- a/shotover/src/transforms/kafka/sink_cluster/shotover_node.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/shotover_node.rs
@@ -14,7 +14,7 @@ pub struct ShotoverNodeConfig {
 }
 
 impl ShotoverNodeConfig {
-    pub fn build(self) -> anyhow::Result<ShotoverNode> {
+    pub(crate) fn build(self) -> anyhow::Result<ShotoverNode> {
         Ok(ShotoverNode {
             address: KafkaAddress::from_str(&self.address)?,
             rack: StrBytes::from_string(self.rack),
@@ -25,7 +25,7 @@ impl ShotoverNodeConfig {
 }
 
 #[derive(Clone)]
-pub struct ShotoverNode {
+pub(crate) struct ShotoverNode {
     pub address: KafkaAddress,
     pub rack: StrBytes,
     pub broker_id: BrokerId,
@@ -35,7 +35,7 @@ pub struct ShotoverNode {
 
 #[atomic_enum]
 #[derive(PartialEq)]
-pub enum ShotoverNodeState {
+pub(crate) enum ShotoverNodeState {
     Up,
     Down,
 }

--- a/shotover/src/transforms/kafka/sink_cluster/shotover_node.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/shotover_node.rs
@@ -1,0 +1,41 @@
+use crate::transforms::kafka::sink_cluster::kafka_node::KafkaAddress;
+use atomic_enum::atomic_enum;
+use kafka_protocol::messages::BrokerId;
+use kafka_protocol::protocol::StrBytes;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct ShotoverNodeConfig {
+    pub address: String,
+    pub rack: String,
+    pub broker_id: i32,
+}
+
+impl ShotoverNodeConfig {
+    pub fn build(self) -> anyhow::Result<ShotoverNode> {
+        Ok(ShotoverNode {
+            address: KafkaAddress::from_str(&self.address)?,
+            rack: StrBytes::from_string(self.rack),
+            broker_id: BrokerId(self.broker_id),
+            state: Arc::new(AtomicShotoverNodeState::new(ShotoverNodeState::Up)),
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct ShotoverNode {
+    pub address: KafkaAddress,
+    pub rack: StrBytes,
+    pub broker_id: BrokerId,
+    #[allow(unused)]
+    state: Arc<AtomicShotoverNodeState>,
+}
+
+#[atomic_enum]
+#[derive(PartialEq)]
+pub enum ShotoverNodeState {
+    Up,
+    Down,
+}


### PR DESCRIPTION
- Add a new `ShotoverNodeState` field to `ShotoverNode`. We are not reusing the existing `NodeState` for Kafka because it's possible that we will have different node states for Shotover in the future.
- Add a new configuration `check_shotover_peers_delay_ms` to `KafkaSinkCluster` which will be used when checking connection to nodes and setting node states.
- Move `ShotoverNode` code into a new file `kafka/sink_cluster/shotover_node.rs`
- Rename `kafka/sink_cluster/node.rs` to `kafka/sink_cluster/kafka_node.rs` and `NodeState` to `KafkaNodeState`