### PR TITLE
Fix CassandraPeersRewrite invalidating the cache of all responses

### DIFF
--- a/shotover/src/transforms/cassandra/peers_rewrite.rs
+++ b/shotover/src/transforms/cassandra/peers_rewrite.rs
@@ -146,14 +146,18 @@ fn rewrite_port(message: &mut Message, column_names: &[Identifier], new_port: u1
         if let CassandraOperation::Result(CassandraResult::Rows { rows, metadata }) =
             &mut frame.operation
         {
+            let mut modified_message = false;
             for (i, col) in metadata.col_specs.iter().enumerate() {
                 if column_names.contains(&Identifier::parse(&col.name)) {
                     for row in rows.iter_mut() {
                         row[i] = GenericValue::Integer(new_port as i64, IntSize::I32);
+                        modified_message = true;
                     }
                 }
             }
-            message.invalidate_cache();
+            if modified_message {
+                message.invalidate_cache();
+            }
         }
     }
 }


### PR DESCRIPTION
closes https://github.com/shotover/shotover-proxy/issues/1923

All messages that pass through shotover are stored in the [Message](https://docs.rs/shotover/latest/shotover/message/struct.Message.html) type. These messages are passed through each of shotover's configured [transforms](https://shotover.io/docs/latest/user-guide/concepts.html#transform) which can inspect and possibly modify the messages.

Please read over this section from the linked `Message` docs:
<img width="980" height="255" alt="image" src="https://github.com/user-attachments/assets/99433db6-645f-48f3-a1e9-90b63c0e543e" />
As it explains the different states a message can be in.


The bug this PR is fixing is that we accidentally call [invalidate_cache](https://docs.rs/shotover/latest/shotover/message/struct.Message.html#method.invalidate_cache) on all responses passing through the CassandraPeersRewrite transform, which means all responses must be reencoded before shotover can send them off.
Reencoding every response is bad for performance, so this PR fixes that.

## Secondary issue

But the old behaviour also means we hit issues due to the incorrect encoding implementation of UDT's one of cassandra less common data types. This PR also works around this issue, since in regular usage of shotover the only cassandra responses that need to be modified are the system.local + system.peers queries which do not use the problematic data types. A ticket is raised to fix this other issue separately https://github.com/shotover/shotover-proxy/issues/1930

## Fix design
The fix is to call `invalidate_cache()` only when we actually modify the contents of the message.
Although `invalidate_cache` is very cheap to call on a message that has already had its cache invalidated, we have to use a boolean to keep track whether we should call it or not.
This is needed to satisfy rust's rules around mutable borrows.
Calling `invalidate_cache` at the point where we set the bool to true gives a compiler error as shown below:
<img width="849" height="294" alt="image" src="https://github.com/user-attachments/assets/2e81a365-0ee8-418f-9480-aadaef463893" />
