### PR TITLE
KafkaSinkCluster: DeleteRecords

### DIFF
--- a/shotover/src/transforms/kafka/sink_cluster/mod.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/mod.rs
@@ -1048,6 +1048,7 @@ The connection to the client has been closed."
                         | RequestBody::AlterConfigs(_)
                         | RequestBody::CreatePartitions(_)
                         | RequestBody::DeleteTopics(_)
+                        | RequestBody::DeleteRecords(_)
                         | RequestBody::CreateAcls(_)
                         | RequestBody::ApiVersions(_),
                     ..

--- a/test-helpers/src/connection/kafka/mod.rs
+++ b/test-helpers/src/connection/kafka/mod.rs
@@ -442,6 +442,14 @@ impl KafkaAdmin {
         }
     }
 
+    pub async fn delete_records(&self, to_delete: &[RecordsToDelete]) {
+        match self {
+            #[cfg(feature = "kafka-cpp-driver-tests")]
+            Self::Cpp(_) => unimplemented!(),
+            Self::Java(java) => java.delete_records(to_delete).await,
+        }
+    }
+
     pub async fn list_offsets(
         &self,
         topic_partitions: HashMap<TopicPartition, OffsetSpec>,
@@ -656,4 +664,10 @@ impl IsolationLevel {
 
 pub struct OffsetAndMetadata {
     pub offset: i64,
+}
+pub struct RecordsToDelete {
+    pub topic_partition: TopicPartition,
+    /// Delete all records with offset less than the provided value.
+    /// If -1 is given delete all records regardless of offset.
+    pub delete_before_offset: i64,
 }


### PR DESCRIPTION
The implementation is straightforward, DeleteRecords can be routed to any node, so we just pick one at random.

The integration test adds deleteRecords support to our java driver wrapper and adds a test case that calls deleteRecords and asserts that the records were deleted.