### PR TITLE
KafkaSinkCluster: error on AlterPartition request

### DIFF
--- a/shotover/src/transforms/kafka/sink_cluster/mod.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/mod.rs
@@ -1042,7 +1042,11 @@ impl KafkaSinkCluster {
                         | RequestBody::UpdateMetadata(_)
                         // It was determined that this message type is only sent between brokers by:
                         // * https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=177049344#KIP730:ProducerIDgenerationinKRaftmode-PublicInterfaces
-                        | RequestBody::AllocateProducerIds(_),
+                        | RequestBody::AllocateProducerIds(_)
+                        // It was determined that this message type is only sent between brokers because:
+                        // * it is not exposed via the Admin client.
+                        // * This KIP discusses the message type and makes no mention of clients using it https://cwiki.apache.org/confluence/display/KAFKA/KIP-704:+Send+a+hint+to+the+partition+leader+to+recover+the+partition
+                        | RequestBody::AlterPartition(_),
                     header:
                         RequestHeader {
                             request_api_key, ..


### PR DESCRIPTION
It was harder to confirm this one is actually exclusively used broker to broker, but seems reasonable to assume so from what I did find.
If we do ever find clients that call this we can implement routing for it then.