### PR TITLE
Dont log message contents

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,9 @@ reqwest = "0.12.0"
 redis = { version = "0.24.0", features = ["tokio-comp", "cluster"] }
 cdrs-tokio = "8.0"
 cassandra-protocol = "3.0"
-tracing = "0.1.15"
+# https://docs.rs/tracing/latest/tracing/level_filters/index.html#compile-time-filters
+# `trace` level is considered development only, and may contain sensitive data, do not include it in release builds.
+tracing = { version = "0.1.15", features = ["release_max_level_debug"] }
 tracing-subscriber = { version = "0.3.1", features = ["env-filter", "json"] }
 tracing-appender = "0.2.0"
 serde_json = "1.0"

--- a/shotover/src/codec/cassandra.rs
+++ b/shotover/src/codec/cassandra.rs
@@ -642,8 +642,7 @@ impl Decoder for CassandraDecoder {
                 Err(CodecReadError::Parser(anyhow!(msg)))
             }
             err => Err(CodecReadError::Parser(anyhow!(
-                "Failed to parse frame {:?}",
-                err
+                "Failed to parse frame {err:?}"
             ))),
         }
     }

--- a/shotover/src/codec/kafka.rs
+++ b/shotover/src/codec/kafka.rs
@@ -297,7 +297,9 @@ impl Encoder<Messages> for KafkaEncoder {
                             }) => {
                                 dst.extend_from_slice(&body.auth_bytes);
                             }
-                            _ => unreachable!("not expected {frame:?}"),
+                            _ => unreachable!(
+                                "Expected kafka sasl authenticate request or response but was not"
+                            ),
                         }
                         Ok(())
                     } else {

--- a/shotover/src/connection.rs
+++ b/shotover/src/connection.rs
@@ -385,8 +385,8 @@ async fn reader_task<C: CodecBuilder + 'static, R: AsyncRead + Unpin + Send + 's
                             force_run_chain.notify_one();
                         }
                         Err(CodecReadError::RespondAndThenCloseConnection(messages)) => {
-                            if let Err(err) = out_tx.send(messages) {
-                                error!("Failed to send RespondAndThenCloseConnection message: {:?}", err);
+                            if out_tx.send(messages).is_err() {
+                                error!("Failed to send RespondAndThenCloseConnection message");
                             }
                             return Err(ConnectionError::ShotoverClosed);
                         }

--- a/shotover/src/frame/cassandra.rs
+++ b/shotover/src/frame/cassandra.rs
@@ -459,6 +459,26 @@ impl CassandraFrame {
         }
     }
 }
+pub(crate) fn operation_name(operation: &CassandraOperation) -> &'static str {
+    match operation {
+        CassandraOperation::Query { .. } => "Query",
+        CassandraOperation::Result(_) => "Result",
+        CassandraOperation::Error(_) => "Error",
+        CassandraOperation::Prepare(_) => "Prepare",
+        CassandraOperation::Execute(_) => "Execute",
+        CassandraOperation::Register(_) => "Register",
+        CassandraOperation::Event(_) => "Event",
+        CassandraOperation::Batch(_) => "Batch",
+        CassandraOperation::Startup(_) => "Startup",
+        CassandraOperation::Ready(_) => "Ready",
+        CassandraOperation::Authenticate(_) => "Authenticate",
+        CassandraOperation::Options(_) => "Options",
+        CassandraOperation::Supported(_) => "Supported",
+        CassandraOperation::AuthChallenge(_) => "AuthChallenge",
+        CassandraOperation::AuthResponse(_) => "AuthResponse",
+        CassandraOperation::AuthSuccess(_) => "AuthSuccess",
+    }
+}
 
 #[derive(PartialEq, Debug, Clone)]
 pub enum CassandraOperation {

--- a/shotover/src/frame/kafka.rs
+++ b/shotover/src/frame/kafka.rs
@@ -44,7 +44,7 @@ impl Display for KafkaFrame {
                         header.unknown_tagged_fields
                     )?;
                 }
-                write!(f, " {:?}", body)?;
+                write!(f, " {body:?}")?;
             }
             KafkaFrame::Response {
                 version,
@@ -63,7 +63,7 @@ impl Display for KafkaFrame {
                         header.unknown_tagged_fields
                     )?;
                 }
-                write!(f, " {body:?}",)?;
+                write!(f, " {body:?}")?;
             }
         }
         Ok(())

