### PR TITLE
Fix shotover WARN logs caused by client disconnections

### DIFF
--- a/shotover-proxy/tests/kafka_int_tests/mod.rs
+++ b/shotover-proxy/tests/kafka_int_tests/mod.rs
@@ -1223,11 +1223,10 @@ async fn force_tcp_rst(address: &str) {
         // Give Shotover's reader task time to start reading from this connection.
         tokio::time::sleep(Duration::from_millis(10)).await;
         // SO_LINGER with zero timeout causes the kernel to send RST instead of FIN.
-        // set_linger is deprecated on tokio TcpStream for the general case, but
-        // the zero-linger case (forcing RST) doesn't cause blocking.
-        #[allow(deprecated)]
-        let _ = stream.set_linger(Some(Duration::ZERO));
-        drop(stream);
+        if let Ok(std_stream) = stream.into_std() {
+            let _ = std_stream.set_linger(Some(Duration::ZERO));
+            drop(std_stream);
+        }
     }
     tokio::time::sleep(Duration::from_millis(50)).await;
 }

--- a/shotover-proxy/tests/kafka_int_tests/mod.rs
+++ b/shotover-proxy/tests/kafka_int_tests/mod.rs
@@ -1115,6 +1115,31 @@ async fn cluster_sasl_plain_multi_shotover(#[case] driver: KafkaDriver) {
     }
 }
 
+/// Verifies that abrupt client disconnects (TCP RST) are handled gracefully without producing WARN logs.
+#[tokio::test]
+async fn cluster_1_rack_single_shotover_connection_reset_handling() {
+    let _docker_compose =
+        docker_compose("tests/test-configs/kafka/cluster-1-rack/docker-compose.yaml");
+    let shotover = shotover_process("tests/test-configs/kafka/cluster-1-rack/topology-single.yaml")
+        .start()
+        .await;
+
+    // Warm up cluster so Shotover's transform chain is initialized.
+    test_helpers::connection::kafka::python::run_python_smoke_test("127.0.0.1:9192").await;
+
+    // Force TCP RST on multiple connections. This should not produce any WARN logs.
+    for _ in 0..10 {
+        force_tcp_rst("127.0.0.1:9192").await;
+    }
+
+    tokio::time::timeout(
+        Duration::from_secs(10),
+        shotover.shutdown_and_then_consume_events(&[]),
+    )
+    .await
+    .expect("Shotover did not shutdown within 10s");
+}
+
 fn multi_shotover_events() -> Vec<EventMatcher> {
     // Shotover nodes can be detected as down during shutdown.
     // We should ignore "Shotover peer ... is down" for multi-shotover tests where shotover nodes are not killed.
@@ -1190,4 +1215,19 @@ fn workaround_rdkafka_connection_reset_bug(
                 .with_count(Count::Any),
         );
     }
+}
+
+/// Connect to `address` and immediately send a TCP RST (not FIN)
+async fn force_tcp_rst(address: &str) {
+    if let Ok(stream) = tokio::net::TcpStream::connect(address).await {
+        // Give Shotover's reader task time to start reading from this connection.
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        // SO_LINGER with zero timeout causes the kernel to send RST instead of FIN.
+        // set_linger is deprecated on tokio TcpStream for the general case, but
+        // the zero-linger case (forcing RST) doesn't cause blocking.
+        #[allow(deprecated)]
+        let _ = stream.set_linger(Some(Duration::ZERO));
+        drop(stream);
+    }
+    tokio::time::sleep(Duration::from_millis(50)).await;
 }

--- a/shotover-proxy/tests/kafka_int_tests/mod.rs
+++ b/shotover-proxy/tests/kafka_int_tests/mod.rs
@@ -1223,10 +1223,11 @@ async fn force_tcp_rst(address: &str) {
         // Give Shotover's reader task time to start reading from this connection.
         tokio::time::sleep(Duration::from_millis(10)).await;
         // SO_LINGER with zero timeout causes the kernel to send RST instead of FIN.
-        if let Ok(std_stream) = stream.into_std() {
-            let _ = std_stream.set_linger(Some(Duration::ZERO));
-            drop(std_stream);
-        }
+        // set_linger is deprecated on tokio TcpStream for the general case, but
+        // the zero-linger case (forcing RST) doesn't cause blocking.
+        #[allow(deprecated)]
+        let _ = stream.set_linger(Some(Duration::ZERO));
+        drop(stream);
     }
     tokio::time::sleep(Duration::from_millis(50)).await;
 }

--- a/shotover/src/source_task.rs
+++ b/shotover/src/source_task.rs
@@ -587,11 +587,13 @@ pub fn spawn_read_write_tasks<
                                     return;
                                 }
                                 Err(CodecReadError::Io(err)) => {
-                                    // I suspect (but have not confirmed) that UnexpectedEof occurs here when the ssl client
-                                    // does not send "close notify" before terminating the connection.
-                                    // We shouldnt report that as a warning because its common for clients to do
-                                    // that for performance reasons.
-                                    if !matches!(err.kind(), ErrorKind::UnexpectedEof) {
+                                    // These IO errors indicate unexpected client disconnects:
+                                    // - UnexpectedEof: SSL client closes without "close notify"
+                                    // - ConnectionReset: client process crashed or was killed (TCP RST)
+                                    if !matches!(
+                                        err.kind(),
+                                        ErrorKind::UnexpectedEof | ErrorKind::ConnectionReset
+                                    ) {
                                         warn!("failed to receive message on tcp stream: {err:?}");
                                     }
                                     return;


### PR DESCRIPTION
This PR handles abrupt client disconnections (e.g., TCP RST) and makes shotover not produce the `WARN shotover::server: failed to receive message on tcp stream: Os` for this case anymore.

See https://github.com/shotover/shotover-proxy/issues/1579#issuecomment-4140259885 for the investigation on the Kafka python client error and warn logs.

This [new integration test](https://github.com/shotover/shotover-proxy/pull/1998/changes#diff-16f741da9aa00be415700d6291cb678585341176da370f86976a1f7cee7ccbe3R1120) can reproduce the WARN log (see [example failed test](https://github.com/shotover/shotover-proxy/actions/runs/23633740321/job/68839147997?pr=1998#step:8:341)) when the fix is not implemented. All tests pass now with the fix.