### PR TITLE
Fix website deploy

### DIFF
--- a/.github/workflows/publish-to-pages.yaml
+++ b/.github/workflows/publish-to-pages.yaml
@@ -1,11 +1,10 @@
 name: publish to github pages
 
 on:
-  # Trigger when there is a new commit on main branch
   push:
+    # Trigger when there is a new commit on main branch
     branches: [ main ]
-  # also trigger when a new release tag is added to the repo
-  push:
+    # also trigger when a new release tag is added to the repo
     tags:
       - "v*"
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@
 
 ## Documentation
 
-For full documentation please go to [https://docs.shotover.io/](https://docs.shotover.io/shotover-blog/docs/user-guide/introduction.html)
+For full documentation please go to [https://shotover.io/docs/latest](https://shotover.io/docs/latest/user-guide/introduction.html)
 
 ## Building
 
 Shotover is supported on Linux and macOS.
-To build Shotover from source please refer to [the contributing documentation](https://docs.shotover.io/shotover-blog/docs/contributing.html)
+To build Shotover from source please refer to [the contributing documentation](https://shotover.io/docs/latest/dev-docs/contributing.html)
 
 ## What is Shotover?
 

--- a/shotover-proxy/config/topology.yaml
+++ b/shotover-proxy/config/topology.yaml
@@ -1,19 +1,19 @@
-# For an overview of topology configuration: https://docs.shotover.io/user-guide/configuration/#topologyyaml
+# For an overview of topology configuration: https://shotover.io/docs/latest/user-guide/configuration/#topologyyaml
 ---
 # The list of sources.
 sources:
   # The source, change from Valkey to the source type of the database protocol you are receiving messages in.
-  # For a list of possible sources: https://docs.shotover.io/sources
+  # For a list of possible sources: https://shotover.io/docs/latest/sources
   - Valkey:
       name: "valkey"
       listen_addr: "127.0.0.1:6379"
       chain:
         # A DebugPrinter transform, reports an INFO log for every message that passes through this transform.
         # You should delete this transform and add as many other transforms in this chain as you need.
-        # For a list of possible transforms: https://docs.shotover.io/transforms/#transforms_1
+        # For a list of possible transforms: https://shotover.io/docs/latest/transforms/#transforms-1
         - DebugPrinter
 
         # A NullSink transform, drops all messages it receives.
         # You will want to replace this with a sink transform to send the message to a database.
-        # For a list of possible transforms: https://docs.shotover.io/transforms/#transforms_1
+        # For a list of possible transforms: https://shotover.io/docs/latest/transforms/#transforms-1
         - NullSink

--- a/shotover/src/config/topology.rs
+++ b/shotover/src/config/topology.rs
@@ -180,7 +180,7 @@ foo source:
       * flush_when_millis_since_last_flush
     
       But none of them were provided.
-      Check https://docs.shotover.io/transforms.html#coalesce for more information.
+      Check https://shotover.io/docs/latest/transforms.html#coalesce for more information.
 "#;
 
         let error = run_test_topology_valkey(vec![

--- a/shotover/src/transforms/coalesce.rs
+++ b/shotover/src/transforms/coalesce.rs
@@ -66,7 +66,7 @@ impl TransformBuilder for Coalesce {
                 "  * flush_when_millis_since_last_flush".into(),
                 "".into(),
                 "  But none of them were provided.".into(),
-                "  Check https://docs.shotover.io/transforms.html#coalesce for more information."
+                "  Check https://shotover.io/docs/latest/transforms.html#coalesce for more information."
                     .into(),
             ]
         } else {


### PR DESCRIPTION
## deploy fix

PR https://github.com/shotover/shotover-proxy/pull/1853 altered the `on:` section of the publish-to-pages workflow such that it would only run when: the branch is main AND the tag starts with `v`.
However the intention was to run when: the branch is main OR the tag starts with `v`.

This PR fixes the issue:
* I verified on my fork of the repo that the behavior is as expected
* and the documentation also indicates this is the correct approach: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-including-branches-and-tags

## link fixes

I also noticed we have a bunch of links to the website which will be invalid with the new website, so I've swapped them over to the new links.