### PR TITLE
Fix local_shotover_broker_id in test configs

### DIFF
--- a/shotover-proxy/tests/test-configs/kafka/cluster-1-rack/topology2.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-1-rack/topology2.yaml
@@ -15,6 +15,6 @@ sources:
               - address: "127.0.0.1:9193"
                 rack: "rack0"
                 broker_id: 2
-            local_shotover_broker_id: 0
+            local_shotover_broker_id: 1
             first_contact_points: ["172.16.1.2:9092"]
             connect_timeout_ms: 3000

--- a/shotover-proxy/tests/test-configs/kafka/cluster-1-rack/topology3.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-1-rack/topology3.yaml
@@ -15,6 +15,6 @@ sources:
               - address: "127.0.0.1:9193"
                 rack: "rack0"
                 broker_id: 2
-            local_shotover_broker_id: 0
+            local_shotover_broker_id: 2
             first_contact_points: ["172.16.1.2:9092"]
             connect_timeout_ms: 3000

--- a/shotover-proxy/tests/test-configs/kafka/cluster-2-racks/topology-rack2.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-2-racks/topology-rack2.yaml
@@ -12,6 +12,6 @@ sources:
               - address: "localhost:9192"
                 rack: "rack2"
                 broker_id: 1
-            local_shotover_broker_id: 0
+            local_shotover_broker_id: 1
             first_contact_points: ["172.16.1.5:9092"]
             connect_timeout_ms: 3000

--- a/shotover-proxy/tests/test-configs/kafka/cluster-sasl-plain/topology2.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-sasl-plain/topology2.yaml
@@ -15,6 +15,6 @@ sources:
               - address: "127.0.0.1:9193"
                 rack: "rack0"
                 broker_id: 2
-            local_shotover_broker_id: 0
+            local_shotover_broker_id: 1
             first_contact_points: ["172.16.1.2:9092"]
             connect_timeout_ms: 3000

--- a/shotover-proxy/tests/test-configs/kafka/cluster-sasl-plain/topology3.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-sasl-plain/topology3.yaml
@@ -15,6 +15,6 @@ sources:
               - address: "127.0.0.1:9193"
                 rack: "rack0"
                 broker_id: 2
-            local_shotover_broker_id: 0
+            local_shotover_broker_id: 2
             first_contact_points: ["172.16.1.2:9092"]
             connect_timeout_ms: 3000

--- a/shotover-proxy/tests/test-configs/kafka/cluster-sasl-scram-over-mtls/topology2.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-sasl-scram-over-mtls/topology2.yaml
@@ -15,7 +15,7 @@ sources:
               - address: "127.0.0.1:9193"
                 rack: "rack0"
                 broker_id: 2
-            local_shotover_broker_id: 0
+            local_shotover_broker_id: 1
             first_contact_points: ["172.16.1.2:9092"]
             authorize_scram_over_mtls:
               # every shotover node purposefully tests a different number of contact points

--- a/shotover-proxy/tests/test-configs/kafka/cluster-sasl-scram-over-mtls/topology3.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-sasl-scram-over-mtls/topology3.yaml
@@ -15,7 +15,7 @@ sources:
               - address: "127.0.0.1:9193"
                 rack: "rack0"
                 broker_id: 2
-            local_shotover_broker_id: 0
+            local_shotover_broker_id: 2
             first_contact_points: ["172.16.1.2:9092"]
             authorize_scram_over_mtls:
               # every shotover node purposefully tests a different number of contact points


### PR DESCRIPTION
Copied from Lucas's comment below:
The `local_shotover_broker_id` field is currently only used for rack aware routing.
We weren't correctly setting it in our integration tests, the tests still passed since rack aware routing is purely an optimization and not needed for correctness.
We really should fix these configs so that we are running our integration tests with a configuration closer to production.

The way the field works is it configures the broker id that shotover should become.
Shotover looks up the entry in `shotover_nodes` that has that broker id and acts as that node.