### PR TITLE
Implement routing for ListOffsets

### DIFF
--- a/test-helpers/src/connection/kafka/mod.rs
+++ b/test-helpers/src/connection/kafka/mod.rs
@@ -280,6 +280,17 @@ impl KafkaAdmin {
         }
     }
 
+    pub async fn list_offsets(
+        &self,
+        topic_partitions: HashMap<TopicPartition, OffsetSpec>,
+    ) -> HashMap<TopicPartition, ListOffsetsResultInfo> {
+        match self {
+            #[cfg(feature = "kafka-cpp-driver-tests")]
+            Self::Cpp(_) => panic!("rdkafka-rs driver does not support list_offsets"),
+            Self::Java(java) => java.list_offsets(topic_partitions).await,
+        }
+    }
+
     pub async fn create_partitions(&self, partitions: &[NewPartition<'_>]) {
         match self {
             #[cfg(feature = "kafka-cpp-driver-tests")]
@@ -313,6 +324,11 @@ impl KafkaAdmin {
     }
 }
 
+#[derive(Eq, PartialEq, Debug)]
+pub struct ListOffsetsResultInfo {
+    pub offset: i32,
+}
+
 pub struct NewTopic<'a> {
     pub name: &'a str,
     pub num_partitions: i32,
@@ -324,7 +340,7 @@ pub struct NewPartition<'a> {
     pub new_partition_count: i32,
 }
 
-#[derive(Clone, Eq, PartialEq, Hash)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct TopicPartition {
     pub topic_name: String,
     pub partition: i32,
@@ -397,6 +413,11 @@ pub struct TopicDescription {
     // None of our tests actually make use of the contents of TopicDescription,
     // instead they just check if the describe succeeded or failed,
     // so this is intentionally left empty for now
+}
+
+pub enum OffsetSpec {
+    Earliest,
+    Latest,
 }
 
 #[derive(Default)]


### PR DESCRIPTION
From inspecting the messages passing through shotover I could see that ListOffsets is hitting NOT_LEADER_OR_FOLLOWER errors. (error code 6)

For example:
```
shotover   02:07:50.445929Z  INFO connection{id=41 source="kafka"}: shotover::transforms::debug::printer: Response: Kafka version:7 correlation_id:54 ListOffsets(ListOffsetsResponse { throttle_time_ms: 0, topics: [ListOffsetsTopicResponse { name: TopicName("partitions3_case4"), partitions: [ListOffsetsPartitionResponse { partition_index: 0, error_code: 6, old_style_offsets: [], timestamp: -1, offset: -1, leader_epoch: -1, unknown_tagged_fields: {} }], unknown_tagged_fields: {} }], unknown_tagged_fields: {} })
```

After some retries it will eventually hit the correct node and succeed:
```
shotover   02:07:51.047014Z  INFO connection{id=41 source="kafka"}: shotover::transforms::debug::printer: Response: Kafka version:7 correlation_id:60 ListOffsets(ListOffsetsResponse { throttle_time_ms: 0, topics: [ListOffsetsTopicResponse { name: TopicName("partitions3_case4"), partitions: [ListOffsetsPartitionResponse { partition_index: 0, error_code: 0, old_style_offsets: [], timestamp: -1, offset: 0, leader_epoch: 0, unknown_tagged_fields: {} }], unknown_tagged_fields: {} }], unknown_tagged_fields: {} })
```
It seems that the java driver is robust enough to retry only the parts of the request that failed, so eventually it will succesfully complete and move on. However, it is still quite slow and wasteful to error like this.
To fix these errors, we need to split and combine the request like we do for fetch and produce messages.

So this PR implements that fetch/combine logic for ListOffsets.

I added an integration test to call the listOffsets method from the admin API.
This test does not fail due to java's robust retry mechanism but I've manually verified that the errors are gone with the new routing logic and the new test adds more coverage of the driver.

Another nice outcome of this fix is that `cluster_1_rack_single_shotover::case_2_java` now completes in 100s down from 110s