### PR TITLE
KafkaSinkCluster: route DescribeLogDirs request

### DIFF
--- a/shotover-proxy/tests/kafka_int_tests/mod.rs
+++ b/shotover-proxy/tests/kafka_int_tests/mod.rs
@@ -585,7 +585,12 @@ async fn cluster_2_racks_multi_shotover(#[case] driver: KafkaDriver) {
 
     let connection_builder = KafkaConnectionBuilder::new(driver, "127.0.0.1:9192");
     test_cases::cluster_test_suite(&connection_builder).await;
-    test_cases::describe_log_dirs(&connection_builder).await;
+
+    #[allow(irrefutable_let_patterns)]
+    if let KafkaDriver::Java = driver {
+        // describeLogDirs is only on java driver
+        test_cases::describe_log_dirs(&connection_builder).await;
+    }
 
     for shotover in shotovers {
         tokio::time::timeout(

--- a/shotover-proxy/tests/kafka_int_tests/mod.rs
+++ b/shotover-proxy/tests/kafka_int_tests/mod.rs
@@ -585,6 +585,7 @@ async fn cluster_2_racks_multi_shotover(#[case] driver: KafkaDriver) {
 
     let connection_builder = KafkaConnectionBuilder::new(driver, "127.0.0.1:9192");
     test_cases::cluster_test_suite(&connection_builder).await;
+    test_cases::describe_log_dirs(&connection_builder).await;
 
     for shotover in shotovers {
         tokio::time::timeout(

--- a/shotover-proxy/tests/kafka_int_tests/test_cases.rs
+++ b/shotover-proxy/tests/kafka_int_tests/test_cases.rs
@@ -3,11 +3,11 @@ use std::{collections::HashMap, time::Duration};
 use test_helpers::{
     connection::kafka::{
         Acl, AclOperation, AclPermissionType, AlterConfig, ConfigEntry, ConsumerConfig,
-        ConsumerGroupDescription, ExpectedResponse, IsolationLevel, KafkaAdmin,
-        KafkaConnectionBuilder, KafkaConsumer, KafkaDriver, KafkaProducer, ListOffsetsResultInfo,
-        NewPartition, NewPartitionReassignment, NewTopic, OffsetAndMetadata, OffsetSpec, Record,
-        RecordsToDelete, ResourcePatternType, ResourceSpecifier, ResourceType, TopicPartition,
-        TransactionDescription,
+        ConsumerGroupDescription, DescribeReplicaLogDirInfo, ExpectedResponse, IsolationLevel,
+        KafkaAdmin, KafkaConnectionBuilder, KafkaConsumer, KafkaDriver, KafkaProducer,
+        ListOffsetsResultInfo, NewPartition, NewPartitionReassignment, NewTopic, OffsetAndMetadata,
+        OffsetSpec, Record, RecordsToDelete, ResourcePatternType, ResourceSpecifier, ResourceType,
+        TopicPartition, TopicPartitionReplica, TransactionDescription,
     },
     docker_compose::DockerCompose,
 };
@@ -1798,6 +1798,95 @@ async fn create_and_list_partition_reassignments(connection_builder: &KafkaConne
     assert_eq!(
         reassignment.adding_replica_broker_ids,
         expected_adding_replica_broker_ids
+    );
+}
+
+// Due to specifying brokers to query directly, this test is specialized to a 2 shotover node, 4 kafka node cluster.
+// So we call it directly from such a test, instead of including it in the test suite.
+pub async fn describe_log_dirs(connection_builder: &KafkaConnectionBuilder) {
+    let admin = connection_builder.connect_admin().await;
+
+    // Create a topic that is replicated to every node in the cluster
+    admin
+        .create_topics_and_wait(&[
+            NewTopic {
+                name: "describe_logs_test",
+                num_partitions: 1,
+                replication_factor: 6,
+            },
+            NewTopic {
+                name: "describe_logs_test2",
+                num_partitions: 1,
+                replication_factor: 6,
+            },
+        ])
+        .await;
+    let producer = connection_builder.connect_producer("all", 100).await;
+    producer
+        .assert_produce(
+            Record {
+                payload: "initial",
+                topic_name: "describe_logs_test",
+                key: None,
+            },
+            Some(0),
+        )
+        .await;
+
+    // describe the topic and assert contains path
+    let result = admin
+        .describe_replica_log_dirs(&[
+            TopicPartitionReplica {
+                topic_name: "describe_logs_test".to_owned(),
+                partition: 0,
+                broker_id: 0,
+            },
+            TopicPartitionReplica {
+                topic_name: "describe_logs_test".to_owned(),
+                partition: 0,
+                broker_id: 1,
+            },
+            TopicPartitionReplica {
+                topic_name: "describe_logs_test2".to_owned(),
+                partition: 0,
+                broker_id: 0,
+            },
+        ])
+        .await;
+    assert_eq!(
+        result,
+        HashMap::from([
+            (
+                TopicPartitionReplica {
+                    topic_name: "describe_logs_test".to_owned(),
+                    partition: 0,
+                    broker_id: 0,
+                },
+                DescribeReplicaLogDirInfo {
+                    path: Some("/bitnami/kafka/data".to_owned())
+                }
+            ),
+            (
+                TopicPartitionReplica {
+                    topic_name: "describe_logs_test".to_owned(),
+                    partition: 0,
+                    broker_id: 1,
+                },
+                DescribeReplicaLogDirInfo {
+                    path: Some("/bitnami/kafka/data".to_owned())
+                }
+            ),
+            (
+                TopicPartitionReplica {
+                    topic_name: "describe_logs_test2".to_owned(),
+                    partition: 0,
+                    broker_id: 0,
+                },
+                DescribeReplicaLogDirInfo {
+                    path: Some("/bitnami/kafka/data".to_owned())
+                }
+            )
+        ])
     );
 }
 

--- a/shotover/src/transforms/kafka/sink_cluster/mod.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/mod.rs
@@ -2229,11 +2229,19 @@ The connection to the client has been closed."
                 } else {
                     let drain = self.pending_requests.drain(..combine_responses).map(|x| {
                         if let PendingRequest {
-                            state: PendingRequestState::Received { response, .. },
+                            state:
+                                PendingRequestState::Received {
+                                    response,
+                                    destination,
+                                    ..
+                                },
                             ..
                         } = x
                         {
-                            response
+                            ResponseToBeCombined {
+                                response,
+                                destination,
+                            }
                         } else {
                             unreachable!("Guaranteed by all_combined_received")
                         }
@@ -2297,12 +2305,12 @@ The connection to the client has been closed."
         result
     }
 
-    fn combine_responses(mut drain: impl Iterator<Item = Message>) -> Result<Message> {
+    fn combine_responses(mut drain: impl Iterator<Item = ResponseToBeCombined>) -> Result<Message> {
         // Take this response as base.
         // Then iterate over all remaining combined responses and integrate them into the base.
         let mut base = drain.next().unwrap();
 
-        match base.frame() {
+        match base.response.frame() {
             Some(Frame::Kafka(KafkaFrame::Response {
                 body: ResponseBody::Fetch(base),
                 ..
@@ -2352,9 +2360,9 @@ The connection to the client has been closed."
                 ..
             })) => Self::combine_describe_groups(base, drain)?,
             Some(Frame::Kafka(KafkaFrame::Response {
-                body: ResponseBody::DescribeLogDirs(base),
+                body: ResponseBody::DescribeLogDirs(base_body),
                 ..
-            })) => Self::combine_describe_log_dirs(base, drain)?,
+            })) => Self::combine_describe_log_dirs(base.destination, base_body, drain)?,
             Some(Frame::Kafka(KafkaFrame::Response {
                 body: ResponseBody::AddPartitionsToTxn(base),
                 version,
@@ -2370,20 +2378,20 @@ The connection to the client has been closed."
             }
         }
 
-        base.invalidate_cache();
+        base.response.invalidate_cache();
 
-        Ok(base)
+        Ok(base.response)
     }
 
     fn combine_fetch_responses(
         base_fetch: &mut FetchResponse,
-        drain: impl Iterator<Item = Message>,
+        drain: impl Iterator<Item = ResponseToBeCombined>,
     ) -> Result<()> {
         for mut next in drain {
             if let Some(Frame::Kafka(KafkaFrame::Response {
                 body: ResponseBody::Fetch(next_fetch),
                 ..
-            })) = next.frame()
+            })) = next.response.frame()
             {
                 for next_response in std::mem::take(&mut next_fetch.responses) {
                     if let Some(base_response) = base_fetch.responses.iter_mut().find(|response| {
@@ -2416,13 +2424,13 @@ The connection to the client has been closed."
 
     fn combine_list_offsets_responses(
         base_list_offsets: &mut ListOffsetsResponse,
-        drain: impl Iterator<Item = Message>,
+        drain: impl Iterator<Item = ResponseToBeCombined>,
     ) -> Result<()> {
         for mut next in drain {
             if let Some(Frame::Kafka(KafkaFrame::Response {
                 body: ResponseBody::ListOffsets(next_list_offsets),
                 ..
-            })) = next.frame()
+            })) = next.response.frame()
             {
                 for next_topic in std::mem::take(&mut next_list_offsets.topics) {
                     if let Some(base_topic) = base_list_offsets
@@ -2456,13 +2464,13 @@ The connection to the client has been closed."
 
     fn combine_offset_for_leader_epoch_responses(
         base_list_offsets: &mut OffsetForLeaderEpochResponse,
-        drain: impl Iterator<Item = Message>,
+        drain: impl Iterator<Item = ResponseToBeCombined>,
     ) -> Result<()> {
         for mut next in drain {
             if let Some(Frame::Kafka(KafkaFrame::Response {
                 body: ResponseBody::OffsetForLeaderEpoch(next_body),
                 ..
-            })) = next.frame()
+            })) = next.response.frame()
             {
                 for next_topic in std::mem::take(&mut next_body.topics) {
                     if let Some(base_topic) = base_list_offsets
@@ -2495,7 +2503,7 @@ The connection to the client has been closed."
 
     fn combine_produce_responses(
         base_produce: &mut ProduceResponse,
-        drain: impl Iterator<Item = Message>,
+        drain: impl Iterator<Item = ResponseToBeCombined>,
     ) -> Result<()> {
         let mut base_responses: HashMap<TopicName, TopicProduceResponse> =
             std::mem::take(&mut base_produce.responses)
@@ -2506,7 +2514,7 @@ The connection to the client has been closed."
             if let Some(Frame::Kafka(KafkaFrame::Response {
                 body: ResponseBody::Produce(next_produce),
                 ..
-            })) = next.frame()
+            })) = next.response.frame()
             {
                 for next_response in std::mem::take(&mut next_produce.responses) {
                     if let Some(base_response) = base_responses.get_mut(&next_response.name) {
@@ -2539,7 +2547,7 @@ The connection to the client has been closed."
 
     fn combine_delete_records(
         base_body: &mut DeleteRecordsResponse,
-        drain: impl Iterator<Item = Message>,
+        drain: impl Iterator<Item = ResponseToBeCombined>,
     ) -> Result<()> {
         let mut base_topics: HashMap<TopicName, DeleteRecordsTopicResult> =
             std::mem::take(&mut base_body.topics)
@@ -2550,7 +2558,7 @@ The connection to the client has been closed."
             if let Some(Frame::Kafka(KafkaFrame::Response {
                 body: ResponseBody::DeleteRecords(next_body),
                 ..
-            })) = next.frame()
+            })) = next.response.frame()
             {
                 for next_response in std::mem::take(&mut next_body.topics) {
                     if let Some(base_response) = base_topics.get_mut(&next_response.name) {
@@ -2582,13 +2590,13 @@ The connection to the client has been closed."
 
     fn combine_delete_groups_responses(
         base_delete_groups: &mut DeleteGroupsResponse,
-        drain: impl Iterator<Item = Message>,
+        drain: impl Iterator<Item = ResponseToBeCombined>,
     ) -> Result<()> {
         for mut next in drain {
             if let Some(Frame::Kafka(KafkaFrame::Response {
                 body: ResponseBody::DeleteGroups(next_delete_groups),
                 ..
-            })) = next.frame()
+            })) = next.response.frame()
             {
                 base_delete_groups
                     .results
@@ -2601,13 +2609,13 @@ The connection to the client has been closed."
 
     fn combine_offset_fetch(
         base_offset_fetch: &mut OffsetFetchResponse,
-        drain: impl Iterator<Item = Message>,
+        drain: impl Iterator<Item = ResponseToBeCombined>,
     ) -> Result<()> {
         for mut next in drain {
             if let Some(Frame::Kafka(KafkaFrame::Response {
                 body: ResponseBody::OffsetFetch(next_offset_fetch),
                 ..
-            })) = next.frame()
+            })) = next.response.frame()
             {
                 base_offset_fetch
                     .groups
@@ -2620,13 +2628,13 @@ The connection to the client has been closed."
 
     fn combine_list_groups(
         base_list_groups: &mut ListGroupsResponse,
-        drain: impl Iterator<Item = Message>,
+        drain: impl Iterator<Item = ResponseToBeCombined>,
     ) -> Result<()> {
         for mut next in drain {
             if let Some(Frame::Kafka(KafkaFrame::Response {
                 body: ResponseBody::ListGroups(next_list_groups),
                 ..
-            })) = next.frame()
+            })) = next.response.frame()
             {
                 base_list_groups
                     .groups
@@ -2639,7 +2647,7 @@ The connection to the client has been closed."
 
     fn combine_describe_producers(
         base: &mut DescribeProducersResponse,
-        drain: impl Iterator<Item = Message>,
+        drain: impl Iterator<Item = ResponseToBeCombined>,
     ) -> Result<()> {
         let mut base_responses: HashMap<TopicName, TopicResponse> =
             std::mem::take(&mut base.topics)
@@ -2650,7 +2658,7 @@ The connection to the client has been closed."
             if let Some(Frame::Kafka(KafkaFrame::Response {
                 body: ResponseBody::DescribeProducers(next),
                 ..
-            })) = next.frame()
+            })) = next.response.frame()
             {
                 for next_response in std::mem::take(&mut next.topics) {
                     if let Some(base_response) = base_responses.get_mut(&next_response.name) {
@@ -2682,13 +2690,13 @@ The connection to the client has been closed."
 
     fn combine_describe_transactions(
         base: &mut DescribeTransactionsResponse,
-        drain: impl Iterator<Item = Message>,
+        drain: impl Iterator<Item = ResponseToBeCombined>,
     ) -> Result<()> {
         for mut next in drain {
             if let Some(Frame::Kafka(KafkaFrame::Response {
                 body: ResponseBody::DescribeTransactions(next),
                 ..
-            })) = next.frame()
+            })) = next.response.frame()
             {
                 base.transaction_states
                     .extend(std::mem::take(&mut next.transaction_states));
@@ -2700,13 +2708,13 @@ The connection to the client has been closed."
 
     fn combine_list_transactions(
         base_list_transactions: &mut ListTransactionsResponse,
-        drain: impl Iterator<Item = Message>,
+        drain: impl Iterator<Item = ResponseToBeCombined>,
     ) -> Result<()> {
         for mut next in drain {
             if let Some(Frame::Kafka(KafkaFrame::Response {
                 body: ResponseBody::ListTransactions(next_list_transactions),
                 ..
-            })) = next.frame()
+            })) = next.response.frame()
             {
                 base_list_transactions
                     .transaction_states
@@ -2720,35 +2728,69 @@ The connection to the client has been closed."
     }
 
     fn combine_describe_log_dirs(
-        base: &mut DescribeLogDirsResponse,
-        drain: impl Iterator<Item = Message>,
+        base_destination: Destination,
+        base_body: &mut DescribeLogDirsResponse,
+        drain: impl Iterator<Item = ResponseToBeCombined>,
     ) -> Result<()> {
+        Self::prepend_destination_to_log_dir(base_destination, base_body);
+
         for mut next in drain {
             if let Some(Frame::Kafka(KafkaFrame::Response {
-                body: ResponseBody::DescribeLogDirs(next),
+                body: ResponseBody::DescribeLogDirs(next_body),
                 ..
-            })) = next.frame()
+            })) = next.response.frame()
             {
-                for result in &mut next.results {
-                    let log_dir = result.log_dir.as_str();
-                    result.log_dir = StrBytes::from_string(format!("{}:{log_dir}", 0));
-                }
-                base.results.extend(std::mem::take(&mut next.results));
+                Self::prepend_destination_to_log_dir(next.destination, next_body);
+                base_body
+                    .results
+                    .extend(std::mem::take(&mut next_body.results));
             }
         }
 
         Ok(())
     }
 
+    /// Rewrite the log dir paths to a custom format to allow results to be disambiguated.
+    /// Usually only 1 file system path can exist on a single broker machine.
+    /// However since shotover represents many different brokers, there can be different log dirs with identical paths associated with a single shotover instance.
+    /// This would be extremely confusing to a user and the client driver could assume that paths are unique.
+    /// So we need to alter the path to include details of which broker the path resides on.
+    ///
+    /// The downsides of this are:
+    /// * This leaks details of the actual kafka cluster to the user
+    /// * The path is no longer a valid path
+    ///
+    /// The only other possible solution I see would be to have shotover error on this request type instead.
+    /// But I think its reasonable to instead take these downsides and provide most of the value of this message type to the user.
+    ///
+    /// For example:
+    /// If the path starts as: /original/log/dir/path
+    /// It will become something like: actual-kafka-broker-id3:/original/log/dir/path
+    fn prepend_destination_to_log_dir(
+        destination: Destination,
+        body: &mut DescribeLogDirsResponse,
+    ) {
+        for result in &mut body.results {
+            let log_dir = result.log_dir.as_str();
+            let altered_log_dir = match destination {
+                Destination::Id(id) => format!("actual-kafka-broker-id{id:?}:{log_dir}"),
+                Destination::ControlConnection => {
+                    unreachable!("DescribeLogDirs are not sent as control connections")
+                }
+            };
+            result.log_dir = StrBytes::from_string(altered_log_dir);
+        }
+    }
+
     fn combine_describe_groups(
         base: &mut DescribeGroupsResponse,
-        drain: impl Iterator<Item = Message>,
+        drain: impl Iterator<Item = ResponseToBeCombined>,
     ) -> Result<()> {
         for mut next in drain {
             if let Some(Frame::Kafka(KafkaFrame::Response {
                 body: ResponseBody::DescribeGroups(next),
                 ..
-            })) = next.frame()
+            })) = next.response.frame()
             {
                 base.groups.extend(std::mem::take(&mut next.groups));
             }
@@ -2759,13 +2801,13 @@ The connection to the client has been closed."
 
     fn combine_add_partitions_to_txn(
         base_add_partitions_to_txn: &mut AddPartitionsToTxnResponse,
-        drain: impl Iterator<Item = Message>,
+        drain: impl Iterator<Item = ResponseToBeCombined>,
     ) -> Result<()> {
         for mut next in drain {
             if let Some(Frame::Kafka(KafkaFrame::Response {
                 body: ResponseBody::AddPartitionsToTxn(next_add_partitions_to_txn),
                 ..
-            })) = next.frame()
+            })) = next.response.frame()
             {
                 base_add_partitions_to_txn
                     .results_by_transaction
@@ -3907,4 +3949,9 @@ fn collect_broker_ids(shotover_nodes_by_rack: ShotoverNodesByRack) -> Vec<Broker
     };
 
     nodes.iter().map(|node| node.broker_id).collect()
+}
+
+struct ResponseToBeCombined {
+    response: Message,
+    destination: Destination,
 }

--- a/test-helpers/src/connection/java.rs
+++ b/test-helpers/src/connection/java.rs
@@ -363,6 +363,7 @@ impl Value {
     }
 
     /// Convert this java value into a native rust type
+    /// When T is Option<U>, it is None when java null, otherwise Some.
     pub(crate) fn into_rust<T>(self) -> T
     where
         T: DeserializeOwned + Any,

--- a/test-helpers/src/connection/kafka/java.rs
+++ b/test-helpers/src/connection/kafka/java.rs
@@ -1,9 +1,10 @@
 use super::{
     Acl, AclOperation, AclPermissionType, AlterConfig, ConsumerConfig, ConsumerGroupDescription,
-    ExpectedResponse, ListOffsetsResultInfo, NewPartition, NewPartitionReassignment, NewTopic,
-    OffsetAndMetadata, OffsetSpec, PartitionReassignment, ProduceResult, ProducerState, Record,
-    RecordsToDelete, ResourcePatternType, ResourceSpecifier, ResourceType, TopicDescription,
-    TopicPartition, TopicPartitionInfo, TransactionDescription,
+    DescribeReplicaLogDirInfo, ExpectedResponse, ListOffsetsResultInfo, NewPartition,
+    NewPartitionReassignment, NewTopic, OffsetAndMetadata, OffsetSpec, PartitionReassignment,
+    ProduceResult, ProducerState, Record, RecordsToDelete, ResourcePatternType, ResourceSpecifier,
+    ResourceType, TopicDescription, TopicPartition, TopicPartitionInfo, TopicPartitionReplica,
+    TransactionDescription,
 };
 use crate::connection::java::{map_iterator, Jvm, Value};
 use anyhow::Result;
@@ -871,6 +872,39 @@ impl KafkaAdminJava {
             .await;
     }
 
+    pub async fn describe_replica_log_dirs(
+        &self,
+        topic_partitions: &[TopicPartitionReplica],
+    ) -> HashMap<TopicPartitionReplica, DescribeReplicaLogDirInfo> {
+        let topic_partitions_java = self.jvm.new_set(
+            "org.apache.kafka.common.TopicPartitionReplica",
+            topic_partitions
+                .iter()
+                .map(|topic_partition| topic_partition_replica_to_java(&self.jvm, topic_partition))
+                .collect(),
+        );
+
+        let results = self
+            .admin
+            .call("describeReplicaLogDirs", vec![topic_partitions_java])
+            .call_async("all", vec![])
+            .await;
+
+        map_iterator(results)
+            .map(|(topic_partition, log_dir_info)| {
+                (
+                    topic_partition_replica_to_rust(topic_partition),
+                    DescribeReplicaLogDirInfo {
+                        path: log_dir_info
+                            .cast("org.apache.kafka.clients.admin.DescribeReplicaLogDirsResult$ReplicaLogDirInfo")
+                            .call("getCurrentReplicaLogDir", vec!())
+                            .into_rust()
+                    },
+                )
+            })
+            .collect()
+    }
+
     pub async fn elect_leaders(&self, topic_partitions: &[TopicPartition]) -> Result<()> {
         let election_type = self
             .jvm
@@ -1049,6 +1083,26 @@ fn topic_partition_to_rust(tp: Value) -> TopicPartition {
     TopicPartition {
         topic_name: tp.call("topic", vec![]).into_rust(),
         partition: tp.call("partition", vec![]).into_rust(),
+    }
+}
+
+fn topic_partition_replica_to_java(jvm: &Jvm, tp: &TopicPartitionReplica) -> Value {
+    jvm.construct(
+        "org.apache.kafka.common.TopicPartitionReplica",
+        vec![
+            jvm.new_string(&tp.topic_name),
+            jvm.new_int(tp.partition),
+            jvm.new_int(tp.broker_id),
+        ],
+    )
+}
+
+fn topic_partition_replica_to_rust(tp: Value) -> TopicPartitionReplica {
+    let tp = tp.cast("org.apache.kafka.common.TopicPartitionReplica");
+    TopicPartitionReplica {
+        topic_name: tp.call("topic", vec![]).into_rust(),
+        partition: tp.call("partition", vec![]).into_rust(),
+        broker_id: tp.call("brokerId", vec![]).into_rust(),
     }
 }
 

--- a/test-helpers/src/connection/kafka/mod.rs
+++ b/test-helpers/src/connection/kafka/mod.rs
@@ -539,6 +539,18 @@ impl KafkaAdmin {
             }
         }
     }
+    pub async fn describe_replica_log_dirs(
+        &self,
+        topic_partitions: &[TopicPartitionReplica],
+    ) -> HashMap<TopicPartitionReplica, DescribeReplicaLogDirInfo> {
+        match self {
+            #[cfg(feature = "kafka-cpp-driver-tests")]
+            Self::Cpp(_) => {
+                panic!("rdkafka-rs driver does not support describe_replica_log_dirs")
+            }
+            Self::Java(java) => java.describe_replica_log_dirs(topic_partitions).await,
+        }
+    }
 
     pub async fn elect_leaders(&self, topic_partitions: &[TopicPartition]) -> Result<()> {
         match self {
@@ -628,6 +640,18 @@ pub struct NewPartition<'a> {
 pub struct TopicPartition {
     pub topic_name: String,
     pub partition: i32,
+}
+
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+pub struct TopicPartitionReplica {
+    pub topic_name: String,
+    pub partition: i32,
+    pub broker_id: i32,
+}
+
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+pub struct DescribeReplicaLogDirInfo {
+    pub path: Option<String>,
 }
 
 pub enum ResourceSpecifier<'a> {


### PR DESCRIPTION
This PR implements routing for `DescribeLogDirs`.

When the java driver routes `DescribeLogDirs` it sends it to a broker specified by the user.
When `kafka-log-dirs.sh` routes `DescribeLogDirs` it sends an identical request to every node in the cluster.
To handle this type of broadcast request shotover routes the request to all nodes in the rack. For other examples look at ListGroups, ListTransactions etc.

We route the request to all nodes in shotover's rack and then combine the results.
We alter the log dir path to avoid collisions with results from other racks, the new path looks like `actual-kafka-broker-id3:/original/log/dir/path`.
For more details on the reasoning behind this, look at the comment on `fn prepend_destination_to_log_dir`.