### PR TITLE
CassandraSinkCluster - improve system.peers error log

### DIFF
--- a/shotover/src/transforms/cassandra/sink_cluster/topology.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/topology.rs
@@ -481,7 +481,7 @@ mod system_local {
 }
 
 mod system_peers {
-    use cassandra_protocol::frame::message_error::ErrorType;
+    use cassandra_protocol::frame::message_error::{ErrorBody, ErrorType};
 
     use super::*;
 
@@ -609,6 +609,9 @@ mod system_peers {
                         ))
                     })
                     .collect(),
+                CassandraOperation::Error(ErrorBody { message, ty }) => Err(anyhow!(
+                    "system.peers or system.peers_v2 returned cassandra error: {ty:?} {message}",
+                )),
                 operation => Err(anyhow!(
                     "system.peers or system.peers_v2 returned unexpected cassandra operation: {}",
                     operation_name(operation)


### PR DESCRIPTION
This PR helps to diagnose issues when the system.peers queries run by the [CassandraSinkCluster](https://shotover.io/docs/latest/transforms.html#cassandrasinkcluster) transform are failing. 
This improved error reporting was needed to diagnose https://github.com/shotover/shotover-proxy/pull/1934

If you are unfamiliar with rust's match functionality, you might want to [read up on them](https://doc.rust-lang.org/book/ch06-02-match.html).

Shotover will query the [system.peers](https://docs.datastax.com/en/cql-oss/3.3/cql/cql_using/useQuerySystemTableCluster.html) table when it needs to learn what cassandra nodes are in the cluster.
In this PR we alter how we handle the response to the `system.peers` table.

Previously cassandra returning an error and cassandra returning an unexpected response were all handled in the same way, just report the type of response we got.
Unfortunately when cassandra returns an error our current handling does not report the actual error that was encountered, making it difficult to diagnose what happened.

So this PR adds specific handling for `CassandraOperation::Error` case so that we report the type and message of the error.
The existing handling remains as a fallback for all other response types.


## Before
`
2025-09-02T02:34:52.802489Z ERROR shotover::transforms::cassandra::sink_cluster::topology: topology task failed, retrying, error was: system.peers or system.peers_v2 returned unexpected cassandra operation: Error
`

## After
`
2025-09-02T03:43:13.523469Z ERROR shotover::transforms::cassandra::sink_cluster::topology: topology task failed, retrying, error was: system.peers or system.peers_v2 returned cassandra error: Invalid table system.peers_v2 does not exist
`
