### PR TITLE
KafkaSinkCluster: Split OffsetFetch

### DIFF
--- a/shotover/src/transforms/kafka/sink_cluster/mod.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/mod.rs
@@ -904,12 +904,6 @@ impl KafkaSinkCluster {
                         let group_id = offset_fetch.group_id.clone();
                         self.route_to_group_coordinator(message, group_id);
                     } else {
-                        // This is possibly dangerous.
-                        // The client could construct a message which is valid for a specific shotover node, but not for any single kafka broker.
-                        // We may need to add some logic to split the request into multiple messages going to different destinations,
-                        // and then reconstruct the response back into a single response
-                        //
-                        // For now just pick the first group as that is sufficient for the simple cases.
                         self.split_and_route_request::<OffsetFetchSplitAndRouter>(message)?;
                     };
                 }
@@ -1384,7 +1378,7 @@ impl KafkaSinkCluster {
     }
 
     /// This method removes all group ids from the DeleteGroups request and returns them split up by their destination.
-    /// If any topics are unroutable they will have their BrokerId set to -1
+    /// If any groups ids are unroutable they will have their BrokerId set to -1
     fn split_delete_groups_request_by_destination(
         &mut self,
         body: &mut DeleteGroupsRequest,
@@ -1406,8 +1400,8 @@ impl KafkaSinkCluster {
         result
     }
 
-    /// This method removes all group ids from the DeleteGroups request and returns them split up by their destination.
-    /// If any topics are unroutable they will have their BrokerId set to -1
+    /// This method removes all groups from the OffsetFetch request and returns them split up by their destination.
+    /// If any groups are unroutable they will have their BrokerId set to -1
     fn split_offset_fetch_request_by_destination(
         &mut self,
         body: &mut OffsetFetchRequest,

--- a/shotover/src/transforms/kafka/sink_cluster/split.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/split.rs
@@ -8,9 +8,10 @@ use crate::{
 };
 use kafka_protocol::messages::{
     add_partitions_to_txn_request::AddPartitionsToTxnTransaction,
-    list_offsets_request::ListOffsetsTopic, offset_for_leader_epoch_request::OffsetForLeaderTopic,
-    produce_request::TopicProduceData, AddPartitionsToTxnRequest, BrokerId, DeleteGroupsRequest,
-    GroupId, ListOffsetsRequest, OffsetForLeaderEpochRequest, ProduceRequest, TopicName,
+    list_offsets_request::ListOffsetsTopic, offset_fetch_request::OffsetFetchRequestGroup,
+    offset_for_leader_epoch_request::OffsetForLeaderTopic, produce_request::TopicProduceData,
+    AddPartitionsToTxnRequest, BrokerId, DeleteGroupsRequest, GroupId, ListOffsetsRequest,
+    OffsetFetchRequest, OffsetForLeaderEpochRequest, ProduceRequest, TopicName,
 };
 use std::collections::HashMap;
 
@@ -162,5 +163,33 @@ impl RequestSplitAndRouter for DeleteGroupsSplitAndRouter {
 
     fn reassemble(request: &mut Self::Request, item: Self::SubRequests) {
         request.groups_names = item;
+    }
+}
+
+pub struct OffsetFetchSplitAndRouter;
+
+impl RequestSplitAndRouter for OffsetFetchSplitAndRouter {
+    type Request = OffsetFetchRequest;
+    type SubRequests = Vec<OffsetFetchRequestGroup>;
+
+    fn split_by_destination(
+        transform: &mut KafkaSinkCluster,
+        request: &mut Self::Request,
+    ) -> HashMap<BrokerId, Self::SubRequests> {
+        transform.split_offset_fetch_request_by_destination(request)
+    }
+
+    fn get_request_frame(request: &mut Message) -> Option<&mut Self::Request> {
+        match request.frame() {
+            Some(Frame::Kafka(KafkaFrame::Request {
+                body: RequestBody::OffsetFetch(request),
+                ..
+            })) => Some(request),
+            _ => None,
+        }
+    }
+
+    fn reassemble(request: &mut Self::Request, item: Self::SubRequests) {
+        request.groups = item;
     }
 }


### PR DESCRIPTION
closes https://github.com/shotover/shotover-proxy/issues/1764

I was not able to find a way to reproduce this, I suspect that no drivers actually make use of this functionality.
Regardless, I think we should just handle this correctly since its pretty straightforward to implement.
I'm fairly confident it is correct due to its similarity to other split messages like DeleteGroups that also route by group id.