### PR TITLE
Refactor sources to use unified Source struct

### DIFF
--- a/shotover/src/sources/cassandra.rs
+++ b/shotover/src/sources/cassandra.rs
@@ -9,7 +9,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{Semaphore, watch};
-use tokio::task::JoinHandle;
 use tracing::{error, info};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -28,56 +27,21 @@ pub struct CassandraConfig {
 impl CassandraConfig {
     pub async fn get_source(
         &self,
-        trigger_shutdown_rx: watch::Receiver<bool>,
-    ) -> Result<Source, Vec<String>> {
-        Ok(Source::Cassandra(
-            CassandraSource::new(
-                self.name.clone(),
-                &self.chain,
-                self.listen_addr.clone(),
-                trigger_shutdown_rx,
-                self.connection_limit,
-                self.hard_connection_limit,
-                self.tls.clone(),
-                self.timeout,
-                self.transport,
-            )
-            .await?,
-        ))
-    }
-}
-
-#[derive(Debug)]
-pub struct CassandraSource {
-    pub join_handle: JoinHandle<()>,
-}
-
-impl CassandraSource {
-    #![allow(clippy::too_many_arguments)]
-    pub async fn new(
-        name: String,
-        chain_config: &TransformChainConfig,
-        listen_addr: String,
         mut trigger_shutdown_rx: watch::Receiver<bool>,
-        connection_limit: Option<usize>,
-        hard_connection_limit: Option<bool>,
-        tls: Option<TlsAcceptorConfig>,
-        timeout: Option<u64>,
-        transport: Option<Transport>,
-    ) -> Result<Self, Vec<String>> {
-        info!("Starting Cassandra source on [{}]", listen_addr);
+    ) -> Result<Source, Vec<String>> {
+        info!("Starting Cassandra source on [{}]", self.listen_addr);
 
         let mut listener = TcpCodecListener::new(
-            chain_config,
-            name.to_string(),
-            listen_addr.clone(),
-            hard_connection_limit.unwrap_or(false),
-            CassandraCodecBuilder::new(Direction::Source, name),
-            Arc::new(Semaphore::new(connection_limit.unwrap_or(512))),
+            &self.chain,
+            self.name.clone(),
+            self.listen_addr.clone(),
+            self.hard_connection_limit.unwrap_or(false),
+            CassandraCodecBuilder::new(Direction::Source, self.name.clone()),
+            Arc::new(Semaphore::new(self.connection_limit.unwrap_or(512))),
             trigger_shutdown_rx.clone(),
-            tls.as_ref().map(TlsAcceptor::new).transpose()?,
-            timeout.map(Duration::from_secs),
-            transport.unwrap_or(Transport::Tcp),
+            self.tls.as_ref().map(TlsAcceptor::new).transpose()?,
+            self.timeout.map(Duration::from_secs),
+            self.transport.unwrap_or(Transport::Tcp),
         )
         .await?;
 
@@ -97,6 +61,6 @@ impl CassandraSource {
             }
         });
 
-        Ok(Self { join_handle })
+        Ok(Source::new(join_handle))
     }
 }

--- a/shotover/src/sources/mod.rs
+++ b/shotover/src/sources/mod.rs
@@ -1,13 +1,13 @@
 //! Sources used to listen for connections and send/recieve with the client.
 
 #[cfg(feature = "cassandra")]
-use crate::sources::cassandra::{CassandraConfig, CassandraSource};
+use crate::sources::cassandra::CassandraConfig;
 #[cfg(feature = "kafka")]
-use crate::sources::kafka::{KafkaConfig, KafkaSource};
+use crate::sources::kafka::KafkaConfig;
 #[cfg(feature = "opensearch")]
-use crate::sources::opensearch::{OpenSearchConfig, OpenSearchSource};
+use crate::sources::opensearch::OpenSearchConfig;
 #[cfg(feature = "valkey")]
-use crate::sources::valkey::{ValkeyConfig, ValkeySource};
+use crate::sources::valkey::ValkeyConfig;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use tokio::sync::watch;
@@ -30,29 +30,17 @@ pub enum Transport {
 }
 
 #[derive(Debug)]
