### PR TITLE
Release shotover 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5009,7 +5009,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shotover"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5080,7 +5080,7 @@ dependencies = [
 
 [[package]]
 name = "shotover-proxy"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/shotover-proxy/Cargo.toml
+++ b/shotover-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shotover-proxy"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Ben <ben@instaclustr.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/shotover/Cargo.toml
+++ b/shotover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shotover"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Ben <ben@instaclustr.com>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
Releasing shotover 0.7.0

### Changelog

- Add git cliff config (#1861)
- Dont log message contents (#1862)
- Update deps (#1863)
- Update scylla-rust-driver (#1840)
- Update to rust 1.84 🦀🦀🦀 (#1865)
- Remove env::set_var usage (#1864)
- Add internal end-to-end docs  (#1849)
- Updated Kafka to 3.9.0-debian-12-r6 (#1866)
- Bump openssl from 0.10.68 to 0.10.70 (#1867)
- Fix CI (#1869)
- Update to Rust 1.85 (#1868)
- Change rustfmt edition to 2024 (#1871)
- Fix docker image build (#1876)
- Remove netlify config (#1872)
- Replace the usage of ubuntu 20.04 (#1877)
- Fix missing docs pages (#1878)
- Prefer aws-lc-rs over ring (#1885)
- Replace Redis async connections with sync ones for pubsub testcases (#1883)
- Upgrade dependencies that do not need code changes (#1886)
- Fix valkey pubsub hang (#1887)
- Upgrade scylla crate to version 1.0.0 (#1888)
- Upgrade rand to 0.9 (#1889)
- Upgrade bincode to version 2.0.1 (#1890)
- Upgrade redis to version 0.29.2 (#1892)
- Bump openssl from 0.10.71 to 0.10.72 (#1895)
- Bump tokio from 1.44.1 to 1.44.2 (#1897)
- Update to rust 1.86 🦀🦀🦀 (#1894)
- Bump crossbeam-channel from 0.5.14 to 0.5.15 (#1898)
- Update deps (#1899)
- KafkaSinkCluster: Fix connect error handling when we dont have cluster metadata yet. (#1905)
- Kafka Shotover proxy doesn't prioritise current rack brokers for sending requests (#1902)
- Rust 1.87 CI fix (#1906)
- 3 dependencies updated (#1910)
- Hotreload interface (#1912)
- Hot Reload Interface testing with Valkey Database (#1913)
- Socket Handoff - UNIX SOCKET SERVER (#1914)
- UNIX SOCKET HANDOFF - CLIENT SIDE IMPLEMENTATION (#1916)
- HotReload Refactor (#1918)
- Update to rust 1.89 (#1919)
- Bump slab from 0.4.10 to 0.4.11 (#1920)
- Refactor sources to use unified Source struct (#1925)
- Listening Socket Extraction for Hot Reload (#1921)
- CassandraSinkCluster - fix system.peers fallback (#1934)
- CassandraSinkCluster - improve system.peers error log (#1933)
- Fix CassandraPeersRewrite invalidating the cache of all responses (#1929)
- Swap all bitnami images over to legacy equivalent (#1941)
- Refactor for hot reload to use UDS Crate (#1940)
- Implement FD transmission via Unix Socket Ancillary Data  (#1942)
- Listening Socket Recreation (#1944)
- Ungraceful Shutdown of Old  Shotover Instances (#1947)
- Using OwnedFD instead of RawFD (#1949)
- Gradual Connection Draining (#1952)
- Add chain and transform to metric definitions in Kafka delegation token creation metrics (#1955)
- CLI CleanUp (#1954)
- BugFix (#1956)
- Testing HotReload when TLS Certificate is Changed (#1957)
- User Configurable Gradual Shutdown (#1960)
- Documentation (#1961)
- Bump version and fix warning (#1963)
- Fix ec2-cargo docs (#1959)
- Ins 38586 kafkasink innaccessible peers metric (#1964)
- Misc website/docs fixes (#1967)