### PR TITLE
Add QueryTypeFilter compatibility to CassandraSinkCluster

### DIFF
--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -330,6 +330,65 @@ async fn cluster_single_rack_v4(#[case] driver: CassandraDriver) {
 }
 
 #[rstest]
+#[cfg_attr(feature = "cassandra-cpp-driver-tests", case::cpp(Cpp))]
+#[case::scylla(Scylla)]
+#[case::cdrs(Cdrs)]
+#[tokio::test(flavor = "multi_thread")]
+async fn cluster_single_rack_v4_query_type_filter(#[case] driver: CassandraDriver) {
+    let _compose = docker_compose("tests/test-configs/cassandra/cluster-v4/docker-compose.yaml");
+
+    let connection = || async {
+        let mut connection = CassandraConnectionBuilder::new("127.0.0.1", 9042, driver)
+            .build()
+            .await;
+        connection
+            .enable_schema_awaiter("172.16.1.2:9044", None)
+            .await;
+        connection
+    };
+    {
+        let shotover = shotover_process(
+            "tests/test-configs/cassandra/cluster-v4/topology-query-type-filter.yaml",
+        )
+        .start()
+        .await;
+
+        let connection = connection().await;
+
+        connection
+            .execute(
+                "CREATE KEYSPACE IF NOT EXISTS test_filter_ks WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }",
+            )
+            .await;
+        connection
+            .execute(
+                "CREATE TABLE IF NOT EXISTS test_filter_ks.test_table (id int PRIMARY KEY, value text)",
+            )
+            .await;
+
+        assert_query_result(&connection, "SELECT * FROM test_filter_ks.test_table", &[]).await;
+
+        let err = connection
+            .execute_fallible(
+                "INSERT INTO test_filter_ks.test_table (id, value) VALUES (1, 'hello')",
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(
+            err,
+            ErrorBody {
+                ty: ErrorType::Server,
+                message: "Message was filtered out by shotover".into()
+            }
+        );
+
+        assert_query_result(&connection, "SELECT * FROM test_filter_ks.test_table", &[]).await;
+
+        shotover.shutdown_and_then_consume_events(&[]).await;
+    }
+}
+
+#[rstest]
 //#[case::cdrs(Cdrs)] // TODO
 #[cfg_attr(feature = "cassandra-cpp-driver-tests", case::cpp(Cpp))]
 #[case::scylla(Scylla)]

--- a/shotover-proxy/tests/cassandra_int_tests/mod.rs
+++ b/shotover-proxy/tests/cassandra_int_tests/mod.rs
@@ -377,7 +377,7 @@ async fn cluster_single_rack_v4_query_type_filter(#[case] driver: CassandraDrive
         assert_eq!(
             err,
             ErrorBody {
-                ty: ErrorType::Server,
+                ty: ErrorType::Invalid,
                 message: "Message was filtered out by shotover".into()
             }
         );

--- a/shotover-proxy/tests/test-configs/cassandra/cluster-v4/topology-query-type-filter.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra/cluster-v4/topology-query-type-filter.yaml
@@ -1,0 +1,17 @@
+---
+sources:
+  - Cassandra:
+      name: "cassandra"
+      listen_addr: "127.0.0.1:9042"
+      chain:
+        - QueryTypeFilter:
+            DenyList: [Write]
+        - CassandraSinkCluster:
+            first_contact_points: ["172.16.1.2:9044", "172.16.1.3:9044"]
+            local_shotover_host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
+            shotover_nodes:
+              - address: "127.0.0.1:9042"
+                data_center: "datacenter1"
+                rack: "rack1"
+                host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
+            connect_timeout_ms: 3000

--- a/shotover-proxy/tests/test-configs/cassandra/cluster-v4/topology-query-type-filter.yaml
+++ b/shotover-proxy/tests/test-configs/cassandra/cluster-v4/topology-query-type-filter.yaml
@@ -5,8 +5,10 @@ sources:
       listen_addr: "127.0.0.1:9042"
       chain:
         - QueryTypeFilter:
+            name: "query-type-filter"
             DenyList: [Write]
         - CassandraSinkCluster:
+            name: "cassandra-sink-cluster"
             first_contact_points: ["172.16.1.2:9044", "172.16.1.3:9044"]
             local_shotover_host_id: "2dd022d6-2937-4754-89d6-02d2933a8f7a"
             shotover_nodes:

--- a/shotover-proxy/tests/transforms/tee.rs
+++ b/shotover-proxy/tests/transforms/tee.rs
@@ -161,7 +161,7 @@ async fn test_fail_with_mismatch() {
         .unwrap_err()
         .to_string();
 
-    let expected = "An error was signalled by the server - ResponseError: ERR The responses from the Tee subchain and down-chain did not match and behavior is set to fail on mismatch";
+    let expected = "An error was signalled by the server - ResponseError: The responses from the Tee subchain and down-chain did not match and behavior is set to fail on mismatch";
     assert_eq!(expected, err);
     shotover.shutdown_and_then_consume_events(&[]).await;
 }

--- a/shotover/src/frame/cassandra.rs
+++ b/shotover/src/frame/cassandra.rs
@@ -115,13 +115,13 @@ impl CassandraMetadata {
         }
     }
 
-    pub fn to_error_response(&self, error: String) -> CassandraFrame {
+    pub fn to_error_response(&self, error: String, error_type: ErrorType) -> CassandraFrame {
         CassandraFrame {
             version: self.version,
             stream_id: self.stream_id,
             operation: CassandraOperation::Error(ErrorBody {
                 message: error,
-                ty: ErrorType::Server,
+                ty: error_type,
             }),
             tracing: Tracing::Response(None),
             warnings: vec![],

--- a/shotover/src/message/mod.rs
+++ b/shotover/src/message/mod.rs
@@ -30,11 +30,33 @@ pub enum Metadata {
     OpenSearch,
 }
 
+/// Protocol-agnostic classification of error responses produced by transforms.
+///
+/// For protocols that distinguish error severity (e.g. Cassandra), each variant maps to the
+/// appropriate protocol-specific error type. For protocols that have a single error format
+/// (e.g. Valkey/Redis), or that do not support generic error responses (e.g. Kafka),
+/// this classification is currently ignored.
+///
+/// Protocol mappings:
+/// - Cassandra: `Internal` -> `ErrorType::Server`, `Rejected` -> `ErrorType::Invalid`
+/// - Valkey: both produce a standard `ERR` response
+/// - Kafka: not applicable (generic error responses are unsupported)
+pub enum MessageErrorType {
+    /// An internal or server-side error, indicating a bug or unexpected failure.
+    Internal,
+    /// The request was intentionally rejected by a transform's policy (e.g. filtered out).
+    Rejected,
+}
+
 impl Metadata {
-    /// Returns an error response with the provided error message.
+    /// Returns an error response with the provided error message and error type.
     /// If the metadata is from a request: the returned `Message` is a valid response to self
     /// If the metadata is from a response: the returned `Message` is a valid replacement of self
-    pub fn to_error_response(&self, error: String) -> Result<Message> {
+    pub fn to_error_response(
+        &self,
+        error: String,
+        error_type: MessageErrorType,
+    ) -> Result<Message> {
         #[allow(unreachable_code)]
         Ok(Message::from_frame(match self {
             #[cfg(feature = "valkey")]
@@ -46,7 +68,14 @@ impl Metadata {
                 Frame::Valkey(ValkeyFrame::Error(message.into()))
             }
             #[cfg(feature = "cassandra")]
-            Metadata::Cassandra(meta) => Frame::Cassandra(meta.to_error_response(error)),
+            Metadata::Cassandra(meta) => {
+                use cassandra_protocol::frame::message_error::ErrorType;
+                let cassandra_error_type = match error_type {
+                    MessageErrorType::Internal => ErrorType::Server,
+                    MessageErrorType::Rejected => ErrorType::Invalid,
+                };
+                Frame::Cassandra(meta.to_error_response(error, cassandra_error_type))
+            }
             // In theory we could actually support kafka errors in some form here but:
             // * kafka errors are defined per response type and many response types only provide an error code without a field for a custom error message.
             //     + Implementing this per response type would add a lot of (localized) complexity but might be worth it.
@@ -396,11 +425,15 @@ impl Message {
     }
 
     /// Returns an error response with the provided error message.
-    pub fn from_response_to_error_response(&self, error: String) -> Result<Message> {
+    pub fn from_response_to_error_response(
+        &self,
+        error: String,
+        error_type: MessageErrorType,
+    ) -> Result<Message> {
         let mut response = self
             .metadata()
             .context("Failed to parse metadata of request or response when producing an error")?
-            .to_error_response(error)?;
+            .to_error_response(error, error_type)?;
 
         if let Some(request_id) = self.request_id() {
             response.set_request_id(request_id)
@@ -410,11 +443,15 @@ impl Message {
     }
 
     /// Returns an error response with the provided error message.
-    pub fn from_request_to_error_response(&self, error: String) -> Result<Message> {
+    pub fn from_request_to_error_response(
+        &self,
+        error: String,
+        error_type: MessageErrorType,
+    ) -> Result<Message> {
         let mut request = self
             .metadata()
             .context("Failed to parse metadata of request or response when producing an error")?
-            .to_error_response(error)?;
+            .to_error_response(error, error_type)?;
 
         request.set_request_id(self.id());
         Ok(request)

--- a/shotover/src/source_task.rs
+++ b/shotover/src/source_task.rs
@@ -4,7 +4,7 @@ use crate::frame::MessageType;
 use crate::hot_reload::protocol::{
     GradualShutdownRequest, HotReloadListenerRequest, HotReloadListenerResponse,
 };
-use crate::message::{Message, MessageIdMap, Messages, Metadata};
+use crate::message::{Message, MessageErrorType, MessageIdMap, Messages, Metadata};
 use crate::sources::Transport;
 use crate::tls::{AcceptError, TlsAcceptor};
 use crate::transforms::chain::{TransformChain, TransformChainBuilder};
@@ -969,7 +969,7 @@ impl PendingRequests {
 
                     match meta.to_error_response(format!(
                         "Internal shotover (or custom transform) bug (chain: {chain_name}): {err:?}"
-                    )) {
+                    ), MessageErrorType::Internal) {
                         Ok(response) => Some(response),
                         Err(err) => {
                             tracing::error!("Failed to create an error from the request even though the protocol supports it {err:?}");
@@ -990,7 +990,7 @@ impl PendingRequests {
 
                     match meta.to_error_response(format!(
                         "Internal shotover (or custom transform) bug (chain: {chain_name}): {err:?}"
-                    )) {
+                    ), MessageErrorType::Internal) {
                         Ok(mut response) => {
                             response.set_request_id(*id);
                             Some(response)

--- a/shotover/src/transforms/cassandra/sink_cluster/connection.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/connection.rs
@@ -27,7 +27,7 @@ impl CassandraConnection {
 
     pub fn send(&mut self, requests: Vec<Message>) -> Result<(), ConnectionError> {
         self.pending_request_stream_ids
-            .extend(requests.iter().map(|x| x.stream_id().unwrap()));
+            .extend(requests.iter().filter_map(|x| x.stream_id()));
         self.connection.send(requests)
     }
 

--- a/shotover/src/transforms/cassandra/sink_cluster/mod.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/mod.rs
@@ -252,7 +252,7 @@ struct CassandraSinkCluster {
 impl CassandraSinkCluster {
     async fn send_message(&mut self, mut requests: Messages) -> Result<Messages> {
         if self.version.is_none() {
-            if let Some(message) = requests.first() {
+            if let Some(message) = requests.iter().find(|m| !m.is_dummy()) {
                 if let Ok(Metadata::Cassandra(CassandraMetadata { version, .. })) =
                     message.metadata()
                 {
@@ -468,6 +468,13 @@ impl CassandraSinkCluster {
         responses: &mut Vec<Message>,
     ) -> Result<()> {
         for mut message in requests.into_iter() {
+            if message.is_dummy() {
+                let mut dummy_response = Message::from_frame(Frame::Dummy);
+                dummy_response.set_request_id(message.id());
+                responses.push(dummy_response);
+                continue;
+            }
+
             if self.pool.nodes().is_empty()
                 || !self.init_handshake_complete
                 // system.local and system.peers must be routed to the same node otherwise the system.local node will be amongst the system.peers nodes and a node will be missing

--- a/shotover/src/transforms/cassandra/sink_cluster/mod.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/mod.rs
@@ -263,10 +263,19 @@ impl CassandraSinkCluster {
                     ));
                 }
             } else {
-                // It's an invariant that self.version is Some.
-                // Since we were unable to set it, we need to return immediately.
-                // We can continue once the client sends its first message.
-                return Ok(vec![]);
+                // self.version must be Some before we can proceed, but if all requests are dummy
+                // (e.g. an upstream QueryTypeFilter replaced every request in this batch),
+                // we must still return a dummy response per request so that upstream transforms
+                // can match by request_id and swap in their error responses.
+                // Version detection will complete once a real message arrives.
+                return Ok(requests
+                    .into_iter()
+                    .map(|request| {
+                        let mut dummy_response = Message::from_frame(Frame::Dummy);
+                        dummy_response.set_request_id(request.id());
+                        dummy_response
+                    })
+                    .collect());
             }
         }
 

--- a/shotover/src/transforms/cassandra/sink_cluster/rewrite.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/rewrite.rs
@@ -307,7 +307,7 @@ impl MessageRewriter {
                         Ok(x) => x,
                         Err(MessageParseError::CassandraError(err)) => {
                             client_peers_response = client_peers_response
-                                        .from_response_to_error_response(format!("{:?}", err.context("Shotover failed to generate system.peers, an error occured when an internal system.peers query was run.")), MessageErrorType::Internal)
+                                        .from_response_to_error_response(format!("{:?}", err.context("Shotover failed to generate system.peers, an error occurred when an internal system.peers query was run.")), MessageErrorType::Internal)
                                         .expect("This must succeed because it is a cassandra message and we already know it to be parseable");
                             responses.push(client_peers_response);
                             return Ok(true);
@@ -318,7 +318,7 @@ impl MessageRewriter {
                         Ok(x) => nodes.extend(x),
                         Err(MessageParseError::CassandraError(err)) => {
                             client_peers_response = client_peers_response
-                                        .from_response_to_error_response(format!("{:?}", err.context("Shotover failed to generate system.peers, an error occured when an internal system.local query was run.")), MessageErrorType::Internal)
+                                        .from_response_to_error_response(format!("{:?}", err.context("Shotover failed to generate system.peers, an error occurred when an internal system.local query was run.")), MessageErrorType::Internal)
                                         .expect("This must succeed because it is a cassandra message and we already know it to be parseable");
                             responses.push(client_peers_response);
                             return Ok(true);
@@ -569,7 +569,7 @@ impl MessageRewriter {
         let mut peers = match parse_system_nodes(peers_response) {
             Ok(x) => x,
             Err(MessageParseError::CassandraError(err)) => {
-                *local_response = local_response.from_response_to_error_response(format!("{:?}", err.context("Shotover failed to generate system.local, an error occured when an internal system.peers query was run.")), MessageErrorType::Internal)
+                *local_response = local_response.from_response_to_error_response(format!("{:?}", err.context("Shotover failed to generate system.local, an error occurred when an internal system.peers query was run.")), MessageErrorType::Internal)
                     .expect("This must succeed because it is a cassandra message and we already know it to be parseable");
                 return Ok(());
             }

--- a/shotover/src/transforms/cassandra/sink_cluster/rewrite.rs
+++ b/shotover/src/transforms/cassandra/sink_cluster/rewrite.rs
@@ -3,7 +3,7 @@ use super::node::ConnectionFactory;
 use super::node_pool::NodePool;
 use crate::frame::cassandra::operation_name;
 use crate::frame::{CassandraFrame, CassandraOperation, CassandraResult, Frame};
-use crate::message::{Message, MessageIdMap, Messages};
+use crate::message::{Message, MessageErrorType, MessageIdMap, Messages};
 use crate::{
     frame::{
         cassandra::{Tracing, parse_statement_single},
@@ -307,7 +307,7 @@ impl MessageRewriter {
                         Ok(x) => x,
                         Err(MessageParseError::CassandraError(err)) => {
                             client_peers_response = client_peers_response
-                                        .from_response_to_error_response(format!("{:?}", err.context("Shotover failed to generate system.peers, an error occured when an internal system.peers query was run.")))
+                                        .from_response_to_error_response(format!("{:?}", err.context("Shotover failed to generate system.peers, an error occured when an internal system.peers query was run.")), MessageErrorType::Internal)
                                         .expect("This must succeed because it is a cassandra message and we already know it to be parseable");
                             responses.push(client_peers_response);
                             return Ok(true);
@@ -318,7 +318,7 @@ impl MessageRewriter {
                         Ok(x) => nodes.extend(x),
                         Err(MessageParseError::CassandraError(err)) => {
                             client_peers_response = client_peers_response
-                                        .from_response_to_error_response(format!("{:?}", err.context("Shotover failed to generate system.peers, an error occured when an internal system.local query was run.")))
+                                        .from_response_to_error_response(format!("{:?}", err.context("Shotover failed to generate system.peers, an error occured when an internal system.local query was run.")), MessageErrorType::Internal)
                                         .expect("This must succeed because it is a cassandra message and we already know it to be parseable");
                             responses.push(client_peers_response);
                             return Ok(true);
@@ -569,7 +569,7 @@ impl MessageRewriter {
         let mut peers = match parse_system_nodes(peers_response) {
             Ok(x) => x,
             Err(MessageParseError::CassandraError(err)) => {
-                *local_response = local_response.from_response_to_error_response(format!("{:?}", err.context("Shotover failed to generate system.local, an error occured when an internal system.peers query was run.")))
+                *local_response = local_response.from_response_to_error_response(format!("{:?}", err.context("Shotover failed to generate system.local, an error occured when an internal system.peers query was run.")), MessageErrorType::Internal)
                     .expect("This must succeed because it is a cassandra message and we already know it to be parseable");
                 return Ok(());
             }

--- a/shotover/src/transforms/filter.rs
+++ b/shotover/src/transforms/filter.rs
@@ -1,5 +1,5 @@
 use super::{DownChainProtocol, TransformContextBuilder, TransformContextConfig, UpChainProtocol};
-use crate::message::{Message, MessageIdMap, Messages, QueryType};
+use crate::message::{Message, MessageErrorType, MessageIdMap, Messages, QueryType};
 use crate::transforms::{ChainState, Transform, TransformBuilder, TransformConfig};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -95,6 +95,7 @@ impl Transform for QueryTypeFilter {
                     request
                         .from_request_to_error_response(
                             "Message was filtered out by shotover".to_owned(),
+                            MessageErrorType::Rejected,
                         )
                         .map_err(|e| e.context("Failed to filter message"))?,
                 );

--- a/shotover/src/transforms/null.rs
+++ b/shotover/src/transforms/null.rs
@@ -1,5 +1,5 @@
 use super::{DownChainProtocol, TransformContextBuilder, TransformContextConfig, UpChainProtocol};
-use crate::message::Messages;
+use crate::message::{MessageErrorType, Messages};
 use crate::transforms::{ChainState, Transform, TransformBuilder, TransformConfig};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -85,8 +85,10 @@ impl Transform for NullSink {
     ) -> Result<Messages> {
         for request in &mut chain_state.requests {
             // reuse the requests to hold the responses to avoid an allocation
-            *request = request
-                .from_request_to_error_response("Handled by shotover null transform".to_string())?;
+            *request = request.from_request_to_error_response(
+                "Handled by shotover null transform".to_string(),
+                MessageErrorType::Internal,
+            )?;
         }
         Ok(std::mem::take(&mut chain_state.requests))
     }

--- a/shotover/src/transforms/tee.rs
+++ b/shotover/src/transforms/tee.rs
@@ -1,7 +1,7 @@
 use super::{DownChainProtocol, TransformContextBuilder, TransformContextConfig, UpChainProtocol};
 use crate::config::chain::TransformChainConfig;
 use crate::http::HttpServerError;
-use crate::message::{Message, MessageIdMap, Messages};
+use crate::message::{Message, MessageErrorType, MessageIdMap, Messages};
 use crate::transforms::chain::{BufferedChain, TransformChainBuilder};
 use crate::transforms::{ChainState, Transform, TransformBuilder, TransformConfig};
 use anyhow::{Context, Result, anyhow};
@@ -295,7 +295,8 @@ impl Transform for Tee {
                             other_message.to_high_level_string()
                         );
                         *keep_message = keep_message.from_response_to_error_response(
-                            "ERR The responses from the Tee subchain and down-chain did not match and behavior is set to fail on mismatch".into()
+                            "ERR The responses from the Tee subchain and down-chain did not match and behavior is set to fail on mismatch".into(),
+                            MessageErrorType::Internal,
                         ).unwrap();
                     },
                 );

--- a/shotover/src/transforms/tee.rs
+++ b/shotover/src/transforms/tee.rs
@@ -295,7 +295,7 @@ impl Transform for Tee {
                             other_message.to_high_level_string()
                         );
                         *keep_message = keep_message.from_response_to_error_response(
-                            "ERR The responses from the Tee subchain and down-chain did not match and behavior is set to fail on mismatch".into(),
+                            "The responses from the Tee subchain and down-chain did not match and behavior is set to fail on mismatch".into(),
                             MessageErrorType::Internal,
                         ).unwrap();
                     },


### PR DESCRIPTION
This PR first adds a [new integration test](https://github.com/shotover/shotover-proxy/pull/1995/changes#diff-3c1b291110379020fb6bc7d1644e2e0027997d5243b1c111d1a927a577f9a2c9R333) to reproduce the incompatibility problem between `QueryTypeFilter` and `CassandraSinkCluster`. This new test places a `QueryTypeFilter` in front of `CassandraSinkCluster` in the transform chain which causes the error below (ref: [example failed CI test](https://github.com/shotover/shotover-proxy/actions/runs/23272375541/job/67668538319?pr=1995)). The problem here is that `QueryTypeFilter` replaces the filtered request with a `Frame::Dummy` which doesn't have a `stream_id`, and passes the dummy frame to the downstream `CassandraSinkCluster` which then runs [x.stream_id().unwrap()](https://github.com/shotover/shotover-proxy/blob/main/shotover/src/transforms/cassandra/sink_cluster/connection.rs#L30), leading to the error of calling `Option::unwrap()` on the `None` value.

```
shotover   23:46:34.417319Z PANIC panicked at shotover/src/transforms/cassandra/sink_cluster/connection.rs:30:59:
called `Option::unwrap()` on a `None` value
   0: __rustc::rust_begin_unwind
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/std/src/panicking.rs:689:5
   1: core::panicking::panic_fmt
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/core/src/panicking.rs:80:14
   2: core::panicking::panic
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/core/src/panicking.rs:150:5
   3: core::option::unwrap_failed
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/core/src/option.rs:2199:5
   4: core::option::Option<T>::unwrap
             at /rustc/4a4ef493e3a1488c6e321570238084b38948f6db/library/core/src/option.rs:1016:21
      shotover::transforms::cassandra::sink_cluster::connection::CassandraConnection::send::{{closure}}
             at /home/runner/work/shotover-proxy/shotover-proxy/shotover/src/transforms/cassandra/sink_cluster/connection.rs:30:59
```

To resolve this incompatibility issue, extra logic for handling dummy message is added to [[‎shotover/src/transforms/cassandra/sink_cluster/connection.rs](https://github.com/shotover/shotover-proxy/pull/1995/changes#diff-459fd25b61f5afd9581a7d2df886a19bae51bf7c54ef34d650d8a53c2157c256) and [‎shotover/src/transforms/cassandra/sink_cluster/mod.rs](https://github.com/shotover/shotover-proxy/pull/1995/changes#diff-065cf4d445a4705348db7b2b2d097beaa9230ccbe9313019c7e9c873d3f19fbb), allowing the new integration test to pass.


Additionally, the Cassandra error type for filtered responses is changed from `ErrorType::Server` to `ErrorType::Invalid` because the Datastax C++ driver defuncts the connection on Server errors which breaks subsequent queries (other drivers handle server errors more gracefully and are fine). 

Specifically, the C++ driver produced this warning (`WARN datastax::internal::core::RequestExecution::on_error_response: Received server error 'Message was filtered out by shotover' from host 127.0.0.1. Defuncting the connection...`) in the integration test, which then led to the error `thread 'cassandra_int_tests::cluster_single_rack_v4_query_type_filter::case_1_cpp' (5539) panicked at test-helpers/src/connection/cassandra/connection/cpp.rs:164:25:
Unexpected cassandra_cpp error: Cassandra error LIB_NO_HOSTS_AVAILABLE: All hosts in current policy attempted and were either unavailable or failed` because the driver regarded nodes as down after defuncting the connection. Example CI run [here](https://github.com/shotover/shotover-proxy/actions/runs/23274203898/job/67674229251).

A filtered query is a rejection instead of a server bug and so `Invalid` is more appropriate than `Server` error here. A new protocol-agonistic `MessageErrorType` enum is hence introduced to support passing the error type from the common `QueryTypeFilter` to the protocol-specific response mapper. 