-pub enum Source {
-    #[cfg(feature = "cassandra")]
-    Cassandra(CassandraSource),
-    #[cfg(feature = "valkey")]
-    Valkey(ValkeySource),
-    #[cfg(feature = "kafka")]
-    Kafka(KafkaSource),
-    #[cfg(feature = "opensearch")]
-    OpenSearch(OpenSearchSource),
+pub struct Source {
+    pub join_handle: JoinHandle<()>,
 }
 
 impl Source {
+    pub fn new(join_handle: JoinHandle<()>) -> Self {
+        Self { join_handle }
+    }
+
     pub fn into_join_handle(self) -> JoinHandle<()> {
-        match self {
-            #[cfg(feature = "cassandra")]
-            Source::Cassandra(c) => c.join_handle,
-            #[cfg(feature = "valkey")]
-            Source::Valkey(r) => r.join_handle,
-            #[cfg(feature = "kafka")]
-            Source::Kafka(r) => r.join_handle,
-            #[cfg(feature = "opensearch")]
-            Source::OpenSearch(o) => o.join_handle,
-        }
+        self.join_handle
     }
 }
 

--- a/shotover/src/sources/valkey.rs
+++ b/shotover/src/sources/valkey.rs
@@ -8,7 +8,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{Semaphore, watch};
-use tokio::task::JoinHandle;
 use tracing::{error, info};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -26,53 +25,20 @@ pub struct ValkeyConfig {
 impl ValkeyConfig {
     pub async fn get_source(
         &self,
-        trigger_shutdown_rx: watch::Receiver<bool>,
-    ) -> Result<Source, Vec<String>> {
-        Ok(Source::Valkey(
-            ValkeySource::new(
-                self.name.clone(),
-                &self.chain,
-                self.listen_addr.clone(),
-                trigger_shutdown_rx,
-                self.connection_limit,
-                self.hard_connection_limit,
-                self.tls.clone(),
-                self.timeout,
-            )
-            .await?,
-        ))
-    }
-}
-
-#[derive(Debug)]
-pub struct ValkeySource {
-    pub join_handle: JoinHandle<()>,
-}
-
-impl ValkeySource {
-    #![allow(clippy::too_many_arguments)]
-    pub async fn new(
-        name: String,
-        chain_config: &TransformChainConfig,
-        listen_addr: String,
         mut trigger_shutdown_rx: watch::Receiver<bool>,
-        connection_limit: Option<usize>,
-        hard_connection_limit: Option<bool>,
-        tls: Option<TlsAcceptorConfig>,
-        timeout: Option<u64>,
-    ) -> Result<ValkeySource, Vec<String>> {
-        info!("Starting Valkey source on [{}]", listen_addr);
+    ) -> Result<Source, Vec<String>> {
+        info!("Starting Valkey source on [{}]", self.listen_addr);
 
         let mut listener = TcpCodecListener::new(
-            chain_config,
-            name.clone(),
-            listen_addr.clone(),
-            hard_connection_limit.unwrap_or(false),
-            ValkeyCodecBuilder::new(Direction::Source, name),
-            Arc::new(Semaphore::new(connection_limit.unwrap_or(512))),
+            &self.chain,
+            self.name.clone(),
+            self.listen_addr.clone(),
+            self.hard_connection_limit.unwrap_or(false),
+            ValkeyCodecBuilder::new(Direction::Source, self.name.clone()),
+            Arc::new(Semaphore::new(self.connection_limit.unwrap_or(512))),
             trigger_shutdown_rx.clone(),
-            tls.as_ref().map(TlsAcceptor::new).transpose()?,
-            timeout.map(Duration::from_secs),
+            self.tls.as_ref().map(TlsAcceptor::new).transpose()?,
+            self.timeout.map(Duration::from_secs),
             Transport::Tcp,
         )
         .await?;
@@ -93,6 +59,6 @@ impl ValkeySource {
             }
         });
 
-        Ok(ValkeySource { join_handle })
+        Ok(Source::new(join_handle))
     }
 }


### PR DESCRIPTION
# Summary
- This PR addresses the issue: https://github.com/shotover/shotover-proxy/issues/1924. 
- Consolidated the protocol-specific `*Source` types (CassandraSource, KafkaSource, ValkeySource, OpenSearchSource) into a single unified Source struct, eliminating code duplication while maintaining identical functionality.