### PR TITLE
Route ListTransactions request

### DIFF
--- a/shotover-proxy/tests/kafka_int_tests/test_cases.rs
+++ b/shotover-proxy/tests/kafka_int_tests/test_cases.rs
@@ -1456,8 +1456,19 @@ async fn list_groups(connection_builder: &KafkaConnectionBuilder) {
 
     let actual_results = admin.list_groups().await;
     if !actual_results.contains(&"list_groups_test".to_owned()) {
-        panic!("Expected to find list_groups_test in {actual_results:?} but was misisng")
+        panic!("Expected to find \"list_groups_test\" in {actual_results:?} but was missing")
     }
+}
+
+async fn list_transactions(connection_builder: &KafkaConnectionBuilder) {
+    let admin = connection_builder.connect_admin().await;
+    let _transaction_producer = connection_builder
+        .connect_producer_with_transactions("some_transaction_id".to_owned())
+        .await;
+
+    let actual_results = admin.list_transactions().await;
+    let expected_results = ["some_transaction_id".to_owned()];
+    assert_eq!(actual_results, expected_results);
 }
 
 async fn cluster_test_suite_base(connection_builder: &KafkaConnectionBuilder) {
@@ -1485,6 +1496,7 @@ pub async fn tests_requiring_all_shotover_nodes(connection_builder: &KafkaConnec
     #[allow(irrefutable_let_patterns)]
     if let KafkaConnectionBuilder::Java(_) = connection_builder {
         list_groups(connection_builder).await;
+        list_transactions(connection_builder).await;
     }
 }
 

--- a/test-helpers/src/connection/kafka/java.rs
+++ b/test-helpers/src/connection/kafka/java.rs
@@ -684,6 +684,25 @@ impl KafkaAdminJava {
         results
     }
 
+    pub async fn list_transactions(&self) -> Vec<String> {
+        let java_results = self
+            .admin
+            .call("listTransactions", vec![])
+            .call_async("all", vec![])
+            .await;
+
+        let mut results = vec![];
+        for java_group in java_results.call("iterator", vec![]).into_iter() {
+            results.push(
+                java_group
+                    .cast("org.apache.kafka.clients.admin.TransactionListing")
+                    .call("transactionalId", vec![])
+                    .into_rust(),
+            )
+        }
+        results
+    }
+
     pub async fn create_acls(&self, acls: Vec<Acl>) {
         let resource_type = self
             .jvm

--- a/test-helpers/src/connection/kafka/mod.rs
+++ b/test-helpers/src/connection/kafka/mod.rs
@@ -461,6 +461,14 @@ impl KafkaAdmin {
         }
     }
 
+    pub async fn list_transactions(&self) -> Vec<String> {
+        match self {
+            #[cfg(feature = "kafka-cpp-driver-tests")]
+            Self::Cpp(_) => panic!("rdkafka-rs driver does not support list_transactions"),
+            Self::Java(java) => java.list_transactions().await,
+        }
+    }
+
     pub async fn create_partitions(&self, partitions: &[NewPartition<'_>]) {
         match self {
             #[cfg(feature = "kafka-cpp-driver-tests")]


### PR DESCRIPTION
This PR implements routing for ListTransactions requests by applying the same routing logic to ListTransactions as we did for ListGroups in https://github.com/shotover/shotover-proxy/pull/1790

However, I found that while the java driver deduplicates entries in ListGroups responses it does not do the same for ListTransactions responses.

So I had to alter the logic in `split_request_by_routing_to_all_brokers` to avoid duplicates.
As a result ListGroups is actually more efficient as we better distribute the load across shotover instances by avoiding querying the same node twice.

The comment on `split_request_by_routing_to_all_brokers` explains the new logic pretty well:
```rust
/// Route broadcast requests to all brokers split across all shotover nodes.
/// That is, each shotover node in a rack will deterministically be assigned a portion of the rack to route the request to.
/// If a shotover node is the only node in its rack it will route to all kafka brokers in the rack.
/// When combined with a client that is routing this request to all shotover nodes, the request will reach each kafka broker exactly once.
```