### PR TITLE
Update to rust 1.86 🦀🦀🦀

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.85"
+channel = "1.86"
 components = ["rustfmt", "clippy"]
 targets = ["aarch64-unknown-linux-gnu"]

--- a/shotover-proxy/tests/cassandra_int_tests/cluster/multi_rack.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cluster/multi_rack.rs
@@ -23,7 +23,7 @@ async fn test_rewrite_system_peers(connection: &CassandraConnection) {
         ResultValue::Any,
         // Unfortunately token generation appears to be non-deterministic but we can at least assert that
         // there are 128 tokens per node
-        ResultValue::Set(std::iter::repeat(ResultValue::Any).take(128).collect()),
+        ResultValue::Set(std::iter::repeat_n(ResultValue::Any, 128).collect()),
     ];
 
     let all_columns = "peer, data_center, host_id, preferred_ip, rack, release_version, rpc_address, schema_version, tokens";
@@ -70,7 +70,7 @@ async fn test_rewrite_system_peers_v2(connection: &CassandraConnection) {
         ResultValue::Any,
         // Unfortunately token generation appears to be non-deterministic but we can at least assert that
         // there are 128 tokens per node
-        ResultValue::Set(std::iter::repeat(ResultValue::Any).take(128).collect()),
+        ResultValue::Set(std::iter::repeat_n(ResultValue::Any, 128).collect()),
     ];
 
     let all_columns = "peer, peer_port, data_center, host_id, native_address, native_port, preferred_ip, preferred_port, rack, release_version, schema_version, tokens";
@@ -126,7 +126,7 @@ async fn test_rewrite_system_local(connection: &CassandraConnection) {
         ResultValue::Any,
         // Unfortunately token generation appears to be non-deterministic but we can at least assert that
         // there are 128 tokens per node
-        ResultValue::Set(std::iter::repeat(ResultValue::Any).take(128).collect()),
+        ResultValue::Set(std::iter::repeat_n(ResultValue::Any, 128).collect()),
         // truncated_at is non deterministic so we cant assert on it.
         ResultValue::Any,
     ];

--- a/shotover-proxy/tests/cassandra_int_tests/cluster/single_rack_v3.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cluster/single_rack_v3.rs
@@ -17,7 +17,7 @@ async fn test_rewrite_system_peers_dummy_peers(connection: &CassandraConnection)
         ResultValue::Any,
         // Unfortunately token generation appears to be non-deterministic but we can at least assert that
         // there are 128 tokens per node
-        ResultValue::Set(std::iter::repeat(ResultValue::Any).take(3 * 128).collect()),
+        ResultValue::Set(std::iter::repeat_n(ResultValue::Any, 3 * 128).collect()),
     ];
     let star_results2 = [
         ResultValue::Inet("127.0.0.1".parse().unwrap()),
@@ -32,7 +32,7 @@ async fn test_rewrite_system_peers_dummy_peers(connection: &CassandraConnection)
         ResultValue::Any,
         // Unfortunately token generation appears to be non-deterministic but we can at least assert that
         // there are 128 tokens per node
-        ResultValue::Set(std::iter::repeat(ResultValue::Any).take(3 * 128).collect()),
+        ResultValue::Set(std::iter::repeat_n(ResultValue::Any, 3 * 128).collect()),
     ];
 
     let all_columns = "peer, data_center, host_id, preferred_ip, rack, release_version, rpc_address, schema_version, tokens";
@@ -83,7 +83,7 @@ async fn test_rewrite_system_local(connection: &CassandraConnection) {
         ResultValue::Any,
         // Unfortunately token generation appears to be non-deterministic but we can at least assert that
         // there are 128 tokens per node
-        ResultValue::Set(std::iter::repeat(ResultValue::Any).take(3 * 128).collect()),
+        ResultValue::Set(std::iter::repeat_n(ResultValue::Any, 3 * 128).collect()),
         ResultValue::Null,
     ];
 

