### PR TITLE
Add true time based flush behaviour to Coalesce transform

### DIFF
--- a/docs/src/transforms.md
+++ b/docs/src/transforms.md
@@ -216,7 +216,7 @@ This transform holds onto messages until a flush condition is met, then sends th
 You must set **at least one** of the flush fields below. You may set both.
 
 * **`flush_when_buffered_message_count`** — flush when the buffer holds at least this many messages.
-* **`flush_when_millis_since_last_flush`** — when **> 0**, Coalesce may flush a non-empty buffer once at least this many milliseconds have passed since the interval was last restarted. The interval restarts only when Coalesce flushes messages to the next transform (including count-based and shutdown flushes) or when it runs with an **empty** buffer and no shutdown flush. **Appending incoming messages does not restart the interval.** Optional if `flush_when_buffered_message_count` is set; omit for count-only flushing.
+* **`flush_when_millis_since_last_flush`** — when **> 0**, Coalesce may flush a non-empty buffer once at least this many milliseconds have passed since the interval was last restarted. The interval restarts only when Coalesce flushes messages to the next transform or when it runs with an **empty** buffer. **Appending incoming messages does not restart the interval.** Optional if `flush_when_buffered_message_count` is set; omit for count-only flushing.
 
 **Count-only** (no millis, or millis omitted): messages that never reach the count stay buffered until the connection is torn down (chain flush on close). Clients may see no response for those requests until then. Add `flush_when_millis_since_last_flush` if you need a time bound on partial batches.
 

--- a/docs/src/transforms.md
+++ b/docs/src/transforms.md
@@ -216,7 +216,7 @@ This transform holds onto messages until a flush condition is met, then sends th
 You must set **at least one** of the flush fields below. You may set both.
 
 * **`flush_when_buffered_message_count`** — flush when the buffer holds at least this many messages.
-* **`flush_when_millis_since_last_flush`** — a per-connection task sleeps for this many milliseconds, then wakes the chain. That wake is a time-based flush when the buffer is non-empty. **Every flush** (time-based, count-based, or shutdown) restarts the sleep, so the next wake is one full interval after the last flush—no separate wall-clock field is used. Must be **> 0**. If you only use count-based flush, **no timer runs**.
+* **`flush_when_millis_since_last_flush`** — when **> 0**, Coalesce may flush a non-empty buffer once at least this many milliseconds have passed since the interval was last restarted. The interval restarts only when Coalesce flushes messages to the next transform (including count-based and shutdown flushes) or when it runs with an **empty** buffer and no shutdown flush. **Appending incoming messages does not restart the interval.** Optional if `flush_when_buffered_message_count` is set; omit for count-only flushing.
 
 **Count-only** (no millis, or millis omitted): messages that never reach the count stay buffered until the connection is torn down (chain flush on close). Clients may see no response for those requests until then. Add `flush_when_millis_since_last_flush` if you need a time bound on partial batches.
 
@@ -225,7 +225,7 @@ You must set **at least one** of the flush fields below. You may set both.
     # Flush when the buffer holds at least this many messages (optional if millis is set).
     flush_when_buffered_message_count: 2000
 
-    # Milliseconds since last flush; optional if count is set. Must be > 0 to enable the timer.
+    # Max time partial batches may wait (ms); optional if count is set. Must be > 0 when set.
     flush_when_millis_since_last_flush: 10000
 ```
 

--- a/docs/src/transforms.md
+++ b/docs/src/transforms.md
@@ -211,17 +211,21 @@ This transform should be used with the `CassandraSinkSingle` transform. It will 
 
 ### Coalesce
 
-This transform holds onto messages until some requirement is met and then sends them batched together.
-Validation will fail if none of the `flush_when_` fields are provided, as this would otherwise result in a Coalesce transform that never flushes.
+This transform holds onto messages until a flush condition is met, then sends them batched together down the chain.
+
+You must set **at least one** of the flush fields below. You may set both.
+
+* **`flush_when_buffered_message_count`** — flush when the buffer holds at least this many messages.
+* **`flush_when_millis_since_last_flush`** — a per-connection task sleeps for this many milliseconds, then wakes the chain. That wake is a time-based flush when the buffer is non-empty. **Every flush** (time-based, count-based, or shutdown) restarts the sleep, so the next wake is one full interval after the last flush—no separate wall-clock field is used. Must be **> 0**. If you only use count-based flush, **no timer runs**.
+
+**Count-only** (no millis, or millis omitted): messages that never reach the count stay buffered until the connection is torn down (chain flush on close). Clients may see no response for those requests until then. Add `flush_when_millis_since_last_flush` if you need a time bound on partial batches.
 
 ```yaml
 - Coalesce:
