### PR TITLE
UNIX SOCKET HANDOFF - CLIENT SIDE IMPLEMENTATION

### DIFF
--- a/shotover-proxy/tests/runner/hotreload_int_tests.rs
+++ b/shotover-proxy/tests/runner/hotreload_int_tests.rs
@@ -1,8 +1,6 @@
 use crate::shotover_process;
 use redis::{Client, Commands};
-use std::time::Duration;
 use test_helpers::docker_compose::docker_compose;
-use tokio::time::sleep;
 
 #[tokio::test]
 async fn test_hotreload_basic_valkey_connection() {
@@ -37,7 +35,6 @@ async fn test_dual_shotover_instances_with_valkey() {
     let client_a = Client::open("valkey://127.0.0.1:6380").unwrap();
     let mut con_a = client_a.get_connection().unwrap();
     let _: () = con_a.set("key_from_a", "value_from_a").unwrap();
-    sleep(Duration::from_secs(5)).await;
 
     //Second shotover
     let shotover_b = shotover_process("tests/test-configs/hotreload/topology-alt.yaml")

--- a/shotover/src/hot_reload_client.rs
+++ b/shotover/src/hot_reload_client.rs
@@ -75,7 +75,7 @@ impl UnixSocketClient {
 }
 
 /// Request listening sockets from an existing Shotover instance during hot reload
-pub async fn request_listening_sockets(socket_path: String) -> Result<()> {
+pub async fn perform_hot_reloading(socket_path: String) -> Result<()> {
     info!(
         "Hot reload CLIENT will request sockets from existing shotover at: {}",
         socket_path
@@ -143,7 +143,7 @@ mod tests {
         let mut server =
             crate::hot_reload_server::UnixSocketServer::new(socket_path.to_string()).unwrap();
         let server_handle = tokio::spawn(async move {
-            server.run().await.ok();
+            server.run().await.unwrap();
         });
 
         // Wait for server to start
@@ -173,14 +173,11 @@ mod tests {
     async fn test_multiple_client_requests() {
         let socket_path = "/tmp/test-multiple-clients.sock";
 
-        // Clean up any existing socket
-        let _ = std::fs::remove_file(socket_path);
-
         // Start server
         let mut server =
             crate::hot_reload_server::UnixSocketServer::new(socket_path.to_string()).unwrap();
         let server_handle = tokio::spawn(async move {
-            server.run().await.ok();
+            server.run().await.unwrap();
         });
 
         wait_for_unix_socket_connection(socket_path, 2000).await;

--- a/shotover/src/hot_reload_client.rs
+++ b/shotover/src/hot_reload_client.rs
@@ -107,7 +107,6 @@ pub async fn request_listening_sockets(socket_path: String) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::Duration;
     #[cfg(test)]
     async fn wait_for_unix_socket_connection(socket_path: &str, timeout_ms: u64) {
         use tokio::net::UnixStream;

--- a/shotover/src/hot_reload_client.rs
+++ b/shotover/src/hot_reload_client.rs
@@ -22,6 +22,7 @@ impl UnixSocketClient {
         }
     }
 
+    #[cfg(test)]
     pub fn with_timeout(mut self, timeout: Duration) -> Self {
         self.timeout_duration = timeout;
         self
@@ -141,14 +142,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_client_with_timeout_builder() {
-        let client = UnixSocketClient::new("/test/path.sock".to_string())
-            .with_timeout(Duration::from_secs(5));
-
-        assert_eq!(client.timeout_duration, Duration::from_secs(5));
-    }
-
-    #[tokio::test]
     async fn test_client_server_integration() {
         let socket_path = "/tmp/test-client-server-integration.sock";
 
@@ -183,7 +176,6 @@ mod tests {
 
         // Cleanup
         server_handle.abort();
-        let _ = std::fs::remove_file(socket_path);
     }
 
     #[tokio::test]

--- a/shotover/src/hot_reload_client.rs
+++ b/shotover/src/hot_reload_client.rs
@@ -1,0 +1,218 @@
+//This module gives clinet-side implementation for socket handoff as part of hot reloading
+//Client will connect to existing shotovers and requests for FDs
+use crate::hot_reload::{Request, Response};
+use anyhow::{Context, Result};
+use serde::de::DeserializeOwned;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::time::timeout;
+use tracing::{debug, info};
+
+pub struct UnixSocketClient {
+    socket_path: String,
+    timeout_duration: Duration,
+}
+
+impl UnixSocketClient {
+    pub fn new(socket_path: String) -> Self {
+        Self {
+            socket_path,
+            timeout_duration: Duration::from_secs(30),
+        }
+    }
+
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout_duration = timeout;
+        self
+    }
+
+    pub async fn send_request(&self, request: Request) -> Result<Response> {
+        info!("Connecting to hot reload server at: {}", self.socket_path);
+
+        let result = timeout(self.timeout_duration, self.send_request_inner(request)).await;
+
+        match result {
+            Ok(response) => response,
+            Err(_) => Err(anyhow::anyhow!(
+                "Hot reload request timed out after {:?}",
+                self.timeout_duration
+            )),
+        }
+    }
+
+    async fn send_request_inner(&self, request: Request) -> Result<Response> {
+        // Connect to server
+        let stream = UnixStream::connect(&self.socket_path)
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to connect to hot reload server at: {}",
+                    self.socket_path
+                )
+            })?;
+
+        let (reader, mut writer) = stream.into_split();
+        let mut reader = BufReader::new(reader);
+
+        // Send request
+        let request_json =
+            serde_json::to_string(&request).context("Failed to serialize request")?;
+
+        debug!("Sending request: {}", request_json);
+        writer
+            .write_all(request_json.as_bytes())
+            .await
+            .context("Failed to send request")?;
+
+        // Read response
+        let response: Response = read_json(&mut reader).await?;
+        debug!("Received response: {:?}", response);
+
+        Ok(response)
+    }
+}
+
+// Reuse the same JSON parsing logic as server
+async fn read_json<T: DeserializeOwned, R: AsyncReadExt + Unpin>(reader: &mut R) -> Result<T> {
+    let mut received_bytes = Vec::new();
+    loop {
+        let mut buf = [0u8; 1024];
+        let n = reader
+            .read(&mut buf)
+            .await
+            .context("Failed to read from stream")?;
+        if n == 0 {
+            return Err(anyhow::anyhow!(
+                "Connection closed before full JSON message received"
+            ));
+        }
+        received_bytes.extend_from_slice(&buf[..n]);
+        match serde_json::from_slice(&received_bytes) {
+            Ok(response) => return Ok(response),
+            Err(e) if e.is_eof() => continue,
+            Err(e) => return Err(e).context("Failed to parse JSON"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_client_timeout() {
+        // Use a path that will cause the connection to hang, not fail immediately
+        // This simulates a server that accepts connections but doesn't respond
+        let client =
+            UnixSocketClient::new("/dev/null".to_string()).with_timeout(Duration::from_millis(100));
+
+        let result = client.send_request(Request::SendListeningSockets).await;
+        assert!(result.is_err());
+        let error_msg = result.unwrap_err().to_string();
+
+        // The error could be either a timeout or a connection error, both are valid
+        assert!(
+            error_msg.contains("timed out") || error_msg.contains("Failed to connect"),
+            "Expected timeout or connection error, got: {}",
+            error_msg
+        );
+    }
+
+    #[tokio::test]
+    async fn test_client_connection_error() {
+        let client = UnixSocketClient::new("/nonexistent/path.sock".to_string());
+
+        let result = client.send_request(Request::SendListeningSockets).await;
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Failed to connect")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_client_with_timeout_builder() {
+        let client = UnixSocketClient::new("/test/path.sock".to_string())
+            .with_timeout(Duration::from_secs(5));
+
+        assert_eq!(client.timeout_duration, Duration::from_secs(5));
+    }
+
+    #[tokio::test]
+    async fn test_client_server_integration() {
+        let socket_path = "/tmp/test-client-server-integration.sock";
+
+        // Clean up any existing socket
+        let _ = std::fs::remove_file(socket_path);
+
+        // Start server
+        let mut server =
+            crate::hot_reload_server::UnixSocketServer::new(socket_path.to_string()).unwrap();
+        let server_handle = tokio::spawn(async move {
+            server.run().await.ok();
+        });
+
+        // Wait for server to start
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Create client and send request
+        let client = UnixSocketClient::new(socket_path.to_string());
+        let response = client
+            .send_request(Request::SendListeningSockets)
+            .await
+            .unwrap();
+
+        // Verify response
+        match response {
+            Response::SendListeningSockets { port_to_fd } => {
+                assert_eq!(port_to_fd.len(), 1);
+                assert!(port_to_fd.contains_key(&6380));
+            }
+            Response::Error(msg) => panic!("Unexpected error response: {}", msg),
+        }
+
+        // Cleanup
+        server_handle.abort();
+        let _ = std::fs::remove_file(socket_path);
+    }
+
+    #[tokio::test]
+    async fn test_multiple_client_requests() {
+        let socket_path = "/tmp/test-multiple-clients.sock";
+
+        // Clean up any existing socket
+        let _ = std::fs::remove_file(socket_path);
+
+        // Start server
+        let mut server =
+            crate::hot_reload_server::UnixSocketServer::new(socket_path.to_string()).unwrap();
+        let server_handle = tokio::spawn(async move {
+            server.run().await.ok();
+        });
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Send multiple requests
+        let client = UnixSocketClient::new(socket_path.to_string());
+
+        for _i in 0..3 {
+            let response = client
+                .send_request(Request::SendListeningSockets)
+                .await
+                .unwrap();
+            match response {
+                Response::SendListeningSockets { port_to_fd } => {
+                    assert_eq!(port_to_fd.len(), 1);
+                }
+                Response::Error(msg) => panic!("Unexpected error response: {}", msg),
+            }
+        }
+
+        // Cleanup
+        server_handle.abort();
+        let _ = std::fs::remove_file(socket_path);
+    }
+}

--- a/shotover/src/hot_reload_client.rs
+++ b/shotover/src/hot_reload_client.rs
@@ -1,10 +1,10 @@
-//This module gives clinet-side implementation for socket handoff as part of hot reloading
+//This module gives client-side implementation for socket handoff as part of hot reloading
 //Client will connect to existing shotovers and requests for FDs
 use crate::hot_reload::{Request, Response};
+use crate::json_parsing::read_json;
 use anyhow::{Context, Result};
-use serde::de::DeserializeOwned;
 use std::time::Duration;
-use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 use tokio::time::timeout;
 use tracing::{debug, info};
@@ -70,29 +70,6 @@ impl UnixSocketClient {
         debug!("Received response: {:?}", response);
 
         Ok(response)
-    }
-}
-
-// Reuse the same JSON parsing logic as server
-async fn read_json<T: DeserializeOwned, R: AsyncReadExt + Unpin>(reader: &mut R) -> Result<T> {
-    let mut received_bytes = Vec::new();
-    loop {
-        let mut buf = [0u8; 1024];
-        let n = reader
-            .read(&mut buf)
-            .await
-            .context("Failed to read from stream")?;
-        if n == 0 {
-            return Err(anyhow::anyhow!(
-                "Connection closed before full JSON message received"
-            ));
-        }
-        received_bytes.extend_from_slice(&buf[..n]);
-        match serde_json::from_slice(&received_bytes) {
-            Ok(response) => return Ok(response),
-            Err(e) if e.is_eof() => continue,
-            Err(e) => return Err(e).context("Failed to parse JSON"),
-        }
     }
 }
 

--- a/shotover/src/hot_reload_server.rs
+++ b/shotover/src/hot_reload_server.rs
@@ -75,7 +75,7 @@ impl UnixSocketServer {
                 port_to_fd.insert(6380, crate::hot_reload::FileDescriptor(10));
 
                 info!(
-                    "Sending response with {} file descriptor(s)",
+                    "Sending response with {} file descriptors",
                     port_to_fd.len()
                 );
 

--- a/shotover/src/hot_reload_server.rs
+++ b/shotover/src/hot_reload_server.rs
@@ -120,8 +120,6 @@ mod tests {
     async fn test_unix_socket_server_basic() {
         let socket_path = "/tmp/test-shotover-hotreload.sock";
 
-        // Clean up any existing socket
-        let _ = std::fs::remove_file(socket_path);
         let server = UnixSocketServer::new(socket_path.to_string()).unwrap();
 
         // Test that socket file was created
@@ -138,7 +136,7 @@ mod tests {
 
         // Start server in background
         let server_handle = tokio::spawn(async move {
-            server.run().await.ok();
+            server.run().await.unwrap();
         });
         wait_for_unix_socket_connection(socket_path, 2000).await;
         let mut stream = UnixStream::connect(socket_path).await.unwrap();

--- a/shotover/src/hot_reload_server.rs
+++ b/shotover/src/hot_reload_server.rs
@@ -73,6 +73,12 @@ impl UnixSocketServer {
 
                 let mut port_to_fd = HashMap::new();
                 port_to_fd.insert(6380, crate::hot_reload::FileDescriptor(10));
+
+                info!(
+                    "Sending response with {} file descriptors",
+                    port_to_fd.len()
+                );
+
                 Response::SendListeningSockets { port_to_fd }
             }
         }

--- a/shotover/src/hot_reload_server.rs
+++ b/shotover/src/hot_reload_server.rs
@@ -75,7 +75,7 @@ impl UnixSocketServer {
                 port_to_fd.insert(6380, crate::hot_reload::FileDescriptor(10));
 
                 info!(
-                    "Sending response with {} file descriptors",
+                    "Sending response with {} file descriptor(s)",
                     port_to_fd.len()
                 );
 

--- a/shotover/src/json_parsing.rs
+++ b/shotover/src/json_parsing.rs
@@ -1,0 +1,25 @@
+use anyhow::{Context, Result};
+use serde::de::DeserializeOwned;
+use tokio::io::AsyncReadExt;
+
+pub async fn read_json<T: DeserializeOwned, R: AsyncReadExt + Unpin>(reader: &mut R) -> Result<T> {
+    let mut received_bytes = Vec::new();
+    loop {
+        let mut buf = [0u8; 1024];
+        let n = reader
+            .read(&mut buf)
+            .await
+            .context("Failed to read from stream")?;
+        if n == 0 {
+            return Err(anyhow::anyhow!(
+                "Connection closed before full JSON message received"
+            ));
+        }
+        received_bytes.extend_from_slice(&buf[..n]);
+        match serde_json::from_slice(&received_bytes) {
+            Ok(response) => return Ok(response),
+            Err(e) if e.is_eof() => continue,
+            Err(e) => return Err(e).context("Failed to parse JSON"),
+        }
+    }
+}

--- a/shotover/src/lib.rs
+++ b/shotover/src/lib.rs
@@ -69,6 +69,7 @@ pub mod hot_reload;
 pub mod hot_reload_client;
 pub mod hot_reload_server;
 mod http;
+pub mod json_parsing;
 pub mod message;
 mod observability;
 pub mod runner;

--- a/shotover/src/lib.rs
+++ b/shotover/src/lib.rs
@@ -66,6 +66,7 @@ pub mod connection;
 mod connection_span;
 pub mod frame;
 pub mod hot_reload;
+pub mod hot_reload_client;
 pub mod hot_reload_server;
 mod http;
 pub mod message;

--- a/shotover/src/runner.rs
+++ b/shotover/src/runner.rs
@@ -135,10 +135,10 @@ impl Shotover {
             tracing::info!(
                 "Hot reloading is ENABLED - shotover will support hot reload operations"
             );
-        } else if params.hotreload_from_socket.is_some() {
+        } else if let Some(socket_path) = &params.hotreload_from_socket {
             tracing::info!(
                 "Hot reload CLIENT will request sockets from existing shotover at: {}",
-                params.hotreload_from_socket.as_ref().unwrap()
+                socket_path
             );
         } else {
             tracing::debug!("Hot reloading is disabled");

--- a/shotover/src/runner.rs
+++ b/shotover/src/runner.rs
@@ -227,7 +227,6 @@ impl Shotover {
 
     /// Begins running shotover, permanently handing control of the appplication over to shotover.
     /// As such this method never returns.
-
     pub fn run_block(self) -> ! {
         let Shotover {
             runtime,

--- a/shotover/src/runner.rs
+++ b/shotover/src/runner.rs
@@ -186,7 +186,7 @@ impl Shotover {
     pub fn run_block(self) -> ! {
         let (trigger_shutdown_tx, trigger_shutdown_rx) = tokio::sync::watch::channel(false);
 
-        let received_file_descriptors = if let Some(socket_path) = &self.hotreload_from_socket {
+        let _received_file_descriptors = if let Some(socket_path) = &self.hotreload_from_socket {
             info!("Hot reload CLIENT mode - requesting socket handoff from existing shotover");
 
             let client = crate::hot_reload_client::UnixSocketClient::new(socket_path.clone());
@@ -223,6 +223,7 @@ impl Shotover {
         } else {
             None
         };
+
         // Setup Unix socket server for hot reload if enabled
         if self.hotreload_enabled {
             info!("Starting shotover with hot reloading enabled");

--- a/test-helpers/src/shotover_process.rs
+++ b/test-helpers/src/shotover_process.rs
@@ -110,6 +110,20 @@ impl ShotoverProcessBuilder {
             .await
     }
 
+    pub fn with_hotreload_from_socket(mut self, socket_path: &str) -> Self {
+        self.additional_args
+            .push("--hotreload-from-socket".to_string());
+        self.additional_args.push(socket_path.to_string());
+        self
+    }
+
+    pub fn with_hotreload_socket_path(mut self, socket_path: &str) -> Self {
+        self.additional_args
+            .push("--hotreload-socket-path".to_string());
+        self.additional_args.push(socket_path.to_string());
+        self
+    }
+
     async fn start_inner(self) -> (BinProcess, Vec<EventMatcher>) {
         let mut args = vec![
             "-t".to_owned(),


### PR DESCRIPTION
## Task 3: Unix Socket Client for Communication

This PR implements a task for the socket handoff feature for hot reload. A Unix Socket Client that will enable replacement shotover instance to communicate with original instance during hot reload operations.

### Core Functions

- Unix Socket Client - Replacement shotover connects to Original Shotover via Unix Domain Sockets
- CLI Integration - A new cli arguement '--hotreload-from-socket' implemeted for client mode
- Request/Response Model - Client sends 'SendListeningSockets' request and receives file descriptors
- Startup Integration: Client automatically connects during shotover initialisation.

### Request flow from Client to Server

- Client connects to Unix socket at specified path
- Sends a JSON request for transferring listening sockets
- Receives a JSON response
- Logging of communication that happend

### What's Next
The communication between the client and the server was sucessful. It was tested by trying and transferring a hardcoded fd between the client and the server rather than using real FD.
Next task is to exact acutal file descriptors from the running shotover instance and then implement unix socket file description passing.