### PR TITLE
Fix windsock cloud benches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,14 +542,15 @@ dependencies = [
 
 [[package]]
 name = "aws-throwaway"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d4e709bb32c8358d4288de37ce6074dc0f51272cbff244e52d80373f2610b0"
+checksum = "398363a30ab455f21ecfe419f717cf79d710db69fcbb677321c0bfdb54d78b94"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
  "futures",
+ "reqwest",
  "russh",
  "russh-keys",
  "serde",
@@ -1593,6 +1594,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "des"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1608,27 +1618,6 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2325,7 +2314,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2679,16 +2668,6 @@ name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
-
-[[package]]
-name = "libredox"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
-dependencies = [
- "bitflags",
- "libc",
-]
 
 [[package]]
 name = "libz-sys"
@@ -3174,12 +3153,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
@@ -3785,17 +3758,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom",
- "libredox",
- "thiserror",
-]
-
-[[package]]
 name = "regex"
 version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3990,9 +3952,9 @@ dependencies = [
 
 [[package]]
 name = "russh"
-version = "0.44.1"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6500eedfaf8cd81597899d896908a4b9cd5cb566db875e843c04ccf92add2c16"
+checksum = "0a229f2a03daea3f62cee897b40329ce548600cca615906d98d58b8db3029b19"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -4003,6 +3965,7 @@ dependencies = [
  "chacha20",
  "ctr",
  "curve25519-dalek",
+ "des",
  "digest",
  "elliptic-curve",
  "flate2",
@@ -4042,9 +4005,9 @@ dependencies = [
 
 [[package]]
 name = "russh-keys"
-version = "0.44.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb8c0bfe024d4edd242f65a2ac6c8bf38a892930050b9eb90909d8fc2c413c8d"
+checksum = "89757474f7c9ee30121d8cc7fe293a954ba10b204a82ccf5850a5352a532ebc7"
 dependencies = [
  "aes",
  "async-trait",
@@ -4056,12 +4019,12 @@ dependencies = [
  "data-encoding",
  "der",
  "digest",
- "dirs",
  "ecdsa",
  "ed25519-dalek",
  "elliptic-curve",
  "futures",
  "hmac",
+ "home",
  "inout",
  "log",
  "md5",
@@ -4661,16 +4624,13 @@ dependencies = [
  "aws-throwaway",
  "bincode",
  "bytes",
- "cassandra-cpp",
  "cassandra-protocol",
  "cdrs-tokio",
  "chacha20poly1305",
- "clap",
  "csv",
  "fred",
  "futures",
  "hex",
- "hex-literal",
  "itertools 0.13.0",
  "opensearch",
  "pretty_assertions",
@@ -4693,7 +4653,6 @@ dependencies = [
  "time",
  "tokio",
  "tokio-bin-process",
- "tokio-util",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -5955,7 +5914,6 @@ name = "windsock-cloud-docker"
 version = "0.1.0"
 dependencies = [
  "shell-quote",
- "subprocess",
  "tokio",
 ]
 

--- a/ec2-cargo/src/main.rs
+++ b/ec2-cargo/src/main.rs
@@ -1,4 +1,6 @@
-use aws_throwaway::{Aws, CleanupResources, Ec2Instance, Ec2InstanceDefinition, InstanceType};
+use aws_throwaway::{
+    Aws, CleanupResources, Ec2Instance, Ec2InstanceDefinition, IngressRestriction, InstanceType,
+};
 use cargo_metadata::{Metadata, MetadataCommand};
 use clap::Parser;
 use shellfish::{async_fn, handler::DefaultAsyncHandler, rustyline::DefaultEditor, Command, Shell};
@@ -47,6 +49,7 @@ async fn main() {
 
     let aws = Aws::builder(CleanupResources::AllResources)
         .use_az(Some("us-east-1b".into()))
+        .use_ingress_restriction(IngressRestriction::LocalPublicAddress)
         .build()
         .await;
     let instance_type = InstanceType::from(args.instance_type.as_str());

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -17,10 +17,8 @@ scylla.workspace = true
 anyhow.workspace = true
 tokio.workspace = true
 tracing.workspace = true
-clap.workspace = true
 rstest = "0.22.0"
 rstest_reuse = "0.7.0"
-cassandra-cpp = { version = "3.0.0", default-features = false }
 test-helpers = { path = "../test-helpers" }
 redis.workspace = true
 chacha20poly1305.workspace = true
@@ -30,11 +28,9 @@ uuid.workspace = true
 itertools.workspace = true
 cdrs-tokio.workspace = true
 redis-protocol.workspace = true
-tokio-util.workspace = true
 bincode.workspace = true
 futures.workspace = true
 hex.workspace = true
-hex-literal.workspace = true
 cassandra-protocol.workspace = true
 bytes.workspace = true
 rand.workspace = true

--- a/shotover-proxy/benches/windsock/cloud/aws.rs
+++ b/shotover-proxy/benches/windsock/cloud/aws.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use aws_throwaway::{Aws, Ec2Instance, InstanceType};
+use aws_throwaway::{Aws, Ec2Instance, IngressRestriction, InstanceType};
 use aws_throwaway::{CleanupResources, Ec2InstanceDefinition};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -25,6 +25,7 @@ impl AwsInstances {
         AwsInstances {
             aws: Aws::builder(CleanupResources::WithAppTag(AWS_THROWAWAY_TAG.to_owned()))
                 .use_az(Some("us-east-1b".into()))
+                .use_ingress_restriction(IngressRestriction::LocalPublicAddress)
                 // shotover metrics port
                 .expose_ports_to_internet(vec![9001])
                 .build()

--- a/windsock-cloud-docker/Cargo.toml
+++ b/windsock-cloud-docker/Cargo.toml
@@ -9,4 +9,3 @@ license = "Apache-2.0"
 [dependencies]
 shell-quote.workspace = true
 tokio.workspace = true
-subprocess.workspace = true


### PR DESCRIPTION
This PR makes use of the new functionality added in https://github.com/shotover/aws-throwaway/pull/60 to fix running benchmarks in our internal environment.

I also cleared out some unused dependencies