### PR TITLE
Release shotover 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4718,7 +4718,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shotover"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4788,7 +4788,7 @@ dependencies = [
 
 [[package]]
 name = "shotover-proxy"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shotover-proxy"
-version = "0.5.3"
+version = "0.6.0"
 authors = ["Ben <ben@instaclustr.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/shotover/Cargo.toml
+++ b/shotover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shotover"
-version = "0.5.3"
+version = "0.6.0"
 authors = ["Ben <ben@instaclustr.com>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
While it would be nice to include [kafka-protocol 0.14](https://github.com/tychedelia/kafka-protocol-rs/pull/101) in shotover 0.6 its not clear when it will be released so I think its best to move forward without it.

This PR releases shotover 0.6 the main changes of which are:
* renaming of redis -> valkey
* forwards compatibility with kafka via ApiVersions rewriting