### PR TITLE
Update integration tests to kafka 3.8.1

### DIFF
--- a/shotover-proxy/benches/windsock/kafka/bench.rs
+++ b/shotover-proxy/benches/windsock/kafka/bench.rs
@@ -144,7 +144,7 @@ impl KafkaBench {
 
             tasks.push(tokio::spawn(async move {
                 node.run_container(
-                    "bitnami/kafka:3.6.1-debian-11-r24",
+                    "bitnami/kafka:3.8.1-debian-12-r1",
                     &[
                         ("ALLOW_PLAINTEXT_LISTENER".to_owned(), "yes".to_owned()),
                         (

--- a/shotover-proxy/tests/test-configs/kafka/bench/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/bench/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   kafka0:
-    image: 'bitnami/kafka:3.6.1-debian-11-r24'
+    image: 'bitnami/kafka:3.8.1-debian-12-r1'
     ports:
       - '9192:9192'
     environment:

--- a/shotover-proxy/tests/test-configs/kafka/cluster-1-rack/docker-compose-short-idle-timeout.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-1-rack/docker-compose-short-idle-timeout.yaml
@@ -9,7 +9,7 @@ networks:
           gateway: 172.16.1.1
 services:
   kafka0:
-    image: &image 'bitnami/kafka:3.6.1-debian-11-r24'
+    image: &image 'bitnami/kafka:3.8.1-debian-12-r1'
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.2

--- a/shotover-proxy/tests/test-configs/kafka/cluster-1-rack/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-1-rack/docker-compose.yaml
@@ -9,7 +9,7 @@ networks:
           gateway: 172.16.1.1
 services:
   kafka0:
-    image: &image 'bitnami/kafka:3.6.1-debian-11-r24'
+    image: &image 'bitnami/kafka:3.8.1-debian-12-r1'
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.2

--- a/shotover-proxy/tests/test-configs/kafka/cluster-2-racks/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-2-racks/docker-compose.yaml
@@ -9,7 +9,7 @@ networks:
           gateway: 172.16.1.1
 services:
   kafka0:
-    image: &image 'bitnami/kafka:3.6.1-debian-11-r24'
+    image: &image 'bitnami/kafka:3.8.1-debian-12-r1'
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.2

--- a/shotover-proxy/tests/test-configs/kafka/cluster-3-racks/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-3-racks/docker-compose.yaml
@@ -9,7 +9,7 @@ networks:
           gateway: 172.16.1.1
 services:
   kafka0:
-    image: &image 'bitnami/kafka:3.6.1-debian-11-r24'
+    image: &image 'bitnami/kafka:3.8.1-debian-12-r1'
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.2

--- a/shotover-proxy/tests/test-configs/kafka/cluster-mtls/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-mtls/docker-compose.yaml
@@ -9,7 +9,7 @@ networks:
           gateway: 172.16.1.1
 services:
   kafka0:
-    image: &image 'bitnami/kafka:3.6.1-debian-11-r24'
+    image: &image 'bitnami/kafka:3.8.1-debian-12-r1'
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.2

--- a/shotover-proxy/tests/test-configs/kafka/cluster-sasl-plain/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-sasl-plain/docker-compose.yaml
@@ -10,7 +10,7 @@ networks:
 
 services:
   kafka0:
-    image: &image 'bitnami/kafka:3.6.1-debian-11-r24'
+    image: &image 'bitnami/kafka:3.8.1-debian-12-r1'
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.2

--- a/shotover-proxy/tests/test-configs/kafka/cluster-sasl-scram-over-mtls/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-sasl-scram-over-mtls/docker-compose.yaml
@@ -10,7 +10,7 @@ networks:
 
 services:
   kafka0:
-    image: &image 'bitnami/kafka:3.6.1-debian-11-r24'
+    image: &image 'bitnami/kafka:3.8.1-debian-12-r1'
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.2

--- a/shotover-proxy/tests/test-configs/kafka/cluster-sasl-scram/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-sasl-scram/docker-compose.yaml
@@ -10,7 +10,7 @@ networks:
 
 services:
   kafka0:
-    image: &image 'bitnami/kafka:3.6.1-debian-11-r24'
+    image: &image 'bitnami/kafka:3.8.1-debian-12-r1'
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.2

--- a/shotover-proxy/tests/test-configs/kafka/cluster-tls/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-tls/docker-compose.yaml
@@ -9,7 +9,7 @@ networks:
           gateway: 172.16.1.1
 services:
   kafka0:
-    image: &image 'bitnami/kafka:3.6.1-debian-11-r24'
+    image: &image 'bitnami/kafka:3.8.1-debian-12-r1'
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.2

--- a/shotover-proxy/tests/test-configs/kafka/passthrough-mtls/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/passthrough-mtls/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   kafka0:
-    image: 'bitnami/kafka:3.6.1-debian-11-r24'
+    image: 'bitnami/kafka:3.8.1-debian-12-r1'
     ports:
       - '9092:9092'
     environment:

--- a/shotover-proxy/tests/test-configs/kafka/passthrough-sasl-plain/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/passthrough-sasl-plain/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   kafka:
-    image: 'bitnami/kafka:3.6.1-debian-11-r24'
+    image: 'bitnami/kafka:3.8.1-debian-12-r1'
     ports:
       - '9092:9092'
       - '9093:9093'

--- a/shotover-proxy/tests/test-configs/kafka/passthrough-sasl-scram/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/passthrough-sasl-scram/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   kafka:
-    image: 'bitnami/kafka:3.6.1-debian-11-r24'
+    image: 'bitnami/kafka:3.8.1-debian-12-r1'
     ports:
       - '9092:9092'
     environment:

--- a/shotover-proxy/tests/test-configs/kafka/passthrough-tls/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/passthrough-tls/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   kafka0:
-    image: 'bitnami/kafka:3.6.1-debian-11-r24'
+    image: 'bitnami/kafka:3.8.1-debian-12-r1'
     ports:
       - '9092:9092'
     environment:

--- a/shotover-proxy/tests/test-configs/kafka/passthrough/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/passthrough/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   kafka0:
-    image: 'bitnami/kafka:3.6.1-debian-11-r24'
+    image: 'bitnami/kafka:3.8.1-debian-12-r1'
     ports:
       - '9092:9092'
     environment:

--- a/shotover-proxy/tests/test-configs/kafka/single-sasl-scram-plaintext-source-tls-sink/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/single-sasl-scram-plaintext-source-tls-sink/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   kafka:
-    image: 'bitnami/kafka:3.6.1-debian-11-r24'
+    image: 'bitnami/kafka:3.8.1-debian-12-r1'
     ports:
       - '9092:9092'
     environment:

--- a/test-helpers/src/docker_compose.rs
+++ b/test-helpers/src/docker_compose.rs
@@ -64,7 +64,7 @@ pub static IMAGE_WAITERS: [Image; 11] = [
         timeout: Duration::from_secs(120),
     },
     Image {
-        name: "bitnami/kafka:3.6.1-debian-11-r24",
+        name: "bitnami/kafka:3.8.1-debian-12-r1",
         log_regex_to_wait_for: r"Kafka Server started",
         timeout: Duration::from_secs(120),
     },


### PR DESCRIPTION
Ensure support for our internal usage of shotover by updating to the kafka version we use.