### PR TITLE
Implement FD transmission via Unix Socket Ancillary Data 

### DIFF
--- a/shotover-proxy/tests/runner/hotreload_int_tests.rs
+++ b/shotover-proxy/tests/runner/hotreload_int_tests.rs
@@ -140,17 +140,6 @@ async fn test_dual_shotover_instances_with_valkey_ancillary_FD() {
     let final_check: String = con_a.get("key_from_a").unwrap();
     assert_eq!(final_check, "value_from_a");
 
-    // Verify no sudo was required
-    let uid = nix::unistd::getuid();
-    if uid.is_root() {
-        warn!("Running as root - cannot validate sudo-free operation");
-    } else {
-        info!(
-            "Running as non-root user (UID: {}) - sudo-free operation confirmed",
-            uid
-        );
-    }
-
     shotover_a.shutdown_and_then_consume_events(&[]).await;
     shotover_b.shutdown_and_then_consume_events(&[]).await;
 }

--- a/shotover-proxy/tests/runner/hotreload_int_tests.rs
+++ b/shotover-proxy/tests/runner/hotreload_int_tests.rs
@@ -28,6 +28,7 @@ async fn test_dual_shotover_instances_with_valkey() {
     let _compose = docker_compose("tests/test-configs/hotreload/docker-compose.yaml");
     let shotover_a = shotover_process("tests/test-configs/hotreload/topology.yaml")
         .with_hotreload(true)
+        .with_log_name("shot_old")
         .with_hotreload_socket_path(socket_path)
         .with_config("tests/test-configs/shotover-config/config_metrics_disabled.yaml")
         .start()
@@ -39,6 +40,7 @@ async fn test_dual_shotover_instances_with_valkey() {
     //Second shotover
     let shotover_b = shotover_process("tests/test-configs/hotreload/topology-alt.yaml")
         .with_hotreload_from_socket(socket_path)
+        .with_log_name("shot_new")
         .with_config("tests/test-configs/shotover-config/config_metrics_disabled.yaml")
         .start()
         .await;
@@ -53,6 +55,101 @@ async fn test_dual_shotover_instances_with_valkey() {
 
     let final_check: String = con_a.get("key_from_a").unwrap();
     assert_eq!(final_check, "value_from_a");
+
+    shotover_a.shutdown_and_then_consume_events(&[]).await;
+    shotover_b.shutdown_and_then_consume_events(&[]).await;
+}
+
+#[tokio::test]
+async fn test_dual_shotover_instances_with_valkey_ancillary_FD() {
+    use std::os::unix::io::AsRawFd;
+    use tracing::{info, warn};
+
+    let socket_path = "/tmp/test-hotreload.sock";
+    let _compose = docker_compose("tests/test-configs/hotreload/docker-compose.yaml");
+
+    // Start first Shotover instance with hot reload enabled
+    let shotover_a = shotover_process("tests/test-configs/hotreload/topology.yaml")
+        .with_hotreload(true)
+        .with_log_name("shot_old")
+        .with_hotreload_socket_path(socket_path)
+        .with_config("tests/test-configs/shotover-config/config_metrics_disabled.yaml")
+        .start()
+        .await;
+
+    let client_a = Client::open("valkey://127.0.0.1:6380").unwrap();
+    let mut con_a = client_a.get_connection().unwrap();
+    let _: () = con_a.set("key_from_a", "value_from_a").unwrap();
+
+    // Wait for shotover_a to be fully initialized
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    // Validate file descriptor passing implementation
+    info!("Testing file descriptor passing implementation");
+    let test_client = crate::hot_reload::client::UnixSocketClient::new(socket_path.to_string());
+
+    match test_client
+        .send_request(crate::hot_reload::protocol::Request::SendListeningSockets)
+        .await
+    {
+        Ok(crate::hot_reload::protocol::Response::SendListeningSockets { port_to_fd }) => {
+            info!(
+                "Successfully received {} file descriptors from shotover_a",
+                port_to_fd.len()
+            );
+
+            // Validate that we received actual file descriptors
+            for (port, fd) in &port_to_fd {
+                info!("Port {} -> FD {}", port, fd.0);
+                assert!(fd.0 > 0, "File descriptor should be positive: {}", fd.0);
+            }
+
+            if port_to_fd.is_empty() {
+                warn!("No file descriptors received - this might indicate no active listeners");
+            } else {
+                info!("File descriptor passing validation passed");
+            }
+        }
+        Ok(crate::hot_reload::protocol::Response::Error(msg)) => {
+            panic!("Hot reload request failed: {}", msg);
+        }
+        Err(e) => {
+            panic!("Failed to communicate with hot reload server: {:?}", e);
+        }
+    }
+
+    // Start second shotover instance that should receive FDs from first
+    let shotover_b = shotover_process("tests/test-configs/hotreload/topology-alt.yaml")
+        .with_hotreload_from_socket(socket_path)
+        .with_log_name("shot_new")
+        .with_config("tests/test-configs/shotover-config/config_metrics_disabled.yaml")
+        .start()
+        .await;
+
+    let client_b = Client::open("valkey://127.0.0.1:6381").unwrap();
+    let mut con_b = client_b.get_connection().unwrap();
+    let _: () = con_b.set("key_from_b", "value_from_b").unwrap();
+
+    // Test cross-instance data access
+    let value_a_from_b: String = con_b.get("key_from_a").unwrap();
+    assert_eq!(value_a_from_b, "value_from_a");
+
+    let value_b_from_a: String = con_a.get("key_from_b").unwrap();
+    assert_eq!(value_b_from_a, "value_from_b");
+
+    let final_check: String = con_a.get("key_from_a").unwrap();
+    assert_eq!(final_check, "value_from_a");
+
+    // Verify no sudo was required
+    let uid = nix::unistd::getuid();
+    if uid.is_root() {
+        warn!("Running as root - cannot validate sudo-free operation");
+    } else {
+        info!(
+            "Running as non-root user (UID: {}) - sudo-free operation confirmed",
+            uid
+        );
+    }
 
     shotover_a.shutdown_and_then_consume_events(&[]).await;
     shotover_b.shutdown_and_then_consume_events(&[]).await;

--- a/shotover-proxy/tests/runner/hotreload_int_tests.rs
+++ b/shotover-proxy/tests/runner/hotreload_int_tests.rs
@@ -62,7 +62,6 @@ async fn test_dual_shotover_instances_with_valkey() {
 
 #[tokio::test]
 async fn test_dual_shotover_instances_with_valkey_ancillary_FD() {
-    use std::os::unix::io::AsRawFd;
     use tracing::{info, warn};
 
     let socket_path = "/tmp/test-hotreload.sock";
@@ -86,13 +85,16 @@ async fn test_dual_shotover_instances_with_valkey_ancillary_FD() {
 
     // Validate file descriptor passing implementation
     info!("Testing file descriptor passing implementation");
-    let test_client = crate::hot_reload::client::UnixSocketClient::new(socket_path.to_string());
+    let test_client =
+        crate::shotover::hot_reload::client::UnixSocketClient::new(socket_path.to_string());
 
     match test_client
-        .send_request(crate::hot_reload::protocol::Request::SendListeningSockets)
+        .send_request(crate::shotover::hot_reload::protocol::Request::SendListeningSockets)
         .await
     {
-        Ok(crate::hot_reload::protocol::Response::SendListeningSockets { port_to_fd }) => {
+        Ok(crate::shotover::hot_reload::protocol::Response::SendListeningSockets {
+            port_to_fd,
+        }) => {
             info!(
                 "Successfully received {} file descriptors from shotover_a",
                 port_to_fd.len()
@@ -110,7 +112,7 @@ async fn test_dual_shotover_instances_with_valkey_ancillary_FD() {
                 info!("File descriptor passing validation passed");
             }
         }
-        Ok(crate::hot_reload::protocol::Response::Error(msg)) => {
+        Ok(crate::shotover::hot_reload::protocol::Response::Error(msg)) => {
             panic!("Hot reload request failed: {}", msg);
         }
         Err(e) => {

--- a/shotover-proxy/tests/runner/hotreload_int_tests.rs
+++ b/shotover-proxy/tests/runner/hotreload_int_tests.rs
@@ -1,7 +1,5 @@
 use crate::shotover_process;
 use redis::{Client, Commands};
-use shotover::hot_reload::client::UnixSocketClient;
-use shotover::hot_reload::protocol::{Request, Response};
 use test_helpers::docker_compose::docker_compose;
 
 #[tokio::test]
@@ -30,7 +28,6 @@ async fn test_dual_shotover_instances_with_valkey() {
     let _compose = docker_compose("tests/test-configs/hotreload/docker-compose.yaml");
     let shotover_a = shotover_process("tests/test-configs/hotreload/topology.yaml")
         .with_hotreload(true)
-        .with_log_name("shot_old")
         .with_hotreload_socket_path(socket_path)
         .with_config("tests/test-configs/shotover-config/config_metrics_disabled.yaml")
         .start()
@@ -42,13 +39,9 @@ async fn test_dual_shotover_instances_with_valkey() {
     //Second shotover
     let shotover_b = shotover_process("tests/test-configs/hotreload/topology-alt.yaml")
         .with_hotreload_from_socket(socket_path)
-        .with_log_name("shot_new")
         .with_config("tests/test-configs/shotover-config/config_metrics_disabled.yaml")
         .start()
         .await;
-
-    tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
-
     let client_b = Client::open("valkey://127.0.0.1:6381").unwrap();
     let mut con_b = client_b.get_connection().unwrap();
     let _: () = con_b.set("key_from_b", "value_from_b").unwrap();
@@ -60,57 +53,6 @@ async fn test_dual_shotover_instances_with_valkey() {
 
     let final_check: String = con_a.get("key_from_a").unwrap();
     assert_eq!(final_check, "value_from_a");
-
-    shotover_a.shutdown_and_then_consume_events(&[]).await;
-    shotover_b.shutdown_and_then_consume_events(&[]).await;
-}
-
-#[tokio::test]
-async fn test_dual_shotover_instances_with_valkey_ancillary_fd() {
-    use tracing::{info, warn};
-
-    let socket_path = "/tmp/test-hotreload.sock";
-    let _compose = docker_compose("tests/test-configs/hotreload/docker-compose.yaml");
-
-    // Start first Shotover instance with hot reload enabled
-    let shotover_a = shotover_process("tests/test-configs/hotreload/topology.yaml")
-        .with_hotreload(true)
-        .with_log_name("shot_old")
-        .with_hotreload_socket_path(socket_path)
-        .with_config("tests/test-configs/shotover-config/config_metrics_disabled.yaml")
-        .start()
-        .await;
-
-    let client_a = Client::open("valkey://127.0.0.1:6380").unwrap();
-    let mut con_a = client_a.get_connection().unwrap();
-    let _: () = con_a.set("key_from_a", "value_from_a").unwrap();
-
-    // Wait for shotover_a to be fully initialized
-    tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
-
-    // Start second shotover instance that should receive FDs from first
-    let shotover_b = shotover_process("tests/test-configs/hotreload/topology-alt.yaml")
-        .with_hotreload_from_socket(socket_path)
-        .with_log_name("shot_new")
-        .with_config("tests/test-configs/shotover-config/config_metrics_disabled.yaml")
-        .start()
-        .await;
-
-    let client_b = Client::open("valkey://127.0.0.1:6381").unwrap();
-    let mut con_b = client_b.get_connection().unwrap();
-    let _: () = con_b.set("key_from_b", "value_from_b").unwrap();
-
-    // Test cross-instance data access
-    let value_a_from_b: String = con_b.get("key_from_a").unwrap();
-    assert_eq!(value_a_from_b, "value_from_a");
-
-    let value_b_from_a: String = con_a.get("key_from_b").unwrap();
-    assert_eq!(value_b_from_a, "value_from_b");
-
-    let final_check: String = con_a.get("key_from_a").unwrap();
-    assert_eq!(final_check, "value_from_a");
-
-    info!("Hot reload with file descriptor passing completed successfully");
 
     shotover_a.shutdown_and_then_consume_events(&[]).await;
     shotover_b.shutdown_and_then_consume_events(&[]).await;

--- a/shotover-proxy/tests/runner/hotreload_int_tests.rs
+++ b/shotover-proxy/tests/runner/hotreload_int_tests.rs
@@ -28,6 +28,7 @@ async fn test_dual_shotover_instances_with_valkey() {
     let _compose = docker_compose("tests/test-configs/hotreload/docker-compose.yaml");
     let shotover_a = shotover_process("tests/test-configs/hotreload/topology.yaml")
         .with_hotreload(true)
+        .with_log_name("shot_old")
         .with_hotreload_socket_path(socket_path)
         .with_config("tests/test-configs/shotover-config/config_metrics_disabled.yaml")
         .start()
@@ -39,6 +40,7 @@ async fn test_dual_shotover_instances_with_valkey() {
     //Second shotover
     let shotover_b = shotover_process("tests/test-configs/hotreload/topology-alt.yaml")
         .with_hotreload_from_socket(socket_path)
+        .with_log_name("shot_new")
         .with_config("tests/test-configs/shotover-config/config_metrics_disabled.yaml")
         .start()
         .await;

--- a/shotover-proxy/tests/runner/hotreload_int_tests.rs
+++ b/shotover-proxy/tests/runner/hotreload_int_tests.rs
@@ -63,7 +63,7 @@ async fn test_dual_shotover_instances_with_valkey() {
 }
 
 #[tokio::test]
-async fn test_dual_shotover_instances_with_valkey_ancillary_FD() {
+async fn test_dual_shotover_instances_with_valkey_ancillary_fd() {
     use tracing::{info, warn};
 
     let socket_path = "/tmp/test-hotreload.sock";

--- a/shotover/src/hot_reload/fd_utils.rs
+++ b/shotover/src/hot_reload/fd_utils.rs
@@ -1,4 +1,4 @@
-//! Safe utilities for working with file descriptors in hot reload context
+//! utilities for working with file descriptors in hot reload context
 
 use anyhow::{Context, Result};
 use std::os::unix::io::OwnedFd;

--- a/shotover/src/hot_reload/fd_utils.rs
+++ b/shotover/src/hot_reload/fd_utils.rs
@@ -7,12 +7,8 @@
 #![allow(unsafe_code)]
 
 use anyhow::{Context, Result};
-use std::os::unix::io::{FromRawFd, OwnedFd, RawFd};
+use std::os::unix::io::OwnedFd;
 use tokio::net::TcpListener;
-
-pub fn take_ownership_of_fd(fd: RawFd) -> OwnedFd {
-    unsafe { OwnedFd::from_raw_fd(fd) }
-}
 
 /// Create a TcpListener from an owned file descriptor and return both the listener and port
 pub fn create_tcp_listener_from_fd(fd: OwnedFd) -> Result<(TcpListener, u16)> {
@@ -38,7 +34,7 @@ pub fn create_tcp_listener_from_fd(fd: OwnedFd) -> Result<(TcpListener, u16)> {
 mod tests {
     use super::*;
     use std::net::TcpListener;
-    use std::os::unix::io::IntoRawFd;
+    use std::os::unix::io::{FromRawFd, IntoRawFd};
 
     #[tokio::test]
     async fn test_create_tcp_listener_from_fd() {

--- a/shotover/src/hot_reload/fd_utils.rs
+++ b/shotover/src/hot_reload/fd_utils.rs
@@ -1,0 +1,51 @@
+//! Safe utilities for working with file descriptors in hot reload context
+//!
+//! This module provides a sound safe API around unsafe file descriptor operations
+//! needed for the hot reload functionality.
+
+// Allow unsafe code in this module as we implement sound safe API around raw FDs
+#![allow(unsafe_code)]
+
+use anyhow::{Context, Result};
+use std::os::unix::io::{FromRawFd, IntoRawFd, RawFd};
+
+pub fn extract_port_from_listener_fd(fd: RawFd) -> Result<u16> {
+    let listener = unsafe { std::net::TcpListener::from_raw_fd(fd) };
+
+    let port = listener
+        .local_addr()
+        .context("Failed to get local address from listener socket")?
+        .port();
+
+    // Convert back to raw FD to avoid dropping the socket
+    let recovered_fd = listener.into_raw_fd();
+
+    // Sanity check that we got the same FD back
+    debug_assert_eq!(
+        fd, recovered_fd,
+        "File descriptor should be preserved during conversion"
+    );
+
+    Ok(port)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::TcpListener;
+
+    #[test]
+    fn test_extract_port_from_listener_fd() {
+        // Create a test listener
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let expected_port = listener.local_addr().unwrap().port();
+        let fd = listener.into_raw_fd();
+
+        // Test our function
+        let extracted_port = extract_port_from_listener_fd(fd).unwrap();
+        assert_eq!(expected_port, extracted_port);
+
+        // Clean up
+        let _listener = unsafe { TcpListener::from_raw_fd(fd) };
+    }
+}

--- a/shotover/src/hot_reload/json_parsing.rs
+++ b/shotover/src/hot_reload/json_parsing.rs
@@ -1,6 +1,3 @@
-// Allow unsafe code in this module for file descriptor handling
-#![allow(unsafe_code)]
-
 use anyhow::{Context, Result};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -45,7 +42,8 @@ pub async fn read_json_with_fds<T: DeserializeOwned>(
         .context("Failed to read packet with FDs from socket")?;
 
     // Convert RawFds to OwnedFds immediately after receiving from recv_fds
-    // This is safe because we just received these FDs from the OS via recv_fds
+    // SAFETY: This is safe because we just received these FDs from the OS via recv_fds
+    #[allow(unsafe_code)]
     let owned_fds: Vec<OwnedFd> = fd_buf[..fds_read]
         .iter()
         .map(|&raw_fd| unsafe { OwnedFd::from_raw_fd(raw_fd) })

--- a/shotover/src/hot_reload/json_parsing.rs
+++ b/shotover/src/hot_reload/json_parsing.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
+use std::os::unix::io::RawFd;
 use uds::tokio::UnixSeqpacketConn;
 
 /// Read a complete JSON message from a SEQPACKET socket
@@ -25,6 +26,42 @@ pub async fn write_json<T: Serialize>(conn: &mut UnixSeqpacketConn, data: &T) ->
     conn.send(&json_bytes)
         .await
         .context("Failed to send JSON packet")?;
+
+    Ok(())
+}
+
+/// Read a complete JSON message from a SEQPACKET socket with file descriptors
+pub async fn read_json_with_fds<T: DeserializeOwned>(
+    conn: &mut UnixSeqpacketConn,
+) -> Result<(T, Vec<RawFd>)> {
+    let mut buf = vec![0u8; 65536]; // Large buffer for JSON messages
+    let mut fd_buf = vec![0i32; 16]; // Buffer for file descriptors
+    let (bytes_read, _truncated, fds_read) = conn
+        .recv_fds(&mut buf, &mut fd_buf)
+        .await
+        .context("Failed to read packet with FDs from socket")?;
+
+    // Resize buffer to actual data received
+    buf.truncate(bytes_read);
+    fd_buf.truncate(fds_read);
+
+    // Parse the complete JSON message
+    let data = serde_json::from_slice(&buf).context("Failed to parse JSON from packet")?;
+
+    Ok((data, fd_buf))
+}
+
+/// Write a complete JSON message to a SEQPACKET socket with file descriptors
+pub async fn write_json_with_fds<T: Serialize>(
+    conn: &mut UnixSeqpacketConn,
+    data: &T,
+    fds: &[RawFd],
+) -> Result<()> {
+    let json_bytes = serde_json::to_vec(data).context("Failed to serialize JSON")?;
+
+    conn.send_fds(&json_bytes, fds)
+        .await
+        .context("Failed to send JSON packet with FDs")?;
 
     Ok(())
 }

--- a/shotover/src/hot_reload/json_parsing.rs
+++ b/shotover/src/hot_reload/json_parsing.rs
@@ -35,7 +35,7 @@ pub async fn read_json_with_fds<T: DeserializeOwned>(
     conn: &mut UnixSeqpacketConn,
 ) -> Result<(T, Vec<RawFd>)> {
     let mut buf = vec![0u8; 65536]; // Large buffer for JSON messages
-    let mut fd_buf = vec![0i32; 16]; // Buffer for file descriptors
+    let mut fd_buf = vec![0i32; 250]; // Buffer for file descriptors
     let (bytes_read, _truncated, fds_read) = conn
         .recv_fds(&mut buf, &mut fd_buf)
         .await

--- a/shotover/src/hot_reload/mod.rs
+++ b/shotover/src/hot_reload/mod.rs
@@ -1,4 +1,5 @@
 pub mod client;
+pub mod fd_utils;
 pub mod json_parsing;
 pub mod protocol;
 pub mod server;

--- a/shotover/src/hot_reload/protocol.rs
+++ b/shotover/src/hot_reload/protocol.rs
@@ -23,6 +23,36 @@ pub enum Response {
     //ShutdownOriginalNode,
     Error(String),
 }
+
+impl Response {
+    /// Collect all file descriptors from the response for ancillary data transmission
+    pub fn collect_fds(&self) -> Vec<RawFd> {
+        match self {
+            Response::SendListeningSockets { port_to_fd } => {
+                port_to_fd.values().map(|fd| fd.0).collect()
+            }
+            Response::Error(_) => Vec::new(),
+        }
+    }
+
+    /// Replace file descriptors in the response with received FDs from ancillary data
+    pub fn replace_fds_with_received(&mut self, received_fds: Vec<RawFd>) {
+        match self {
+            Response::SendListeningSockets { port_to_fd } => {
+                let mut fd_iter = received_fds.into_iter();
+                for fd in port_to_fd.values_mut() {
+                    if let Some(new_fd) = fd_iter.next() {
+                        fd.0 = new_fd;
+                    }
+                }
+            }
+            Response::Error(_) => {
+                // No FDs to replace in error responses
+            }
+        }
+    }
+}
+
 /// Request sent from hot reload server to TcpCodecListener
 pub struct HotReloadListenerRequest {
     pub return_chan: tokio::sync::oneshot::Sender<HotReloadListenerResponse>,

--- a/shotover/src/hot_reload/protocol.rs
+++ b/shotover/src/hot_reload/protocol.rs
@@ -20,19 +20,6 @@ pub enum Response {
     //ShutdownOriginalNode,
     Error(String),
 }
-
-impl Response {
-    /// Collect all file descriptors from the response for ancillary data transmission
-    pub fn collect_fds(&self) -> Vec<RawFd> {
-        match self {
-            Response::SendListeningSockets => Vec::new(), // FDs will be passed separately
-            Response::Error(_) => Vec::new(),
-        }
-    }
-
-    pub fn replace_fds_with_received(&mut self, _received_fds: Vec<RawFd>) {}
-}
-
 /// Request sent from hot reload server to TcpCodecListener
 pub struct HotReloadListenerRequest {
     pub return_chan: tokio::sync::oneshot::Sender<HotReloadListenerResponse>,

--- a/shotover/src/hot_reload/server.rs
+++ b/shotover/src/hot_reload/server.rs
@@ -197,7 +197,7 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn test_request_response() {
-        use crate::hot_reload::json_parsing::{read_json, write_json, write_json_with_fds};
+        use crate::hot_reload::json_parsing::{read_json, write_json};
         use uds::tokio::UnixSeqpacketConn;
 
         let socket_path = "/tmp/test-shotover-request-response.sock";

--- a/shotover/src/hot_reload/server.rs
+++ b/shotover/src/hot_reload/server.rs
@@ -219,9 +219,10 @@ mod tests {
         // Verify response
         match response {
             Response::SendListeningSockets => {
-                assert_eq!(port_to_fd.len(), 0);
+                // Test passes if we get the correct response variant
+                // File descriptors are now sent via ancillary data
             }
-            _ => panic!("Wrong response type"),
+            Response::Error(err) => panic!("Unexpected error response: {}", err),
         }
 
         // Clean up

--- a/shotover/src/hot_reload/server.rs
+++ b/shotover/src/hot_reload/server.rs
@@ -218,7 +218,7 @@ mod tests {
 
         // Verify response
         match response {
-            Response::SendListeningSockets { port_to_fd } => {
+            Response::SendListeningSockets => {
                 assert_eq!(port_to_fd.len(), 0);
             }
             _ => panic!("Wrong response type"),

--- a/shotover/src/hot_reload/server.rs
+++ b/shotover/src/hot_reload/server.rs
@@ -172,14 +172,11 @@ pub fn start_hot_reload_server(socket_path: String, sources: &[Source]) {
     });
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_os = "linux"))]
 mod tests {
-    #[cfg(target_os = "linux")]
     use super::*;
-    #[cfg(target_os = "linux")]
     use crate::hot_reload::tests::wait_for_unix_socket_connection;
 
-    #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn test_unix_socket_server_basic() {
         let socket_path = "/tmp/test-shotover-hotreload.sock";
@@ -194,7 +191,6 @@ mod tests {
         assert!(!Path::new(socket_path).exists());
     }
 
-    #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn test_request_response() {
         use crate::hot_reload::json_parsing::{read_json, write_json};

--- a/shotover/src/server.rs
+++ b/shotover/src/server.rs
@@ -288,9 +288,10 @@ impl<C: CodecBuilder + 'static> TcpCodecListener<C> {
 
     /// Handle hot reload request by extracting file descriptor and responding
     async fn handle_hot_reload_request(&mut self, request: HotReloadListenerRequest) {
-        let response = if let Some(ref listener) = self.listener {
+        let response = if let Some(listener) = self.listener.take() {
             // Extract the file descriptor from the TcpListener
             let fd = listener.as_raw_fd();
+            std::mem::forget(listener);
 
             // Split once from the right to support hostnames and [IPv6]:port formats.
             let port = self
@@ -300,9 +301,10 @@ impl<C: CodecBuilder + 'static> TcpCodecListener<C> {
                 .unwrap();
 
             tracing::info!("Hot reload: Extracting socket FD {} for port {}", fd, port);
-
+            /*
             // Stop accepting new connections by setting listener to None
             self.listener = None;
+            */
 
             HotReloadListenerResponse::HotReloadResponse {
                 port,

--- a/shotover/src/server.rs
+++ b/shotover/src/server.rs
@@ -288,9 +288,10 @@ impl<C: CodecBuilder + 'static> TcpCodecListener<C> {
 
     /// Handle hot reload request by extracting file descriptor and responding
     async fn handle_hot_reload_request(&mut self, request: HotReloadListenerRequest) {
-        let response = if let Some(ref listener) = self.listener {
+        let response = if let Some(listener) = self.listener.take() {
             // Extract the file descriptor from the TcpListener
             let fd = listener.as_raw_fd();
+            std::mem::forget(listener);
 
             // Split once from the right to support hostnames and [IPv6]:port formats.
             let port = self
@@ -300,9 +301,6 @@ impl<C: CodecBuilder + 'static> TcpCodecListener<C> {
                 .unwrap();
 
             tracing::info!("Hot reload: Extracting socket FD {} for port {}", fd, port);
-
-            // Stop accepting new connections by setting listener to None
-            self.listener = None;
 
             HotReloadListenerResponse::HotReloadResponse {
                 port,

--- a/shotover/src/server.rs
+++ b/shotover/src/server.rs
@@ -288,10 +288,9 @@ impl<C: CodecBuilder + 'static> TcpCodecListener<C> {
 
     /// Handle hot reload request by extracting file descriptor and responding
     async fn handle_hot_reload_request(&mut self, request: HotReloadListenerRequest) {
-        let response = if let Some(listener) = self.listener.take() {
+        let response = if let Some(ref listener) = self.listener {
             // Extract the file descriptor from the TcpListener
             let fd = listener.as_raw_fd();
-            std::mem::forget(listener);
 
             // Split once from the right to support hostnames and [IPv6]:port formats.
             let port = self
@@ -301,10 +300,9 @@ impl<C: CodecBuilder + 'static> TcpCodecListener<C> {
                 .unwrap();
 
             tracing::info!("Hot reload: Extracting socket FD {} for port {}", fd, port);
-            /*
+
             // Stop accepting new connections by setting listener to None
             self.listener = None;
-            */
 
             HotReloadListenerResponse::HotReloadResponse {
                 port,


### PR DESCRIPTION
## Summary

Implements actual file descriptor passing using [Unix socket ancillary data](https://doc.rust-lang.org/std/os/unix/net/struct.SocketAncillary.html#method.add_fds), building on the PR -https://github.com/shotover/shotover-proxy/pull/1940's [UDS crate](https://docs.rs/uds/latest/uds/tokio/struct.UnixSeqpacketConn.html#method.send_fds) foundation. This eliminates the need for sudo access by leveraging the kernel's built-in file descriptor transfer mechanism.

## Why This Change?

Previously, our hot reload used pidfd_getfd which required sudo privileges. Unix sockets provide an out-of-band mechanism for sending file descriptors between processes using ancillary data. This tells the OS that the destination process now has permission to access the FD, eliminating the need for privileged access.

## How It Works

-  If FDs are present, uses write_json_with_fds() to send both JSON and CDs
- Client receives both using read_json_with_fds()
- Client updates response with received FDs using replace_fds_with_received()
-  Kernel assigns new FD numbers in receiving process (proving actual transfer)

## Protocol Simplification
Simplified the hot reload protocol by removing the port_to_fd HashMap from the response structure. 

### Protocol Changes:
- Simplified `Response::SendListeningSockets` to have no fields (previously contained `port_to_fd: HashMap<u32, FileDescriptor>`)
- File descriptors are now transmitted separately via Unix domain socket ancillary data
- Port information is extracted directly from file descriptors using `TcpListener::local_addr().port()`

## Safety Improvements
- Implements sound file descriptor handling following Rust's safety principles
- Unsafe operations are properly isolated in dedicated functions
- Uses OwnedFd instead of RawFd in public APIs to ensure memory safety

## Benefits

- Eliminates sudo requirement for hot reload operations
- Kernel manages FD permissions automatically
- Type-safe file descriptor handling
- Simplified protocol reduces complexity



