### PR TITLE
"redis" -> "valkey" docs misc changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,7 +31,7 @@ A clear and concise description of what you expected to happen.
 ## Systems and Version:
  - OS
  - Shotover Version
- - Version of 3rd party software e.g. Cassandra, Redis
+ - Version of 3rd party software e.g. Cassandra, Valkey
 
 ## Additional context
 Add any other context about the problem here.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,4 +52,4 @@ jobs:
         # some things to explicitly point out:
         # * clippy also reports rustc warnings and errors
         # * clippy --all-targets is not run so we only build the shotover_proxy executable without the tests/benches
-        run: cargo hack --feature-powerset --at-least-one-of redis,cassandra,kafka,opensearch clippy --locked ${{ matrix.cargo_flags }} --package shotover-proxy -- -D warnings
+        run: cargo hack --feature-powerset --at-least-one-of valkey,cassandra,kafka,opensearch clippy --locked ${{ matrix.cargo_flags }} --package shotover-proxy -- -D warnings

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -47,7 +47,7 @@ jobs:
       # some things to explicitly point out:
       # * clippy also reports rustc warnings and errors
       # * clippy --all-targets causes clippy to run against tests and examples which it doesnt do by default.
-      run: cargo hack --feature-powerset --at-least-one-of redis,cassandra,kafka,opensearch clippy --all-targets --locked -- -D warnings
+      run: cargo hack --feature-powerset --at-least-one-of valkey,cassandra,kafka,opensearch clippy --all-targets --locked -- -D warnings
     - name: Report disk usage
       run: |
         df -h

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,20 @@
 Any breaking changes to the `topology.yaml` or `shotover` rust API should be documented here.
 This assists us in knowing when to make the next release a breaking release and assists users with making upgrades to new breaking releases.
 
+## 0.6.0
+
+Redis has been renamed to Valkey.
+This affects the rust API, the topology.yaml and all documentation.
+
+### shotover rust API
+
+* All modules and types containing redis have been renamed to refer to valkey instead.
+
+### topology.yaml
+
+* transforms renamed: `RedisSinkCluster` -> `ValkeySinkCluster`, `RedisSinkSingle` -> `ValkeySinkSingle`
+* sources renamed: `Redis` -> `Valkey`
+
 ## 0.5.0
 
 ### shotover rust API

--- a/docs/src/dev-docs/contributing.md
+++ b/docs/src/dev-docs/contributing.md
@@ -45,10 +45,10 @@ To use nextest:
 1. Install nextest: `cargo install cargo-nextest --locked`
 2. Then run the tests: `cargo nextest run`
 
-The tests rely on configuration in `tests/test-configs/`, so if for example, you wanted to manually setup the services for the redis-passthrough test, you could run these commands in the `shotover-proxy` directory:
+The tests rely on configuration in `tests/test-configs/`, so if for example, you wanted to manually setup the services for the valkey-passthrough test, you could run these commands in the `shotover-proxy` directory:
 
-* `docker-compose -f shotover-proxy/tests/test-configs/redis-passthrough/docker-compose.yaml up`
-* `cargo run -- --topology-file tests/test-configs/redis-passthrough/topology.yaml`
+* `docker-compose -f shotover-proxy/tests/test-configs/valkey-passthrough/docker-compose.yaml up`
+* `cargo run -- --topology-file tests/test-configs/valkey-passthrough/topology.yaml`
 
 ## Submitting a PR
 

--- a/docs/src/dev-docs/debugging.md
+++ b/docs/src/dev-docs/debugging.md
@@ -36,11 +36,11 @@ sources:
             connect_timeout_ms: 3000
 ```
 
-For a simple redis request/response, the logs will look like:
+For a simple valkey request/response, the logs will look like:
 
 ```plain
-shotover   06:37:14.712042Z  INFO connection{id=2 source="redis"}: shotover::transforms::debug::printer: Request: Redis Array([BulkString(b"GET"), BulkString(b"bar")])
-shotover   06:37:14.712212Z  INFO connection{id=2 source="redis"}: shotover::transforms::debug::printer: Response: Redis BulkString(b"foo")
+shotover   06:37:14.712042Z  INFO connection{id=2 source="valkey"}: shotover::transforms::debug::printer: Request: Valkey Array([BulkString(b"GET"), BulkString(b"bar")])
+shotover   06:37:14.712212Z  INFO connection{id=2 source="valkey"}: shotover::transforms::debug::printer: Response: Valkey BulkString(b"foo")
 ```
 
 ## Run the test

--- a/docs/src/sources.md
+++ b/docs/src/sources.md
@@ -2,8 +2,8 @@
 
 | Source                              | Implementation Status |
 |-------------------------------------|-----------------------|
-|[Cassandra](#cassandra)              |Alpha                  |
-|[Redis](#redis)                      |Beta                   |
+|[Cassandra](#cassandra)              |Beta                   |
+|[Valkey](#valkey)                    |Beta                   |
 
 ## Cassandra
 
@@ -51,10 +51,10 @@ Cassandra:
     ...
 ```
 
