### PR TITLE
KafkaSinkCluster: fix response recombine

### DIFF
--- a/shotover/src/transforms/debug/force_parse.rs
+++ b/shotover/src/transforms/debug/force_parse.rs
@@ -109,24 +109,26 @@ impl Transform for DebugForceParse {
         &mut self,
         chain_state: &'shorter mut ChainState<'longer>,
     ) -> Result<Messages> {
-        for message in &mut chain_state.requests {
+        for request in &mut chain_state.requests {
             if self.parse_requests {
-                message.frame();
+                request.frame();
             }
             if self.encode_requests {
-                message.invalidate_cache();
+                request.frame();
+                request.invalidate_cache();
             }
         }
 
         let mut response = chain_state.call_next_transform().await;
 
-        if let Ok(response) = response.as_mut() {
-            for message in response {
+        if let Ok(responses) = response.as_mut() {
+            for response in responses {
                 if self.parse_responses {
-                    message.frame();
+                    response.frame();
                 }
                 if self.encode_responses {
-                    message.invalidate_cache();
+                    response.frame();
+                    response.invalidate_cache();
                 }
             }
         }

--- a/shotover/src/transforms/kafka/sink_cluster/mod.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/mod.rs
@@ -1516,7 +1516,6 @@ impl KafkaSinkCluster {
         // Take this response as base.
         // Then iterate over all remaining combined responses and integrate them into the base.
         let mut base = drain.next().unwrap();
-        base.invalidate_cache();
 
         match base.frame() {
             Some(Frame::Kafka(KafkaFrame::Response {
@@ -1533,6 +1532,8 @@ impl KafkaSinkCluster {
                 ))
             }
         }
+
+        base.invalidate_cache();
 
         Ok(base)
     }

--- a/shotover/src/transforms/redis/cluster_ports_rewrite.rs
+++ b/shotover/src/transforms/redis/cluster_ports_rewrite.rs
@@ -105,16 +105,16 @@ impl Transform for RedisClusterPortsRewrite {
                         if let Some(frame) = response.frame() {
                             rewrite_port_slot(frame, self.new_port)
                                 .context("failed to rewrite CLUSTER SLOTS port")?;
+                            response.invalidate_cache();
                         }
-                        response.invalidate_cache();
                     }
                     // Rewrite the ports in the cluster nodes responses
                     Some(RequestType::ClusterNodes) => {
                         if let Some(frame) = response.frame() {
                             rewrite_port_node(frame, self.new_port)
                                 .context("failed to rewrite CLUSTER NODES port")?;
+                            response.invalidate_cache();
                         }
-                        response.invalidate_cache();
                     }
                     None => {}
                 }


### PR DESCRIPTION
## Context
Shotover `Message`s have 3 states they can be in, they progress from `RawBytes` -> `Parsed` -> `Modified`

https://github.com/shotover/shotover-proxy/blob/0db4f69e39eec2944c6a9141bbad7b2919613aee/shotover/src/message/mod.rs#L564-L576

When `Message::frame()` is called the message is moved to the `Parsed` state.
When `Message::invalidate_cache()` is called and the message is in `Parsed` state the message is moved to `Modified` State.

These states allow shotover to maintain a source of truth for the message without throwing away work.
For example:
* once the frame is parsed from the raw bytes (`Parsed` or `Modified`) the frame never needs to be reparsed.
* As long as the frame has not been modified (`RawBytes` or `Parsed`) the encoding stage does not need to reencode the raw bytes from the frame.

While this is excellent for performance it unfortunately makes it harder to use this API correctly.

## The fix

This PR fixes a bug in the KafkaSinkCluster logic for recombining responses from split requests.
The problem was that we were calling `base.invalidate_cache();` before calling `base.frame()`, which results in the original bytes not being cleared.
The result of this is that the unmodified base response is sent to the client.
So if we were recombining 3 responses, only 1/3 of the response would be returned to the client.

So this PR fixes the ordering to resolve this issue in KafkaSinkCluster.

## Preventing future issues

But this PR also adds an error log to catch similar issues in the future.
It also adjusts some other usage of `invalidate_cache` to avoid hitting this error.

We might want to adjust the semantics of `invalidate_cache` in the future, maybe rename it to `clear_raw_bytes` or something, since we never ended up implementing cached fields as per the original design. But I dont see a clear correct design, so I'll leave it alone for now.