### PR TITLE
Fix hang in gocql init

### DIFF
--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -467,6 +467,51 @@ async fn cluster_multi_rack_2_per_rack(#[case] driver: CassandraDriver) {
     cluster::multi_rack::test_topology_task(None, expected_nodes, 16).await;
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn cluster_multi_rack_2_per_rack_go_smoke_test() {
+    let _compose = docker_compose(
+        "tests/test-configs/cassandra/cluster-multi-rack-2-per-rack/docker-compose.yaml",
+    );
+
+    let shotover_rack1 = shotover_process(
+        "tests/test-configs/cassandra/cluster-multi-rack-2-per-rack/topology_rack1.yaml",
+    )
+    .with_config("tests/test-configs/shotover-config/config1.yaml")
+    .with_log_name("Rack1")
+    .start()
+    .await;
+    let shotover_rack2 = shotover_process(
+        "tests/test-configs/cassandra/cluster-multi-rack-2-per-rack/topology_rack2.yaml",
+    )
+    .with_log_name("Rack2")
+    .with_config("tests/test-configs/shotover-config/config2.yaml")
+    .start()
+    .await;
+    let shotover_rack3 = shotover_process(
+        "tests/test-configs/cassandra/cluster-multi-rack-2-per-rack/topology_rack3.yaml",
+    )
+    .with_config("tests/test-configs/shotover-config/config3.yaml")
+    .with_log_name("Rack3")
+    .start()
+    .await;
+
+    test_helpers::connection::cassandra::go::run_go_smoke_test().await;
+
+    // gocql driver will route execute requests to its control connection during initialization which results in out of rack requests.
+    // This warning is correctly triggered in that case.
+    // The warning occurs only in rack1, gocql driver always picks rack 1 for its control connection
+    shotover_rack1
+        .shutdown_and_then_consume_events(&[EventMatcher::new()
+            .with_level(Level::Warn)
+            .with_target("shotover::transforms::cassandra::sink_cluster::node_pool")
+            .with_message("No suitable nodes to route to found within rack. This error only occurs in debug builds as it should never occur in an ideal integration test situation.")
+            .with_count(Count::Any)
+            ])
+        .await;
+    shotover_rack2.shutdown_and_then_consume_events(&[]).await;
+    shotover_rack3.shutdown_and_then_consume_events(&[]).await;
+}
+
 #[rstest]
 #[case::scylla(Scylla)]
 //#[case::cdrs(Cdrs)] // TODO

--- a/shotover/src/transforms/cassandra/sink_cluster/rewrite.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/rewrite.rs
@@ -119,7 +119,7 @@ impl MessageRewriter {
                 RewriteTableTy::Prepare { clone_index } => {
                     let mut first = true;
                     for node in pool.nodes().iter() {
-                        if node.is_up && node.rack == self.local_shotover_node.rack {
+                        if node.is_up {
                             if first {
                                 let message_id = messages[*clone_index].id();
                                 self.prepare_requests_to_destination_nodes


### PR DESCRIPTION
closes https://github.com/shotover/shotover-proxy/issues/1793

This PR reproduces the issue in an integration test and then fixes the issue with a code change.

## The problem
Shotover works well with clients that perform token aware routing of prepared execute requests.
However, if the client is not performing token aware routing, shotover may not be able to route the execute request correctly.
And while the gocql driver is initializing it sends execute requests through its control connection (not routed by token) therefore hitting this issue.
As a result the gocql driver ends up in a loop as it keeps retrying but never succeeding to prepared and execute the query.

The exact issue follows this flow:

1.   client sends request to create prepared query over control connection
2.   shotover routes request to all nodes in its rack
3.   all cassandra nodes in the rack respond with success
4.   shotover combines these responses into a single success response to send back to client
6.   client attempts to execute query over control connection
7.   shotover (correctly) routes the request to its true destination which is outside of shotovers rack.
8.   cassandra responds with error because there is no such prepared query on this cassandra node since it is outside of shotovers rack and only the nodes within shotovers rack have the query prepared.
9.   shotover returns error response to client.
10. client receives error and retries the whole process, returning to step 1


## The original fix

The absolute simplest fix is to have shotover send the prepare request to all cassandra nodes in the cluster, not just the cassandra nodes in shotover's rack.

However, this has some performance issues as we now need to send a message to all nodes in the cluster, likely forcing shotover to open new connections to them, and requiring out of rack communication.
As a result I considered alternative fixes.

## ~~The final fix~~

~~The final fix used in this PR is to route the request to a random node within the rack and have that node route to the correct node.
This:~~
~~* simplifies our routing logic.~~
~~* avoids the performance concerns of routing prepare requests to all nodes.~~
~~* Has the downside that we remove the fallback to out of node requests.~~

~~The only case where this fallback would be used is if all cassandra nodes in a shotover instance's rack are down.
This is very rare, but possible.
However if we have lost an entire rack of cassandra nodes then we have lost a large chunk of the cassandra cluster, so if we start sending out of rack requests we might start to overwhelm any still functioning racks.
Better for shotover to just handle this case as an error.~~

~~The final fix is implemented as a 2nd commit ontop of the original fix which is the 1st commit.~~
Final fix is reverted, it is common to run with a rack of 1 cassandra node, so this is actually quite dangerous.

We will explore any possible performance fixes once we have clusters running with shotover with high cassandra node count.