### PR TITLE
KafkaSinkCluster: route ListGroups request

### DIFF
--- a/shotover-proxy/tests/kafka_int_tests/mod.rs
+++ b/shotover-proxy/tests/kafka_int_tests/mod.rs
@@ -426,7 +426,7 @@ async fn cluster_1_rack_multi_shotover_with_1_shotover_down(#[case] driver: Kafk
 
     // create a new connection and produce and consume messages
     let new_connection_builder = KafkaConnectionBuilder::new(driver, "localhost:9193");
-    test_cases::cluster_test_suite(&new_connection_builder).await;
+    test_cases::cluster_test_suite_with_lost_shotover_node(&new_connection_builder).await;
 
     let mut expected_events = multi_shotover_events();
     // Other shotover nodes should detect the killed node at least once
@@ -485,7 +485,7 @@ async fn cluster_3_racks_multi_shotover_with_2_shotover_down(#[case] driver: Kaf
 
     // create a new connection and produce and consume messages
     let new_connection_builder = KafkaConnectionBuilder::new(driver, "localhost:9193");
-    test_cases::cluster_test_suite(&new_connection_builder).await;
+    test_cases::cluster_test_suite_with_lost_shotover_node(&new_connection_builder).await;
 
     let mut expected_events = multi_shotover_events();
     // The UP shotover node should detect the killed nodes at least once
@@ -537,7 +537,7 @@ async fn cluster_3_racks_multi_shotover_with_1_shotover_missing(#[case] driver: 
 
     // Send some produce and consume requests
     let connection_builder = KafkaConnectionBuilder::new(driver, "localhost:9192");
-    test_cases::cluster_test_suite(&connection_builder).await;
+    test_cases::cluster_test_suite_with_lost_shotover_node(&connection_builder).await;
 
     let mut expected_events = multi_shotover_events();
     // Other shotover nodes should detect the missing node at least once

--- a/test-helpers/src/connection/kafka/java.rs
+++ b/test-helpers/src/connection/kafka/java.rs
@@ -665,6 +665,25 @@ impl KafkaAdminJava {
         results
     }
 
+    pub async fn list_groups(&self) -> Vec<String> {
+        let java_results = self
+            .admin
+            .call("listConsumerGroups", vec![])
+            .call_async("all", vec![])
+            .await;
+
+        let mut results = vec![];
+        for java_group in java_results.call("iterator", vec![]).into_iter() {
+            results.push(
+                java_group
+                    .cast("org.apache.kafka.clients.admin.ConsumerGroupListing")
+                    .call("groupId", vec![])
+                    .into_rust(),
+            )
+        }
+        results
+    }
+
     pub async fn create_acls(&self, acls: Vec<Acl>) {
         let resource_type = self
             .jvm

--- a/test-helpers/src/connection/kafka/mod.rs
+++ b/test-helpers/src/connection/kafka/mod.rs
@@ -456,7 +456,7 @@ impl KafkaAdmin {
     pub async fn list_groups(&self) -> Vec<String> {
         match self {
             #[cfg(feature = "kafka-cpp-driver-tests")]
-            Self::Cpp(_) => panic!("rdkafka-rs driver does not support list_offsets"),
+            Self::Cpp(_) => panic!("rdkafka-rs driver does not support list_groups"),
             Self::Java(java) => java.list_groups().await,
         }
     }

--- a/test-helpers/src/connection/kafka/mod.rs
+++ b/test-helpers/src/connection/kafka/mod.rs
@@ -453,6 +453,14 @@ impl KafkaAdmin {
         }
     }
 
+    pub async fn list_groups(&self) -> Vec<String> {
+        match self {
+            #[cfg(feature = "kafka-cpp-driver-tests")]
+            Self::Cpp(_) => panic!("rdkafka-rs driver does not support list_offsets"),
+            Self::Java(java) => java.list_groups().await,
+        }
+    }
+
     pub async fn create_partitions(&self, partitions: &[NewPartition<'_>]) {
         match self {
             #[cfg(feature = "kafka-cpp-driver-tests")]


### PR DESCRIPTION
This turned out to be more complicated than I initially thought.

When `AdminClient.listConsumerGroups` is called, the java driver sends a `ListGroups` request to all brokers and then combines the responses, removing any duplicate entries.

To ensure that all groups are included shotover should also send requests to all brokers and combine them.
However we should avoid sending requests outside of shotovers rack to reduce the load of the operation.
This should still include all the results as the client will query all shotover nodes, and each shotover node will query a portion of the kafka brokers, ensuring all kafka nodes are queried.

A second commit was added to avoid running the new test case in the tests with a down shotover node, since that resulted in test failures as the down shotover node can not report its racks groups.
It might be easier to review that commit separately from the main commit.