### PR TITLE
Remove `env::set_var` usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,20 +861,6 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "cargo_metadata"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8769706aad5d996120af43197bf46ef6ad0fda35216b4505f926a365a232d924"
@@ -1689,7 +1675,7 @@ name = "ec2-cargo"
 version = "0.1.0"
 dependencies = [
  "aws-throwaway",
- "cargo_metadata 0.19.1",
+ "cargo_metadata",
  "clap",
  "shell-quote",
  "shellfish",
@@ -5283,14 +5269,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-bin-process"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0581e13b120b43f94b33fac60d6d7b37327e1dddad1b422b72b8dfbda0a453cd"
+checksum = "10d848fd97fa3976101be388f3d1f3952d9b3f84a6e741b3c07c55e029d8be05"
 dependencies = [
  "anyhow",
- "cargo_metadata 0.18.1",
+ "cargo_metadata",
  "chrono",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "nix 0.29.0",
  "nu-ansi-term 0.50.1",
  "regex-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ clap = { version = "4.0.4", features = ["cargo", "derive"] }
 async-trait = "0.1.30"
 typetag = "0.2.5"
 aws-throwaway = { version = "0.6.0", default-features = false }
-tokio-bin-process = "0.6.0"
+tokio-bin-process = "0.7.0"
 ordered-float = { version = "4.0.0", features = ["serde"] }
 shell-quote = { default-features = false, features = ["bash"], version = "0.7.0" }
 pretty_assertions = "1.4.0"

--- a/custom-transforms-example/tests/test.rs
+++ b/custom-transforms-example/tests/test.rs
@@ -4,7 +4,9 @@ use redis::Cmd;
 use std::time::Duration;
 use test_helpers::connection::valkey_connection;
 use test_helpers::docker_compose::docker_compose;
-use test_helpers::shotover_process::{bin_path, BinProcess, EventMatcher, Level};
+use test_helpers::shotover_process::{
+    bin_path, BinProcess, BinProcessBuilder, EventMatcher, Level,
+};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_custom_transform() {
@@ -37,12 +39,16 @@ async fn test_custom_transform() {
 }
 
 async fn shotover_proxy(topology_path: &str) -> BinProcess {
-    let mut shotover = BinProcess::start_binary(
-        bin_path!("custom-transforms-example"),
-        "shotover",
-        &["-t", topology_path, "--log-format", "json"],
-    )
-    .await;
+    let mut shotover = BinProcessBuilder::from_path(bin_path!("custom-transforms-example"))
+        .with_log_name(Some("shotover".to_owned()))
+        .with_args(vec![
+            "-t".to_owned(),
+            topology_path.to_owned(),
+            "--log-format".to_owned(),
+            "json".to_owned(),
+        ])
+        .start()
+        .await;
 
     tokio::time::timeout(
         Duration::from_secs(30),

--- a/shotover-proxy/benches/windsock/cloud/aws.rs
+++ b/shotover-proxy/benches/windsock/cloud/aws.rs
@@ -438,7 +438,7 @@ pub async fn upload_shotover(instance: &Ec2Instance) {
 
     instance
         .ssh()
-        .push_file(local_shotover_path, Path::new("shotover-bin"))
+        .push_file(&local_shotover_path, Path::new("shotover-bin"))
         .await;
     instance
         .ssh()

--- a/test-helpers/src/docker_compose.rs
+++ b/test-helpers/src/docker_compose.rs
@@ -1,5 +1,5 @@
 use docker_compose_runner::*;
-use std::{env, time::Duration};
+use std::time::Duration;
 
 pub use docker_compose_runner::DockerCompose;
 
@@ -12,11 +12,6 @@ pub fn docker_compose(file_path: &str) -> DockerCompose {
 
 /// Creates a new DockerCompose running an instance of moto the AWS mocking server
 pub fn new_moto() -> DockerCompose {
-    // Overwrite any existing AWS credential env vars belonging to the user with dummy values to be sure that
-    // we wont hit their real AWS account in the case of a bug in shotover or the test
-    env::set_var("AWS_ACCESS_KEY_ID", "dummy-access-key");
-    env::set_var("AWS_SECRET_ACCESS_KEY", "dummy-access-key-secret");
-
     docker_compose("tests/transforms/docker-compose-moto.yaml")
 }
 


### PR DESCRIPTION
~~Blocked on https://github.com/shotover/tokio-bin-process/pull/44~~

[Rust 2024 will be marking `env::set_var` as unsafe](https://doc.rust-lang.org/edition-guide/rust-2024/newly-unsafe-functions.html), since unsafe is forbidden in this repo we need to remove all usage of `env::set_var` before we can upgrade to rust 2024.
This PR removes a specific usage of `env::set_var` and replaces it with a more specific version that only sets the env vars of a specific child process.

However achieving this was a little complex:
1. First we update to the latest version of tokio-bin-process, the new version uses a builder API for constructing `BinProcess`s which required a bunch of changes to how we use it.
2. Then we use the new `with_env_var` method on the builder to set the required env vars.

After this PR there is still some usage of `env::set_var` but removing that is more complicated so it is left as follow up work.