### PR TITLE
Fix missing docs pages

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -19,3 +19,5 @@
 - [Contributing](./dev-docs/contributing.md)
   - [Debugging](./dev-docs/debugging.md)
   - [Internal End-to-End Overview](./dev-docs/end-to-end-overview.md)
+  - [Setting up Linux](./dev-docs/setting-up-linux.md)
+  - [Setting up macOS](./dev-docs/setting-up-macos.md)


### PR DESCRIPTION
There are currently some dead links on this page: https://shotover.io/docs/main/dev-docs/contributing.html
This PR fixes that.

The SUMMARY.md file is used to generate the sidebar:
![image](https://github.com/user-attachments/assets/67b8768a-3a98-4ed3-be89-bed6668e2c38)

And pages not included in the sidebar are not generated at all.
So to ensure these pages are generated, this PR includes them in the sidebar.