### PR TITLE
KafkaSinkCluster: route OffsetDelete

### DIFF
--- a/shotover/src/transforms/kafka/sink_cluster/mod.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/mod.rs
@@ -940,6 +940,13 @@ impl KafkaSinkCluster {
                     self.split_and_route_request::<DeleteGroupsSplitAndRouter>(request)?;
                 }
                 Some(Frame::Kafka(KafkaFrame::Request {
+                    body: RequestBody::OffsetDelete(offset_delete),
+                    ..
+                })) => {
+                    let group_id = offset_delete.group_id.clone();
+                    self.route_to_group_coordinator(request, group_id);
+                }
+                Some(Frame::Kafka(KafkaFrame::Request {
                     body: RequestBody::TxnOffsetCommit(txn_offset_commit),
                     ..
                 })) => {

--- a/test-helpers/src/connection/java.rs
+++ b/test-helpers/src/connection/java.rs
@@ -245,6 +245,14 @@ impl Jvm {
         }
     }
 
+    /// Construct a java set containing the provided elements
+    pub(crate) fn new_set(&self, element_type: &str, elements: Vec<Value>) -> Value {
+        self.construct(
+            "java.util.HashSet",
+            vec![self.new_list(element_type, elements)],
+        )
+    }
+
     /// Construct a java map containing the provided key value pairs
     pub(crate) fn new_map(&self, key_values: Vec<(Value, Value)>) -> Value {
         let map = self.construct("java.util.HashMap", vec![]);
@@ -408,4 +416,15 @@ impl Iterator for JavaIterator {
             None
         }
     }
+}
+
+pub fn map_iterator(map: Value) -> impl Iterator<Item = (Value, Value)> {
+    map.cast("java.util.Map")
+        .call("entrySet", vec![])
+        .call("iterator", vec![])
+        .into_iter()
+        .map(|entry| {
+            let entry = entry.cast("java.util.Map$Entry");
+            (entry.call("getKey", vec![]), entry.call("getValue", vec![]))
+        })
 }

--- a/test-helpers/src/connection/kafka/mod.rs
+++ b/test-helpers/src/connection/kafka/mod.rs
@@ -477,6 +477,36 @@ impl KafkaAdmin {
         }
     }
 
+    pub async fn list_consumer_group_offsets(
+        &self,
+        group_id: String,
+    ) -> HashMap<String, HashMap<TopicPartition, OffsetAndMetadata>> {
+        match self {
+            #[cfg(feature = "kafka-cpp-driver-tests")]
+            Self::Cpp(_) => {
+                panic!("rdkafka-rs driver does not support list_consumer_group_offsets")
+            }
+            Self::Java(java) => java.list_consumer_group_offsets(group_id).await,
+        }
+    }
+
+    pub async fn delete_consumer_group_offsets(
+        &self,
+        group_id: String,
+        topic_partitions: &[TopicPartition],
+    ) {
+        match self {
+            #[cfg(feature = "kafka-cpp-driver-tests")]
+            Self::Cpp(_) => {
+                panic!("rdkafka-rs driver does not support delete_consumer_group_offsets")
+            }
+            Self::Java(java) => {
+                java.delete_consumer_group_offsets(group_id, topic_partitions)
+                    .await
+            }
+        }
+    }
+
     pub async fn create_partitions(&self, partitions: &[NewPartition<'_>]) {
         match self {
             #[cfg(feature = "kafka-cpp-driver-tests")]
@@ -662,6 +692,7 @@ impl IsolationLevel {
     }
 }
 
+#[derive(PartialEq, Debug)]
 pub struct OffsetAndMetadata {
     pub offset: i64,
 }


### PR DESCRIPTION
This PR is mostly adding new methods to the java driver wrapper and adding an integration test case.
The listConsumerGroupOffsets and deleteConsumerGroupOffsets methods of the java admin client are now exposed, and we use them to write an integration test that lists all offsets of a group, deletes one of them and then lists them again to assert that it is deleted.

The actual implementation is straightforward: route the OffsetDelete request using the standard group coordinator routing via group id

It is a bit surprising that listConsumerGroupOffsets doesnt have a corresponding message type but it actually reuses the OffsetFetch message type used by the consumer client. So there are no changes to shotover required to support this functionality.