### PR TITLE
Swap all bitnami images over to legacy equivalent

### DIFF
--- a/custom-transforms-example/config/docker-compose.yaml
+++ b/custom-transforms-example/config/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   valkey-one:
-    image: bitnami/valkey:7.2.5-debian-12-r9
+    image: bitnamilegacy/valkey:7.2.5-debian-12-r9
     ports:
       - "1111:6379"
     environment:

--- a/docs/src/examples/valkey-clustering-aware.md
+++ b/docs/src/examples/valkey-clustering-aware.md
@@ -24,7 +24,7 @@ Below we can see an example of a Valkey node and it's Shotover sidecar. Notice t
 ```YAML
 
 valkey-node-0:
-  image: bitnami/valkey-cluster:7.2.5-debian-12-r4
+  image: bitnamilegacy/valkey-cluster:7.2.5-debian-12-r4
   networks:
     cluster_subnet:
       ipv4_address: 172.16.1.2

--- a/shotover-proxy/benches/windsock/kafka/bench.rs
+++ b/shotover-proxy/benches/windsock/kafka/bench.rs
@@ -144,7 +144,7 @@ impl KafkaBench {
 
             tasks.push(tokio::spawn(async move {
                 node.run_container(
-                    "bitnami/kafka:3.9.0-debian-12-r6",
+                    "bitnamilegacy/kafka:3.9.0-debian-12-r6",
                     &[
                         ("ALLOW_PLAINTEXT_LISTENER".to_owned(), "yes".to_owned()),
                         (

--- a/shotover-proxy/benches/windsock/valkey/bench.rs
+++ b/shotover-proxy/benches/windsock/valkey/bench.rs
@@ -518,7 +518,7 @@ impl ValkeyCluster {
                     wait_for.push(tokio::spawn(async move {
                         instance
                             .run_container(
-                                "bitnami/valkey-cluster:7.2.5-debian-12-r4",
+                                "bitnamilegacy/valkey-cluster:7.2.5-debian-12-r4",
                                 &[
                                     ("ALLOW_EMPTY_PASSWORD".to_owned(), "yes".to_owned()),
                                     (
@@ -534,7 +534,7 @@ impl ValkeyCluster {
                 let node_addresses = self.private_ips();
                 cluster_creator
                     .run_container(
-                        "bitnami/valkey-cluster:7.2.5-debian-12-r4",
+                        "bitnamilegacy/valkey-cluster:7.2.5-debian-12-r4",
                         &[
                             ("ALLOW_EMPTY_PASSWORD".to_owned(), "yes".to_owned()),
                             (

--- a/shotover-proxy/tests/test-configs/cassandra/valkey-cache/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra/valkey-cache/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   valkey-one:
-    image: bitnami/valkey:7.2.5-debian-12-r9
+    image: bitnamilegacy/valkey:7.2.5-debian-12-r9
     ports:
       - "6379:6379"
     environment:

--- a/shotover-proxy/tests/test-configs/hotreload/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/hotreload/docker-compose.yaml
@@ -1,7 +1,7 @@
-  services:
-    valkey-one:
-      image: bitnami/valkey:7.2.5-debian-12-r9
-      ports:
-        - "6379:6379"
-      environment:
-        ALLOW_EMPTY_PASSWORD: "yes"
+services:
+  valkey-one:
+    image: bitnamilegacy/valkey:7.2.5-debian-12-r9
+    ports:
+      - "6379:6379"
+    environment:
+      ALLOW_EMPTY_PASSWORD: "yes"

--- a/shotover-proxy/tests/test-configs/kafka/bench/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/bench/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   kafka0:
-    image: 'bitnami/kafka:3.9.0-debian-12-r6'
+    image: 'bitnamilegacy/kafka:3.9.0-debian-12-r6'
     ports:
       - '9192:9192'
     environment:

--- a/shotover-proxy/tests/test-configs/kafka/cluster-1-rack/docker-compose-short-idle-timeout.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-1-rack/docker-compose-short-idle-timeout.yaml
@@ -9,7 +9,7 @@ networks:
           gateway: 172.16.1.1
 services:
   kafka0:
-    image: &image 'bitnami/kafka:3.9.0-debian-12-r6'
+    image: &image 'bitnamilegacy/kafka:3.9.0-debian-12-r6'
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.2

--- a/shotover-proxy/tests/test-configs/kafka/cluster-1-rack/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-1-rack/docker-compose.yaml
@@ -9,7 +9,7 @@ networks:
           gateway: 172.16.1.1
 services:
   kafka0:
-    image: &image 'bitnami/kafka:3.9.0-debian-12-r6'
+    image: &image 'bitnamilegacy/kafka:3.9.0-debian-12-r6'
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.2

--- a/shotover-proxy/tests/test-configs/kafka/cluster-2-racks/docker-compose-rebalance-protocol.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-2-racks/docker-compose-rebalance-protocol.yaml
@@ -9,7 +9,7 @@ networks:
           gateway: 172.16.1.1
 services:
   kafka0:
-    image: &image 'bitnami/kafka:3.9.0-debian-12-r6'
+    image: &image 'bitnamilegacy/kafka:3.9.0-debian-12-r6'
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.2

--- a/shotover-proxy/tests/test-configs/kafka/cluster-2-racks/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-2-racks/docker-compose.yaml
@@ -9,7 +9,7 @@ networks:
           gateway: 172.16.1.1
 services:
   kafka0:
-    image: &image 'bitnami/kafka:3.9.0-debian-12-r6'
+    image: &image 'bitnamilegacy/kafka:3.9.0-debian-12-r6'
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.2

--- a/shotover-proxy/tests/test-configs/kafka/cluster-3-racks/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-3-racks/docker-compose.yaml
@@ -9,7 +9,7 @@ networks:
           gateway: 172.16.1.1
 services:
   kafka0:
-    image: &image 'bitnami/kafka:3.9.0-debian-12-r6'
+    image: &image 'bitnamilegacy/kafka:3.9.0-debian-12-r6'
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.2

--- a/shotover-proxy/tests/test-configs/kafka/cluster-mtls/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-mtls/docker-compose.yaml
@@ -9,7 +9,7 @@ networks:
           gateway: 172.16.1.1
 services:
   kafka0:
-    image: &image 'bitnami/kafka:3.9.0-debian-12-r6'
+    image: &image 'bitnamilegacy/kafka:3.9.0-debian-12-r6'
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.2

--- a/shotover-proxy/tests/test-configs/kafka/cluster-sasl-plain/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-sasl-plain/docker-compose.yaml
@@ -10,7 +10,7 @@ networks:
 
 services:
   kafka0:
-    image: &image 'bitnami/kafka:3.9.0-debian-12-r6'
+    image: &image 'bitnamilegacy/kafka:3.9.0-debian-12-r6'
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.2

--- a/shotover-proxy/tests/test-configs/kafka/cluster-sasl-scram-over-mtls/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-sasl-scram-over-mtls/docker-compose.yaml
@@ -10,7 +10,7 @@ networks:
 
 services:
   kafka0:
-    image: &image 'bitnami/kafka:3.9.0-debian-12-r6'
+    image: &image 'bitnamilegacy/kafka:3.9.0-debian-12-r6'
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.2

--- a/shotover-proxy/tests/test-configs/kafka/cluster-sasl-scram/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-sasl-scram/docker-compose.yaml
@@ -10,7 +10,7 @@ networks:
 
 services:
   kafka0:
-    image: &image 'bitnami/kafka:3.9.0-debian-12-r6'
+    image: &image 'bitnamilegacy/kafka:3.9.0-debian-12-r6'
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.2

--- a/shotover-proxy/tests/test-configs/kafka/cluster-tls/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/cluster-tls/docker-compose.yaml
@@ -9,7 +9,7 @@ networks:
           gateway: 172.16.1.1
 services:
   kafka0:
-    image: &image 'bitnami/kafka:3.9.0-debian-12-r6'
+    image: &image 'bitnamilegacy/kafka:3.9.0-debian-12-r6'
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.2

--- a/shotover-proxy/tests/test-configs/kafka/passthrough-mtls/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/passthrough-mtls/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   kafka0:
-    image: 'bitnami/kafka:3.9.0-debian-12-r6'
+    image: 'bitnamilegacy/kafka:3.9.0-debian-12-r6'
     ports:
       - '9092:9092'
     environment:

--- a/shotover-proxy/tests/test-configs/kafka/passthrough-sasl-plain/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/passthrough-sasl-plain/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   kafka:
-    image: 'bitnami/kafka:3.9.0-debian-12-r6'
+    image: 'bitnamilegacy/kafka:3.9.0-debian-12-r6'
     ports:
       - '9092:9092'
       - '9093:9093'

--- a/shotover-proxy/tests/test-configs/kafka/passthrough-sasl-scram/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/passthrough-sasl-scram/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   kafka:
-    image: 'bitnami/kafka:3.9.0-debian-12-r6'
+    image: 'bitnamilegacy/kafka:3.9.0-debian-12-r6'
     ports:
       - '9092:9092'
     environment:

--- a/shotover-proxy/tests/test-configs/kafka/passthrough-tls/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/passthrough-tls/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   kafka0:
-    image: 'bitnami/kafka:3.9.0-debian-12-r6'
+    image: 'bitnamilegacy/kafka:3.9.0-debian-12-r6'
     ports:
       - '9092:9092'
     environment:

--- a/shotover-proxy/tests/test-configs/kafka/passthrough/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/passthrough/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   kafka0:
-    image: 'bitnami/kafka:3.9.0-debian-12-r6'
+    image: 'bitnamilegacy/kafka:3.9.0-debian-12-r6'
     ports:
       - '9092:9092'
     environment:

--- a/shotover-proxy/tests/test-configs/kafka/single-sasl-scram-plaintext-source-tls-sink/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/kafka/single-sasl-scram-plaintext-source-tls-sink/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   kafka:
-    image: 'bitnami/kafka:3.9.0-debian-12-r6'
+    image: 'bitnamilegacy/kafka:3.9.0-debian-12-r6'
     ports:
       - '9092:9092'
     environment:

--- a/shotover-proxy/tests/test-configs/log-to-file/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/log-to-file/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   valkey-one:
-    image: bitnami/valkey:7.2.5-debian-12-r9
+    image: bitnamilegacy/valkey:7.2.5-debian-12-r9
     ports:
       - "1111:6379"
     environment:

--- a/shotover-proxy/tests/test-configs/valkey/cluster-auth/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/valkey/cluster-auth/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   valkey-node-0:
-    image: &image bitnami/valkey-cluster:7.2.5-debian-12-r4
+    image: &image bitnamilegacy/valkey-cluster:7.2.5-debian-12-r4
     ports:
       - "2230:6379"
     environment: &environment

--- a/shotover-proxy/tests/test-configs/valkey/cluster-dr/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/valkey/cluster-dr/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   valkey-node-0:
-    image: &image bitnami/valkey-cluster:7.2.5-debian-12-r4
+    image: &image bitnamilegacy/valkey-cluster:7.2.5-debian-12-r4
     ports:
       - "2220:6379"
     environment: &node-environment

--- a/shotover-proxy/tests/test-configs/valkey/cluster-handling/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/valkey/cluster-handling/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.2
-    image: &image bitnami/valkey-cluster:7.2.5-debian-12-r4
+    image: &image bitnamilegacy/valkey-cluster:7.2.5-debian-12-r4
     environment: &environment
       - 'ALLOW_EMPTY_PASSWORD=yes'
       - 'VALKEY_NODES=valkey-node-0 valkey-node-1 valkey-node-2 valkey-node-3 valkey-node-4 valkey-node-5'

--- a/shotover-proxy/tests/test-configs/valkey/cluster-hiding/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/valkey/cluster-hiding/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.2
-    image: &image bitnami/valkey-cluster:7.2.5-debian-12-r4
+    image: &image bitnamilegacy/valkey-cluster:7.2.5-debian-12-r4
     environment: &environment
       - 'ALLOW_EMPTY_PASSWORD=yes'
       - 'VALKEY_NODES=valkey-node-0 valkey-node-1 valkey-node-2 valkey-node-3 valkey-node-4 valkey-node-5'

--- a/shotover-proxy/tests/test-configs/valkey/cluster-ports-rewrite/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/valkey/cluster-ports-rewrite/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   valkey-node-0:
-    image: &image bitnami/valkey-cluster:7.2.5-debian-12-r4
+    image: &image bitnamilegacy/valkey-cluster:7.2.5-debian-12-r4
     ports:
       - "2220:6379"
     environment: &environment

--- a/shotover-proxy/tests/test-configs/valkey/cluster-tls/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/valkey/cluster-tls/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
     networks:
       cluster_subnet:
         ipv4_address: 172.16.1.2
-    image: &image bitnami/valkey-cluster:7.2.5-debian-12-r4
+    image: &image bitnamilegacy/valkey-cluster:7.2.5-debian-12-r4
     volumes:
       - &keys ../tls/certs:/usr/local/etc/valkey/certs
 

--- a/shotover-proxy/tests/test-configs/valkey/tls-no-client-auth/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/valkey/tls-no-client-auth/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   valkey-one:
-    image: bitnami/valkey:7.2.5-debian-12-r9
+    image: bitnamilegacy/valkey:7.2.5-debian-12-r9
     ports:
       - "1111:6379"
     volumes:

--- a/shotover-proxy/tests/test-configs/valkey/tls-no-verify-hostname/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/valkey/tls-no-verify-hostname/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   valkey-one:
-    image: bitnami/valkey:7.2.5-debian-12-r9
+    image: bitnamilegacy/valkey:7.2.5-debian-12-r9
     ports:
       - "1111:6379"
     volumes:

--- a/shotover-proxy/tests/test-configs/valkey/tls/docker-compose.yaml
+++ b/shotover-proxy/tests/test-configs/valkey/tls/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   valkey-one:
-    image: bitnami/valkey:7.2.5-debian-12-r9
+    image: bitnamilegacy/valkey:7.2.5-debian-12-r9
     ports:
       - "1111:6379"
     volumes:

--- a/test-helpers/src/docker_compose.rs
+++ b/test-helpers/src/docker_compose.rs
@@ -15,7 +15,7 @@ pub fn new_moto() -> DockerCompose {
     docker_compose("tests/transforms/docker-compose-moto.yaml")
 }
 
-pub static IMAGE_WAITERS: [Image; 10] = [
+pub static IMAGE_WAITERS: [Image; 9] = [
     Image {
         name: "motoserver/moto",
         log_regex_to_wait_for: r"Press CTRL\+C to quit",
@@ -27,20 +27,15 @@ pub static IMAGE_WAITERS: [Image; 10] = [
         timeout: Duration::from_secs(120),
     },
     Image {
-        name: "bitnami/valkey:7.2.5-debian-12-r9",
+        name: "bitnamilegacy/valkey:7.2.5-debian-12-r9",
         log_regex_to_wait_for: r"Ready to accept connections",
         timeout: Duration::from_secs(120),
     },
     Image {
-        name: "bitnami/valkey-cluster:7.2.5-debian-12-r4",
+        name: "bitnamilegacy/valkey-cluster:7.2.5-debian-12-r4",
         //`Cluster state changed` is created by the node services
         //`Cluster correctly created` is created by the init service
         log_regex_to_wait_for: r"Cluster state changed|Cluster correctly created",
-        timeout: Duration::from_secs(120),
-    },
-    Image {
-        name: "bitnami/cassandra:4.0.6",
-        log_regex_to_wait_for: r"Startup complete",
         timeout: Duration::from_secs(120),
     },
     Image {
@@ -59,7 +54,7 @@ pub static IMAGE_WAITERS: [Image; 10] = [
         timeout: Duration::from_secs(120),
     },
     Image {
-        name: "bitnami/kafka:3.9.0-debian-12-r6",
+        name: "bitnamilegacy/kafka:3.9.0-debian-12-r6",
         log_regex_to_wait_for: r"Kafka Server started",
         timeout: Duration::from_secs(120),
     },


### PR DESCRIPTION
Bitnami is deleting ALL of their existing docker image tags and putting them behind a paywall.
We use bitnami images extensively in our integration tests to provide real valkey, cassandra, kafka etc. instances to test shotover with.
bitnami have started performing brownouts of their images and this has impacted @ric-pro ability to work yesterday.
The images will be removed permanently, one week from now.

Bitnami have recreated all previously existing tags under the `bitnamilegacy` account, but will not be creating any new releases under that account.
Since we only use these images for local/CI testing purposes, and have very specific versions tagged anyway, I dont think there is any issue with just swapping to those `bitnamilegacy` images indefinitely.
If we need to start testing a new release of a DB, we can look to migrate off bitnami for that DB at that time.

This PR updates:
* All our `docker-compose.yaml` files we use to spin up DB clusters.
* some benchmark rust files, which manually create a cluster through docker commands instead of using docker-compose
* `test-helpers/src/docker_compose.rs` defines some metadata we use to determine if a docker container created in a test has finished starting up, since the image names are used here too, we also have to update this file.

All integration tests are run in CI, and since CI passed we know this change is working.

More details on the bitnami change: https://github.com/bitnami/containers/issues/83267