### PR TITLE
KafkaSinkCluster: Fix DeleteRecords routing

### DIFF
--- a/test-helpers/src/connection/kafka/mod.rs
+++ b/test-helpers/src/connection/kafka/mod.rs
@@ -268,7 +268,7 @@ impl KafkaConsumer {
         }
     }
 
-    async fn consume(&mut self, timeout: Duration) -> ExpectedResponse {
+    pub async fn consume(&mut self, timeout: Duration) -> ExpectedResponse {
         match self {
             #[cfg(feature = "kafka-cpp-driver-tests")]
             Self::Cpp(cpp) => cpp.consume(timeout).await,


### PR DESCRIPTION
I didnt inspect the messages passing through for error codes in https://github.com/shotover/shotover-proxy/pull/1799 and allowed an incorrect routing implementation through.
It still passed the test due to java driver retrying on failure and shotover eventually randomly choosing the correct node to route to.

This PR fixes the issue by properly routing DeleteRecords by splitting it up and routing according to the node hosting the partition. The splitting logic is the same as fetch and produce message types but needs to be reimplemented to operate on the DeleteRecords struct instead.

I added a new integration test case to get coverage over the case where splitting happens (more than one partition to delete)