### PR TITLE
Fix docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /shotover-proxy
 
 COPY ./ ./
 
-RUN cargo build -p shotover-proxy --release
+RUN rustup toolchain install && cargo build -p shotover-proxy --release
 
 FROM debian:bookworm-slim
 


### PR DESCRIPTION
rustup 1.28 has made its way into the docker image we use as a base, so its time to land this CI fix.
https://github.com/shotover/shotover-proxy/pull/1875 contains more CI fixes, but we cant land those until rustup 1.85 makes it into the github actions runner images.

I would pin the docker image to prevent future breakage, but it seems they dont version their tags.
