### PR TITLE
KafkaSinkCluster: Fix connect error handling when we dont have cluster metadata yet.

### DIFF
--- a/shotover/src/transforms/kafka/sink_cluster/mod.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/mod.rs
@@ -2202,8 +2202,9 @@ The connection to the client has been closed."
                         }
                     });
 
-                    // Leave the Kafka node as it as in case it's None. It's then bubbled up
-                    // and show a less confused message when there is a misconfiguration.
+                    // kafka_node will be None when the cluster metadata hasnt been populated yet.
+                    // This is guaranteed to happen when the cluster is down and shotover has never connected to the cluster.
+                    // In that case we dont set anything and allow regular error handling to continue.
                     if let Some(node) = kafka_node {
                         node.set_state(KafkaNodeState::Down);
                     }


### PR DESCRIPTION
closes https://github.com/shotover/shotover-proxy/issues/1903

This issue obfuscated the real cause while trying to resolve a local setup issue.
I imagine it could also lead to confusion in possible production misconfigurations as well.
Solution: that unwrap needs to be replaced with an if let so that we do nothing when its None