### PR TITLE
Update more deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -176,7 +176,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -670,9 +670,9 @@ checksum = "6141bc859dd66c4775d89945dda7ca392994d8efacecb756502d7dc32fb7e2cd"
 
 [[package]]
 name = "cassandra-protocol"
-version = "3.3.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f792501116fe2f54392f0449d653f4d2ad31c659ae9a095681fae507ceef373"
+checksum = "b2faf8e5541be05d79b509daba93d307c779d4fc9312cfc297ed3ea0204706ef"
 dependencies = [
  "arc-swap",
  "bitflags",
@@ -680,14 +680,14 @@ dependencies = [
  "chrono",
  "crc32fast",
  "derivative",
- "derive_more 1.0.0",
+ "derive_more",
  "float_eq",
  "integer-encoding",
- "itertools 0.13.0",
- "lz4_flex",
+ "itertools 0.14.0",
+ "lz4_flex 0.12.0",
  "num-bigint",
  "snap",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "time",
  "uuid",
 ]
@@ -721,16 +721,16 @@ dependencies = [
 
 [[package]]
 name = "cdrs-tokio"
-version = "8.1.9"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6aab6c612cc4340d3ebb275c246fc350c5492974a935eee748ea5e487aa6d8"
+checksum = "9226c4c7a6a39ebe673379d45c9db80971b21739cc672bb70ba17d6e58fbd7c9"
 dependencies = [
  "arc-swap",
  "atomic",
  "bytemuck",
  "cassandra-protocol",
  "derivative",
- "derive_more 2.1.1",
+ "derive_more",
  "futures",
  "fxhash",
  "itertools 0.14.0",
@@ -774,7 +774,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -784,7 +795,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -1088,6 +1099,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cql3-parser"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,7 +1273,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -1438,32 +1458,11 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
-dependencies = [
- "derive_more-impl 1.0.0",
-]
-
-[[package]]
-name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
- "derive_more-impl 2.1.1",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "unicode-xid",
+ "derive_more-impl",
 ]
 
 [[package]]
@@ -1677,7 +1676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1996,6 +1995,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -2291,7 +2291,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2537,7 +2537,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2756,6 +2756,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab6473172471198271ff72e9379150e9dfd70d8e533e0752a27e515b48dd375e"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2794,9 +2803,9 @@ dependencies = [
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.17.2"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b166dea96003ee2531cf14833efedced545751d800f03535801d833313f8c15"
+checksum = "3589659543c04c7dc5526ec858591015b87cd8746583b51b48ef4353f99dbcda"
 dependencies = [
  "base64",
  "indexmap 2.13.0",
@@ -2939,7 +2948,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3374,7 +3383,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -3386,7 +3395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -3549,6 +3558,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20 0.10.0",
+ "getrandom 0.4.1",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3586,6 +3606,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rand_pcg"
@@ -3650,9 +3676,9 @@ dependencies = [
 
 [[package]]
 name = "rdkafka"
-version = "0.37.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b52c81ac3cac39c9639b95c20452076e74b8d9a71bc6fc4d83407af2ea6fff"
+checksum = "d7956f9ac12b5712e50372d9749a3102f4810a8d42481c5eae3748d36d585bcf"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -3959,7 +3985,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "cbc",
- "chacha20",
+ "chacha20 0.9.1",
  "ctr",
  "curve25519-dalek",
  "data-encoding",
@@ -4075,7 +4101,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4289,7 +4315,7 @@ dependencies = [
  "bytes",
  "chrono",
  "itertools 0.14.0",
- "lz4_flex",
+ "lz4_flex 0.11.5",
  "scylla-macros",
  "snap",
  "stable_deref_trait",
@@ -4464,7 +4490,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4481,7 +4507,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4551,7 +4577,7 @@ dependencies = [
  "httparse",
  "itertools 0.14.0",
  "kafka-protocol",
- "lz4_flex",
+ "lz4_flex 0.12.0",
  "metrics",
  "metrics-exporter-prometheus",
  "nonzero_ext",
@@ -4559,7 +4585,7 @@ dependencies = [
  "ordered-float",
  "pretty-hex",
  "pretty_assertions",
- "rand 0.9.2",
+ "rand 0.10.0",
  "redis-protocol",
  "rustls",
  "rustls-pemfile",
@@ -4602,7 +4628,7 @@ dependencies = [
  "opensearch",
  "pretty_assertions",
  "prometheus-parse",
- "rand 0.9.2",
+ "rand 0.10.0",
  "redis",
  "redis-protocol",
  "regex",
@@ -4731,7 +4757,7 @@ dependencies = [
  "aes",
  "aes-gcm",
  "cbc",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "ctr",
  "poly1305",
@@ -4914,7 +4940,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5725,7 +5751,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ serde_yaml = "0.9.17"
 uuid = { version = "1.0.0", features = ["serde", "v4"] }
 reqwest = { version = "0.13.0", default-features = false, features = ["http2"] }
 redis = { version = "0.29.2", features = ["tokio-comp", "tokio-rustls-comp", "tls-rustls-insecure", "cluster"] }
-cdrs-tokio = "8.0"
-cassandra-protocol = "3.0"
+cdrs-tokio = "9.0"
+cassandra-protocol = "4.0"
 # https://docs.rs/tracing/latest/tracing/level_filters/index.html#compile-time-filters
 # `trace` level is considered development only, and may contain sensitive data, do not include it in release builds.
 tracing = { version = "0.1.15", features = ["release_max_level_debug"] }
@@ -53,7 +53,7 @@ redis-protocol = { version = "6.0.0", features = ["bytes"] }
 futures = "0.3"
 hex = "0.4.3"
 hex-literal = "1.0.0"
-rand = { version = "0.9.0", default-features = false }
+rand = { version = "0.10.0", default-features = false, features = ["thread_rng"] }
 clap = { version = "4.0.4", features = ["cargo", "derive"] }
 async-trait = "0.1.30"
 typetag = "0.2.5"

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,21 @@ This assists us in knowing when to make the next release a breaking release and 
 
 ## 0.8.0
 
+### topology.yaml
+
+* Removed deprecated `shotover_chain_messages_per_batch_count` metric
+* Removed `Protect` transform
 * Removed websocket support
+
+## 0.7.0
+
+### shotover rust API
+
+* only known breaking changes are new versions of reexported dependencies
+
+### topology.yaml
+
+* No breaking changes
 
 ## 0.6.0
 

--- a/shotover-proxy/tests/cassandra_int_tests/batch_statements.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/batch_statements.rs
@@ -1,4 +1,4 @@
-use rand::Rng;
+use rand::RngExt;
 use test_helpers::connection::cassandra::{
     CassandraConnection, ResultValue, assert_query_result, run_query,
 };

--- a/shotover-proxy/tests/cassandra_int_tests/routing.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/routing.rs
@@ -175,7 +175,7 @@ mod compound_key {
 mod composite_key {
 
     use super::assert_eq;
-    use rand::{Rng, distr::Alphanumeric};
+    use rand::{RngExt, distr::Alphanumeric};
     use test_helpers::connection::cassandra::{
         CassandraConnection, Consistency, ResultValue, run_query,
     };

--- a/shotover-proxy/tests/runner/observability_int_tests.rs
+++ b/shotover-proxy/tests/runner/observability_int_tests.rs
@@ -14,7 +14,6 @@ async fn test_metrics() {
 # TYPE connections_opened counter
 # TYPE shotover_available_connections_count gauge
 # TYPE shotover_chain_failures_count counter
-# TYPE shotover_chain_messages_per_batch_count summary
 # TYPE shotover_chain_requests_batch_size summary
 # TYPE shotover_chain_responses_batch_size summary
 # TYPE shotover_chain_total_count counter
@@ -26,16 +25,6 @@ async fn test_metrics() {
 connections_opened{source="valkey"}
 shotover_available_connections_count{source="valkey"}
 shotover_chain_failures_count{chain="valkey"}
-shotover_chain_messages_per_batch_count_count{chain="valkey"}
-shotover_chain_messages_per_batch_count_sum{chain="valkey"}
-shotover_chain_messages_per_batch_count{chain="valkey",quantile="0"}
-shotover_chain_messages_per_batch_count{chain="valkey",quantile="0.1"}
-shotover_chain_messages_per_batch_count{chain="valkey",quantile="0.5"}
-shotover_chain_messages_per_batch_count{chain="valkey",quantile="0.9"}
-shotover_chain_messages_per_batch_count{chain="valkey",quantile="0.95"}
-shotover_chain_messages_per_batch_count{chain="valkey",quantile="0.99"}
-shotover_chain_messages_per_batch_count{chain="valkey",quantile="0.999"}
-shotover_chain_messages_per_batch_count{chain="valkey",quantile="1"}
 shotover_chain_requests_batch_size_count{chain="valkey"}
 shotover_chain_requests_batch_size_sum{chain="valkey"}
 shotover_chain_requests_batch_size{chain="valkey",quantile="0"}

--- a/shotover-proxy/tests/valkey_int_tests/basic_driver_tests.rs
+++ b/shotover-proxy/tests/valkey_int_tests/basic_driver_tests.rs
@@ -5,7 +5,7 @@ use fred::clients::Client;
 use fred::interfaces::ClientLike;
 use pretty_assertions::assert_eq;
 use rand::distr::Alphanumeric;
-use rand::{Rng, rng};
+use rand::{RngExt, rng};
 use redis::aio::MultiplexedConnection;
 use redis::cluster::ClusterConnection;
 use redis::{AsyncCommands, Commands, ErrorKind, RedisError, Value};

--- a/shotover/Cargo.toml
+++ b/shotover/Cargo.toml
@@ -48,8 +48,8 @@ governor = { version = "0.10", default-features = false, features = [
 ] }
 nonzero_ext = "0.3.0"
 version-compare = { version = "0.2", optional = true }
-rand = { features = ["small_rng"], workspace = true }
-lz4_flex = { version = "0.11.0", optional = true }
+rand = { workspace = true }
+lz4_flex = { version = "0.12.0", optional = true }
 clap.workspace = true
 itertools.workspace = true
 bytes.workspace = true
@@ -91,7 +91,7 @@ http = { version = "1.0.0", optional = true }
 
 #Observability
 metrics = "0.24.0"
-metrics-exporter-prometheus = { version = "0.17.0", default-features = false }
+metrics-exporter-prometheus = { version = "0.18.0", default-features = false }
 tracing.workspace = true
 tracing-subscriber.workspace = true
 tracing-appender.workspace = true

--- a/shotover/src/transforms/chain.rs
+++ b/shotover/src/transforms/chain.rs
@@ -246,9 +246,6 @@ impl TransformChainBuilder {
             }
         ).collect();
 
-        // This is deprecated but give users some time to migrate to the requests/responses versions that have replaced this metric
-        histogram!("shotover_chain_messages_per_batch_count", "chain" => name).record(0);
-
         let chain_requests_batch_size =
             histogram!("shotover_chain_requests_batch_size", "chain" => name);
         let chain_responses_batch_size =

--- a/shotover/src/transforms/kafka/sink_cluster/shotover_node.rs
+++ b/shotover/src/transforms/kafka/sink_cluster/shotover_node.rs
@@ -5,7 +5,7 @@ use kafka_protocol::messages::BrokerId;
 use kafka_protocol::protocol::StrBytes;
 use metrics::{Gauge, gauge};
 use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
+use rand::{RngExt, SeedableRng};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::sync::atomic::Ordering;

--- a/test-helpers/Cargo.toml
+++ b/test-helpers/Cargo.toml
@@ -31,7 +31,7 @@ reqwest.workspace = true
 tracing-subscriber.workspace = true
 anyhow.workspace = true
 rcgen.workspace = true
-rdkafka = { version = "0.37", features = ["cmake-build"], optional = true }
+rdkafka = { version = "0.39", features = ["cmake-build"], optional = true }
 docker-compose-runner = "0.3.0"
 j4rs = "0.24.0"
 futures-util = "0.3.28"

--- a/test-helpers/src/connection/kafka/cpp.rs
+++ b/test-helpers/src/connection/kafka/cpp.rs
@@ -142,11 +142,11 @@ impl KafkaProducerCpp {
             .unwrap();
 
         if let Some(offset) = expected_offset {
-            assert_eq!(delivery_status.1, offset, "Unexpected offset");
+            assert_eq!(delivery_status.offset, offset, "Unexpected offset");
         }
 
         ProduceResult {
-            partition: delivery_status.0,
+            partition: delivery_status.partition,
         }
     }
 


### PR DESCRIPTION
More updates:

* rand, provides random number generation
  - the Rng crate was renamed to RngExt
  - thread_rng feature is now required, technically this was always required, but another one of our dependencies was pulling in the feature, so we didnt need to do it ourselves. Since we are now on rand 0.10, and that dependency is still using 0.9, it is no longer pulling in `thread_rng` feature for the version of rand that we use, so we need to set that feature ourselves
* rdkafka, delivery status is now stored as a struct instead of a tuple - nice!
* metrics-exporter-prometheus, it now processes the name of one of our metrics differently to avoid the double `_count_count` naming.
  + the only metric affected by this is deprecated, so rather than rename it I've removed the metric entirely.