--- a/shotover-proxy/tests/cassandra_int_tests/cluster/single_rack_v4.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/cluster/single_rack_v4.rs
@@ -69,9 +69,9 @@ async fn test_rewrite_system_peers_dummy_peers(
         // Unfortunately token generation appears to be non-deterministic but we can at least assert that
         // there are 128 tokens per node
         if let CassandraDriver::Cdrs = driver {
-            ResultValue::List(std::iter::repeat(ResultValue::Any).take(3 * 128).collect())
+            ResultValue::List(std::iter::repeat_n(ResultValue::Any, 3 * 128).collect())
         } else {
-            ResultValue::Set(std::iter::repeat(ResultValue::Any).take(3 * 128).collect())
+            ResultValue::Set(std::iter::repeat_n(ResultValue::Any, 3 * 128).collect())
         },
     ];
     let star_results2 = [
@@ -88,9 +88,9 @@ async fn test_rewrite_system_peers_dummy_peers(
         // Unfortunately token generation appears to be non-deterministic but we can at least assert that
         // there are 128 tokens per node
         if let CassandraDriver::Cdrs = driver {
-            ResultValue::List(std::iter::repeat(ResultValue::Any).take(3 * 128).collect())
+            ResultValue::List(std::iter::repeat_n(ResultValue::Any, 3 * 128).collect())
         } else {
-            ResultValue::Set(std::iter::repeat(ResultValue::Any).take(3 * 128).collect())
+            ResultValue::Set(std::iter::repeat_n(ResultValue::Any, 3 * 128).collect())
         },
     ];
 
@@ -138,9 +138,9 @@ async fn test_rewrite_system_peers_v2_dummy_peers(
         // Unfortunately token generation appears to be non-deterministic but we can at least assert that
         // there are 128 tokens per node
         if let CassandraDriver::Cdrs = driver {
-            ResultValue::List(std::iter::repeat(ResultValue::Any).take(3 * 128).collect())
+            ResultValue::List(std::iter::repeat_n(ResultValue::Any, 3 * 128).collect())
         } else {
-            ResultValue::Set(std::iter::repeat(ResultValue::Any).take(3 * 128).collect())
+            ResultValue::Set(std::iter::repeat_n(ResultValue::Any, 3 * 128).collect())
         },
     ];
     let star_results2 = [
@@ -159,9 +159,9 @@ async fn test_rewrite_system_peers_v2_dummy_peers(
         // Unfortunately token generation appears to be non-deterministic but we can at least assert that
         // there are 128 tokens per node
         if let CassandraDriver::Cdrs = driver {
-            ResultValue::List(std::iter::repeat(ResultValue::Any).take(3 * 128).collect())
+            ResultValue::List(std::iter::repeat_n(ResultValue::Any, 3 * 128).collect())
         } else {
-            ResultValue::Set(std::iter::repeat(ResultValue::Any).take(3 * 128).collect())
+            ResultValue::Set(std::iter::repeat_n(ResultValue::Any, 3 * 128).collect())
         },
     ];
 
@@ -215,9 +215,9 @@ async fn test_rewrite_system_local(connection: &CassandraConnection, driver: Cas
         // Unfortunately token generation appears to be non-deterministic but we can at least assert that
         // there are 128 tokens per node
         if let CassandraDriver::Cdrs = driver {
-            ResultValue::List(std::iter::repeat(ResultValue::Any).take(3 * 128).collect())
+            ResultValue::List(std::iter::repeat_n(ResultValue::Any, 3 * 128).collect())
         } else {
-            ResultValue::Set(std::iter::repeat(ResultValue::Any).take(3 * 128).collect())
+            ResultValue::Set(std::iter::repeat_n(ResultValue::Any, 3 * 128).collect())
         },
         // truncated_at is non deterministic so we cant assert on it.
         ResultValue::Any,

--- a/shotover/src/transforms/cassandra/sink_cluster/token_ring.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/token_ring.rs
@@ -46,10 +46,10 @@ impl TokenRing {
     /// Walk the token ring to figure out which nodes are acting as replicas for the given query.
     /// The way we do this depends on the replication strategy used:
     /// * ReplicationStrategy::SimpleStrategy - Each cassandra node has many tokens assigned to it to form the token ring.
-    ///     Take the hashed key (token) and walk along the token ring starting at the token in the ring after the token from our key.
-    ///     Return the nodes belonging to the first replication_factor number of tokens encountered.
+    ///   Take the hashed key (token) and walk along the token ring starting at the token in the ring after the token from our key.
+    ///   Return the nodes belonging to the first replication_factor number of tokens encountered.
     /// * ReplicationStrategy::NetworkTopologyStrategy - The same as the simple strategy but also:
-    ///     When we walk the token ring we need to skip tokens belonging to nodes in a rack we have already encountered in this walk.
+    ///   When we walk the token ring we need to skip tokens belonging to nodes in a rack we have already encountered in this walk.
     ///
     /// For more info: https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/architecture/archDataDistributeReplication.html
     pub fn iter_replica_nodes<'a>(

--- a/shotover/src/transforms/kafka/sink_cluster/connections.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/connections.rs
@@ -21,8 +21,8 @@ pub enum Destination {
     /// The control connection is a bit weird:
     /// * while !auth_complete it needs to be routed to via `PendingRequest`
     /// * However, once auth_complete is true, Destination::ControlConnection should never be routed to.
-    ///     Instead, at this point control_send_receive must be called which will immediately return a
-    ///     response in place without going through the routing logic.
+    ///   Instead, at this point control_send_receive must be called which will immediately return a
+    ///   response in place without going through the routing logic.
     ///
     /// TODO: In the future it might make sense to remove control_send_receive in favor of always routing to the control connection.
     ///       This will avoid latency spikes where a response is delayed because we have to wait for a metadata request to come back.


### PR DESCRIPTION
https://blog.rust-lang.org/2025/04/03/Rust-1.86.0.html
The main exciting thing for us is much faster linux aarch64 builds, since rustc is now compiled with thinLTO + PGO on that platform.

The repeat_n changes are to address the new clippy lint: https://rust-lang.github.io/rust-clippy/stable/index.html#manual_repeat_n
The doc comment changes are to address the new clippy lint: https://rust-lang.github.io/rust-clippy/stable/index.html#doc_overindented_list_items