### PR TITLE
CassandraSinkCluster - fix system.peers fallback

### DIFF
--- a/shotover/src/transforms/cassandra/sink_cluster/topology.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/topology.rs
@@ -481,6 +481,8 @@ mod system_local {
 }
 
 mod system_peers {
+    use cassandra_protocol::frame::message_error::ErrorType;
+
     use super::*;
 
     pub async fn query(
@@ -532,7 +534,7 @@ mod system_peers {
             ..
         })) = message.frame()
         {
-            return error.message == "unconfigured table peers_v2";
+            return error.ty == ErrorType::Invalid;
         }
 
         false


### PR DESCRIPTION
closes https://github.com/shotover/shotover-proxy/issues/1923

In shotover's [CassandraSinkCluster](https://shotover.io/docs/latest/transforms.html#cassandrasinkcluster) transform we query `system.peers_v2` to get the full list of cassandra nodes in the cluster.
We specifically prefer `system.peers_v2` over `system.peers` since it includes port information, without which we need to assume the default port of 9042.

This PR fixes the CassandraSinkCluster transform to be compatible with the [DSE](https://www.datastax.com/resources/datasheet/datastax-enterprise) database which does not have a `system.peers_v2` table and only has a `system.peers` table. Consider:

| DB | `system.peers` | `system.peers_v2` | officially support by shotover |
|----|--------|--------|--|
| DSE | yes | no | no |
| Cassandra 3 | yes |no | yes |
| Cassandra 4 | yes | yes | yes |
| Cassandra 5 | yes | yes | yes |


While we already have logic to support Cassandra 3 which falls back to `system.peers` it relied on the exact error message output by Cassandra 3 which was `unconfigured table peers_v2`.
When shotover hits a missing `peers_v2` table in DSE, DSE instead returns the error `table system.peers_v2 does not exist`.
This meant our fallback logic wasnt working for DSE.
To fix this we instead use the error type instead of error message to detect when to fallback, as this supports both DSE and Cassandra 3.
We dont want to have any error result in fallback, as an intermittent failure could result in Shotover running in a degraded state without the extra port information we need from `system.peers_v2`.

This has been manually tested to verify it resolves the issue.
I do not think any additional tests need to be written.
We do not officially support DSE, since running integration tests for it is impractical.
And we have integration tests for all the databases we do support (Cassandra 3, 4 and 5) which demonstrate that system.peers is used for 4 and 5 and that we successfully fallback for 3.