### PR TITLE
Fix valkey test_save

### DIFF
--- a/shotover-proxy/tests/valkey_int_tests/basic_driver_tests.rs
+++ b/shotover-proxy/tests/valkey_int_tests/basic_driver_tests.rs
@@ -155,8 +155,8 @@ async fn test_save(connection: &mut Connection) {
         "expected lastsave2 > 0, but lastsave was {lastsave2}"
     );
     assert!(
-        lastsave2 > lastsave1,
-        "expected lastsave2 > lastsave1, but was {lastsave2} > {lastsave1}"
+        lastsave2 >= lastsave1,
+        "expected lastsave2 >= lastsave1, but was {lastsave2} > {lastsave1}"
     );
 }
 


### PR DESCRIPTION
On a sufficiently fast machine these tests fail since the timestamps are equal.
The fix is to use `>=` comparison to allow the equal case to also pass the test.