### PR TITLE
CI fix Attempt #3

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -76,7 +76,7 @@ jobs:
       # This workaround is to force j4rs to be rebuilt from scratch via cargo clean.
       # This has a cost on CI runtime and in the future we should find another solution as discussed above.
     - name: Workaround j4rs cache issue
-      run: cargo clean -p j4rs
+      run: cargo clean -p j4rs ${{ matrix.cargo_flags }}
 
     - name: Build tests
       run: |


### PR DESCRIPTION
https://github.com/shotover/shotover-proxy/pull/1808 was a success, but it only fixed debug builds, leaving all of the release builds broken as well.
To fix this, this PR includes the `${{ matrix.cargo_flags }}` in the clean flags.
This will include `--release` for release builds and nothing for debug builds, ensuring that release builds also have j4rs built from scratch, same as debug builds.

I'm not sure why #1808 seemed to completely fix the issue, maybe the main branch caches hadnt actually been written to yet.