### PR TITLE
Release shotover 0.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4649,7 +4649,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shotover"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4719,7 +4719,7 @@ dependencies = [
 
 [[package]]
 name = "shotover-proxy"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shotover-proxy"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Ben <ben@instaclustr.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/shotover/Cargo.toml
+++ b/shotover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shotover"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Ben <ben@instaclustr.com>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
Before we merge https://github.com/shotover/shotover-proxy/pull/1822 lets do one final release of the 0.5.x version.