### PR TITLE
Fix sasl with python-kafka

### DIFF
--- a/shotover/benches/benches/codec/kafka.rs
+++ b/shotover/benches/benches/codec/kafka.rs
@@ -1,7 +1,7 @@
 use bytes::{Bytes, BytesMut};
 use criterion::{criterion_group, BatchSize, Criterion};
 use shotover::codec::kafka::KafkaCodecBuilder;
-use shotover::codec::{CodecBuilder, CodecState, Direction};
+use shotover::codec::{CodecBuilder, CodecState, Direction, KafkaCodecState};
 use shotover::message::Message;
 use tokio_util::codec::{Decoder, Encoder};
 
@@ -77,9 +77,10 @@ fn criterion_benchmark(c: &mut Criterion) {
         {
             let mut message = Message::from_bytes(
                 Bytes::from(message.to_vec()),
-                CodecState::Kafka {
+                CodecState::Kafka(KafkaCodecState {
                     request_header: None,
-                },
+                    raw_sasl: None,
+                }),
             );
             // force the message to be parsed and clear raw message
             message.frame();
@@ -113,9 +114,10 @@ fn criterion_benchmark(c: &mut Criterion) {
         for (message, _) in KAFKA_REQUESTS {
             let mut message = Message::from_bytes(
                 Bytes::from(message.to_vec()),
-                CodecState::Kafka {
+                CodecState::Kafka(KafkaCodecState {
                     request_header: None,
-                },
+                    raw_sasl: None,
+                }),
             );
             // force the message to be parsed and clear raw message
             message.frame();

--- a/shotover/benches/benches/codec/kafka.rs
+++ b/shotover/benches/benches/codec/kafka.rs
@@ -1,7 +1,8 @@
 use bytes::{Bytes, BytesMut};
 use criterion::{criterion_group, BatchSize, Criterion};
 use shotover::codec::kafka::KafkaCodecBuilder;
-use shotover::codec::{CodecBuilder, CodecState, Direction, KafkaCodecState};
+use shotover::codec::kafka::KafkaCodecState;
+use shotover::codec::{CodecBuilder, CodecState, Direction};
 use shotover::message::Message;
 use tokio_util::codec::{Decoder, Encoder};
 
@@ -79,7 +80,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 Bytes::from(message.to_vec()),
                 CodecState::Kafka(KafkaCodecState {
                     request_header: None,
-                    raw_sasl: None,
+                    raw_sasl: false,
                 }),
             );
             // force the message to be parsed and clear raw message
@@ -116,7 +117,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 Bytes::from(message.to_vec()),
                 CodecState::Kafka(KafkaCodecState {
                     request_header: None,
-                    raw_sasl: None,
+                    raw_sasl: false,
                 }),
             );
             // force the message to be parsed and clear raw message

--- a/shotover/src/codec/kafka.rs
+++ b/shotover/src/codec/kafka.rs
@@ -1,10 +1,14 @@
 use super::{message_latency, CodecWriteError, Direction};
-use crate::codec::{CodecBuilder, CodecReadError, CodecState};
-use crate::frame::MessageType;
+use crate::codec::{CodecBuilder, CodecReadError, CodecState, KafkaCodecState};
+use crate::frame::kafka::KafkaFrame;
+use crate::frame::{Frame, MessageType};
 use crate::message::{Encodable, Message, MessageId, Messages};
 use anyhow::{anyhow, Result};
 use bytes::BytesMut;
-use kafka_protocol::messages::ApiKey;
+use kafka_protocol::messages::{
+    ApiKey, RequestHeader as RequestHeaderProtocol, RequestKind, ResponseHeader, ResponseKind,
+    SaslAuthenticateRequest, SaslAuthenticateResponse,
+};
 use metrics::Histogram;
 use std::sync::mpsc;
 use std::time::Instant;
@@ -12,6 +16,7 @@ use tokio_util::codec::{Decoder, Encoder};
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct RequestHeader {
+    // TODO: this should be i16???
     pub api_key: ApiKey,
     pub version: i16,
 }
@@ -57,15 +62,25 @@ impl CodecBuilder for KafkaCodecBuilder {
     }
 }
 
+#[derive(Debug)]
 pub struct RequestInfo {
     header: RequestHeader,
     id: MessageId,
+    expect_raw_sasl: Option<SaslType>,
+}
+
+#[derive(Debug, Clone, PartialEq, Copy)]
+pub enum SaslType {
+    Plain,
+    ScramMessage1,
+    ScramMessage2,
 }
 
 pub struct KafkaDecoder {
     // Some when Sink (because it receives responses)
     request_header_rx: Option<mpsc::Receiver<RequestInfo>>,
     direction: Direction,
+    expect_raw_sasl: Option<SaslType>,
 }
 
 impl KafkaDecoder {
@@ -76,12 +91,13 @@ impl KafkaDecoder {
         KafkaDecoder {
             request_header_rx,
             direction,
+            expect_raw_sasl: None,
         }
     }
 }
 
 fn get_length_of_full_message(src: &BytesMut) -> Option<usize> {
-    if src.len() > 4 {
+    if src.len() >= 4 {
         let size = u32::from_be_bytes(src[0..4].try_into().unwrap()) as usize + 4;
         if size <= src.len() {
             Some(size)
@@ -106,28 +122,133 @@ impl Decoder for KafkaDecoder {
                 self.direction,
                 pretty_hex::pretty_hex(&bytes)
             );
-            let message = if let Some(rx) = self.request_header_rx.as_ref() {
-                let RequestInfo { header, id } = rx
-                    .recv()
-                    .map_err(|_| CodecReadError::Parser(anyhow!("kafka encoder half was lost")))?;
-                let mut message = Message::from_bytes_at_instant(
-                    bytes.freeze(),
-                    CodecState::Kafka {
-                        request_header: Some(header),
+
+            struct Meta {
+                request_header: RequestHeader,
+                message_id: Option<u128>,
+            }
+
+            let request_info = self
+                .request_header_rx
+                .as_ref()
+                .map(|rx| {
+                    rx.recv()
+                        .map_err(|_| CodecReadError::Parser(anyhow!("kafka encoder half was lost")))
+                })
+                .transpose()?;
+
+            let message = if self.expect_raw_sasl.is_some() {
+                // Convert the unframed raw sasl into a framed sasl
+                // This allows transforms to correctly parse the message and inspect the sasl request
+                let kafka_frame = match self.direction {
+                    Direction::Source => KafkaFrame::Request {
+                        header: RequestHeaderProtocol::default()
+                            .with_request_api_key(ApiKey::SaslAuthenticateKey as i16),
+                        body: RequestKind::SaslAuthenticate(
+                            SaslAuthenticateRequest::default().with_auth_bytes(bytes.freeze()),
+                        ),
                     },
-                    Some(received_at),
-                );
-                message.set_request_id(id);
-                message
-            } else {
-                Message::from_bytes_at_instant(
-                    bytes.freeze(),
-                    CodecState::Kafka {
-                        request_header: None,
+                    Direction::Sink => KafkaFrame::Response {
+                        version: 0,
+                        header: ResponseHeader::default(),
+                        body: ResponseKind::SaslAuthenticate(
+                            SaslAuthenticateResponse::default().with_auth_bytes(bytes.freeze()),
+                            // TODO: we need to set with_error_code
+                        ),
                     },
+                };
+                let codec_state = CodecState::Kafka(KafkaCodecState {
+                    request_header: None,
+                    raw_sasl: self.expect_raw_sasl,
+                });
+                self.expect_raw_sasl = match self.expect_raw_sasl {
+                    Some(SaslType::Plain) => None,
+                    Some(SaslType::ScramMessage1) => Some(SaslType::ScramMessage2),
+                    Some(SaslType::ScramMessage2) => None,
+                    None => None,
+                };
+                Message::from_frame_and_codec_state_at_instant(
+                    Frame::Kafka(kafka_frame),
+                    codec_state,
                     Some(received_at),
                 )
+            } else {
+                let meta = if let Some(RequestInfo {
+                    header,
+                    id,
+                    expect_raw_sasl,
+                }) = request_info
+                {
+                    if let Some(expect_raw_sasl) = expect_raw_sasl {
+                        self.expect_raw_sasl = Some(expect_raw_sasl);
+                    }
+                    Meta {
+                        request_header: header,
+                        message_id: Some(id),
+                    }
+                } else {
+                    Meta {
+                        request_header: RequestHeader {
+                            api_key: ApiKey::try_from(i16::from_be_bytes(
+                                bytes[4..6].try_into().unwrap(),
+                            ))
+                            .unwrap(),
+                            version: i16::from_be_bytes(bytes[6..8].try_into().unwrap()),
+                        },
+                        message_id: None,
+                    }
+                };
+                let mut message = if let Some(id) = meta.message_id.as_ref() {
+                    let mut message = Message::from_bytes_at_instant(
+                        bytes.freeze(),
+                        CodecState::Kafka(KafkaCodecState {
+                            request_header: Some(meta.request_header),
+                            raw_sasl: None,
+                        }),
+                        Some(received_at),
+                    );
+                    message.set_request_id(*id);
+                    message
+                } else {
+                    Message::from_bytes_at_instant(
+                        bytes.freeze(),
+                        CodecState::Kafka(KafkaCodecState {
+                            request_header: None,
+                            raw_sasl: None,
+                        }),
+                        Some(received_at),
+                    )
+                };
+
+                if meta.request_header.api_key == ApiKey::SaslHandshakeKey
+                    && meta.request_header.version == 0
+                {
+                    // Only parse the full frame once we manually check its a v0 sasl handshake
+                    if let Some(Frame::Kafka(KafkaFrame::Request {
+                        body: RequestKind::SaslHandshake(sasl_handshake),
+                        ..
+                    })) = message.frame()
+                    {
+                        self.expect_raw_sasl = Some(match sasl_handshake.mechanism.as_str() {
+                            "PLAIN" => SaslType::Plain,
+                            "SCRAM-SHA-512" => SaslType::ScramMessage1,
+                            "SCRAM-SHA-256" => SaslType::ScramMessage1,
+                            mechanism => {
+                                return Err(CodecReadError::Parser(anyhow!(
+                                    "Unknown sasl mechanism {mechanism}"
+                                )))
+                            }
+                        });
+
+                        // Clear raw bytes of the message to force the encoder to encode from frame.
+                        // This is needed because the encoder only has access to the frame if it does not have any raw bytes,
+                        // and the encoder needs to inspect the frame to set its own sasl state.
+                        message.invalidate_cache();
+                    }
+                }
+                message
             };
+
             Ok(Some(vec![message]))
         } else {
             Ok(None)
@@ -167,28 +288,86 @@ impl Encoder<Messages> for KafkaEncoder {
             let response_is_dummy = m.response_is_dummy();
             let id = m.id();
             let received_at = m.received_from_source_or_sink_at;
+            let codec_state = m.codec_state.as_kafka();
+            let mut expect_raw_sasl = None;
             let result = match m.into_encodable() {
                 Encodable::Bytes(bytes) => {
                     dst.extend_from_slice(&bytes);
                     Ok(())
                 }
-                Encodable::Frame(frame) => frame.into_kafka().unwrap().encode(dst),
+                Encodable::Frame(frame) => {
+                    if codec_state.raw_sasl.is_some() {
+                        match frame {
+                            Frame::Kafka(KafkaFrame::Request {
+                                body: RequestKind::SaslAuthenticate(body),
+                                ..
+                            }) => {
+                                dst.extend_from_slice(&body.auth_bytes);
+                            }
+                            Frame::Kafka(KafkaFrame::Response {
+                                body: ResponseKind::SaslAuthenticate(body),
+                                ..
+                            }) => {
+                                dst.extend_from_slice(&body.auth_bytes);
+                            }
+                            _ => unreachable!("not expected {frame:?}"),
+                        }
+                        Ok(())
+                    } else {
+                        let frame = frame.into_kafka().unwrap();
+                        // it is garanteed that all v0 SaslHandshakes will be in a parsed state since we parse it in the KafkaDecoder.
+                        if let KafkaFrame::Request {
+                            body: RequestKind::SaslHandshake(sasl_handshake),
+                            header,
+                        } = &frame
+                        {
+                            if header.request_api_version == 0 {
+                                expect_raw_sasl = Some(match sasl_handshake.mechanism.as_str() {
+                                    "PLAIN" => SaslType::Plain,
+                                    "SCRAM-SHA-512" => SaslType::ScramMessage1,
+                                    "SCRAM-SHA-256" => SaslType::ScramMessage1,
+                                    mechanism => {
+                                        return Err(CodecWriteError::Encoder(anyhow!(
+                                            "Unknown sasl mechanism {mechanism}"
+                                        )))
+                                    }
+                                });
+                            }
+                        }
+                        frame.encode(dst)
+                    }
+                }
             };
 
             // Skip if the message wrote nothing to dst, possibly due to being a dummy message.
             // or if it will generate a dummy response
             if !dst[start..].is_empty() && !response_is_dummy {
                 if let Some(tx) = self.request_header_tx.as_ref() {
-                    let api_key = i16::from_be_bytes(dst[start + 4..start + 6].try_into().unwrap());
-                    let version = i16::from_be_bytes(dst[start + 6..start + 8].try_into().unwrap());
-                    let api_key = ApiKey::try_from(api_key).map_err(|_| {
-                        CodecWriteError::Encoder(anyhow!("unknown api key {api_key}"))
-                    })?;
-                    tx.send(RequestInfo {
-                        header: RequestHeader { api_key, version },
+                    let header = if codec_state.raw_sasl.is_some() {
+                        RequestHeader {
+                            api_key: ApiKey::SaslAuthenticateKey,
+                            version: 0,
+                        }
+                    } else {
+                        let api_key =
+                            i16::from_be_bytes(dst[start + 4..start + 6].try_into().unwrap());
+                        let version =
+                            i16::from_be_bytes(dst[start + 6..start + 8].try_into().unwrap());
+                        // TODO: handle unknown API key
+                        let api_key = ApiKey::try_from(api_key).map_err(|_| {
+                            CodecWriteError::Encoder(anyhow!("unknown api key {api_key}"))
+                        })?;
+
+                        RequestHeader { api_key, version }
+                    };
+
+                    let request_info = RequestInfo {
+                        header,
                         id,
-                    })
-                    .map_err(|e| CodecWriteError::Encoder(anyhow!(e)))?;
+                        expect_raw_sasl,
+                    };
+                    tx.send(request_info)
+                        .map_err(|e| CodecWriteError::Encoder(anyhow!(e)))?;
                 }
             }
 

--- a/shotover/src/codec/mod.rs
+++ b/shotover/src/codec/mod.rs
@@ -5,9 +5,7 @@ use crate::{frame::MessageType, message::Messages};
 use cassandra_protocol::compression::Compression;
 use core::fmt;
 #[cfg(feature = "kafka")]
-use kafka::RequestHeader;
-#[cfg(feature = "kafka")]
-use kafka::SaslMessageState;
+use kafka::KafkaCodecState;
 use metrics::{histogram, Histogram};
 use tokio_util::codec::{Decoder, Encoder};
 
@@ -89,18 +87,6 @@ impl CodecState {
             }
         }
     }
-}
-
-#[cfg(feature = "kafka")]
-#[derive(Debug, Clone, PartialEq, Copy)]
-pub struct KafkaCodecState {
-    /// When the message is:
-    /// a request - this value is None
-    /// a response - this value is Some and contains the header values of the corresponding request.
-    pub request_header: Option<RequestHeader>,
-    /// When `Some` this message is not a valid kafka protocol message and is instead a raw SASL message.
-    /// KafkaFrame will parse this as a SaslHandshake to hide the legacy raw SASL message from transform implementations.
-    pub raw_sasl: Option<SaslMessageState>,
 }
 
 #[derive(Debug)]

--- a/shotover/src/frame/kafka.rs
+++ b/shotover/src/frame/kafka.rs
@@ -1,4 +1,5 @@
 use crate::codec::kafka::RequestHeader as CodecRequestHeader;
+use crate::codec::KafkaCodecState;
 use anyhow::{anyhow, Context, Result};
 use bytes::{BufMut, Bytes, BytesMut};
 use kafka_protocol::messages::{ApiKey, RequestHeader, ResponseHeader};
@@ -68,15 +69,12 @@ impl Display for KafkaFrame {
 }
 
 impl KafkaFrame {
-    pub fn from_bytes(
-        mut bytes: Bytes,
-        request_header: Option<CodecRequestHeader>,
-    ) -> Result<Self> {
+    pub fn from_bytes(mut bytes: Bytes, codec_state: KafkaCodecState) -> Result<Self> {
         // remove length header
         let _ = bytes.split_to(4);
 
-        match request_header {
-            Some(request_header) => KafkaFrame::parse_response(bytes, request_header),
+        match &codec_state.request_header {
+            Some(request_header) => KafkaFrame::parse_response(bytes, *request_header),
             None => KafkaFrame::parse_request(bytes),
         }
     }

--- a/shotover/src/frame/kafka.rs
+++ b/shotover/src/frame/kafka.rs
@@ -1,5 +1,5 @@
+use crate::codec::kafka::KafkaCodecState;
 use crate::codec::kafka::RequestHeader as CodecRequestHeader;
-use crate::codec::KafkaCodecState;
 use anyhow::{anyhow, Context, Result};
 use bytes::{BufMut, Bytes, BytesMut};
 use kafka_protocol::messages::{
@@ -72,7 +72,7 @@ impl Display for KafkaFrame {
 
 impl KafkaFrame {
     pub fn from_bytes(mut bytes: Bytes, codec_state: KafkaCodecState) -> Result<Self> {
-        if codec_state.raw_sasl.is_some() {
+        if codec_state.raw_sasl {
             match &codec_state.request_header {
                 Some(_) => Ok(KafkaFrame::Response {
                     version: 0,

--- a/shotover/src/frame/mod.rs
+++ b/shotover/src/frame/mod.rs
@@ -1,8 +1,8 @@
 //! parsed AST-like representations of messages
 
-use crate::codec::CodecState;
 #[cfg(feature = "kafka")]
-use crate::codec::KafkaCodecState;
+use crate::codec::kafka::KafkaCodecState;
+use crate::codec::CodecState;
 use anyhow::{anyhow, Result};
 use bytes::Bytes;
 #[cfg(feature = "cassandra")]
@@ -98,7 +98,7 @@ impl Frame {
             #[cfg(feature = "kafka")]
             Frame::Kafka(_) => CodecState::Kafka(KafkaCodecState {
                 request_header: None,
-                raw_sasl: None,
+                raw_sasl: false,
             }),
             Frame::Dummy => CodecState::Dummy,
             #[cfg(feature = "opensearch")]

--- a/shotover/src/frame/mod.rs
+++ b/shotover/src/frame/mod.rs
@@ -1,6 +1,8 @@
 //! parsed AST-like representations of messages
 
 use crate::codec::CodecState;
+#[cfg(feature = "kafka")]
+use crate::codec::KafkaCodecState;
 use anyhow::{anyhow, Result};
 use bytes::Bytes;
 #[cfg(feature = "cassandra")]
@@ -94,9 +96,10 @@ impl Frame {
             #[cfg(feature = "redis")]
             Frame::Redis(_) => CodecState::Redis,
             #[cfg(feature = "kafka")]
-            Frame::Kafka(_) => CodecState::Kafka {
+            Frame::Kafka(_) => CodecState::Kafka(KafkaCodecState {
                 request_header: None,
-            },
+                raw_sasl: None,
+            }),
             Frame::Dummy => CodecState::Dummy,
             #[cfg(feature = "opensearch")]
             Frame::OpenSearch(_) => CodecState::OpenSearch,

--- a/shotover/src/message/mod.rs
+++ b/shotover/src/message/mod.rs
@@ -158,6 +158,23 @@ impl Message {
         }
     }
 
+    /// This method should be called when you have just a Frame of a message.
+    /// This is expected to be used by transforms that are generating custom messages.
+    /// Providing just the Frame results in better performance when only the Frame is available.
+    pub fn from_frame_and_codec_state_at_instant(
+        frame: Frame,
+        codec_state: CodecState,
+        received_from_source_or_sink_at: Option<Instant>,
+    ) -> Self {
+        Message {
+            codec_state,
+            inner: Some(MessageInner::Modified { frame }),
+            received_from_source_or_sink_at,
+            id: rand::random(),
+            request_id: None,
+        }
+    }
+
     /// This method should be called when generating a new request travelling down a seperate chain to an original request.
     /// The generated request will share the same MessageId as the message it is diverged from.
     pub fn from_frame_diverged(frame: Frame, diverged_from: &Message) -> Self {

--- a/shotover/src/message/mod.rs
+++ b/shotover/src/message/mod.rs
@@ -158,23 +158,6 @@ impl Message {
         }
     }
 
-    /// This method should be called when you have just a Frame of a message.
-    /// This is expected to be used by transforms that are generating custom messages.
-    /// Providing just the Frame results in better performance when only the Frame is available.
-    pub fn from_frame_and_codec_state_at_instant(
-        frame: Frame,
-        codec_state: CodecState,
-        received_from_source_or_sink_at: Option<Instant>,
-    ) -> Self {
-        Message {
-            codec_state,
-            inner: Some(MessageInner::Modified { frame }),
-            received_from_source_or_sink_at,
-            id: rand::random(),
-            request_id: None,
-        }
-    }
-
     /// This method should be called when generating a new request travelling down a seperate chain to an original request.
     /// The generated request will share the same MessageId as the message it is diverged from.
     pub fn from_frame_diverged(frame: Frame, diverged_from: &Message) -> Self {

--- a/shotover/src/transforms/kafka/sink_cluster/connections.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/connections.rs
@@ -238,16 +238,14 @@ impl Connections {
         } else {
             KafkaNodeState::Up
         };
-        nodes
-            .iter()
-            .find(|x| match destination {
-                Destination::Id(id) => x.broker_id == id,
-                Destination::ControlConnection => {
-                    &x.kafka_address == self.control_connection_address.as_ref().unwrap()
-                }
-            })
-            .unwrap()
-            .set_state(node_state);
+        if let Some(node) = nodes.iter().find(|x| match destination {
+            Destination::Id(id) => x.broker_id == id,
+            Destination::ControlConnection => {
+                &x.kafka_address == self.control_connection_address.as_ref().unwrap()
+            }
+        }) {
+            node.set_state(node_state);
+        }
 
         if old_connection
             .map(|old| old.pending_requests_count())

--- a/shotover/src/transforms/kafka/sink_cluster/mod.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/mod.rs
@@ -2972,10 +2972,9 @@ impl KafkaSinkCluster {
 
             metadata.controller_id = shotover_node.broker_id;
         } else {
-            return Err(anyhow!(
-                "Invalid metadata, controller points at unknown broker {:?}",
-                metadata.controller_id
-            ));
+            // controller is either -1 or an unknown broker
+            // In both cases it is reasonable to set to -1 to indicate the controller is unknown.
+            metadata.controller_id = BrokerId(-1);
         }
 
         Ok(())

--- a/shotover/src/transforms/kafka/sink_cluster/mod.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/mod.rs
@@ -273,8 +273,10 @@ impl AtomicBrokerId {
     }
 
     fn set(&self, value: BrokerId) {
-        self.0
-            .store(value.0.into(), std::sync::atomic::Ordering::Relaxed)
+        if value != -1 {
+            self.0
+                .store(value.0.into(), std::sync::atomic::Ordering::Relaxed)
+        }
     }
 
     fn clear(&self) {
@@ -989,7 +991,8 @@ impl KafkaSinkCluster {
                         | RequestBody::AlterConfigs(_)
                         | RequestBody::CreatePartitions(_)
                         | RequestBody::DeleteTopics(_)
-                        | RequestBody::CreateAcls(_),
+                        | RequestBody::CreateAcls(_)
+                        | RequestBody::ApiVersions(_),
                     ..
                 })) => self.route_to_random_broker(message),
 
@@ -2406,9 +2409,9 @@ impl KafkaSinkCluster {
                         ResponseError::try_from_code(topic.error_code)
                     {
                         tracing::info!(
-                                "Response to CreateTopics included error NOT_CONTROLLER and so reset controller broker, previously was {:?}",
-                                self.controller_broker.get()
-                            );
+                            "Response to CreateTopics included error NOT_CONTROLLER and so reset controller broker, previously was {:?}",
+                            self.controller_broker.get()
+                        );
                         self.controller_broker.clear();
                         break;
                     }

--- a/test-helpers/src/connection/kafka/python.rs
+++ b/test-helpers/src/connection/kafka/python.rs
@@ -28,6 +28,58 @@ pub async fn run_python_smoke_test(address: &str) {
     .unwrap();
 }
 
+pub async fn run_python_smoke_test_sasl_plain(address: &str, user: &str, password: &str) {
+    ensure_uv_is_installed().await;
+
+    let project_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/connection/kafka/python");
+    let uv_binary = uv_binary_path();
+    let config = format!(
+        r#"{{
+    'bootstrap_servers': ["{address}"],
+    'security_protocol': "SASL_PLAINTEXT",
+    'sasl_mechanism': "PLAIN",
+    'sasl_plain_username': "{user}",
+    'sasl_plain_password': "{password}",
+}}"#
+    );
+    tokio::time::timeout(
+        Duration::from_secs(60),
+        run_command_async(
+            &project_dir,
+            uv_binary.to_str().unwrap(),
+            &["run", "main.py", &config],
+        ),
+    )
+    .await
+    .unwrap();
+}
+
+pub async fn run_python_smoke_test_sasl_scram(address: &str, user: &str, password: &str) {
+    ensure_uv_is_installed().await;
+
+    let project_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/connection/kafka/python");
+    let uv_binary = uv_binary_path();
+    let config = format!(
+        r#"{{
+    'bootstrap_servers': ["{address}"],
+    'security_protocol': "SASL_PLAINTEXT",
+    'sasl_mechanism': "SCRAM-SHA-256",
+    'sasl_plain_username': "{user}",
+    'sasl_plain_password': "{password}",
+}}"#
+    );
+    tokio::time::timeout(
+        Duration::from_secs(60),
+        run_command_async(
+            &project_dir,
+            uv_binary.to_str().unwrap(),
+            &["run", "main.py", &config],
+        ),
+    )
+    .await
+    .unwrap();
+}
+
 /// Install a specific version of UV to:
 /// * avoid developers having to manually install an external tool
 /// * avoid issues due to a different version being installed

--- a/test-helpers/src/connection/kafka/python.rs
+++ b/test-helpers/src/connection/kafka/python.rs
@@ -80,6 +80,32 @@ pub async fn run_python_smoke_test_sasl_scram(address: &str, user: &str, passwor
     .unwrap();
 }
 
+pub async fn run_python_bad_auth_sasl_scram(address: &str, user: &str, password: &str) {
+    ensure_uv_is_installed().await;
+
+    let project_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/connection/kafka/python");
+    let uv_binary = uv_binary_path();
+    let config = format!(
+        r#"{{
+    'bootstrap_servers': ["{address}"],
+    'security_protocol': "SASL_PLAINTEXT",
+    'sasl_mechanism': "SCRAM-SHA-256",
+    'sasl_plain_username': "{user}",
+    'sasl_plain_password': "{password}",
+}}"#
+    );
+    tokio::time::timeout(
+        Duration::from_secs(60),
+        run_command_async(
+            &project_dir,
+            uv_binary.to_str().unwrap(),
+            &["run", "auth_fail.py", &config],
+        ),
+    )
+    .await
+    .unwrap();
+}
+
 /// Install a specific version of UV to:
 /// * avoid developers having to manually install an external tool
 /// * avoid issues due to a different version being installed

--- a/test-helpers/src/connection/kafka/python/auth_fail.py
+++ b/test-helpers/src/connection/kafka/python/auth_fail.py
@@ -1,0 +1,18 @@
+from kafka import KafkaConsumer
+from kafka import KafkaProducer
+from kafka.errors import KafkaError
+import sys
+
+def main():
+    config = eval(sys.argv[1])
+    print("Running kafka-python script with config:")
+    print(config)
+
+    try:
+        KafkaProducer(**config)
+        raise Exception("KafkaProducer was succesfully created but expected to fail due to using incorrect username/password")
+    except KafkaError:
+        print("kafka-python auth_fail script passed all test cases")
+
+if __name__ == "__main__":
+    main()

--- a/test-helpers/src/lib.rs
+++ b/test-helpers/src/lib.rs
@@ -42,6 +42,7 @@ pub async fn run_command_async(current_dir: &Path, command: &str, args: &[&str])
     let output = tokio::process::Command::new(command)
         .args(args)
         .current_dir(current_dir)
+        .kill_on_drop(true)
         .status()
         .await
         .unwrap();


### PR DESCRIPTION
This PR implements the legacy SASL implementation still in use by the python driver.
I am not aware of any other drivers that use it.

The [protocol docs](https://kafka.apache.org/protocol.html#sasl_handshake) describe the situation pretty well.
To summarize, when the client sends a SaslHandshake request of version 0, the client and broker will perform all SASL communication over raw packets.

Implementing this within shotover requires a lot of complexity, but it is ultimately manageable, and the implementation does not impact non-legacy SASL.

While the docs do not specify this, I am assuming that the client will always send its raw sasl requests immediately after sending a v0 SaslHandshake. The python driver at least behaves this way, and we would have to resort to heuristics to detect message types if any driver did behave this way.

## Overview of implementation

To implement this functionality the following is done:

### CodecState

Refer to this comment about CodecState:
```rust
/// Database protocols are often designed such that their messages can be parsed without knowledge of any state of prior messages.
/// When protocols remain stateless, Shotover's parser implementations can remain fairly simple.
/// However in the real world there is often some kind of connection level state that we need to track in order to parse messages.
///
/// Shotover solves this issue via this enum which provides any of the connection level state required to decode and then reencode messages.
/// 1. The Decoder includes this value in all messages it produces.
/// 2. If any transforms call `.frame()` this value is used to parse the frame of the message.
/// 3. The Encoder uses this value to reencode the message if it has been modified.
```

In this PR `CodecState::Kafka` is expanded to contain `KafkaCodecState` struct which contains the existing request_header field along with the new `raw_sasl: Option<SaslRequestState>` field. When this field is None the standard message handling occurs, when it is Some special encoding and decoding paths will be taken to pretend the raw sasl messages are SaslAuthenticate v0 messages. This ensures that the transforms can treat these raw messages just like they do for the regular sasl messages, completely hiding the distinction from them. This makes KafkaSinkCluster simple to implement and also makes any possible future transforms simple to implement too.

### Codecs

In order to correctly populate the `CodecState` value, the `KafkaEncoder` and `KafkaDecoder` need to coordinate with each other to keep track of any SaslHandshake v0 that pass through in order to mark the following messages as raw sasl messages in the KafkaCodecState.

### Overall Flow

client request -> kafka (SaslHandshake v0)

1. Source KafkaDecoder detects SaslHandshake v0, sets `self.expect_raw_sasl = Some(_)`
2. Sink KafkaEncoder detects SaslHandshake v0, sends `expect_raw_sasl = Some()` to Sink KafkaDecoder

kafka response -> client (SaslHandshake v0)

3. Sink KafkaDecoder, receives `self.expect_raw_sasl = Some(_)` from KafkaDecoder
4. Source KafkaEncoder does nothing in particular of note

client request -> kafka (raw sasl)

5. Source KafkaDecoder assumes that the request is a raw sasl request due to `self.expect_raw_sasl` being Some, as a result it sets the `KafkaCodecState::raw_sasl` field on the message.
6. Transforms may successfully parse the request due to the `KafkaCodecState::raw_sasl` field.
7. Sink KafkaEncoder knows that the request is a raw sasl request due to the `KafkaCodecState::raw_sasl` field.

kafka response -> client  (raw sasl)

8. Source KafkaDecoder assumes that the response is a raw sasl response due to `self.expect_raw_sasl` being Some, as a result it sets the `KafkaCodecState::raw_sasl` field on the message.
9. Transforms may successfully parse the response due to the `KafkaCodecState::raw_sasl` field.
10. Sink KafkaEncoder knows that the response is a raw sasl response due to the `KafkaCodecState::raw_sasl` field.

## Other fixes

There were a few unrelated misc fixes that were needed to get the new integration tests working.
* avoid panic due to hitting a connection error before we fetch broker metadata (connections.rs:241)
* avoid warning on ApiVersions request sent outside of handshake
* Avoid killing shotover connection when cluster reports controller is -1 (indicates controller is not ready yet)
* only set the controller id metadata when its not -1, due to the AtomicBrokerId's set/unset abstraction, if we set it to -1 we wont lookup for new values since it appears set but is actually -1.
* create_topics is added to main.py to ensure that the topic already exists, since auto topic creation was hitting some kind of race condition in the python driver.
* `.kill_on_drop(true)` is needed to ensure the python scripts do not linger around after a failed test.

## New tests

Added tests for:
* running python driver over sasl scram over mtls - includes test to ensure incorrect credentials are rejected.
* running python driver over sasl plain

## Alternatives

We could submit a patch to the python driver that upgrades it to use the modern SASL implementation.
This is probably worth doing if we ever have the resources to spare.
But we should probably still still ship this implementation so that we can handle any other drivers out there still using this old SASL implementation. I dont think kafka has ever deprecated old parts of the protocol before.