-    # When this field is provided a flush will occur when the specified number of messages are currently held in the buffer.
+    # Flush when the buffer holds at least this many messages (optional if millis is set).
     flush_when_buffered_message_count: 2000
 
-    # When this field is provided a flush will occur when the following occurs in sequence:
-    # 1. the specified number of milliseconds have passed since the last flush ocurred
-    # 2. a new message is received
+    # Milliseconds since last flush; optional if count is set. Must be > 0 to enable the timer.
     flush_when_millis_since_last_flush: 10000
 ```
 

--- a/shotover/src/config/topology.rs
+++ b/shotover/src/config/topology.rs
@@ -284,14 +284,14 @@ foo source:
     }
 
     #[tokio::test]
-    async fn test_validate_coalesce() {
+    async fn test_validate_coalesce_neither_flush_field() {
         let expected = r#"Topology errors
 foo source:
   foo chain:
     Coalesce:
-      Need to provide at least one of these fields:
+      Provide at least one of:
       * flush_when_buffered_message_count
-      * flush_when_millis_since_last_flush
+      * flush_when_millis_since_last_flush (must be greater than 0)
     
       But none of them were provided.
       Check https://shotover.io/docs/latest/transforms.html#coalesce for more information.

--- a/shotover/src/config/topology.rs
+++ b/shotover/src/config/topology.rs
@@ -315,6 +315,33 @@ foo source:
     }
 
     #[tokio::test]
+    async fn test_validate_coalesce_millis_zero() {
+        let expected = r#"Topology errors
+foo source:
+  foo chain:
+    Coalesce:
+      flush_when_millis_since_last_flush must be greater than 0 when set.
+      Check https://shotover.io/docs/latest/transforms.html#coalesce for more information.
+"#;
+
+        let error = run_test_topology_valkey(vec![
+            Box::new(CoalesceConfig {
+                name: "coalesce".to_string(),
+                flush_when_buffered_message_count: Some(100),
+                flush_when_millis_since_last_flush: Some(0),
+            }),
+            Box::new(NullSinkConfig {
+                name: "sink".to_string(),
+            }),
+        ])
+        .await
+        .unwrap_err()
+        .to_string();
+
+        assert_eq!(error, expected);
+    }
+
+    #[tokio::test]
     async fn test_validate_chain_terminating_in_middle() {
         let expected = r#"Topology errors
 foo source:

--- a/shotover/src/transforms/coalesce.rs
+++ b/shotover/src/transforms/coalesce.rs
@@ -5,15 +5,15 @@ use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
 use tokio::sync::{Notify, RwLock};
+use tokio::time::{Duration, Instant};
 
 struct Coalesce {
     flush_when_buffered_message_count: Option<usize>,
     buffer: Messages,
     /// When set, a time-based flush is due once `last_flush` is at least this old (see docs).
     millis_interval: Option<Duration>,
-    /// Shared with the timer task so it sleeps only the **remaining** time until the interval elapses.
+    /// Shared with the timer task (`tokio::time::Instant` matches `tokio::time::sleep`).
     /// Timer uses `read()`; transform uses `write()` when a run restarts the millis clock (`tokio::sync::RwLock` is write-preferring).
     last_flush: Option<Arc<RwLock<Instant>>>,
     /// Wake the timer when `last_flush` changes so it recomputes remaining sleep (see docs).
@@ -233,8 +233,8 @@ mod test {
     use pretty_assertions::assert_eq;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::time::Duration;
     use tokio::sync::Notify;
+    use tokio::time::Duration;
     use tokio::task::JoinHandle;
 
     /// Counts every `force_run_chain.notify_one()` the millis timer (or anything else) performs.

--- a/shotover/src/transforms/coalesce.rs
+++ b/shotover/src/transforms/coalesce.rs
@@ -99,6 +99,19 @@ impl TransformBuilder for CoalesceBuilder {
             let force_run_chain = transform_context.force_run_chain.clone();
             let restart_task = restart.clone();
             let last_flush_task = last_flush;
+            // Background millis timer flow:
+            // 1) Sleep does not start until someone calls `restart.notify_one()` (startup and each
+            //    transform-side "clock restart" path do this).
+            // 2) After wakeup, read `last_flush` and compute `remaining = interval - elapsed`.
+            // 3) Wait for whichever happens first:
+            //    - another restart notification -> recompute remaining from the new `last_flush`
+            //    - sleep(remaining) completes   -> interval is due
+            // 4) When due, call `force_run_chain.notify_one()` so the source runs the chain; if
+            //    there are buffered messages, Coalesce will flush them in `transform`.
+            // 5) Loop back and wait for the next restart notification before arming the next cycle.
+            //
+            // This design makes the interval relative to the latest restart point and avoids races
+            // where a stale sleep fires after `last_flush` has already moved forward.
             let handle = tokio::spawn(async move {
                 loop {
                     // Wait until the transform has set `last_flush` for this cycle (startup or post-flush).

--- a/shotover/src/transforms/coalesce.rs
+++ b/shotover/src/transforms/coalesce.rs
@@ -234,8 +234,8 @@ mod test {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tokio::sync::Notify;
-    use tokio::time::Duration;
     use tokio::task::JoinHandle;
+    use tokio::time::Duration;
 
     /// Counts every `force_run_chain.notify_one()` the millis timer (or anything else) performs.
     /// Tokio `Notify` delivers each `notify_one` to one waiter; this task is the only waiter in tests.

--- a/shotover/src/transforms/coalesce.rs
+++ b/shotover/src/transforms/coalesce.rs
@@ -4,15 +4,30 @@ use crate::transforms::{ChainState, Transform, TransformBuilder, TransformConfig
 use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use std::time::Instant;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+use tokio::sync::Notify;
 
-#[derive(Clone)]
 struct Coalesce {
     name: String,
     flush_when_buffered_message_count: Option<usize>,
-    flush_when_millis_since_last_flush: Option<u128>,
+    flush_when_millis_since_last_flush: Option<u64>,
     buffer: Messages,
-    last_write: Instant,
+    /// Background timer sets this before `force_run_chain`; transform clears it to detect a timer-driven run.
+    timer_flush_pending: Option<Arc<AtomicBool>>,
+    /// Notify to restart the sleep so the next wake is `duration` after the last flush.
+    restart_sleep_after_flush: Option<Arc<Notify>>,
+    /// Aborted in [`Drop`] when the connection chain is torn down.
+    timer_task: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl Drop for Coalesce {
+    fn drop(&mut self) {
+        if let Some(h) = self.timer_task.take() {
+            h.abort();
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -20,7 +35,7 @@ struct Coalesce {
 pub struct CoalesceConfig {
     pub name: String,
     pub flush_when_buffered_message_count: Option<usize>,
-    pub flush_when_millis_since_last_flush: Option<u128>,
+    pub flush_when_millis_since_last_flush: Option<u64>,
 }
 
 const NAME: &str = "Coalesce";
@@ -40,7 +55,9 @@ impl TransformConfig for CoalesceConfig {
             buffer: Vec::with_capacity(self.flush_when_buffered_message_count.unwrap_or(0)),
             flush_when_buffered_message_count: self.flush_when_buffered_message_count,
             flush_when_millis_since_last_flush: self.flush_when_millis_since_last_flush,
-            last_write: Instant::now(),
+            timer_flush_pending: None,
+            restart_sleep_after_flush: None,
+            timer_task: None,
         }))
     }
 
@@ -58,8 +75,40 @@ impl TransformConfig for CoalesceConfig {
 }
 
 impl TransformBuilder for Coalesce {
-    fn build(&self, _transform_context: TransformContextBuilder) -> Box<dyn Transform> {
-        Box::new(self.clone())
+    fn build(&self, transform_context: TransformContextBuilder) -> Box<dyn Transform> {
+        let mut coalesce = Coalesce {
+            name: self.name.clone(),
+            flush_when_buffered_message_count: self.flush_when_buffered_message_count,
+            flush_when_millis_since_last_flush: self.flush_when_millis_since_last_flush,
+            buffer: Vec::with_capacity(self.flush_when_buffered_message_count.unwrap_or(0)),
+            timer_flush_pending: None,
+            restart_sleep_after_flush: None,
+            timer_task: None,
+        };
+
+        if let Some(ms) = self.flush_when_millis_since_last_flush.filter(|&m| m > 0) {
+            let duration = Duration::from_millis(ms);
+            let pending = Arc::new(AtomicBool::new(false));
+            let restart = Arc::new(Notify::new());
+
+            coalesce.timer_flush_pending = Some(pending.clone());
+            coalesce.restart_sleep_after_flush = Some(restart.clone());
+
+            let handle = tokio::spawn(async move {
+                loop {
+                    tokio::select! {
+                        _ = restart.notified() => {}
+                        _ = tokio::time::sleep(duration) => {
+                            pending.store(true, Ordering::Relaxed);
+                            transform_context.force_run_chain.notify_one();
+                        }
+                    }
+                }
+            });
+            coalesce.timer_task = Some(handle);
+        }
+
+        Box::new(coalesce)
     }
 
     fn get_name(&self) -> &str {
@@ -71,22 +120,24 @@ impl TransformBuilder for Coalesce {
     }
 
     fn validate(&self) -> Vec<String> {
-        if self.flush_when_buffered_message_count.is_none()
-            && self.flush_when_millis_since_last_flush.is_none()
-        {
-            vec![
+        let has_count = self.flush_when_buffered_message_count.is_some();
+        let has_timer_millis = self
+            .flush_when_millis_since_last_flush
+            .is_some_and(|m| m > 0);
+        if !has_count && !has_timer_millis {
+            return vec![
                 "Coalesce:".into(),
-                "  Need to provide at least one of these fields:".into(),
+                "  Provide at least one of:".into(),
                 "  * flush_when_buffered_message_count".into(),
-                "  * flush_when_millis_since_last_flush".into(),
+                "  * flush_when_millis_since_last_flush (must be greater than 0)".into(),
                 "".into(),
                 "  But none of them were provided.".into(),
                 "  Check https://shotover.io/docs/latest/transforms.html#coalesce for more information."
                     .into(),
-            ]
-        } else {
-            vec![]
+            ];
         }
+
+        vec![]
     }
 }
 
@@ -100,24 +151,34 @@ impl Transform for Coalesce {
         &mut self,
         chain_state: &'shorter mut ChainState<'longer>,
     ) -> Result<Messages> {
+        // No millis timer → no pending flag; timer task is not running.
+        let timer_wake = match &self.timer_flush_pending {
+            Some(pending) => pending.swap(false, Ordering::Relaxed),
+            None => false,
+        };
+
         self.buffer.append(&mut chain_state.requests);
+
+        if self.buffer.is_empty() && !chain_state.flush {
+            return Ok(vec![]);
+        }
+
+        let millis_wants_flush = timer_wake && !self.buffer.is_empty();
 
         let flush_buffer = chain_state.flush
             || self
                 .flush_when_buffered_message_count
                 .map(|n| self.buffer.len() >= n)
                 .unwrap_or(false)
-            || self
-                .flush_when_millis_since_last_flush
-                .map(|ms| self.last_write.elapsed().as_millis() >= ms)
-                .unwrap_or(false);
+            || millis_wants_flush;
 
         if flush_buffer {
-            if self.flush_when_millis_since_last_flush.is_some() {
-                self.last_write = Instant::now()
-            }
             std::mem::swap(&mut self.buffer, &mut chain_state.requests);
-            chain_state.call_next_transform().await
+            let out = chain_state.call_next_transform().await?;
+            if let Some(n) = &self.restart_sleep_after_flush {
+                n.notify_one();
+            }
+            Ok(out)
         } else {
             Ok(vec![])
         }
@@ -126,105 +187,98 @@ impl Transform for Coalesce {
 
 #[cfg(all(test, feature = "valkey"))]
 mod test {
-    use crate::frame::{Frame, ValkeyFrame};
+    use crate::frame::{Frame, MessageType, ValkeyFrame};
     use crate::message::Message;
     use crate::transforms::chain::TransformAndMetrics;
-    use crate::transforms::coalesce::Coalesce;
+    use crate::transforms::coalesce::CoalesceConfig;
     use crate::transforms::loopback::Loopback;
-    use crate::transforms::{ChainState, Transform};
+    use crate::transforms::{
+        ChainState, Transform, TransformConfig, TransformContextBuilder, TransformContextConfig,
+    };
     use pretty_assertions::assert_eq;
-    use std::time::{Duration, Instant};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+    use tokio::sync::Notify;
+    use tokio::task::JoinHandle;
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_count() {
-        let mut coalesce = Coalesce {
-            name: "coalesce".to_string(),
-            flush_when_buffered_message_count: Some(100),
-            flush_when_millis_since_last_flush: None,
-            buffer: Vec::with_capacity(100),
-            last_write: Instant::now(),
-        };
-
-        let mut chain = vec![TransformAndMetrics::new(
-            Box::new(Loopback::new("loopback".to_string())),
-            "loopback",
-            "Loopback",
-        )];
-
-        let requests: Vec<_> = (0..25)
-            .map(|_| Message::from_frame(Frame::Valkey(ValkeyFrame::Null)))
-            .collect();
-
-        assert_responses_len(&mut chain, &mut coalesce, &requests, 0).await;
-        assert_responses_len(&mut chain, &mut coalesce, &requests, 0).await;
-        assert_responses_len(&mut chain, &mut coalesce, &requests, 0).await;
-        assert_responses_len(&mut chain, &mut coalesce, &requests, 100).await;
-        assert_responses_len(&mut chain, &mut coalesce, &requests, 0).await;
+    /// Counts every `force_run_chain.notify_one()` the millis timer (or anything else) performs.
+    /// Tokio `Notify` delivers each `notify_one` to one waiter; this task is the only waiter in tests.
+    struct ForceRunNotifyCounter {
+        count: Arc<AtomicUsize>,
+        _recorder: JoinHandle<()>,
     }
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_wait() {
-        let mut coalesce = Coalesce {
-            name: "coalesce".to_string(),
-            flush_when_buffered_message_count: None,
-            flush_when_millis_since_last_flush: Some(100),
-            buffer: Vec::with_capacity(100),
-            last_write: Instant::now(),
-        };
+    impl ForceRunNotifyCounter {
+        fn spawn(force_run_chain: Arc<Notify>) -> Self {
+            let count = Arc::new(AtomicUsize::new(0));
+            let count_task = count.clone();
+            let force = force_run_chain.clone();
+            let recorder = tokio::spawn(async move {
+                loop {
+                    force.notified().await;
+                    count_task.fetch_add(1, Ordering::Relaxed);
+                }
+            });
+            Self {
+                count,
+                _recorder: recorder,
+            }
+        }
 
-        let mut chain = vec![TransformAndMetrics::new(
-            Box::new(Loopback::new("loopback".to_string())),
-            "loopback",
-            "Loopback",
-        )];
-
-        let requests: Vec<_> = (0..25)
-            .map(|_| Message::from_frame(Frame::Valkey(ValkeyFrame::Null)))
-            .collect();
-
-        assert_responses_len(&mut chain, &mut coalesce, &requests, 0).await;
-        tokio::time::sleep(Duration::from_millis(10_u64)).await;
-        assert_responses_len(&mut chain, &mut coalesce, &requests, 0).await;
-        tokio::time::sleep(Duration::from_millis(100_u64)).await;
-        assert_responses_len(&mut chain, &mut coalesce, &requests, 75).await;
-        assert_responses_len(&mut chain, &mut coalesce, &requests, 0).await;
+        fn get(&self) -> usize {
+            self.count.load(Ordering::Relaxed)
+        }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_wait_or_count() {
-        let mut coalesce = Coalesce {
-            name: "coalesce".to_string(),
-            flush_when_buffered_message_count: Some(100),
-            flush_when_millis_since_last_flush: Some(100),
-            buffer: Vec::with_capacity(100),
-            last_write: Instant::now(),
-        };
+    impl Drop for ForceRunNotifyCounter {
+        fn drop(&mut self) {
+            self._recorder.abort();
+        }
+    }
 
-        let mut chain = vec![TransformAndMetrics::new(
+    /// Production `build` with a shared `force_run_chain` for assertions.
+    async fn coalesce_from_config_with_force_notify(
+        flush_when_buffered_message_count: Option<usize>,
+        flush_when_millis_since_last_flush: Option<u64>,
+    ) -> (Box<dyn Transform>, Arc<Notify>) {
+        let force_run_chain = Arc::new(Notify::new());
+        let config = CoalesceConfig {
+            name: "coalesce".to_string(),
+            flush_when_buffered_message_count,
+            flush_when_millis_since_last_flush,
+        };
+        let transform = config
+            .get_builder(TransformContextConfig {
+                chain_name: "test".to_string(),
+                up_chain_protocol: MessageType::Valkey,
+            })
+            .await
+            .unwrap()
+            .build(TransformContextBuilder {
+                force_run_chain: force_run_chain.clone(),
+                client_details: String::new(),
+            });
+        (transform, force_run_chain)
+    }
+
+    fn test_chain() -> Vec<TransformAndMetrics> {
+        vec![TransformAndMetrics::new(
             Box::new(Loopback::new("loopback".to_string())),
             "loopback",
             "Loopback",
-        )];
+        )]
+    }
 
-        let requests: Vec<_> = (0..25)
+    fn batch_of_25() -> Vec<Message> {
+        (0..25)
             .map(|_| Message::from_frame(Frame::Valkey(ValkeyFrame::Null)))
-            .collect();
-
-        assert_responses_len(&mut chain, &mut coalesce, &requests, 0).await;
-        tokio::time::sleep(Duration::from_millis(10_u64)).await;
-        assert_responses_len(&mut chain, &mut coalesce, &requests, 0).await;
-        tokio::time::sleep(Duration::from_millis(100_u64)).await;
-        assert_responses_len(&mut chain, &mut coalesce, &requests, 75).await;
-        assert_responses_len(&mut chain, &mut coalesce, &requests, 0).await;
-        assert_responses_len(&mut chain, &mut coalesce, &requests, 0).await;
-        assert_responses_len(&mut chain, &mut coalesce, &requests, 0).await;
-        assert_responses_len(&mut chain, &mut coalesce, &requests, 100).await;
-        assert_responses_len(&mut chain, &mut coalesce, &requests, 0).await;
+            .collect()
     }
 
     async fn assert_responses_len(
         chain: &mut [TransformAndMetrics],
-        coalesce: &mut Coalesce,
+        coalesce: &mut dyn Transform,
         requests: &[Message],
         expected_len: usize,
     ) {
@@ -233,6 +287,147 @@ mod test {
         assert_eq!(
             coalesce.transform(&mut wrapper).await.unwrap().len(),
             expected_len
+        );
+    }
+
+    /// Flush when the buffer reaches `flush_when_buffered_message_count` (no millis timer).
+    ///
+    /// **Notify count:** `force_run_chain` is never used — expect **0** throughout (no background task).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn flush_on_buffer_limit() {
+        let (mut coalesce, force) = coalesce_from_config_with_force_notify(Some(100), None).await;
+        let counter = ForceRunNotifyCounter::spawn(force);
+        // notify count: 0
+        assert_eq!(counter.get(), 0);
+
+        let mut chain = test_chain();
+        let requests = batch_of_25();
+
+        assert_responses_len(&mut chain, &mut *coalesce, &requests, 0).await;
+        assert_eq!(counter.get(), 0); // still 0
+        assert_responses_len(&mut chain, &mut *coalesce, &requests, 0).await;
+        assert_eq!(counter.get(), 0);
+        assert_responses_len(&mut chain, &mut *coalesce, &requests, 0).await;
+        assert_eq!(counter.get(), 0);
+        assert_responses_len(&mut chain, &mut *coalesce, &requests, 100).await;
+        assert_eq!(counter.get(), 0); // count flush does not call notify_one
+        assert_responses_len(&mut chain, &mut *coalesce, &requests, 0).await;
+        assert_eq!(counter.get(), 0);
+    }
+
+    /// Flush when the millis timer fires; simulates the source running the chain with an empty client batch.
+    ///
+    /// **Notify count:** goes **up by at least 1** each time the sleep interval elapses; each `notify_one`
+    /// is what wakes the source so the chain can run and Coalesce can flush.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn flush_on_timer() {
+        const INTERVAL_MS: u64 = 100;
+        let (mut coalesce, force) =
+            coalesce_from_config_with_force_notify(None, Some(INTERVAL_MS)).await;
+        let counter = ForceRunNotifyCounter::spawn(force);
+        assert_eq!(counter.get(), 0);
+
+        let mut chain = test_chain();
+        let requests = batch_of_25();
+
+        assert_responses_len(&mut chain, &mut *coalesce, &requests, 0).await;
+        tokio::time::sleep(Duration::from_millis(10_u64)).await;
+        assert_responses_len(&mut chain, &mut *coalesce, &requests, 0).await;
+
+        tokio::time::sleep(Duration::from_millis(INTERVAL_MS + 15)).await;
+        // First interval: expect >= 1 notify
+        assert!(
+            counter.get() >= 1,
+            "timer should call force_run_chain::notify_one after interval"
+        );
+
+        assert_responses_len(&mut chain, &mut *coalesce, &[], 50).await;
+
+        let after_first_flush = counter.get();
+        assert!(
+            after_first_flush >= 1,
+            "at least one notify before empty-batch flush"
+        );
+
+        tokio::time::sleep(Duration::from_millis(INTERVAL_MS + 15)).await;
+        // Second interval: strictly more notifies than after first flush
+        assert!(
+            counter.get() > after_first_flush,
+            "timer should notify again for the next interval"
+        );
+
+        assert_responses_len(&mut chain, &mut *coalesce, &[], 0).await;
+    }
+
+    /// Timer fires while there is nothing buffered — `force_run_chain` still signals, but Coalesce does not flush.
+    ///
+    /// **Notify count:** **≥ 1** after waiting past the interval (timer still calls `notify_one`).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn flush_on_timer_empty_buffer_only_notifies() {
+        const INTERVAL_MS: u64 = 80;
+        let (mut coalesce, force) =
+            coalesce_from_config_with_force_notify(None, Some(INTERVAL_MS)).await;
+        let counter = ForceRunNotifyCounter::spawn(force);
+
+        let mut chain = test_chain();
+
+        tokio::time::sleep(Duration::from_millis(INTERVAL_MS + 20)).await;
+        assert!(counter.get() >= 1); // notify fired; no messages to flush
+        assert_responses_len(&mut chain, &mut *coalesce, &[], 0).await;
+    }
+
+    /// Buffer limit and millis timer both enabled: timer-driven flush, then count-driven flush.
+    ///
+    /// **Notify count:** **≥ 1** before the timer-assisted flush (75 msgs). Further timer ticks may occur
+    /// while adding batches for the count flush; count-based flush does **not** call `notify_one`.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn flush_on_both_timer_and_buffer_limit() {
+        const INTERVAL_MS: u64 = 100;
+        let (mut coalesce, force) =
+            coalesce_from_config_with_force_notify(Some(100), Some(INTERVAL_MS)).await;
+        let counter = ForceRunNotifyCounter::spawn(force);
+        assert_eq!(counter.get(), 0);
+
+        let mut chain = test_chain();
+        let requests = batch_of_25();
+
+        assert_responses_len(&mut chain, &mut *coalesce, &requests, 0).await;
+        tokio::time::sleep(Duration::from_millis(10_u64)).await;
+        assert_responses_len(&mut chain, &mut *coalesce, &requests, 0).await;
+
+        tokio::time::sleep(Duration::from_millis(INTERVAL_MS + 15)).await;
+        let notifies_before_timer_driven_flush = counter.get();
+        assert!(
+            notifies_before_timer_driven_flush >= 1,
+            "timer path must signal force_run_chain"
+        );
+
+        assert_responses_len(&mut chain, &mut *coalesce, &requests, 75).await;
+
+        assert_responses_len(&mut chain, &mut *coalesce, &requests, 0).await;
+        assert_responses_len(&mut chain, &mut *coalesce, &requests, 0).await;
+        assert_responses_len(&mut chain, &mut *coalesce, &requests, 0).await;
+        assert_responses_len(&mut chain, &mut *coalesce, &requests, 100).await;
+    }
+
+    /// Both limits configured, but the buffer hits its threshold before the (long) timer fires.
+    ///
+    /// **Notify count:** **0** — only the count path runs; the millis task has not completed an interval yet.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn flush_on_buffer_limit_before_timer() {
+        let (mut coalesce, force) =
+            coalesce_from_config_with_force_notify(Some(50), Some(10_000)).await;
+        let counter = ForceRunNotifyCounter::spawn(force);
+        let mut chain = test_chain();
+        let requests = batch_of_25();
+
+        assert_responses_len(&mut chain, &mut *coalesce, &requests, 0).await;
+        assert_eq!(counter.get(), 0);
+        assert_responses_len(&mut chain, &mut *coalesce, &requests, 50).await;
+        assert_eq!(
+            counter.get(),
+            0,
+            "force_run_chain must not run until the 10s timer fires"
         );
     }
 }

--- a/shotover/src/transforms/coalesce.rs
+++ b/shotover/src/transforms/coalesce.rs
@@ -5,21 +5,27 @@ use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
-use tokio::sync::Notify;
+use std::time::{Duration, Instant};
+use tokio::sync::{Notify, RwLock};
 
 struct Coalesce {
-    name: String,
     flush_when_buffered_message_count: Option<usize>,
-    flush_when_millis_since_last_flush: Option<u64>,
     buffer: Messages,
-    /// Background timer sets this before `force_run_chain`; transform clears it to detect a timer-driven run.
-    timer_flush_pending: Option<Arc<AtomicBool>>,
-    /// Notify to restart the sleep so the next wake is `duration` after the last flush.
+    /// When set, a time-based flush is due once `last_flush` is at least this old (see docs).
+    millis_interval: Option<Duration>,
+    /// Shared with the timer task so it sleeps only the **remaining** time until the interval elapses.
+    /// Timer uses `read()`; transform uses `write()` when a run restarts the millis clock (`tokio::sync::RwLock` is write-preferring).
+    last_flush: Option<Arc<RwLock<Instant>>>,
+    /// Wake the timer when `last_flush` changes so it recomputes remaining sleep (see docs).
     restart_sleep_after_flush: Option<Arc<Notify>>,
     /// Aborted in [`Drop`] when the connection chain is torn down.
     timer_task: Option<tokio::task::JoinHandle<()>>,
+}
+
+struct CoalesceBuilder {
+    name: String,
+    flush_when_buffered_message_count: Option<usize>,
+    flush_when_millis_since_last_flush: Option<u64>,
 }
 
 impl Drop for Coalesce {
@@ -50,14 +56,10 @@ impl TransformConfig for CoalesceConfig {
         &self,
         _transform_context: TransformContextConfig,
     ) -> Result<Box<dyn TransformBuilder>> {
-        Ok(Box::new(Coalesce {
+        Ok(Box::new(CoalesceBuilder {
             name: self.name.clone(),
-            buffer: Vec::with_capacity(self.flush_when_buffered_message_count.unwrap_or(0)),
             flush_when_buffered_message_count: self.flush_when_buffered_message_count,
             flush_when_millis_since_last_flush: self.flush_when_millis_since_last_flush,
-            timer_flush_pending: None,
-            restart_sleep_after_flush: None,
-            timer_task: None,
         }))
     }
 
@@ -74,37 +76,49 @@ impl TransformConfig for CoalesceConfig {
     }
 }
 
-impl TransformBuilder for Coalesce {
+impl TransformBuilder for CoalesceBuilder {
     fn build(&self, transform_context: TransformContextBuilder) -> Box<dyn Transform> {
         let mut coalesce = Coalesce {
-            name: self.name.clone(),
             flush_when_buffered_message_count: self.flush_when_buffered_message_count,
-            flush_when_millis_since_last_flush: self.flush_when_millis_since_last_flush,
             buffer: Vec::with_capacity(self.flush_when_buffered_message_count.unwrap_or(0)),
-            timer_flush_pending: None,
+            millis_interval: None,
+            last_flush: None,
             restart_sleep_after_flush: None,
             timer_task: None,
         };
 
         if let Some(ms) = self.flush_when_millis_since_last_flush.filter(|&m| m > 0) {
-            let duration = Duration::from_millis(ms);
-            let pending = Arc::new(AtomicBool::new(false));
+            let interval = Duration::from_millis(ms);
             let restart = Arc::new(Notify::new());
+            let last_flush = Arc::new(RwLock::new(Instant::now()));
 
-            coalesce.timer_flush_pending = Some(pending.clone());
+            coalesce.millis_interval = Some(interval);
+            coalesce.last_flush = Some(last_flush.clone());
             coalesce.restart_sleep_after_flush = Some(restart.clone());
 
+            let force_run_chain = transform_context.force_run_chain.clone();
+            let restart_task = restart.clone();
+            let last_flush_task = last_flush;
             let handle = tokio::spawn(async move {
                 loop {
-                    tokio::select! {
-                        _ = restart.notified() => {}
-                        _ = tokio::time::sleep(duration) => {
-                            pending.store(true, Ordering::Relaxed);
-                            transform_context.force_run_chain.notify_one();
+                    // Wait until the transform has set `last_flush` for this cycle (startup or post-flush).
+                    restart_task.notified().await;
+
+                    loop {
+                        let remaining = {
+                            let last = *last_flush_task.read().await;
+                            interval.saturating_sub(last.elapsed())
+                        };
+                        tokio::select! {
+                            _ = restart_task.notified() => {}
+                            _ = tokio::time::sleep(remaining) => break,
                         }
                     }
+
+                    force_run_chain.notify_one();
                 }
             });
+            restart.notify_one();
             coalesce.timer_task = Some(handle);
         }
 
@@ -120,6 +134,18 @@ impl TransformBuilder for Coalesce {
     }
 
     fn validate(&self) -> Vec<String> {
+        if self
+            .flush_when_millis_since_last_flush
+            .is_some_and(|m| m == 0)
+        {
+            return vec![
+                "Coalesce:".into(),
+                "  flush_when_millis_since_last_flush must be greater than 0 when set.".into(),
+                "  Check https://shotover.io/docs/latest/transforms.html#coalesce for more information."
+                    .into(),
+            ];
+        }
+
         let has_count = self.flush_when_buffered_message_count.is_some();
         let has_timer_millis = self
             .flush_when_millis_since_last_flush
@@ -151,19 +177,25 @@ impl Transform for Coalesce {
         &mut self,
         chain_state: &'shorter mut ChainState<'longer>,
     ) -> Result<Messages> {
-        // No millis timer → no pending flag; timer task is not running.
-        let timer_wake = match &self.timer_flush_pending {
-            Some(pending) => pending.swap(false, Ordering::Relaxed),
-            None => false,
-        };
-
         self.buffer.append(&mut chain_state.requests);
 
+        let millis_due = match (self.millis_interval, &self.last_flush) {
+            (Some(interval), Some(last_arc)) => {
+                let last = *last_arc.read().await;
+                last.elapsed() >= interval
+            }
+            _ => false,
+        };
+
         if self.buffer.is_empty() && !chain_state.flush {
+            if let (Some(last_arc), Some(n)) = (&self.last_flush, &self.restart_sleep_after_flush) {
+                *last_arc.write().await = Instant::now();
+                n.notify_one();
+            }
             return Ok(vec![]);
         }
 
-        let millis_wants_flush = timer_wake && !self.buffer.is_empty();
+        let millis_wants_flush = millis_due && !self.buffer.is_empty();
 
         let flush_buffer = chain_state.flush
             || self
@@ -175,6 +207,9 @@ impl Transform for Coalesce {
         if flush_buffer {
             std::mem::swap(&mut self.buffer, &mut chain_state.requests);
             let out = chain_state.call_next_transform().await?;
+            if let Some(last_arc) = &self.last_flush {
+                *last_arc.write().await = Instant::now();
+            }
             if let Some(n) = &self.restart_sleep_after_flush {
                 n.notify_one();
             }


### PR DESCRIPTION
Closes : https://github.com/shotover/shotover-proxy/issues/1673 

This PR introduces a background timer that will force the Transfrom chain to run if a time based flush definition is present when the time since last flush is greater than the time defined. 

Last flush is considered to be the time 
1. When messages were truely flushed due meeting some condition.
2. When the chain runs and the messages to flush is empty. 