### PR TITLE
Quick fix for website generator

### DIFF
--- a/website/src/main.rs
+++ b/website/src/main.rs
@@ -27,7 +27,7 @@ fn main() {
     }
 
     let root = current_dir.join("website").join("root");
-    std::fs::remove_dir_all(&root).unwrap();
+    std::fs::remove_dir_all(&root).ok();
     std::fs::create_dir_all(&root).unwrap();
 
     if let Err(err) = docs::generate_all_docs(current_dir) {


### PR DESCRIPTION
While this line passes locally for me since the file always exists, in an environment where the code has never run before the file does not exist, resulting in website generation failing in CI.
This PR fixes it by ignoring the error instead of unwrapping.