### PR TITLE
Release shotover 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4486,7 +4486,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shotover"
-version = "0.4.1"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "shotover-proxy"
-version = "0.4.1"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shotover-proxy"
-version = "0.4.1"
+version = "0.5.1"
 authors = ["Ben <ben@instaclustr.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/shotover/Cargo.toml
+++ b/shotover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shotover"
-version = "0.4.1"
+version = "0.5.1"
 authors = ["Ben <ben@instaclustr.com>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
Version 0.5.0 is skipped since the `v0.5.0-preview1` tag ended up being used as 0.5.0 internally.