### PR TITLE
Upgrade bincode to version 2.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,6 +771,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4888,7 +4908,7 @@ dependencies = [
  "backtrace-ext",
  "base64 0.22.1",
  "bigdecimal",
- "bincode",
+ "bincode 2.0.1",
  "bytes",
  "cached",
  "cassandra-protocol",
@@ -4950,7 +4970,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "aws-throwaway",
- "bincode",
+ "bincode 2.0.1",
  "bytes",
  "cassandra-protocol",
  "cdrs-tokio",
@@ -5821,6 +5841,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5894,6 +5920,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "void"
@@ -6285,7 +6317,7 @@ checksum = "8f186f03f8f547e6eb32a314c55e52754e3315eb299c9d27e4d1758eb1e254f8"
 dependencies = [
  "anyhow",
  "async-trait",
- "bincode",
+ "bincode 1.3.3",
  "clap",
  "console",
  "copy_dir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ subprocess = "0.2.7"
 chacha20poly1305 = { version = "0.10.0", features = ["std"] }
 csv = "1.2.0"
 redis-protocol = { version = "6.0.0", features = ["bytes"] }
-bincode = "2.0.1"
+bincode = { version = "2.0.1", features = ["serde"] }
 futures = "0.3"
 hex = "0.4.3"
 hex-literal = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ subprocess = "0.2.7"
 chacha20poly1305 = { version = "0.10.0", features = ["std"] }
 csv = "1.2.0"
 redis-protocol = { version = "6.0.0", features = ["bytes"] }
-bincode = "1.3.1"
+bincode = "2.0.1"
 futures = "0.3"
 hex = "0.4.3"
 hex-literal = "1.0.0"

--- a/shotover-proxy/build/install_ubuntu_packages.sh
+++ b/shotover-proxy/build/install_ubuntu_packages.sh
@@ -28,7 +28,7 @@ if [ ! -f "$FILE_PATH" ]; then
     git clone --depth 1 --branch $VERSION https://github.com/datastax/cpp-driver
     pushd cpp-driver
 
-    cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_INSTALL_LIBDIR:PATH=/usr/lib -Wno-error .
+    cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_INSTALL_LIBDIR:PATH=/usr/lib -Wno-error .
     make
 
     mkdir -p $PACKAGE_NAME/DEBIAN

--- a/shotover-proxy/tests/cassandra_int_tests/protect.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/protect.rs
@@ -138,7 +138,7 @@ pub async fn test(shotover_session: &CassandraConnection, direct_session: &Cassa
 
         // protected values are stored encrypted
         if let ResultValue::Blob(value) = &row[2] {
-            let _: Protected = bincode::deserialize(value).unwrap();
+            let _: Protected = bincode::serde::decode_from_slice(value).unwrap().0;
         } else {
             panic!("expected 3rd column to be ResultValue::Blob in {row:?}");
         }

--- a/shotover-proxy/tests/cassandra_int_tests/protect.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/protect.rs
@@ -138,7 +138,9 @@ pub async fn test(shotover_session: &CassandraConnection, direct_session: &Cassa
 
         // protected values are stored encrypted
         if let ResultValue::Blob(value) = &row[2] {
-            let _: Protected = bincode::serde::decode_from_slice(value).unwrap().0;
+            let _: Protected = bincode::serde::decode_from_slice(value, bincode::config::legacy())
+                .unwrap()
+                .0;
         } else {
             panic!("expected 3rd column to be ResultValue::Blob in {row:?}");
         }


### PR DESCRIPTION
Upgrade the `bincode` crate to version 2.0.1

The option `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` has been added to the `cmake` command in `install_ubuntu_packages.sh` to solve the build failure when building cpp packages.