--- a/shotover/src/frame/mod.rs
+++ b/shotover/src/frame/mod.rs
@@ -237,14 +237,14 @@ impl Display for Frame {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
             #[cfg(feature = "cassandra")]
-            Frame::Cassandra(frame) => write!(f, "Cassandra {}", frame),
+            Frame::Cassandra(frame) => write!(f, "Cassandra {frame}"),
             #[cfg(feature = "valkey")]
-            Frame::Valkey(frame) => write!(f, "Valkey {:?}", frame),
+            Frame::Valkey(frame) => write!(f, "Valkey {frame:?}"),
             #[cfg(feature = "kafka")]
-            Frame::Kafka(frame) => write!(f, "Kafka {}", frame),
+            Frame::Kafka(frame) => write!(f, "Kafka {frame}"),
             Frame::Dummy => write!(f, "Shotover internal dummy message"),
             #[cfg(feature = "opensearch")]
-            Frame::OpenSearch(frame) => write!(f, "OpenSearch: {:?}", frame),
+            Frame::OpenSearch(frame) => write!(f, "OpenSearch: {frame:?}"),
         }
     }
 }

--- a/shotover/src/frame/valkey.rs
+++ b/shotover/src/frame/valkey.rs
@@ -27,10 +27,7 @@ pub fn valkey_query_name(frame: &ValkeyFrame) -> Option<String> {
                     return Some(query_type);
                 }
                 Err(err) => {
-                    tracing::error!(
-                        "Failed to convert valkey bulkstring to string, err: {:?}",
-                        err
-                    )
+                    tracing::error!("Failed to convert valkey bulkstring to string, err: {err:?}")
                 }
             }
         }

--- a/shotover/src/message/mod.rs
+++ b/shotover/src/message/mod.rs
@@ -553,7 +553,7 @@ impl Message {
             message_type,
         }) = &self.inner
         {
-            format!("Unparseable {:?} message {:?}", message_type, bytes)
+            format!("Unparseable {message_type:?} message {bytes:?}")
         } else {
             unreachable!("self.frame() failed so MessageInner must still be RawBytes")
         }

--- a/shotover/src/transforms/cassandra/sink_cluster/mod.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/mod.rs
@@ -559,7 +559,7 @@ impl CassandraSinkCluster {
                     }
                     Err(GetReplicaErr::NoPreparedMetadata) => {
                         let id = execute.id.clone();
-                        tracing::info!("forcing re-prepare on {:?}", id);
+                        tracing::info!("forcing re-prepare on {id:?}");
                         // this shotover node doesn't have the metadata.
                         // send an unprepared error in response to force
                         // the client to reprepare the query
@@ -632,7 +632,7 @@ impl CassandraSinkCluster {
             self.set_control_connection(connection, address);
         }
         tracing::info!(
-            "Control connection finalized against node at: {:?}",
+            "Control connection finalized against node at: {}",
             self.control_connection_address.unwrap()
         );
 

--- a/shotover/src/transforms/chain.rs
+++ b/shotover/src/transforms/chain.rs
@@ -96,7 +96,7 @@ impl BufferedChain {
                         chain_state.flush,
                         one_tx,
                     ))
-                    .map_err(|e| anyhow!("Couldn't send message to wrapped chain {:?}", e))
+                    .map_err(|e| anyhow!("Couldn't send message to wrapped chain {e}"))
                     .await?
             }
             Some(timeout) => {
@@ -110,7 +110,7 @@ impl BufferedChain {
                         ),
                         Duration::from_micros(timeout),
                     )
-                    .map_err(|e| anyhow!("Couldn't send message to wrapped chain {:?}", e))
+                    .map_err(|e| anyhow!("Couldn't send message to wrapped chain {e}"))
                     .await?
             }
         }
@@ -137,7 +137,7 @@ impl BufferedChain {
                             chain_state.requests,
                             chain_state.local_addr,
                         ))
-                        .map_err(|e| anyhow!("Couldn't send message to wrapped chain {:?}", e))
+                        .map_err(|e| anyhow!("Couldn't send message to wrapped chain {e}"))
                         .await?
                 }
                 Some(timeout) => {
@@ -149,7 +149,7 @@ impl BufferedChain {
                             ),
                             Duration::from_micros(timeout),
                         )
-                        .map_err(|e| anyhow!("Couldn't send message to wrapped chain {:?}", e))
+                        .map_err(|e| anyhow!("Couldn't send message to wrapped chain {e}"))
                         .await?
                 }
             }