-## Redis
+## Valkey
 
 ```yaml
-Redis:
+Valkey:
   # The address to listen from
   listen_addr: "127.0.0.1:6379"
 
@@ -72,9 +72,9 @@ Redis:
   # Removing this field will disable TLS.
   #tls:
   #  # Path to the certificate file, typically named with a .crt extension.
-  #  certificate_path: "tls/redis.crt"
+  #  certificate_path: "tls/valkey.crt"
   #  # Path to the private key file, typically named with a .key extension.
-  #  private_key_path: "tls/redis.key"
+  #  private_key_path: "tls/valkey.key"
   #  # Path to the certificate authority file typically named ca.crt.
   #  # When this field is provided client authentication will be enabled.
   #  #certificate_authority_path: "tls/ca.crt"

--- a/docs/src/user-guide/configuration.md
+++ b/docs/src/user-guide/configuration.md
@@ -25,14 +25,14 @@ The topology file is the primary method for defining how Shotover behaves.
 Consider this example `topology.yaml`:
 
 ```yaml
-# This example listens on two different localhost ports and routes messages to a single redis instance on localhost.
+# This example listens on two different localhost ports and routes messages to a single valkey instance on localhost.
 # Requests received on port 1000 will have metrics recorded on the types of messages sent, while port 1001 will not have those metrics.
 ---
 # The list of sources
 sources:
   # First we define the source that will listen for connections from the client and then communicate to the client once a connection is opened.
-  - Redis:
-      name: "redis"
+  - Valkey:
+      name: "valkey"
       listen_addr: "127.0.0.1:1000"
       # Next we define the transform chain that will process messages received by this source
       chain:
@@ -41,16 +41,16 @@ sources:
             name: "Main chain"
         # The final transform is a sink, it receives requests from the previous transform and sends them to an actual DB instance.
         # When it receives a response back it routes the response back through every transform in the chain and finally back to the client.
-        - RedisSinkSingle:
+        - ValkeySinkSingle:
             remote_address: "127.0.0.1:6379"
             connect_timeout_ms: 3000
 
   # A second source definition, this time we lack the QueryCounter transform.
-  - Redis:
-      name: "redis"
+  - Valkey:
+      name: "valkey"
       listen_addr: "127.0.0.1:1001"
       chain:
-        - RedisSinkSingle:
+        - ValkeySinkSingle:
             remote_address: "127.0.0.1:6379"
             connect_timeout_ms: 3000
 ```

--- a/docs/src/user-guide/writing-custom-transforms.md
+++ b/docs/src/user-guide/writing-custom-transforms.md
@@ -19,14 +19,14 @@ git clone https://github.com/shotover/shotover-custom-transforms-template
 
 The template comes with:
 
-* two example transforms: the `redis-get-rewrite` and `kafka-fetch-rewrite` crates
+* two example transforms: the `valkey-get-rewrite` and `kafka-fetch-rewrite` crates
   * By convention, each transform is its own rust crate
 * the final shotover binary: the `shotover-bin` crate
   * this also contains integration tests in `shotover-bin/tests`, make sure to utiilize them!
 
 Use an example transform that matches the protocol you are working with as a base. e.g.
 
-* redis-get-rewrite - for redis
+* valkey-get-rewrite - for valkey
 * kafka-fetch-rewrite - for kafka
 
 ## Running the project

--- a/test-helpers/src/connection/mod.rs
+++ b/test-helpers/src/connection/mod.rs
@@ -2,5 +2,5 @@ pub mod cassandra;
 
 pub(crate) mod java;
 pub mod kafka;
-// redis_connection is named differently to the cassandra module because it contains raw functions instead of a struct with methods
+// valkey_connection is named differently to the cassandra module because it contains raw functions instead of a struct with methods
 pub mod valkey_connection;


### PR DESCRIPTION
Covers most of the remaining changes:
* Adds a changelog entry for shotover 0.6
* A bunch of docs fixes
* Fix feature change missed in https://github.com/shotover/shotover-proxy/pull/1836 , it seems like a bug in `cargo hack` that this was able to slip through, I've raised an issue here https://github.com/taiki-e/cargo-hack/issues/259

Remaining work:
* Update example docs in this repo
* rename redis-cache directory - https://github.com/shotover/shotover-proxy/pull/1848
* Update external example repos - TODO after release of shotover 0.6