### PR TITLE
Update to rust 1.89

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.87.0"
+channel = "1.89.0"
 components = ["rustfmt", "clippy"]
 targets = ["aarch64-unknown-linux-gnu"]

--- a/shotover/benches/benches/chain.rs
+++ b/shotover/benches/benches/chain.rs
@@ -317,7 +317,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 }
 
 #[cfg(feature = "alpha-transforms")]
-fn cassandra_parsed_query(query: &str) -> ChainState {
+fn cassandra_parsed_query(query: &str) -> ChainState<'_> {
     ChainState::new_with_addr(
         vec![Message::from_frame(Frame::Cassandra(CassandraFrame {
             version: Version::V4,

--- a/shotover/src/frame/cassandra.rs
+++ b/shotover/src/frame/cassandra.rs
@@ -533,7 +533,7 @@ fn filter_batch_queries(batch: &mut BatchStatement) -> Option<&mut CassandraStat
 
 impl CassandraOperation {
     /// Return all queries contained within CassandaOperation::Query and CassandraOperation::Batch
-    pub fn queries(&mut self) -> QueryIterator {
+    pub fn queries(&mut self) -> QueryIterator<'_> {
         match self {
             CassandraOperation::Query { query, .. } => QueryIterator::Query(std::iter::once(query)),
             CassandraOperation::Batch(batch) => {

--- a/shotover/src/transforms/kafka/sink_cluster/mod.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/mod.rs
@@ -4097,7 +4097,7 @@ fn partition_shotover_nodes_by_rack<'a>(
 /// Panics if `nodes_in_rack` and `nodes_out_of_rack` are both empty.
 /// The local shotover node is always UP, so this should never panic.
 fn select_shotover_node_by_hash(
-    shotover_nodes_by_rack: ShotoverNodesByRack,
+    shotover_nodes_by_rack: ShotoverNodesByRack<'_>,
     hash: usize,
 ) -> &ShotoverNode {
     let nodes = if !shotover_nodes_by_rack.nodes_in_rack.is_empty() {

--- a/test-helpers/src/connection/kafka/cpp.rs
+++ b/test-helpers/src/connection/kafka/cpp.rs
@@ -452,7 +452,7 @@ fn resource_specifier<'a>(specifier: &'a super::ResourceSpecifier<'a>) -> Resour
     }
 }
 
-fn resource_specifier_ref(specifier: &OwnedResourceSpecifier) -> ResourceSpecifier {
+fn resource_specifier_ref(specifier: &OwnedResourceSpecifier) -> ResourceSpecifier<'_> {
     match specifier {
         OwnedResourceSpecifier::Topic(topic) => ResourceSpecifier::Topic(topic),
         OwnedResourceSpecifier::Group(group) => ResourceSpecifier::Group(group),


### PR DESCRIPTION
Updates from rust 1.87 to rust 1.89

The code changes are to fix a new warning introduced in rust 1.89.
For complete details see [the release blog](https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/#mismatched-lifetime-syntaxes-lint).
But the purpose of the new warning is just to enforce consistency in the way lifetimes are written. The original and new code are functionally identical.

The perf improvements picked up by codspeed are due to rust 1.88 fixing a perf bug in 1.87 that [we knowingly allowed through](https://github.com/shotover/shotover-proxy/pull/1906#issuecomment-2982858924).