### PR TITLE
Attempt to fix CI

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -43,6 +43,10 @@ jobs:
         # Otherwise only the last build to finish would get saved to the cache.
         # We allow different test_flags to share a cache as they should have identical build outputs
         key: ${{ matrix.runner }} - ${{ matrix.cargo_flags }}
+        cache-directories: |
+          target/debug/jassets
+          target/release/jassets
+
         # this line means that only the main branch writes to the cache
         # benefits:
         # * prevents main branch caches from being evicted in favor of a PR cache


### PR DESCRIPTION
This PR fixes a tricky CI caching issue introduced by https://github.com/shotover/shotover-proxy/pull/1801

#1801 pulled in https://github.com/astonbitecode/j4rs/pull/115 which fixes j4rs so that the build.rs script runs on the first build only, instead of on the first and second builds only. (it never ran on 3rd, 4th etc. builds)

However we are accidentally relying on this fact in our CI setup.
We build j4rs which sets up the target/debug/jassets directory.
The main branch CI run caches the `target` directory excluding jassets since its not a typical rust target file.
On the next PR branch run CI restores `target` from the main branch cache such that j4rs is fully compiled (no build.rs to run) but the jassets directory is missing.
Previously, since the build.rs would rerun on the 2nd rerun the jassets directory would be repopulated.
But that is no longer the case, and so the tests explode since jassets is missing.

To fix this issue, this PR adds the jassets directory to the rust-cache github actions config.
Its impossible to test this without merging since the main branch cache write only occurs after a PR is merged.
But it should fix it and if it doesnt fix the issue we'll just try something else.