--- a/shotover/src/transforms/debug/log_to_file.rs
+++ b/shotover/src/transforms/debug/log_to_file.rs
@@ -115,7 +115,7 @@ impl Transform for DebugLogToFile {
 }
 
 async fn log_message(message: &Message, path: &Path) -> Result<()> {
-    info!("Logged message to {:?}", path);
+    info!("Logged message to {path:?}");
     match message.clone().into_encodable() {
         Encodable::Bytes(bytes) => {
             tokio::fs::write(path, bytes)

--- a/shotover/src/transforms/kafka/sink_cluster/scram_over_mtls.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/scram_over_mtls.rs
@@ -125,7 +125,7 @@ async fn task(
                     &username,
                     delegation_token_lifetime
                 ).await
-                .with_context(|| format!("Failed to recreate delegation token for {:?}", username))?;
+                .with_context(|| format!("Failed to recreate delegation token for {username:?}"))?;
                 username_to_token.insert(username.clone(), token);
                 recreate_queue.push(username.clone());
 

--- a/shotover/src/transforms/protect/crypto.rs
+++ b/shotover/src/transforms/protect/crypto.rs
@@ -51,7 +51,7 @@ pub async fn decrypt(
 ) -> Result<GenericValue> {
     let bytes = match value {
         GenericValue::Bytes(bytes) => bytes,
-        _ => bail!("expected varchar to decrypt but was {:?}", value),
+        _ => bail!("expected varchar to decrypt but was not varchar"),
     };
     let protected: Protected = bincode::deserialize(bytes)?;
 

--- a/shotover/src/transforms/tee.rs
+++ b/shotover/src/transforms/tee.rs
@@ -574,8 +574,7 @@ async fn put_result_source(
         "regular-chain" => ResultSource::RegularChain,
         _ => {
             return Err(HttpServerError(anyhow!(
-                r"Invalid value for result source: {:?}, should be 'tee-chain' or 'regular-chain'",
-                new_result_source
+                r"Invalid value for result source: {new_result_source:?}, should be 'tee-chain' or 'regular-chain'"
             )));
         }
     };

--- a/shotover/src/transforms/util/cluster_connection_pool.rs
+++ b/shotover/src/transforms/util/cluster_connection_pool.rs
@@ -90,10 +90,7 @@ impl<C: CodecBuilder + 'static, A: Authenticator<T>, T: Token> ConnectionPool<C,
         token: &Option<T>,
         connection_count: usize,
     ) -> Result<Vec<Connection>, ConnectionError<A::Error>> {
-        debug!(
-            "getting {} pool connections to {} with token: {:?}",
-            connection_count, address, token
-        );
+        debug!("getting {connection_count} pool connections to {address} with token: {token:?}",);
 
         let mut lanes = self.lanes.lock().await;
         let lane = lanes.entry(token.clone()).or_default();
@@ -205,7 +202,7 @@ pub fn spawn_read_write_tasks<
     tokio::spawn(async move {
         tokio::select! {
             result = tx_process(dummy_request_tx, stream_tx, out_rx, return_tx, encoder) => if let Err(e) = result {
-                trace!("connection write-closed with error: {:?}", e);
+                trace!("connection write-closed with error: {e:?}");
             } else {
                 trace!("connection write-closed gracefully");
             },
@@ -218,7 +215,7 @@ pub fn spawn_read_write_tasks<
     tokio::spawn(
         async move {
             if let Err(e) = rx_process(dummy_request_rx, stream_rx, return_rx, decoder).await {
-                trace!("connection read-closed with error: {:?}", e);
+                trace!("connection read-closed with error: {e:?}");
             } else {
                 trace!("connection read-closed gracefully");
             }

--- a/shotover/src/transforms/valkey/cluster_ports_rewrite.rs
+++ b/shotover/src/transforms/valkey/cluster_ports_rewrite.rs
@@ -137,9 +137,9 @@ fn rewrite_port_slot(frame: &mut Frame, new_port: u16) -> Result<()> {
                             [ValkeyFrame::BulkString(_ip), ValkeyFrame::Integer(port), ..] => {
                                 *port = new_port.into();
                             }
-                            _ => bail!("expected host-port in slot map but was: {:?}", frame),
+                            _ => bail!("expected slot to start with bulkstring followed by integer, but was something else"),
                         },
-                        _ => bail!("unexpected value in slot map: {:?}", frame),
+                        _ => bail!("non array value in slot map"),
                     }
                 }
             };


### PR DESCRIPTION
This PR removes all cases that could possibly lead to logging message contents:
* The first and most important change is to remove trace level logs from release binaries. This is done by adding the `release_max_level_debug` feature. This allows trace level logs to log message contents for debugging purposes while making it impossible for these logs to make it into production.
* Move a few debug level logs to trace level logs since they include message contents.
* Remove message contents from some errors that include values, these errors needed to be combined with another bug in shotover or a bug in the client or DB for message contents to be logged. This PR removes that possibility entirely.
* the vast majority of the PR is just minor syntax cleanup of moving arguments inline with the format string, since I was auditing every log it made sense to do at the same time. These kinds of cleanups make such audits easier to perform in the future.


None of the issues I found were severe enough to warrant an immediate patch release. Since it would take an unusual configuration or another bug in shotover for message contents to be logged.