### PR TITLE
Install cassandra-cpp driver via precompiled package instead of building from source

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,11 +29,6 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
     steps:
-      - name: cache custom ubuntu packages
-        uses: actions/cache@v4
-        with:
-          path: shotover-proxy/build/packages
-          key: ubuntu-22.04-packages
       - uses: actions/checkout@v4
         # We purposefully dont cache here as build_and_test will always be the bottleneck
         # so we should leave the cache alone so build_and_test can make more use of it.

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -51,11 +51,6 @@ jobs:
           # downsides:
           # * PRs that update rust version or changes deps will be slow to iterate on due to changes not being cached.
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - name: cache custom ubuntu packages
-        uses: actions/cache@v4
-        with:
-          path: shotover-proxy/build/packages
-          key: ubuntu-24.04-packages
       - name: Install ubuntu packages
         run: shotover-proxy/build/install_ubuntu_packages.sh
       - name: Install nextest
@@ -116,11 +111,6 @@ jobs:
     needs: build_check_and_upload
     steps:
       - uses: actions/checkout@v4
-      - name: cache custom ubuntu packages
-        uses: actions/cache@v4
-        with:
-          path: shotover-proxy/build/packages
-          key: ubuntu-24.04-packages
       - name: Install ubuntu packages
         run: shotover-proxy/build/install_ubuntu_packages.sh
       - name: Install nextest

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,11 +30,6 @@ jobs:
           # downsides:
           # * PRs that update rust version or changes deps will be slow to iterate on due to changes not being cached.
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - name: cache custom ubuntu packages
-        uses: actions/cache@v4
-        with:
-          path: shotover-proxy/build/packages
-          key: ubuntu-24.04-packages
       - name: Install ubuntu packages
         run: shotover-proxy/build/install_ubuntu_packages.sh
       - name: Install cargo-hack

--- a/shotover-proxy/build/cassandra-cpp-driver.control
+++ b/shotover-proxy/build/cassandra-cpp-driver.control
@@ -1,7 +1,0 @@
-Package: cassandra-cpp-driver
-Version: VERSION
-Section: base
-Priority: optional
-Architecture: amd64
-Maintainer: Shotover team
-Description: cassandra cpp-driver installed by shotover


### PR DESCRIPTION
This driver is an optional dependency used by some integration tests.

Currently we build it from source, since the maintainers did not provide .deb packages for recent ubuntu versions.
But since they now provide packages for ubuntu 22.04, this PR changes CI to download the precompiled package instead of building from scratch.

This PR reduces the following CI time:
* ~5s on cached builds (because we skip cmake install, which we could technically do with the current approach)
* ~2m on uncached builds. (because we skip compiling the cassandra-cpp driver.