### PR TITLE
KafkaSinkCluster: route ConsumerGroupDescribe request

### DIFF
--- a/shotover/src/transforms/kafka/sink_cluster/split.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/split.rs
@@ -11,8 +11,8 @@ use kafka_protocol::messages::{
     delete_records_request::DeleteRecordsTopic, describe_producers_request::TopicRequest,
     list_offsets_request::ListOffsetsTopic, offset_fetch_request::OffsetFetchRequestGroup,
     offset_for_leader_epoch_request::OffsetForLeaderTopic, produce_request::TopicProduceData,
-    AddPartitionsToTxnRequest, BrokerId, DeleteGroupsRequest, DeleteRecordsRequest,
-    DescribeGroupsRequest, DescribeLogDirsRequest, DescribeProducersRequest,
+    AddPartitionsToTxnRequest, BrokerId, ConsumerGroupDescribeRequest, DeleteGroupsRequest,
+    DeleteRecordsRequest, DescribeGroupsRequest, DescribeLogDirsRequest, DescribeProducersRequest,
     DescribeTransactionsRequest, GroupId, ListGroupsRequest, ListOffsetsRequest,
     ListTransactionsRequest, OffsetFetchRequest, OffsetForLeaderEpochRequest, ProduceRequest,
     TopicName, TransactionalId,
@@ -391,5 +391,33 @@ impl RequestSplitAndRouter for DescribeGroupsSplitAndRouter {
 
     fn reassemble(request: &mut Self::Request, item: Self::SubRequests) {
         request.groups = item;
+    }
+}
+
+pub struct ConsumerGroupDescribeSplitAndRouter;
+
+impl RequestSplitAndRouter for ConsumerGroupDescribeSplitAndRouter {
+    type Request = ConsumerGroupDescribeRequest;
+    type SubRequests = Vec<GroupId>;
+
+    fn split_by_destination(
+        transform: &mut KafkaSinkCluster,
+        request: &mut Self::Request,
+    ) -> HashMap<BrokerId, Self::SubRequests> {
+        transform.split_consumer_group_describe_request_by_destination(request)
+    }
+
+    fn get_request_frame(request: &mut Message) -> &mut Self::Request {
+        match request.frame() {
+            Some(Frame::Kafka(KafkaFrame::Request {
+                body: RequestBody::ConsumerGroupDescribe(request),
+                ..
+            })) => request,
+            _ => unreachable!(),
+        }
+    }
+
+    fn reassemble(request: &mut Self::Request, item: Self::SubRequests) {
+        request.group_ids = item;
     }
 }


### PR DESCRIPTION
This PR will remain as draft until https://github.com/shotover/shotover-proxy/pull/1825 is landed. Changes on top of #1825 are in a separate commit.

ConsumerGroupDescribe is a replacement for the existing DescribeGroups message type.

No need to add new integration tests for this PR as we are already hitting this message type in our integration tests, we have avoided implementing this message type in shotover by modifying ApiVersions responses to instruct the client that we do not support ConsumerGroupDescribe.
This PR removes the ApiVersions rewrite so that the driver will make use of ConsumerGroupDescribe and then implements routing logic for ConsumerGroupDescribe.
ConsumerGroupDescribe requests are split up by group id, like the existing routing logic for message types DeleteGroups, DescribeGroups etc.
