### PR TITLE
Fix binary release

### DIFF
--- a/shotover-proxy/build/build_release.sh
+++ b/shotover-proxy/build/build_release.sh
@@ -15,6 +15,6 @@ cp -r ../config shotover
 # extract the crate version from Cargo.toml
 CRATE_VERSION="$(cargo metadata --format-version 1 --offline --no-deps | jq -c -M -r '.packages[] | select(.name == "shotover-proxy") | .version')"
 tar -cvzf out.tar.gz shotover
-mv out.tar.gz shotover-proxy-linux_amd64-${CRATE_VERSION}.tar.gz
+mv out.tar.gz ../../shotover-proxy-linux_amd64-${CRATE_VERSION}.tar.gz
 
 rm -rf shotover


### PR DESCRIPTION
In https://github.com/instaclustr/atsc/pull/141 I discovered that shotover's compiled binary had a bug preventing it from being included in releases for over a year.

This PR applies the same fix as done in the ATSC repo, which fixed the problem over there.