### PR TITLE
kafka_int_tests: cleanup delete_groups test

### DIFF
--- a/shotover-proxy/tests/kafka_int_tests/test_cases.rs
+++ b/shotover-proxy/tests/kafka_int_tests/test_cases.rs
@@ -124,6 +124,11 @@ async fn admin_setup(connection_builder: &KafkaConnectionBuilder) {
     admin.delete_topics(&["to_delete"]).await
 }
 
+async fn admin_cleanup(connection_builder: &KafkaConnectionBuilder) {
+    let admin = connection_builder.connect_admin().await;
+    admin.delete_groups(&["some_group"]).await;
+}
+
 /// Attempt to make the driver batch produce requests for different topics into the same request
 /// This is important to test since shotover has complex logic for splitting these batch requests into individual requests.
 pub async fn produce_consume_multi_topic_batch(connection_builder: &KafkaConnectionBuilder) {
@@ -1358,7 +1363,7 @@ pub async fn standard_test_suite(connection_builder: &KafkaConnectionBuilder) {
     }
 
     produce_consume_acks0(connection_builder).await;
-    connection_builder.admin_cleanup().await;
+    admin_cleanup(connection_builder).await;
 }
 
 pub async fn cluster_test_suite(connection_builder: &KafkaConnectionBuilder) {

--- a/test-helpers/src/connection/kafka/java.rs
+++ b/test-helpers/src/connection/kafka/java.rs
@@ -508,6 +508,16 @@ impl KafkaAdminJava {
             .await;
     }
 
+    pub async fn delete_groups(&self, to_delete: &[&str]) {
+        let to_delete: Vec<Value> = to_delete.iter().map(|x| self.jvm.new_string(x)).collect();
+        let topics = self.jvm.new_list("java.lang.String", to_delete);
+
+        self.admin
+            .call("deleteConsumerGroups", vec![topics])
+            .call_async("all", vec![])
+            .await;
+    }
+
     pub async fn create_partitions(&self, partitions: &[NewPartition<'_>]) {
         let partitions: Vec<(Value, Value)> = partitions
             .iter()

--- a/test-helpers/src/connection/kafka/mod.rs
+++ b/test-helpers/src/connection/kafka/mod.rs
@@ -123,14 +123,6 @@ impl KafkaConnectionBuilder {
             .await
             .unwrap_err()
     }
-
-    pub async fn admin_cleanup(&self) {
-        match self {
-            #[cfg(feature = "kafka-cpp-driver-tests")]
-            Self::Cpp(cpp) => cpp.admin_cleanup().await,
-            Self::Java(_) => {}
-        }
-    }
 }
 
 pub enum KafkaProducer {
@@ -439,6 +431,14 @@ impl KafkaAdmin {
             #[cfg(feature = "kafka-cpp-driver-tests")]
             Self::Cpp(cpp) => cpp.delete_topics(to_delete).await,
             Self::Java(java) => java.delete_topics(to_delete).await,
+        }
+    }
+
+    pub async fn delete_groups(&self, to_delete: &[&str]) {
+        match self {
+            #[cfg(feature = "kafka-cpp-driver-tests")]
+            Self::Cpp(cpp) => cpp.delete_groups(to_delete).await,
+            Self::Java(java) => java.delete_groups(to_delete).await,
         }
     }
 


### PR DESCRIPTION
This PR cleans up the existing testing for kafka delete_groups:
* Previously there was an admin_cleanup function in the cpp driver modules that was hardcoded to the cpp driver.
    + this was leftover from the very earliest integration tests we had for kafka
    + This PR moves this logic into the higher level `kafka_int_tests` module, calling the new `KafkaAdmin::delete_groups` method 
* Previously the java driver was untested, but this PR adds a delete_groups implementation for the java driver.
* Previously we ignored some failures in the cpp driver when deleting groups, I've not been able to reproduce those failures, so I just removed the extra handling.